### PR TITLE
SSL: Use the default cipher from the recent nodejs version.

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,7 +222,10 @@ d.run(function () {
 
 				var https = require('https').createServer({
 					key: privateKey,
-					cert: certificate
+					cert: certificate,
+					ciphers:	"ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:"+
+										"ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:"+
+										"!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA"
 				}, app);
 
 				var https_io = require('socket.io')(https);


### PR DESCRIPTION
Use the default cipher from the recent nodejs version to prevent the usage from the weak RC4 cipher.
You can check this with:
https://www.ssllabs.com/ssltest/analyze.html?d=login.lisk.io