### PR TITLE
Allow the setup off the logging path in config.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ var config = {
 	}
 }
 
-var logger = new Logger({echo: appConfig.consoleLogLevel, errorLevel: appConfig.fileLogLevel});
+var logger = new Logger({echo: appConfig.consoleLogLevel, errorLevel: appConfig.fileLogLevel, filename: appConfig.logFileName });
 
 var d = require('domain').create();
 


### PR DESCRIPTION
The logfile path can now setup in the config.json: 
```
{
...
  "fileLogLevel": "info",
  "consoleLogLevel": "log",
  "logFileName": "/var/log/lisk.log",
```
see issue #80 
