### PR TITLE
Allow the setup of logging path in config.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ var config = {
 	}
 }
 
-var logger = new Logger({echo: appConfig.consoleLogLevel, errorLevel: appConfig.fileLogLevel});
+var logger = new Logger({echo: appConfig.consoleLogLevel, errorLevel: appConfig.fileLogLevel, filename: appConfig.logFileName });
 
 var d = require('domain').create();
 


### PR DESCRIPTION
The logfile path can now setup in the config.json:
```
{
  "port": 7000,
  "address": "0.0.0.0",
  "serveHttpAPI": true,
  "serveHttpWallet": true,
  "version": "0.2.0",
  "fileLogLevel": "info",
  "consoleLogLevel": "log",
  "logFileName": "/var/log/lisk.log",
```
see #80 
