### PR TITLE
Correct error message

### DIFF
--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -35,7 +35,7 @@ function Vote() {
 		}
 
 		if (!trs.asset.votes || !trs.asset.votes.length) {
-			return setImmediate(cb, "Not enough spare votes available");
+			return setImmediate(cb, "No votes sent");
 		}
 
 		if (trs.asset.votes && trs.asset.votes.length > 33) {


### PR DESCRIPTION
As mentioned by fix here: https://github.com/LiskHQ/lisk/issues/108
This check should be if votes were actually send to the function
I believe the check of spare votes left is handled here: https://github.com/LiskHQ/lisk/blob/development/modules/delegates.js#L653