### PR TITLE
fix issue on pending transactions not searcheable

### DIFF
--- a/modules/multisignatures.js
+++ b/modules/multisignatures.js
@@ -432,6 +432,9 @@ shared.pending = function (req, cb) {
 		}
 
 		var transactions = modules.transactions.getUnconfirmedTransactionList();
+		transactions=transactions.filter(function(transaction){
+			return transaction.senderPublicKey===query.publicKey;
+		});
 
 		var pendings = [];
 		async.eachSeries(transactions, function (item, cb) {


### PR DESCRIPTION
The rationale behind this: the way it works was to check only the first pending transaction and then if not matching the first it stopped here. this least is just filtering pending transactions matching publicKey