### PR TITLE
Added nethash fix #131

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "fileLogLevel": "info",
     "logFileName": "logs.log",
     "consoleLogLevel": "log",
-    "sharePort": true,
+    "nethash": "e2f8f69ec6ab4b12550a314bd867c46e64e429961bb427514a3a534c602ff467",
     "db": {
         "host": "localhost",
         "port": 5432,

--- a/modules/system.js
+++ b/modules/system.js
@@ -4,7 +4,7 @@ var os = require("os"),
 // Private fields
 var modules, library, self, private = {}, shared = {};
 
-private.version, private.osName, private.port, private.sharePort;
+private.version, private.osName, private.port, private.nethash;
 
 // Constructor
 function System(cb, scope) {
@@ -14,7 +14,7 @@ function System(cb, scope) {
 
 	private.version = library.config.version;
 	private.port = library.config.port;
-	private.sharePort = Number(!!library.config.sharePort);
+	private.nethash = library.config.nethash;
 	private.osName = os.platform() + os.release();
 
 	setImmediate(cb, null, self);
@@ -35,8 +35,8 @@ System.prototype.getPort = function () {
 	return private.port;
 }
 
-System.prototype.getSharePort = function () {
-	return private.sharePort;
+System.prototype.getNethash = function () {
+	return private.nethash;
 }
 
 System.prototype.sandboxApi = function (call, args, cb) {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -54,7 +54,6 @@ private.attachApi = function () {
 		}
 
 		req.headers['port'] = req.peer.port;
-		req.headers['share-port'] = parseInt(req.headers['share-port']);
 
 		req.sanitize(req.headers, {
 			type: "object",
@@ -68,24 +67,22 @@ private.attachApi = function () {
 					type: "string",
 					maxLength: 64
 				},
-				'share-port': {
-					type: 'integer',
-					minimum: 0,
-					maximum: 1
+				nethash: {
+					type: 'string',
+					maxLength: 64
 				},
-				'version': {
+				version: {
 					type: 'string',
 					maxLength: 11
 				}
 			},
-			required: ["port", 'share-port', 'version']
+			required: ["port", 'nethash', 'version']
 		}, function (err, report, headers) {
 			if (err) return next(err);
 			if (!report.isValid) return res.status(500).send({status: false, error: report.issues});
 
 			req.peer.state = 2;
 			req.peer.os = headers.os;
-			req.peer.sharePort = Number(headers['share-port']);
 			req.peer.version = headers.version;
 
 			if (req.body && req.body.dappid) {
@@ -549,7 +546,6 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
 		}
 
 		response.headers['port'] = parseInt(response.headers['port']);
-		response.headers['share-port'] = parseInt(response.headers['share-port']);
 
 		var report = library.scheme.validate(response.headers, {
 			type: "object",
@@ -563,17 +559,16 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
 					minimum: 1,
 					maximum: 65535
 				},
-				'share-port': {
-					type: "integer",
-					minimum: 0,
-					maximum: 1
+				nethash: {
+					type: 'string',
+					maxLength: 64
 				},
 				version: {
 					type: "string",
 					maxLength: 11
 				}
 			},
-			required: ['port', 'share-port', 'version']
+			required: ['port', 'nethash', 'version']
 		});
 
 		if (!report) {
@@ -586,7 +581,6 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
 				port: response.headers['port'],
 				state: 2,
 				os: response.headers['os'],
-				sharePort: Number(!!response.headers['share-port']),
 				version: response.headers['version']
 			});
 		}
@@ -607,7 +601,7 @@ Transport.prototype.onBind = function (scope) {
 		os: modules.system.getOS(),
 		version: modules.system.getVersion(),
 		port: modules.system.getPort(),
-		'share-port': modules.system.getSharePort()
+		nethash: modules.system.getNethash()
 	}
 }
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS "multisignatures"("min" INT NOT NULL, "lifetime" INT 
 CREATE TABLE IF NOT EXISTS "dapps"("transactionId" VARCHAR(20) NOT NULL, "name" VARCHAR(32) NOT NULL, "description" VARCHAR(160), "tags" VARCHAR(160), "link" TEXT, "type" INT NOT NULL, "category" INT NOT NULL, "icon" TEXT, FOREIGN KEY("transactionId") REFERENCES "trs"("id") ON DELETE CASCADE);
 CREATE TABLE IF NOT EXISTS "intransfer"("dappId" VARCHAR(20) NOT NULL, "transactionId" VARCHAR(20) NOT NULL, FOREIGN KEY("transactionId") REFERENCES "trs"("id") ON DELETE CASCADE);
 CREATE TABLE IF NOT EXISTS "outtransfer"("transactionId" VARCHAR(20) NOT NULL, "dappId" VARCHAR(20) NOT NULL, "outTransactionId" VARCHAR(20) NOT NULL UNIQUE, FOREIGN KEY("transactionId") REFERENCES "trs"("id") ON DELETE CASCADE);
-CREATE TABLE IF NOT EXISTS "peers"("id" SERIAL NOT NULL PRIMARY KEY, "ip" INET NOT NULL, "port" SMALLINT NOT NULL, "state" SMALLINT NOT NULL, "os" VARCHAR(64), "sharePort" SMALLINT NOT NULL, "version" VARCHAR(11), "clock" BIGINT);
+CREATE TABLE IF NOT EXISTS "peers"("id" SERIAL NOT NULL PRIMARY KEY, "ip" INET NOT NULL, "port" SMALLINT NOT NULL, "state" SMALLINT NOT NULL, "os" VARCHAR(64), "version" VARCHAR(11), "clock" BIGINT);
 CREATE TABLE IF NOT EXISTS "peers_dapp"("peerId" INT NOT NULL, "dappid" VARCHAR(20) NOT NULL, FOREIGN KEY("peerId") REFERENCES "peers"("id") ON DELETE CASCADE);
 
 /* Unique Indexes */

--- a/test/config.json
+++ b/test/config.json
@@ -7,7 +7,7 @@
     "fileLogLevel": "info",
     "logFileName": "logs.log",
     "consoleLogLevel": "log",
-    "sharePort": true,
+    "nethash":"198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d",
     "db": {
         "host": "localhost",
         "port": 5432,

--- a/test/lib/accounts.js
+++ b/test/lib/accounts.js
@@ -16,7 +16,6 @@ var Saccount = {
     "balance": 0
 };
 
-console.log("Starting account-test suite");
 
 describe("Account", function() {
 
@@ -313,5 +312,4 @@ describe("Account", function() {
             });
     });
 
-    console.log("Finished Account-test suite");
 });

--- a/test/lib/dapps.js
+++ b/test/lib/dapps.js
@@ -22,7 +22,6 @@ var Account1 = node.randomTxAccount();
 var Account2 = node.randomTxAccount();
 var Account3 = node.randomTxAccount();
 
-console.log("Starting Dapps test suite");
 
 describe("Dapps", function () {
 
@@ -1275,5 +1274,4 @@ describe("Dapps", function () {
 
    });
 
-   console.log("Finished Account-test suite");
 });

--- a/test/lib/delegates.js
+++ b/test/lib/delegates.js
@@ -15,12 +15,6 @@ R2account.username=Raccount.username.toUpperCase();
 
 var test = 0;
 
-// Print data to console
-console.log("Starting delegates test-suite");
-console.log("Password for random account is: " + Raccount.password);
-console.log("Random LISK is: " + (node.LISK / node.normalizer));
-console.log("Random delegate username is: " + Raccount.username);
-
 // Starting tests //
 
   describe("Delegates", function() {
@@ -937,5 +931,4 @@ console.log("Random delegate username is: " + Raccount.username);
         });
     });
 
-    console.log("Finished delegates-test suite");
 });

--- a/test/lib/miscellaneous.js
+++ b/test/lib/miscellaneous.js
@@ -93,26 +93,6 @@ describe("Miscellaneous tests (peers, blocks, etc)", function () {
         });
 
         test = test + 1;
-        it(test + ". Get peers list by parameters: sharePort. Should be ok", function (done) {
-            var shared = 1, limit = 100, offset = 0;
-            node.api.get("/peers?shared="+shared+"&limit="+limit+"&offset="+offset)
-                .set("Accept", "application/json")
-                .expect("Content-Type", /json/)
-                .expect(200)
-                .end(function (err, res) {
-                    //console.log(JSON.stringify(res.body));
-                    node.expect(res.body).to.have.property("success").to.be.true;
-                    node.expect(res.body).to.have.property("peers").that.is.an("array");
-                    if (res.body.peers.length > 0) {
-                        for (var i = 0; i < res.body.peers.length; i++) {
-                            node.expect(res.body.peers[i].sharePort).to.equal(parseInt(shared));
-                        }
-                    }
-                    done();
-                });
-        });
-
-        test = test + 1;
         it(test + ". Get peers list by parameters: limit. Should be ok", function (done) {
             var limit = 3, offset = 0;
             node.api.get("/peers?&limit="+limit+"&offset="+offset)

--- a/test/lib/multisignatures.js
+++ b/test/lib/multisignatures.js
@@ -130,9 +130,6 @@ function makeKeysGroup () {
 // Used for test labeling
 var test = 0;
 
-// Print data to console
-console.log("Starting multisignature-test suite");
-
 // Starting tests //
 
 describe("Multisignatures", function () {

--- a/test/lib/peers.blocks.js
+++ b/test/lib/peers.blocks.js
@@ -1,0 +1,43 @@
+var node = require("./../variables.js"),
+  crypto = require("crypto");
+
+var genesisblock = require("../../genesisBlock.json");
+
+describe("Testing /peer/blocks API", function () {
+
+  it("create a dummy block sent with wrong nethash on header. should fail because of wrong nethash", function (done) {
+    node.peer.post("/blocks")
+      .set("Accept", "application/json")
+      .set("version",node.version)
+      .set("nethash", "wrongnethash")
+      .set("port",node.config.port)
+      .send({
+        dummy:"dummy"
+      })
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .end(function (err, res) {
+        //console.log(JSON.stringify(res.body));
+        node.expect(res.body).to.have.property("success").to.be.false;
+        node.expect(res.body.expected).to.equal(node.config.nethash);
+        done();
+      });
+  });
+
+  it("get blocks. should succeed and return nethash in header", function (done) {
+    node.peer.get("/blocks")
+      .set("Accept", "application/json")
+      .set("version",node.version)
+      .set("port",node.config.port)
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .end(function (err, res) {
+        //console.log(JSON.stringify(res.body.blocks));
+        node.expect(res.headers.nethash).to.equal(node.config.nethash);
+        node.expect(res.body.blocks.length).to.be.greaterThan(1);
+        done();
+      });
+  });
+
+
+});

--- a/test/lib/peers.delegates.js
+++ b/test/lib/peers.delegates.js
@@ -4,7 +4,7 @@ var node = require("./../variables.js"),
 var account = node.randomAccount();
 var account2 = node.randomAccount();
 
-describe("Peers delegates transactions", function () {
+describe("Testing /peer/transactions API with delegates management", function () {
   it("Creating a delegate with an invalid username. Should not be ok", function (done) {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")

--- a/test/lib/peers.delegates.js
+++ b/test/lib/peers.delegates.js
@@ -9,7 +9,7 @@ describe("Peers delegates transactions", function () {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")
       .set("version", node.version)
-      .set("share-port", 1)
+      .set("nethash", node.config.nethash)
       .set("port", node.config.port)
       .send({
         secret: account.password
@@ -21,7 +21,7 @@ describe("Peers delegates transactions", function () {
         node.api.put("/transactions")
           .set("Accept", "application/json")
           .set("version", node.version)
-          .set("share-port", 1)
+          .set("nethash", node.config.nethash)
           .set("port", node.config.port)
           .send({
             secret: node.Gaccount.password,
@@ -39,7 +39,7 @@ describe("Peers delegates transactions", function () {
               node.peer.post("/transactions")
                 .set("Accept", "application/json")
                 .set("version",node.version)
-                .set("share-port", 1)
+                .set("nethash", node.config.nethash)
                 .set("port", node.config.port)
                 .send({
                   transaction: transaction
@@ -63,7 +63,7 @@ describe("Peers delegates transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version", node.version)
-      .set("share-port", 1)
+      .set("nethash", node.config.nethash)
       .set("port", node.config.port)
       .send({
         transaction: transaction
@@ -84,7 +84,7 @@ describe("Peers delegates transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version", node.version)
-      .set("share-port", 1)
+      .set("nethash", node.config.nethash)
       .set("port", node.config.port)
       .send({
         transaction: transaction
@@ -105,7 +105,7 @@ describe("Peers delegates transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version", node.version)
-      .set("share-port", 1)
+      .set("nethash", node.config.nethash)
       .set("port", node.config.port)
       .send({
         transaction: transaction
@@ -123,7 +123,7 @@ describe("Peers delegates transactions", function () {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")
       .set("version", node.version)
-      .set("share-port", 1)
+      .set("nethash", node.config.nethash)
       .set("port", node.config.port)
       .send({
         secret: account2.password
@@ -136,7 +136,7 @@ describe("Peers delegates transactions", function () {
         node.api.put("/transactions")
           .set("Accept", "application/json")
           .set("version", node.version)
-          .set("share-port", 1)
+          .set("nethash", node.config.nethash)
           .set("port", node.config.port)
           .send({
             secret: node.Gaccount.password,
@@ -155,7 +155,7 @@ describe("Peers delegates transactions", function () {
               node.peer.post("/transactions")
                 .set("Accept", "application/json")
                 .set("version", node.version)
-                .set("share-port", 1)
+                .set("nethash", node.config.nethash)
                 .set("port", node.config.port)
                 .send({
                   transaction: transaction
@@ -172,7 +172,7 @@ describe("Peers delegates transactions", function () {
                   node.peer.post("/transactions")
                     .set("Accept", "application/json")
                     .set("version", node.version)
-                    .set("share-port", 1)
+                    .set("nethash", node.config.nethash)
                     .set("port", node.config.port)
                     .send({
                       transaction: transaction2
@@ -196,7 +196,7 @@ describe("Peers delegates transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version", node.version)
-      .set("share-port", 1)
+      .set("nethash", node.config.nethash)
       .set("port", node.config.port)
       .send({
         transaction: transaction

--- a/test/lib/peers.secondpassword.js
+++ b/test/lib/peers.secondpassword.js
@@ -5,7 +5,7 @@ var account = node.randomAccount();
 var account2 = node.randomAccount();
 var account3 = node.randomAccount();
 
-describe("Peers second signature transactions", function () {
+describe("Testing /peer/transactions API with second signature management", function () {
   it("Send second signature from account that doesn't have it. Should return not ok", function (done) {
     var transaction = node.lisk.transaction.createTransaction("1L", 1, node.Gaccount.password, account.secondPassword);
     node.peer.post("/transactions")

--- a/test/lib/peers.secondpassword.js
+++ b/test/lib/peers.secondpassword.js
@@ -11,7 +11,7 @@ describe("Peers second signature transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -31,7 +31,7 @@ describe("Peers second signature transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -49,7 +49,7 @@ describe("Peers second signature transactions", function () {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         secret: account.password
@@ -61,7 +61,7 @@ describe("Peers second signature transactions", function () {
         node.api.put("/transactions")
           .set("Accept", "application/json")
           .set("version",node.version)
-          .set("share-port",1)
+          .set("nethash", node.config.nethash)
           .set("port",node.config.port)
           .send({
             secret: node.Gaccount.password,
@@ -82,7 +82,7 @@ describe("Peers second signature transactions", function () {
               node.peer.post("/transactions")
                 .set("Accept", "application/json")
                 .set("version",node.version)
-                .set("share-port",1)
+                .set("nethash", node.config.nethash)
                 .set("port",node.config.port)
                 .send({
                   transaction: transaction
@@ -105,7 +105,7 @@ describe("Peers second signature transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -126,7 +126,7 @@ describe("Peers second signature transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -145,7 +145,7 @@ describe("Peers second signature transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -165,7 +165,7 @@ describe("Peers second signature transactions", function () {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         secret: account2.password
@@ -179,7 +179,7 @@ describe("Peers second signature transactions", function () {
         node.api.put("/transactions")
           .set("Accept", "application/json")
           .set("version",node.version)
-          .set("share-port",1)
+          .set("nethash", node.config.nethash)
           .set("port",node.config.port)
           .send({
             secret: node.Gaccount.password,
@@ -198,7 +198,7 @@ describe("Peers second signature transactions", function () {
               node.peer.post("/transactions")
                 .set("Accept", "application/json")
                 .set("version",node.version)
-                .set("share-port",1)
+                .set("nethash", node.config.nethash)
                 .set("port",node.config.port)
                 .send({
                   transaction: transaction
@@ -212,7 +212,7 @@ describe("Peers second signature transactions", function () {
                     node.peer.post("/transactions")
                       .set("Accept", "application/json")
                       .set("version",node.version)
-                      .set("share-port",1)
+                      .set("nethash", node.config.nethash)
                       .set("port",node.config.port)
                       .send({
                         transaction: sendTransaction
@@ -235,7 +235,7 @@ describe("Peers second signature transactions", function () {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         secret: account3.password
@@ -261,7 +261,7 @@ describe("Peers second signature transactions", function () {
               node.peer.post("/transactions")
                 .set("Accept", "application/json")
                 .set("version",node.version)
-                .set("share-port",1)
+                .set("nethash", node.config.nethash)
                 .set("port",node.config.port)
                 .send({
                   transaction: sendTransaction
@@ -275,7 +275,7 @@ describe("Peers second signature transactions", function () {
                   node.peer.post("/transactions")
                     .set("Accept", "application/json")
                     .set("version",node.version)
-                    .set("share-port",1)
+                    .set("nethash", node.config.nethash)
                     .set("port",node.config.port)
                     .send({
                       transaction: transaction
@@ -291,7 +291,7 @@ describe("Peers second signature transactions", function () {
                         node.api.get("/transactions/get?id=" + sendTransaction.id)
                           .set("Accept", "application/json")
                           .set("version",node.version)
-                          .set("share-port",1)
+                          .set("nethash", node.config.nethash)
                           .set("port",node.config.port)
                           .expect("Content-Type", /json/)
                           .expect(200)
@@ -302,7 +302,7 @@ describe("Peers second signature transactions", function () {
                             node.api.get("/transactions/get?id=" + transaction.id)
                               .set("Accept", "application/json")
                               .set("version",node.version)
-                              .set("share-port",1)
+                              .set("nethash", node.config.nethash)
                               .set("port",node.config.port)
                               .expect("Content-Type", /json/)
                               .expect(200)

--- a/test/lib/peers.transactions.js
+++ b/test/lib/peers.transactions.js
@@ -3,8 +3,29 @@ var node = require("./../variables.js"),
 
 var genesisblock = require("../../genesisBlock.json");
 
-describe("Peers transactions", function () {
-  it("create transaction. should return ok", function (done) {
+describe("Testing /peer/transactions API with sending LISK", function () {
+
+  it("create good transaction sent with wrong nethash on header. should fail", function (done) {
+    var transaction = node.lisk.transaction.createTransaction("1L", 1, node.Gaccount.password);
+    node.peer.post("/transactions")
+      .set("Accept", "application/json")
+      .set("version",node.version)
+      .set("nethash", "wrongnethash")
+      .set("port",node.config.port)
+      .send({
+        transaction: transaction
+      })
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .end(function (err, res) {
+        console.log(JSON.stringify(res.body));
+        node.expect(res.body).to.have.property("success").to.be.false;
+        node.expect(res.body.expected).to.equal(node.config.nethash);
+        done();
+      });
+  });
+
+  it("create same good transaction sent with right nethash on header. should return ok", function (done) {
     var transaction = node.lisk.transaction.createTransaction("1L", 1, node.Gaccount.password);
     node.peer.post("/transactions")
       .set("Accept", "application/json")

--- a/test/lib/peers.transactions.js
+++ b/test/lib/peers.transactions.js
@@ -9,7 +9,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -28,7 +28,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -48,7 +48,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -70,7 +70,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -90,7 +90,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -112,7 +112,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -134,7 +134,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -155,7 +155,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -174,7 +174,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -194,7 +194,7 @@ describe("Peers transactions", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction

--- a/test/lib/peers.votes.js
+++ b/test/lib/peers.votes.js
@@ -89,7 +89,7 @@ describe("Peers votes", function () {
       node.peer.post("/transactions")
         .set("Accept", "application/json")
         .set("version", node.version)
-        .set("share-port", 1)
+        .set("nethash", node.config.nethash)
         .set("port", node.config.port)
         .send({
           transaction: transaction
@@ -110,7 +110,7 @@ describe("Peers votes", function () {
     node.peer.post("/transactions")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         transaction: transaction
@@ -131,7 +131,7 @@ describe("Peers votes", function () {
       node.peer.post("/transactions")
         .set("Accept", "application/json")
         .set("version", node.version)
-        .set("share-port", 1)
+        .set("nethash", node.config.nethash)
         .set("port", node.config.port)
         .send({
           transaction: transaction
@@ -145,7 +145,7 @@ describe("Peers votes", function () {
           node.peer.post("/transactions")
             .set("Accept", "application/json")
             .set("version", node.version)
-            .set("share-port", 1)
+            .set("nethash", node.config.nethash)
             .set("port", node.config.port)
             .send({
               transaction: transaction2
@@ -166,7 +166,7 @@ describe("Peers votes", function () {
     node.api.post("/accounts/open")
       .set("Accept", "application/json")
       .set("version",node.version)
-      .set("share-port",1)
+      .set("nethash", node.config.nethash)
       .set("port",node.config.port)
       .send({
         secret: account.password
@@ -186,7 +186,7 @@ describe("Peers votes", function () {
         node.api.put("/transactions")
           .set("Accept", "application/json")
           .set("version",node.version)
-          .set("share-port",1)
+          .set("nethash", node.config.nethash)
           .set("port",node.config.port)
           .send({
             secret: node.Gaccount.password,
@@ -203,7 +203,7 @@ describe("Peers votes", function () {
               node.peer.post("/transactions")
                 .set("Accept", "application/json")
                 .set("version",node.version)
-                .set("share-port",1)
+                .set("nethash", node.config.nethash)
                 .set("port",node.config.port)
                 .send({
                   transaction: transaction
@@ -227,7 +227,7 @@ describe("Peers votes", function () {
       node.peer.post("/transactions")
         .set("Accept", "application/json")
         .set("version",node.version)
-        .set("share-port",1)
+        .set("nethash", node.config.nethash)
         .set("port",node.config.port)
         .send({
           transaction: transaction

--- a/test/lib/peers.votes.js
+++ b/test/lib/peers.votes.js
@@ -6,70 +6,80 @@ var account = node.randomAccount();
 var delegate1Voted = false;
 var delegate2Voted = false;
 
-var delegate1="cd4605500c55816592a531c6e357dfe6075f9c0d5bffc961d6847ed8f6e9c190";
-var delegate2="0ac9f9bf9a35ae05176121392ce308765ee8c956d3d86acf6a23959155dd35b4";
+var delegate1;
+var delegate2;
 node.chai.config.includeStack = true;
 
 describe("Peers votes", function () {
   before(function (done) {
-    node.api.get("/accounts/delegates/?address=" + node.Gaccount.address)
+    node.api.get("/delegates/")
       .expect("Content-Type", /json/)
       .expect(200)
       .end(function (err, res) {
-        var transaction=null;
-        //console.log(JSON.stringify(res.body));
         node.expect(res.body).to.have.property("success").to.be.true;
         if (res.body.success == true){
-          node.expect(res.body).to.have.property("delegates").that.is.an("array");
-          if (res.body.delagates !== null) {
-            for (var i = 0; i < res.body.delegates.length; i++) {
-              if (res.body.delegates[i].publicKey == delegate1) {
-                delegate1Voted = true;
-              }
-              else if (res.body.delegates[i].publicKey == delegate2){
-                delegate2Voted = true;
-              }
-            }
-          }
-          else {
-            console.log("Accounts returned null. Unable to proceed with test");
-          }
-        }
-        else {
-          console.log("Check if already voted request failed or account array null");
-          done();
-        }
-        if (!delegate1Voted && !delegate2Voted) {
-          transaction = node.lisk.vote.createVote(node.Gaccount.password, ["+"+delegate1, "+"+delegate2]);
-        }
-        else if (delegate1Voted && !delegate2Voted) {
-          transaction = node.lisk.vote.createVote(node.Gaccount.password, ["+"+delegate2]);
-        }
-        else if (delegate2Voted && !delegate1Voted) {
-          transaction = node.lisk.vote.createVote(node.Gaccount.password, ["+"+delegate1]);
-        }
-        if (transaction!==null) {
-          node.peer.post("/transactions")
-            .set("Accept", "application/json")
-            .set("version", node.version)
-            .set("share-port", 1)
-            .set("port", node.config.port)
-            .send({
-              transaction: transaction
-            })
+          delegate1=res.body.delegates[1].publicKey;
+          delegate2=res.body.delegates[2].publicKey;
+
+          node.api.get("/accounts/delegates/?address=" + node.Gaccount.address)
             .expect("Content-Type", /json/)
             .expect(200)
             .end(function (err, res) {
-              console.log("Sent vote fix for delegates");
-              //console.log("Sent: " + JSON.stringify(transaction) + " Got reply: " + JSON.stringify(res.body));
+              var transaction=null;
+              //console.log(JSON.stringify(res.body));
               node.expect(res.body).to.have.property("success").to.be.true;
-              done();
+              if (res.body.success == true){
+                node.expect(res.body).to.have.property("delegates").that.is.an("array");
+                if (res.body.delagates !== null) {
+                  for (var i = 0; i < res.body.delegates.length; i++) {
+                    if (res.body.delegates[i].publicKey == delegate1) {
+                      delegate1Voted = true;
+                    }
+                    else if (res.body.delegates[i].publicKey == delegate2){
+                      delegate2Voted = true;
+                    }
+                  }
+                }
+                else {
+                  console.log("Accounts returned null. Unable to proceed with test");
+                }
+              }
+              else {
+                console.log("Check if already voted request failed or account array null");
+                done();
+              }
+              if (!delegate1Voted && !delegate2Voted) {
+                transaction = node.lisk.vote.createVote(node.Gaccount.password, ["+"+delegate1, "+"+delegate2]);
+              }
+              else if (delegate1Voted && !delegate2Voted) {
+                transaction = node.lisk.vote.createVote(node.Gaccount.password, ["+"+delegate2]);
+              }
+              else if (delegate2Voted && !delegate1Voted) {
+                transaction = node.lisk.vote.createVote(node.Gaccount.password, ["+"+delegate1]);
+              }
+              if (transaction!==null) {
+                node.peer.post("/transactions")
+                  .set("Accept", "application/json")
+                  .set("version", node.version)
+                  .set("port", node.config.port)
+                  .send({
+                    transaction: transaction
+                  })
+                  .expect("Content-Type", /json/)
+                  .expect(200)
+                  .end(function (err, res) {
+                    console.log("Sent vote fix for delegates");
+                    console.log("Sent: " + JSON.stringify(transaction) + " Got reply: " + JSON.stringify(res.body));
+                    node.expect(res.body).to.have.property("success").to.be.true;
+                    done();
+                  });
+              }
+              else {
+                done();
+              }
             });
-        }
-        else {
-          done();
-        }
-      });
+          }
+        });
   });
 
   test = test + 1;

--- a/test/lib/peers.votes.js
+++ b/test/lib/peers.votes.js
@@ -10,7 +10,7 @@ var delegate1;
 var delegate2;
 node.chai.config.includeStack = true;
 
-describe("Peers votes", function () {
+describe("Testing /peer/transactions API with votes management", function () {
   before(function (done) {
     node.api.get("/delegates/")
       .expect("Content-Type", /json/)

--- a/test/lib/transactions.js
+++ b/test/lib/transactions.js
@@ -20,14 +20,9 @@ var randomLISK = 0;
 // Used for test labeling
 var test = 0;
 
-// Print data to console
-console.log("Starting transactions-test suite");
-console.log("Password for Account 1 is: " + Account1.password);
-console.log("Password for Account 2 is: " + Account2.password);
-
 // Starting tests //
 
-describe("Transactions", function() {
+describe("Testing /api/transactions", function() {
 
     before(function (done) {
         node.api.post("/accounts/open")

--- a/test/variables.js
+++ b/test/variables.js
@@ -185,8 +185,8 @@ function waitForNewBlock(height, cb) {
 function addPeers(numOfPeers, cb) {
   var operatingSystems = ["win32","win64","ubuntu","debian", "centos"];
   var ports = [4000, 5000, 7000, 8000];
-  var sharePortOptions = [0,1];
-  var os,version,port,sharePort;
+
+  var os,version,port;
 
   var i = 0;
   async.whilst(function () {
@@ -195,7 +195,6 @@ function addPeers(numOfPeers, cb) {
     os = operatingSystems[randomizeSelection(operatingSystems.length)];
     version = config.version;
     port = ports[randomizeSelection(ports.length)];
-    // sharePort = sharePortOptions[randomizeSelection(sharePortOptions.length)];
 
     request({
       type: "GET",
@@ -204,7 +203,7 @@ function addPeers(numOfPeers, cb) {
       headers: {
         "version": version,
         "port": port,
-        "share-port": 0,
+        "nethash": config.nethash,
         "os": os
       }
     }, function (err, resp, body) {


### PR DESCRIPTION
Fix for #131 
The strategy here is to force POST on /peer/... to include nethash, that identifies the network through its genesis payloadHash. It rejects the POST early if not present or wrong.
Conversely when you get data from peers (via GET /peers/...), nethash is checked on the response headers before going any further (ie processing data and update peer in database).
- Tests adapted and passed
- added tests for /peer/transactions and /peer/blocks
- removed share-port
- config.json should set a nethash flag (equals to genesis block payloadHash)

on side note, peers.votes.js has been fixed in order to work whenever genesisBlock change.