### PR TITLE
whiteList / blackList extension allowing cidr subnets

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ var https = require("https");
 var fs = require("fs");
 var z_schema = require("z-schema");
 var util = require("util");
+var checkIpInList = require("./helpers/checklist.js");
 var Sequence = require("./helpers/sequence.js");
 
 process.stdin.resume();
@@ -333,25 +334,15 @@ d.run(function () {
 
 				if (parts.length > 1) {
 					if (parts[1] == "api") {
-						if (scope.config.api.access.whiteList.length > 0) {
-							if (scope.config.api.access.whiteList.indexOf(ip) < 0) {
-								res.sendStatus(403);
-							} else {
-								next();
-							}
-						} else {
+						if (!checkIpInList(scope.config.api.access.whiteList, ip))
+							res.sendStatus(403);
+						else
 							next();
-						}
 					} else if (parts[1] == "peer") {
-						if (scope.config.peers.blackList.length > 0) {
-							if (scope.config.peers.blackList.indexOf(ip) >= 0) {
-								res.sendStatus(403);
-							} else {
-								next();
-							}
-						} else {
+						if (checkIpInList(scope.config.peers.blackList, ip))
+							res.sendStatus(403);
+						else
 							next();
-						}
 					} else {
 						next();
 					}

--- a/helpers/checklist.js
+++ b/helpers/checklist.js
@@ -1,0 +1,46 @@
+var ip = require('ip');
+
+/*
+  checks, if ip address is in list (e.g. whitelist, blacklist
+  @param list an array of ip addresses or ip subnets
+  @param addr the ip address to check if in array
+  @param returnListIsEmpty the return value, if list is empty (default: true)
+  @returns true if ip is in the list, false otherwise
+*/
+function CheckIpInList(list, addr, returnListIsEmpty)
+  {
+	returnListIsEmpty = returnListIsEmpty || true;
+
+  if (!list._subNets)   // first call, create subnet list
+    {
+    list._subNets = [];
+    for (var i=list.length-1; i>=0; i--)
+      {
+      var entry = list[i];
+      if (ip.isV4Format(entry))       // IPv4 host entry
+        entry = entry + "/32";
+      else if (ip.isV6Format(entry))  // IPv6 host entry
+        entry = entry + "/128";
+      try
+        {
+        var subnet = ip.cidrSubnet(entry);
+        list._subNets.push(subnet);
+        }
+      catch (err)
+        {
+				// entry was not a valid ip address, log an error?
+        }
+      };
+    }
+  if (list._subNets.length==0)
+    return returnListIsEmpty;
+
+  // check subnets
+  for (var i=0, n=list._subNets.length; i<n; i++)
+    if (list._subNets[i].contains(addr))
+      return true;
+
+  return false;
+  }
+
+module.exports = CheckIpInList;

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -14,6 +14,7 @@ var transactionTypes = require("../helpers/transactionTypes.js");
 var MilestoneBlocks = require("../helpers/milestoneBlocks.js");
 var sandboxHelper = require("../helpers/sandbox.js");
 var sql = require("../sql/delegates.js");
+var checkIpInList = require("../helpers/checklist.js");
 var _ = require("underscore");
 
 // Private fields
@@ -346,7 +347,7 @@ private.attachApi = function () {
 
 			var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 
-			if (library.config.forging.access.whiteList.length > 0 && library.config.forging.access.whiteList.indexOf(ip) < 0) {
+			if (!checkIpInList(library.config.forging.access.whiteList, ip)) {
 				return res.json({success: false, error: "Access denied"});
 			}
 
@@ -400,7 +401,7 @@ private.attachApi = function () {
 
 			var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 
-			if (library.config.forging.access.whiteList.length > 0 && library.config.forging.access.whiteList.indexOf(ip) < 0) {
+			if (!checkIpInList(library.config.forging.access.whiteList, ip)) {
 				return res.json({success: false, error: "Access denied"});
 			}
 


### PR DESCRIPTION
    - allow cidr subnet definitions in whiteList/blackList (config.json) (e.g. "a.b.c.d/x")
    - more stable whiteList/blackList definition, do dependency on spellings (e.g. 127.0.0.1 is identical 127.0.0.001)

This PR replaces #102 
It only contains the necessary commit