### PR TITLE
Improvement/log order and format

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -46,7 +46,11 @@ module.exports = function (config) {
 			data && (log["data"] = snipsecret(data));
 
 			if (config.levels[config.errorLevel] <= config.levels[log.level]) {
-				log_file.write(JSON.stringify(log) + "\n");
+				if (log.data){
+					log_file.write(util.format("[%s] %s | %s - %s\n", log.level, log.timestamp, log.message, log.data));
+				} else {
+					log_file.write(util.format("[%s] %s | %s\n", log.level, log.timestamp, log.message));
+				}
 			}
 			if (config.echo && config.levels[config.echo] <= config.levels[log.level]) {
 				try {

--- a/logger.js
+++ b/logger.js
@@ -55,17 +55,23 @@ module.exports = function (config) {
 			}
 
 			data && (log["data"] = snipsecret(data));
+			var data_str = log.data ? log.data : "";
+			var level_str = config.level_abbr[log.level] ? config.level_abbr[log.level] : "???";
 
 			if (config.levels[config.errorLevel] <= config.levels[log.level]) {
 				if (log.data){
-					log_file.write(util.format("[%s] %s | %s - %s\n", config.level_abbr[log.level], log.timestamp, log.message, log.data));
+					log_file.write(util.format("[%s] %s | %s - %s\n", level_str, log.timestamp, log.message, data_str));
 				} else {
-					log_file.write(util.format("[%s] %s | %s\n", config.level_abbr[log.level], log.timestamp, log.message));
+					log_file.write(util.format("[%s] %s | %s\n", level_str, log.timestamp, log.message));
 				}
 			}
 			if (config.echo && config.levels[config.echo] <= config.levels[log.level]) {
 				try {
-					console.log(log.level.bgYellow.black, log.timestamp.grey, log.message, log.data ? log.data : "");
+					if (log.data){
+						console.log("["+level_str.bgYellow.black+"]", log.timestamp.grey, "|", log.message);
+					} else {
+						console.log("["+level_str.bgYellow.black+"]", log.timestamp.grey, "|", log.message, "-", data_str);
+					}
 				}catch (e){
 					console.log(e)
 				}

--- a/logger.js
+++ b/logger.js
@@ -68,9 +68,9 @@ module.exports = function (config) {
 			if (config.echo && config.levels[config.echo] <= config.levels[log.level]) {
 				try {
 					if (log.data){
-						console.log("["+level_str.bgYellow.black+"]", log.timestamp.grey, "|", log.message);
-					} else {
 						console.log("["+level_str.bgYellow.black+"]", log.timestamp.grey, "|", log.message, "-", data_str);
+					} else {
+						console.log("["+level_str.bgYellow.black+"]", log.timestamp.grey, "|", log.message);
 					}
 				}catch (e){
 					console.log(e)

--- a/logger.js
+++ b/logger.js
@@ -1,5 +1,6 @@
 var strftime = require("strftime").utc();
 var fs = require("fs");
+var util = require('util');
 require("colors");
 
 module.exports = function (config) {

--- a/logger.js
+++ b/logger.js
@@ -17,6 +17,16 @@ module.exports = function (config) {
 		"fatal": 6
 	}
 
+	config.level_abbr = config.level_abbr || {
+		"trace" : "trc",
+		"debug" : "dbg",
+		"log": "log",
+		"info": "inf",
+		"warn": "WRN",
+		"error": "ERR",
+		"fatal": "FTL"
+	}
+
 	config.filename = config.filename || __dirname + "/logs.log";
 
 	config.errorLevel = config.errorLevel || "log";
@@ -48,9 +58,9 @@ module.exports = function (config) {
 
 			if (config.levels[config.errorLevel] <= config.levels[log.level]) {
 				if (log.data){
-					log_file.write(util.format("[%s] %s | %s - %s\n", log.level, log.timestamp, log.message, log.data));
+					log_file.write(util.format("[%s] %s | %s - %s\n", config.level_abbr[log.level], log.timestamp, log.message, log.data));
 				} else {
-					log_file.write(util.format("[%s] %s | %s\n", log.level, log.timestamp, log.message));
+					log_file.write(util.format("[%s] %s | %s\n", config.level_abbr[log.level], log.timestamp, log.message));
 				}
 			}
 			if (config.echo && config.levels[config.echo] <= config.levels[log.level]) {

--- a/logger.js
+++ b/logger.js
@@ -55,7 +55,7 @@ module.exports = function (config) {
 			}
 
 			data && (log["data"] = snipsecret(data));
-			var data_str = log.data ? log.data : "";
+			var data_str = log.data ? JSON.stringify(log.data) : "";
 			var level_str = config.level_abbr[log.level] ? config.level_abbr[log.level] : "???";
 
 			if (config.levels[config.errorLevel] <= config.levels[log.level]) {


### PR DESCRIPTION
reason: the log output was going haywire since the aligned timestamp was at the end of the log entry and the message in between.

What I did:
- formatted log output
- aligned log output
- shortened log output (no json, more readable)