### PR TITLE
Use local mocha dependency for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ cp test/config.json test/genesisBlock.json .
 wagon stock borrow episode laundry kitten salute link globe zero feed marble
 ```
 
-Install mocha (globally):
-
-```
-sudo npm install mocha -g
-```
-
 Launch lisk (runs on port 4000):
 
 ```
@@ -122,8 +116,8 @@ npm test
 Run individual tests:
 
 ```
-mocha test/lib/accounts.js
-mocha test/lib/transactions.js
+npm test -- test/lib/accounts.js
+npm test -- test/lib/transactions.js
 ```
 
 ## Authors

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node app.js",
-    "test": "mocha",
-    "cov": "mocha --require blanket -R html-cov test/helpers test/logic > tmp/coverage.html"
+    "test": "./node_modules/.bin/mocha",
+    "cov": "./node_modules/.bin/mocha --require blanket -R html-cov test/helpers test/logic > tmp/coverage.html"
   },
   "author": "Boris Povod <boris@crypti.me>, Pavel Nekrasov <landgraf.paul@gmail.com>",
   "dependencies": {


### PR DESCRIPTION
"As of **npm@2.0.0**, you can use custom arguments when executing scripts. The special option -- is used by getopt to delimit the end of the options. npm will pass all the arguments after the -- directly to your script" - [npm docs](https://docs.npmjs.com/cli/run-script)

so there is no reason to use a global install of mocha anymore, this also comes handy with test/integration servers not having to install mocha as external dependency