### PR TITLE
improved peer connection

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -13,6 +13,8 @@ require("colors");
 var modules, library, self, private = {}, shared = {};
 
 private.loaded = false;
+// holding the network height network.height and "good peers" (ie reachable and with height close to network.height) network.peers
+private.network = null;
 private.isActive = false;
 private.loadingLastBlock = null;
 private.genesisBlock = null;
@@ -64,16 +66,6 @@ private.syncTrigger = function (turnOn) {
 	}
 }
 
-private.loadFullDb = function (peer, cb) {
-	peer = modules.peer.inspect(peer);
-
-	var commonBlockId = private.genesisBlock.block.id;
-
-	library.logger.info("Loading blocks from genesis from " + peer.string);
-
-	modules.blocks.loadBlocksFromPeer(peer, commonBlockId, cb);
-}
-
 private.findUpdate = function (lastBlock, peer, cb) {
 	peer = modules.peer.inspect(peer);
 
@@ -85,17 +77,22 @@ private.findUpdate = function (lastBlock, peer, cb) {
 		}
 
 		library.logger.info("Found common block " + commonBlock.id + " (at " + commonBlock.height + ")" + " with peer " + peer.string);
+
+		// toRemove > 0 means node has forked from the other peer
+		// in this case we will remove the "wrong blocks"
+		// TODO: note from fixcrypt: I think removing blocks does not work here.
 		var toRemove = lastBlock.height - commonBlock.height;
 
 		if (toRemove > constants.activeDelegates * 10) {
 			library.logger.warn("Long fork, ban 60 min", peer.string);
 			modules.peer.state(peer.ip, peer.port, 0, 3600);
-			return cb();
+			return cb("Remote peer not in sync");
 		}
 
 		var overTransactionList = [];
 		modules.transactions.undoUnconfirmedList(function (err, unconfirmedList) {
 			if (err) {
+				// Database likely messed up
 				return process.exit(0);
 			}
 
@@ -128,7 +125,7 @@ private.findUpdate = function (lastBlock, peer, cb) {
 				function (cb) {
 					library.logger.debug("Loading blocks from peer " + peer.string);
 
-					modules.blocks.loadBlocksFromPeer(peer, commonBlock.id, function (err, lastValidBlock) {
+					modules.blocks.loadBlocksFromPeer(peer, function (err, lastValidBlock) {
 						if (err) {
 							modules.transactions.deleteHiddenTransaction();
 							library.logger.warn("Failed to load blocks, ban 60 min", peer.string);
@@ -229,7 +226,7 @@ private.loadBlocks = function (lastBlock, cb) {
 		method: "GET"
 	}, function (err, data) {
 		if (err) {
-			return cb();
+			return cb(err);
 		}
 
 		data.peer = modules.peer.inspect(data.peer);
@@ -250,17 +247,12 @@ private.loadBlocks = function (lastBlock, cb) {
 
 		if (!report) {
 			library.logger.warn("Failed to parse blockchain height: " + data.peer.string + "\n" + library.scheme.getLastError());
-			return cb();
+			return cb(err);
 		}
 
 		if (bignum(modules.blocks.getLastBlock().height).lt(data.body.height)) { // Diff in chainbases
 			private.blocksToSync = data.body.height;
-
-			if (lastBlock.id != private.genesisBlock.block.id) { // Have to find common block
-				private.findUpdate(lastBlock, data.peer, cb);
-			} else { // Have to load full db
-				private.loadFullDb(data.peer, cb);
-			}
+			private.findUpdate(lastBlock, data.peer, cb);
 		} else {
 			cb();
 		}
@@ -499,7 +491,195 @@ private.loadBlockChain = function () {
 	});
 }
 
+private.loadBlocksFromNetwork = function(cb) {
+	var counterrorload=0;
+	var loaded=false;
+	self.getNetwork(function(err, network){
+		if(err) {
+			private.loadBlocksFromNetwork(cb);
+		}
+		else {
+			async.whilst(
+				function () {
+					return !loaded && counterrorload < 5;
+				},
+				function (next) {
+					var peer = network.peers[Math.floor(Math.random()*network.peers.length)];
+					var lastBlockId = modules.blocks.getLastBlock().id;
+					modules.blocks.loadBlocksFromPeer(peer, function(err, lastValidBlock){
+						if(err){
+							library.logger.error("Could not load blocks from " + peer.ip, err);
+							library.logger.info("Trying to reload from another random peer");
+							counterrorload=counterrorload + 1;
+						}
+						loaded = lastValidBlock.id == lastBlockId;
+						next();
+					});
+				},
+				function (error) {
+					if(counterrorload == 5){
+						library.logger.info("Peer is not well connected to network, resyncing from network");
+						return private.loadBlocksFromNetwork(cb);
+					}
+					if(error){
+						library.logger.error("Could not load blocks from network", error);
+						return cb(error);
+					}
+					return cb();
+				}
+			);
+		}
+	});
+}
+
+
+// Given a list of peers with associated blockchain height (heights={peer:peer, height:height}), we find a list of good peers (likely to sync with)
+// Histogram cut removing peers far from the most common observed height (not as easy as it sounds since the histogram has likely been made accross few blocks time. Needs to aggregate).
+private.findGoodPeers = function(heights){
+	heights = heights.filter(function(item){
+		return item != null;
+	});
+  // Ordering the peers with descending height
+  heights=heights.sort(function (a,b){
+    return b.height - a.height;
+  });
+
+  // Assuming at least > 10% of network is in good health
+  if(heights.length < 10){
+    return null;
+  }
+  else {
+		var histogram = {};
+		var max = 0;
+		var height;
+
+		for(i in heights){
+			var val = parseInt(heights[i].height / 2) * 2;
+			histogram[val] = (histogram[val] ? histogram[val] : 0) + 1;
+			if(histogram[val] > max){
+				max = histogram[val];
+				height = val;
+			}
+		}
+
+		var peers = heights.filter(function(item){
+			return item && Math.abs(height - item.height) < 2;
+		}).map(function(item){
+			// add the height info to the peer
+			item.peer.height=item.height;
+			return item.peer;
+		});
+    return {height:height, peers: peers};
+  }
+}
+
 // Public methods
+
+// Rationale:
+// - we pick 100 random peers from a random peer (could be unreachable...),
+// - then for each of them we grab the height of their blockchain.
+// - With this list we try to get a peer with sensibly good blockchain height (see private.findGoodPeer for actual strategy)
+Loader.prototype.getNetwork = function(cb) {
+	// if private.network is not so far from current node height, just return the cached one.
+	if(private.network && Math.abs(private.network.height - modules.blocks.getLastBlock().height) < 101){
+		return setImmediate(cb, null, private.network);
+	}
+	//fetch a list of 100 random peers
+	modules.transport.getFromRandomPeer({
+		api: '/list',
+		method: 'GET'
+	}, function (err, data) {
+		if (err) {
+			library.logger.info("Could not connect properly to the network", err);
+			library.logger.info("Retrying...", err);
+			return self.getNetwork(cb);
+		}
+
+		var report = library.scheme.validate(data.body.peers, {type: "array", required: true, uniqueItems: true});
+		library.scheme.validate(data.body, {
+			type: "object",
+			properties: {
+				peers: {
+					type: "array",
+					uniqueItems: true
+				}
+			},
+			required: ['peers']
+		}, function (err) {
+			if (err) {
+				return cb(err);
+			}
+
+			var peers = data.body.peers;
+
+			// For each peer, we will get the height and find the maximum
+			async.map(peers, function (peer, cb) {
+				var ispeervalid = library.scheme.validate(peer, {
+					type: "object",
+					properties: {
+						ip: {
+							type: "string"
+						},
+						port: {
+							type: "integer",
+							minimum: 1,
+							maximum: 65535
+						},
+						state: {
+							type: "integer",
+							minimum: 0,
+							maximum: 3
+						},
+						os: {
+							type: "string"
+						},
+						version: {
+							type: "string"
+						}
+					},
+					required: ['ip', 'port', 'state']
+				});
+
+
+				if (ispeervalid) {
+					modules.transport.getFromPeer(peer, {
+						api: "/height",
+						method: "GET"
+					}, function (err, result) {
+						if (err) {
+							return cb(err);
+						}
+						var isheightvalid = library.scheme.validate(result.body, {
+							type: "object",
+							properties: {
+								"height": {
+									type: "integer",
+									minimum: 0
+								}
+							}, required: ["height"]
+						});
+
+						if (isheightvalid) {
+							library.logger.info("Checking blockchain on " + result.peer.string + " - received height: " + result.body.height);
+							var peer = modules.peer.inspect(result.peer);
+							return cb(null,{peer: peer, height: result.body.height});
+						}
+					});
+				}
+			},function(err, heights){
+				private.network=private.findGoodPeers(heights);
+
+				if(!private.network){
+					return setImmediate(cb, "Could not find enough good peers to connect");
+				}
+				else{
+					return setImmediate(cb, null, private.network);
+				}
+			});
+		});
+	});
+}
+
 Loader.prototype.syncing = function () {
 	return !!private.syncIntervalId;
 }
@@ -511,22 +691,18 @@ Loader.prototype.sandboxApi = function (call, args, cb) {
 // Events
 Loader.prototype.onPeerReady = function () {
 	setImmediate(function nextLoadBlock() {
-		if (!private.loaded) return;
-		private.isActive = true;
 		library.sequence.add(function (cb) {
+			private.isActive = true;
 			private.syncTrigger(true);
-			var lastBlock = modules.blocks.getLastBlock();
-			private.loadBlocks(lastBlock, cb);
+			private.loadBlocksFromNetwork(cb);
 		}, function (err) {
-			err && library.logger.error("Blocks timer:", err);
+			err && library.logger.error("Blocks timer", err);
+			private.isActive = false;
 			private.syncTrigger(false);
 			private.blocksToSync = 0;
-
-			private.isActive = false;
-			if (!private.loaded) return;
-
-			setTimeout(nextLoadBlock, 9 * 1000)
 		});
+		library.logger.debug("Checking blockchain for new block in 10s");
+		setTimeout(nextLoadBlock, 10 * 1000);
 	});
 
 	setImmediate(function nextLoadUnconfirmedTransactions() {


### PR DESCRIPTION
This PR try to improve the peer discovery and the synchronisation process.
- a new function Loader.loadBlocksFromNetwork is the main entry point
- Block.downloadBlocksFromPeer has been simplify, removing the loop to download multiple batches. This loop has been moved to Loader.loadBlocksFromNetwork

Loader.loadBlocksFromNetwork basically follow these steps :
- poll 100 random peers from the network for blokchain height (Loader.getNetwork)
- perform histogram cut to select only the good peers (basically the ones with height close to the majority) (findGoodPeers)
- cache these peers (in private.network). This cache is flushed every round.
- call Block.downloadBlocksFromPeer from a random good peers until blockchain is in sync.

There is a fallback if to many errors occured when loading blockchain from peers, the whole private.network is reset to try to improve connectivity.

On routine basis this function is still the main entry. It will improved to use findUpdate (this function will be also rewritten).

Should be working as is.