### PR TITLE
add api for cold wallet

### DIFF
--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -281,14 +281,14 @@ private.attachApi = function () {
 	});
 }
 
-private.openAccount = function (secret, cb) {
+// Public methods
+Accounts.prototype.openAccount = function (secret, cb) {
 	var hash = crypto.createHash('sha256').update(secret, 'utf8').digest();
 	var keypair = ed.MakeKeypair(hash);
 
 	self.setAccountAndGet({ publicKey: keypair.publicKey.toString('hex') }, cb);
 }
 
-// Public methods
 Accounts.prototype.generateAddressByPublicKey = function (publicKey) {
 	var publicKeyHash = crypto.createHash('sha256').update(publicKey, 'hex').digest();
 	var temp = new Buffer(8);
@@ -388,7 +388,7 @@ shared.open = function (req, cb) {
 			return cb(err[0].message);
 		}
 
-		private.openAccount(body.secret, function (err, account) {
+		self.openAccount(body.secret, function (err, account) {
 			var accountData = null;
 
 			if (!err) {
@@ -492,7 +492,7 @@ shared.generatePublickey = function (req, cb) {
 			return cb(err[0].message);
 		}
 
-		private.openAccount(body.secret, function (err, account) {
+		self.openAccount(body.secret, function (err, account) {
 			var publicKey = null;
 			if (!err && account) {
 				publicKey = account.publicKey;

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -938,37 +938,37 @@ shared.addUnconfirmedTransactions = function (req, cb) {
 		properties: {
 			id: {
 				type: 'string',
-		minLength: 1
+				minLength: 1
 			},
-		senderId: {
-			type: "string",
-		minLength: 1
-		},
-		type: {
-			type: "integer",
-		minimum: 0,
-		},
-		timestapmp: {
-			type: "integer",
-		minimum: 0,
-		},
-		recipientId: {
-			type: "string",
-			minLength: 1
-		},
-		amount: {
-			type: "integer",
-			minimum: 1,
-			maximum: constants.totalAmount
-		},
-		senderPublicKey: {
-			type: "string",
-			format: "publicKey"
-		},
-		signature: {
-			type: "string",
-			format: "signature"
-		}
+			senderId: {
+				type: "string",
+				minLength: 1
+			},
+			type: {
+				type: "integer",
+				minimum: 0,
+			},
+			timestapmp: {
+				type: "integer",
+				minimum: 0,
+			},
+			recipientId: {
+				type: "string",
+				minLength: 1
+			},
+			amount: {
+				type: "integer",
+				minimum: 1,
+				maximum: constants.totalAmount
+			},
+			senderPublicKey: {
+				type: "string",
+				format: "publicKey"
+			},
+			signature: {
+				type: "string",
+				format: "signature"
+			}
 		},
 		required: ["id", "type", "timestamp", "recipientId", "amount", "senderPublicKey", "signature"]
 	}, function (err) {

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -150,6 +150,8 @@ private.attachApi = function () {
 		"get /get": "getTransaction",
 		"get /unconfirmed/get": "getUnconfirmedTransaction",
 		"get /unconfirmed": "getUnconfirmedTransactions",
+		"put /unconfirmed": "addUnconfirmedTransactions",
+		"put /signed": "createSignedTransaction",
 		"put /": "addTransactions"
 	});
 
@@ -700,6 +702,67 @@ shared.getUnconfirmedTransactions = function (req, cb) {
 	});
 }
 
+shared.createSignedTransaction = function (req, cb) {
+	var body = req.body;
+	library.scheme.validate(body, {
+		type: "object",
+		properties: {
+			secret: {
+				type: "string",
+				minLength: 1,
+				maxLength: 100
+			},
+			amount: {
+				type: "integer",
+				minimum: 1,
+				maximum: constants.totalAmount
+			},
+			recipientId: {
+				type: "string",
+				minLength: 1
+			}
+		},
+		required: ["secret", "amount", "recipientId"]
+	}, function (err) {
+		if (err) {
+			return cb(err[0].message);
+		}
+
+		modules.accounts.openAccount(body.secret, function (err, account) {
+			if (err) {
+				return cb(err);
+			}
+
+			var hash = crypto.createHash('sha256').update(body.secret, 'utf8').digest();
+			var keypair = ed.MakeKeypair(hash);
+
+			try {
+				var transaction = library.logic.transaction.create({
+					type: transactionTypes.SEND,
+						amount: body.amount,
+						sender: account,
+						recipientId: body.recipientId,
+						keypair: keypair
+				});
+			} catch (e) {
+				return cb(e.toString());
+			}
+
+			cb(null, {
+				id: transaction.id,
+				type: transaction.type,
+				timestamp: transaction.timestamp,
+				senderId: transaction.senderId,
+				recipientId: transaction.recipientId,
+				amount: transaction.amount,
+				asset: transaction.asset,
+				senderPublicKey: transaction.senderPublicKey,
+				signature: transaction.signature
+			});
+		});
+	});
+}
+
 shared.addTransactions = function (req, cb) {
 	var body = req.body;
 	library.scheme.validate(body, {
@@ -858,6 +921,79 @@ shared.addTransactions = function (req, cb) {
 					});
 				}
 			});
+		}, function (err, transaction) {
+			if (err) {
+				return cb(err);
+			}
+
+			return cb(null, {transactionId: transaction[0].id});
+		});
+	});
+}
+
+shared.addUnconfirmedTransactions = function (req, cb) {
+	var body = req.body;
+	library.scheme.validate(body, {
+		type: "object",
+		properties: {
+			id: {
+				type: 'string',
+		minLength: 1
+			},
+		senderId: {
+			type: "string",
+		minLength: 1
+		},
+		type: {
+			type: "integer",
+		minimum: 0,
+		},
+		timestapmp: {
+			type: "integer",
+		minimum: 0,
+		},
+		recipientId: {
+			type: "string",
+			minLength: 1
+		},
+		amount: {
+			type: "integer",
+			minimum: 1,
+			maximum: constants.totalAmount
+		},
+		senderPublicKey: {
+			type: "string",
+			format: "publicKey"
+		},
+		signature: {
+			type: "string",
+			format: "signature"
+		}
+		},
+		required: ["id", "type", "timestamp", "recipientId", "amount", "senderPublicKey", "signature"]
+	}, function (err) {
+		if (err) {
+			return cb(err[0].message);
+		}
+
+
+		console.log(body.id);
+		library.balancesSequence.add(function (cb) {
+			var transaction = {
+				id: body.id,
+				type: body.type,
+				amount: body.amount,
+				senderPublicKey: body.senderPublicKey,
+				requesterPublicKey: null,
+				recipientId: body.recipientId,
+				timestamp: body.timestamp,
+				signature: body.signature,
+				fee: constants.fees.send,
+				asset: body.asset
+			};
+
+			modules.transactions.receiveTransactions([transaction], cb);
+
 		}, function (err, transaction) {
 			if (err) {
 				return cb(err);

--- a/test/lib/transactions.js
+++ b/test/lib/transactions.js
@@ -364,6 +364,189 @@ describe("GET /api/transactions", function () {
     });
 });
 
+describe("PUT /api/transactions/signed", function () {
+
+    it("Using valid parameters. Should be ok", function (done) {
+        node.onNewBlock(function (err) {
+            node.expect(err).to.be.not.ok;
+            var amountToSend = 100000000;
+            node.api.put("/transactions/signed")
+                .set("Accept", "application/json")
+                .send({
+                    secret: Account1.password,
+                    amount: amountToSend,
+                    recipientId: Account2.address
+                })
+                .expect("Content-Type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    node.expect(res.body).to.have.property("success").to.be.true;
+                    node.expect(res.body).to.have.property("id");
+                    node.expect(res.body).to.have.property("timestamp");
+                    node.expect(res.body).to.have.property("recipientId");
+                    node.expect(res.body).to.have.property("asset");
+                    node.expect(res.body).to.have.property("senderPublicKey");
+                    node.expect(res.body).to.have.property("signature");
+                    node.expect(res.body.type).equal(0);
+                    node.expect(res.body.amount).equal(amountToSend);
+
+                    done();
+                });
+        });
+    });
+
+    it("Using negative amount. Should fail", function (done) {
+        var amountToSend = -100000000;
+
+        node.api.put("/transactions/signed")
+            .set("Accept", "application/json")
+            .send({
+                secret: Account1.password,
+                amount: amountToSend,
+                recipientId: Account2.address
+            })
+            .expect("Content-Type", /json/)
+            .expect(200)
+            .end(function (err, res) {
+                node.expect(res.body).to.have.property("success").to.be.false;
+                node.expect(res.body).to.have.property("error");
+                done();
+            });
+    });
+
+    it("Using float amount. Should fail", function (done) {
+        var amountToSend = 1.2;
+        node.api.put("/transactions/signed")
+            .set("Accept", "application/json")
+            .send({
+                secret: Account1.password,
+                amount: amountToSend,
+                recipientId: Account2.address
+            })
+            .expect("Content-Type", /json/)
+            .expect(200)
+            .end(function (err, res) {
+                node.expect(res.body).to.have.property("success").to.be.false;
+                node.expect(res.body).to.have.property("error");
+                done();
+            });
+    });
+
+    it("Using zero amount. Should fail", function (done) {
+        this.timeout(5000);
+        setTimeout(function () {
+            node.api.put("/transactions/signed")
+                .set("Accept", "application/json")
+                .send({
+                    secret: Account1.password,
+                    amount: 0,
+                    recipientId: Account2.address
+                })
+                .expect("Content-Type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    node.expect(res.body).to.have.property("success").to.be.false;
+                    node.expect(res.body).to.have.property("error");
+                    done();
+                });
+        }, 1000);
+    });
+
+    it("Using positive overflown amount. Should fail", function (done) {
+        this.timeout(5000);
+        setTimeout(function () {
+            node.api.put("/transactions/signed")
+                .set("Accept", "application/json")
+                .send({
+                    secret: Account1.password,
+                    amount: 1298231812939123812939123912939123912931823912931823912903182309123912830123981283012931283910231203,
+                    recipientId: Account2.address
+                })
+                .expect("Content-Type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    node.expect(res.body).to.have.property("success").to.be.false;
+                    node.expect(res.body).to.have.property("error");
+                    done();
+                });
+        }, 1000);
+    });
+
+    it("Using negative overflown amount. Should fail", function (done) {
+        this.timeout(5000);
+        setTimeout(function () {
+            node.api.put("/transactions/signed")
+                .set("Accept", "application/json")
+                .send({
+                    secret: Account1.password,
+                    amount: -1298231812939123812939123912939123912931823912931823912903182309123912830123981283012931283910231203,
+                    recipientId: Account2.address
+                })
+                .expect("Content-Type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    node.expect(res.body).to.have.property("success").to.be.false;
+                    node.expect(res.body).to.have.property("error");
+                    done();
+                });
+        }, 1000);
+    });
+
+    it("Using small fractional amount. Should be ok", function (done) {
+        this.timeout(5000);
+        setTimeout(function () {
+            node.api.put("/transactions/signed")
+                .set("Accept", "application/json")
+                .send({
+                    secret: Account1.password,
+                    amount: 1,
+                    recipientId: Account2.address
+                })
+                .expect("Content-Type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    node.expect(res.body).to.have.property("success").to.be.true;
+                    node.expect(res.body).to.have.property("id");
+                    done();
+                });
+        }, 1000);
+    });
+
+    it("Using no passphase. Should fail", function (done) {
+        var amountToSend = 100000000;
+        node.api.put("/transactions/signed")
+            .set("Accept", "application/json")
+            .send({
+                amount: amountToSend,
+                recipientId: Account2.address
+            })
+            .expect("Content-Type", /json/)
+            .expect(200)
+            .end(function (err, res) {
+                node.expect(res.body).to.have.property("success").to.be.false;
+                node.expect(res.body).to.have.property("error");
+                done();
+            });
+    });
+
+    it("Using no recipient. Should fail", function (done) {
+        var amountToSend = 100000000;
+        node.api.put("/transactions/signed")
+            .set("Accept", "application/json")
+            .send({
+                secret: Account1.password,
+                amount: amountToSend
+            })
+            .expect("Content-Type", /json/)
+            .expect(200)
+            .end(function (err, res) {
+                node.expect(res.body).to.have.property("success").to.be.false;
+                node.expect(res.body).to.have.property("error");
+                done();
+            });
+    });
+});
+
 describe("PUT /api/transactions", function () {
 
     it("Using valid parameters. Should be ok", function (done) {
@@ -586,6 +769,270 @@ describe("PUT /api/transactions", function () {
                 node.expect(res.body).to.have.property("error");
                 done();
             });
+    });
+});
+
+describe("PUT /api/transactions/unconfirmed", function () {
+    var amountToSend = 100000000;
+    var signedTransaction = {};
+
+    beforeEach(function (done) {
+        node.api.put("/transactions/signed")
+        .set("Accept", "application/json")
+        .send({
+            secret: Account1.password,
+            amount: amountToSend,
+            recipientId: Account2.address
+        })
+    .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.true;
+            if (res.body.success == true && res.body.id != null) {
+                signedTransaction.id = res.body.id;
+                signedTransaction.type = res.body.type;
+                signedTransaction.timestamp = res.body.timestamp;
+                signedTransaction.recipientId = res.body.recipientId;
+                signedTransaction.amount = res.body.amount;
+                signedTransaction.fee = res.body.fee;
+                signedTransaction.asset = res.body.asset;
+                signedTransaction.senderPublicKey = res.body.senderPublicKey;
+                signedTransaction.signature = res.body.signature;
+            } else {
+                node.expect("TEST").to.equal("FAILED");
+            }
+            done();
+        });
+    });
+
+    it("Using valid parameters. Should be ok", function (done) {
+        node.onNewBlock(function (err) {
+            node.expect(err).to.be.not.ok;
+            node.api.put("/transactions/unconfirmed")
+            .set("Accept", "application/json")
+            .send(signedTransaction)
+            .expect("Content-Type", /json/)
+            .expect(200)
+            .end(function (err, res) {
+                node.expect(res.body).to.have.property("success").to.be.true;
+                node.expect(res.body).to.have.property("transactionId");
+                if (res.body.success == true && res.body.transactionId != null) {
+                    expectedFee = node.expectedFee(amountToSend);
+                    Account1.balance -= (amountToSend + expectedFee);
+                    Account2.balance += amountToSend;
+                    Account1.transactions.push(transactionCount);
+                    transactionList[transactionCount] = {
+                        "sender": Account1.address,
+                        "recipient": Account2.address,
+                        "brutoSent": (amountToSend + expectedFee) / node.normalizer,
+                        "fee": expectedFee / node.normalizer,
+                        "nettoSent": amountToSend / node.normalizer,
+                        "txId": res.body.transactionId,
+                        "type": node.TxTypes.SEND
+                    }
+                    transactionCount += 1;
+
+                } else {
+                    node.expect("TEST").to.equal("FAILED");
+                }
+                done();
+            });
+        });
+    });
+
+    it("Using negative amount. Should fail", function (done) {
+        signedTransaction.amount = -100000000;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using float amount. Should fail", function (done) {
+        signedTransaction.amount = 1.2;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using zero amount. Should fail", function (done) {
+        signedTransaction.amount = 0;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using positive overflown amount. Should fail", function (done) {
+        signedTransaction.amount = 1298231812939123812939123912939123912931823912931823912903182309123912830123981283012931283910231203;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using negative overflown amount. Should fail", function (done) {
+        signedTransaction.amount = -1298231812939123812939123912939123912931823912931823912903182309123912830123981283012931283910231203;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no transaction id. Should fail", function (done) {
+        signedTransaction.id = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no type Should fail", function (done) {
+        signedTransaction.type = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no timestamp Should fail", function (done) {
+        signedTransaction.timestamp = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no recipientId Should fail", function (done) {
+        signedTransaction.recipientId = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no amount Should fail", function (done) {
+        signedTransaction.amount = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no senderPublicKey Should fail", function (done) {
+        signedTransaction.senderPublicKey = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using no signature Should fail", function (done) {
+        signedTransaction.signature = null;
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
+    });
+
+    it("Using invalid signature Should fail", function (done) {
+        signedTransaction.signature = "535dc062d8c6817f153edb747c8a1d07892e93bed36d18c8d84a0c13fca01fad8aa667b5d0635e58e0548ec34365845b06a200f2fdbfecf15b8e8948056ff108";
+
+        node.api.put("/transactions/unconfirmed")
+        .set("Accept", "application/json")
+        .send(signedTransaction)
+        .expect("Content-Type", /json/)
+        .expect(200)
+        .end(function (err, res) {
+            node.expect(res.body).to.have.property("success").to.be.false;
+            node.expect(res.body).to.have.property("error");
+            done();
+        });
     });
 });
 


### PR DESCRIPTION
This PR try to enable cold wallet that keep secret phrase just under offline server.

### motivation
Current lisk client is just for online.
Secret was included in request for create transaction.
So account which has huge amount of blance is not safe.
If keep secret in offline server at all time, this problem will improve.

### use scenario
* 1. create signed transaction in offline node  
```
$ curl -XPUT 'http://localhost/api/transactions/signed' -H "Content-type: application/json" -d '{"secret":"xxxx","amount": xxxx,"recipientId": "xxxxL"}'
{"success":true,"id":"8382130011750128797","type":0,"timestamp":6703979,"recipientId":"xxxxL","amount":xxxx,"asset":{},"senderPublicKey":"xxxx","signature":"xxxx"}
```

* 2. convey result to online server and put transaction to online node
```
curl -XPUT 'http://online.node/api/transactions/unconfirmed' -H "Content-type: application/json" -d '{"success":true,"id":"xxxx","type":0,"timestamp":xxxx,"recipientId":"xxxx","amount":1000000000,"asset":{},"senderPublicKey":"xxxx","signature":"xxxx"}'
{"success":true,"transactionId":"xxxx"}
```

* 3. after that, the transaction will be broadcast and put into block

### coping plan
Create 2 entry point, to sign transaction and to create new transaction with signed transaction.
2nd passphase is not supported for now.