### PR TITLE
Fix for #260: Process no blocks from peers, if the config.forge.force mode is set

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -719,6 +719,10 @@ Loader.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 Loader.prototype.onPeerReady = function () {
+	if (library.config.forging.force) {
+		return;
+		}
+
 	setImmediate(function nextLoadBlock () {
 		library.sequence.add(function (cb) {
 			__private.isActive = true;


### PR DESCRIPTION
This PR fixes issue #260.  

Assuming, there are no peers from the same network, all blocks from peers are ignored.

Admittedly, this is a fairly radical method.
The other way could be to return the methods
- loadBlocksFromNetwork()
- getNetwork()

immediately with an error or limit the recursive calls to a defined number of rounds.
This would also prevent the risk of stack overflow.