### PR TITLE
Address missing publickey bug for /api/accounts/open

### DIFF
--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -96,7 +96,7 @@ __private.attachApi = function () {
 	router.use(function (req, res, next) {
 		res.status(500).send({success: false, error: 'API endpoint was not found'});
 	});
-
+			
 	library.network.app.use('/api/accounts', router);
 	library.network.app.use(function (err, req, res, next) {
 		if (!err) { return next(); }
@@ -116,6 +116,9 @@ __private.openAccount = function (secret, cb) {
 		}
 
 		if (account) {
+			 if (account.publicKey == null) {
+                     		account.publicKey = publicKey;
+			 }                  
 			return setImmediate(cb, null, account);
 		} else {
 			return setImmediate(cb, null, {


### PR DESCRIPTION
When an account is created in Lisk, a publickey is not assigned to a wallet ID until the first transmitting transaction. To resolve issues related to not having a publicKey, we must assign it based on the hash of the Secret Key if the value is null when pulled from the Database.

This pull request resolves this issue for lisk-ui https://github.com/LiskHQ/lisk-ui/issues/75