### PR TITLE
Fix --config param when ./config.json is not valid

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var appConfig = require('./config.json');
 var async = require('async');
 var checkIpInList = require('./helpers/checkIpInList.js');
 var extend = require('extend');
@@ -35,8 +34,11 @@ program
 	.option('-s, --snapshot <round>', 'verify snapshot')
 	.parse(process.argv);
 
+var appConfig;
 if (program.config) {
 	appConfig = require(path.resolve(process.cwd(), program.config));
+} else {
+  appConfig = require('./config.json');
 }
 
 if (program.port) {


### PR DESCRIPTION
It wasn't possible to specify a different config file in that case:

```
■■■■[slaweet:~/git/lisk] development(+1/-98)* 8 ± node app.js --config test/config.json 

module.js:485
    throw err;
          ^
SyntaxError: /home/slaweet/git/lisk/config.json: Unexpected end of input
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:482:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/slaweet/git/lisk/app.js:3:17)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```
