### PR TITLE
Configure topAccounts api endpoint via config.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,9 @@ if (program.snapshot) {
 	);
 }
 
+//Define top endpoint availability
+process.env.TOP =  appConfig.topAccounts;
+
 var config = {
 	db: appConfig.db,
 	modules: {

--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "logFileName": "logs/lisk.log",
     "consoleLogLevel": "info",
     "trustProxy": false,
+    "topAccounts": false,
     "db": {
         "host": "localhost",
         "port": 5432,


### PR DESCRIPTION
Addresses: https://github.com/LiskHQ/lisk/issues/285

This endpoint is necessary for topAccounts functionality when hosting Lisk Explorer. The flag will be default set to false. Explorer operators will need to be aware of this flag upon implementation so they can correct their config.json accordingly.