### PR TITLE
Allow "+" char in os version check

### DIFF
--- a/helpers/z_schema.js
+++ b/helpers/z_schema.js
@@ -106,7 +106,7 @@ z_schema.registerFormat('os', function (str) {
     return true;
   }
 
-  return /^[a-z0-9-_.]+$/ig.test(str);
+  return /^[a-z0-9-_.+]+$/ig.test(str);
 });
 
 z_schema.registerFormat('version', function (str) {


### PR DESCRIPTION
It's used in some kernels, for example: "3.18.11-v7+"