### PR TITLE
Add broadhash & consensus % info to API endpoint

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -749,7 +749,9 @@ shared.sync = function (req, cb) {
 	return setImmediate(cb, null, {
 		syncing: self.syncing(),
 		blocks: __private.blocksToSync,
-		height: modules.blocks.getLastBlock().height
+		height: modules.blocks.getLastBlock().height,
+		broadhash: modules.system.getBroadhash(),
+		consensus: modules.transport.consensus()
 	});
 };
 


### PR DESCRIPTION
Endpoint: /api/loader/status/sync
Change will help third-party scripts with better nodes management. For exmaple - script can constantly observe consensus % on few nodes and pick for forging the best one.