### PR TITLE
Add delegate forging statistics

### DIFF
--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -1529,5 +1529,29 @@ shared.getStatus = function (req, cb) {
 	});
 };
 
+
+shared.aggregateBlocksReward = function (req, cb) {
+	if (!__private.loaded) {
+		return setImmediate(cb, 'Blockchain is loading');
+	}
+
+	library.schema.validate(req.body, schema.aggregateBlocksReward, function (err) {
+		if (err) {
+			return setImmediate(cb, err[0].message);
+		}
+
+		/*SELECT 
+		sum ("b_totalFee") as fees,
+		sum ("b_reward") as reward,
+		count (*) as count
+		FROM
+		public.blocks_list
+		WHERE 
+		"b_generatorPublicKey" != '' and "b_timestamp" > 9999
+		*/
+		return setImmediate(cb, null, {fees: data.fees, reward: data.rewards, count: data.count});
+	});
+};
+
 // Export
 module.exports = Blocks;

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -1406,15 +1406,16 @@ Blocks.prototype.aggregateBlocksReward = function (filter, cb) {
 	params.generatorPublicKey = filter.generatorPublicKey;
 
 	where.push('"b_timestamp" >= ${start}');
-	params.start = filter.start;
+	params.start = filter.start - constants.epochTime.getTime ()  / 1000;
 
 	where.push('"b_timestamp" <= ${end}');
-	params.end = filter.end;
+	params.end = filter.end - constants.epochTime.getTime () / 1000; 
 
 	library.db.query(sql.aggregateBlocksReward({
 		where: where,
 	}), params).then(function (rows) {
 		var data = rows[0];
+		console.log (data);
 		data = { fees: data.fees || '0', rewards: data.rewards || '0', count: data.count || '0' };
 
 		return setImmediate(cb, null, data);

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -1415,16 +1415,14 @@ Blocks.prototype.aggregateBlocksReward = function (filter, cb) {
 		where: where,
 	}), params).then(function (rows) {
 		var data = rows[0];
-		console.log (data);
 		data = { fees: data.fees || '0', rewards: data.rewards || '0', count: data.count || '0' };
 
 		return setImmediate(cb, null, data);
 	}).catch(function (err) {
 		library.logger.error(err.stack);
-		return setImmediate(cb, 'Blocks#list error');
+		return setImmediate(cb, 'Blocks#aggregateBlocksReward error');
 	});
 };
-
 
 // Shared
 shared.getBlock = function (req, cb) {
@@ -1557,7 +1555,6 @@ shared.getStatus = function (req, cb) {
 		supply:    __private.blockReward.calcSupply(__private.lastBlock.height)
 	});
 };
-
 
 // Export
 module.exports = Blocks;

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -1397,8 +1397,6 @@ Blocks.prototype.cleanup = function (cb) {
 	}
 };
 
-
-
 Blocks.prototype.aggregateBlocksReward = function (filter, cb) {
 	var params = {}, where = [];
 
@@ -1416,7 +1414,6 @@ Blocks.prototype.aggregateBlocksReward = function (filter, cb) {
 	}), params).then(function (rows) {
 		var data = rows[0];
 		data = { fees: data.fees || '0', rewards: data.rewards || '0', count: data.count || '0' };
-
 		return setImmediate(cb, null, data);
 	}).catch(function (err) {
 		library.logger.error(err.stack);

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -755,13 +755,20 @@ shared.getForgedByAccount = function (req, cb) {
 			return setImmediate(cb, err[0].message);
 		}
 
-		modules.accounts.getAccount({publicKey: req.body.generatorPublicKey}, ['fees', 'rewards'], function (err, account) {
-			if (err || !account) {
-				return setImmediate(cb, err || 'Account not found');
-			}
-			var forged = bignum(account.fees).plus(bignum(account.rewards)).toString();
-			return setImmediate(cb, null, {fees: account.fees, rewards: account.rewards, forged: forged});
-		});
+		if (req.body.start && req.body.end) {
+			modules.blocks.aggregateBlocksReward({generatorPublicKey: req.body.generatorPublicKey, start: req.body.start, end: req.body.end}, function (err, reward) {
+				var forged = bignum(reward.fees).plus(bignum(reward.rewards)).toString();
+				return setImmediate(cb, null, {fees: reward.fees, rewards: reward.rewards, forged: forged, count: reward.count});
+			});
+		} else {
+			modules.accounts.getAccount({publicKey: req.body.generatorPublicKey}, ['fees', 'rewards'], function (err, account) {
+				if (err || !account) {
+					return setImmediate(cb, err || 'Account not found');
+				}
+				var forged = bignum(account.fees).plus(bignum(account.rewards)).toString();
+				return setImmediate(cb, null, {fees: account.fees, rewards: account.rewards, forged: forged});
+			});
+		}
 	});
 };
 

--- a/schema/delegates.js
+++ b/schema/delegates.js
@@ -116,10 +116,10 @@ module.exports = {
 				format: 'publicKey'
 			},
 			start: {
-				type: 'string'
+				type: 'integer'
 			},
 			end: {
-				type: 'string'
+				type: 'integer'
 			}
 		},
 		required: ['generatorPublicKey']

--- a/schema/delegates.js
+++ b/schema/delegates.js
@@ -114,6 +114,12 @@ module.exports = {
 			generatorPublicKey: {
 				type: 'string',
 				format: 'publicKey'
+			},
+			start: {
+				type: 'string'
+			},
+			end: {
+				type: 'string'
 			}
 		},
 		required: ['generatorPublicKey']

--- a/sql/blocks.js
+++ b/sql/blocks.js
@@ -27,7 +27,7 @@ var BlocksSql = {
 
   aggregateBlocksReward: function (params) {
     return [
-      'SELECT sum ("b_totalFee") as fees, sum ("b_reward") as reward, count (*) as count',
+      'SELECT sum ("b_totalFee") as fees, sum ("b_reward") as rewards, count (*) as count',
 		  'FROM blocks_list',
       (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
     ].filter(Boolean).join(' ');

--- a/sql/blocks.js
+++ b/sql/blocks.js
@@ -24,6 +24,15 @@ var BlocksSql = {
     ].filter(Boolean).join(' ');
   },
 
+
+  aggregateBlocksReward: function (params) {
+    return [
+      'SELECT sum ("b_totalFee") as fees, sum ("b_reward") as reward, count (*) as count',
+		  'FROM blocks_list',
+      (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
+    ].filter(Boolean).join(' ');
+  },
+
   list: function (params) {
     return [
       'SELECT * FROM blocks_list',

--- a/sql/blocks.js
+++ b/sql/blocks.js
@@ -24,10 +24,9 @@ var BlocksSql = {
     ].filter(Boolean).join(' ');
   },
 
-
   aggregateBlocksReward: function (params) {
     return [
-      'SELECT sum ("b_totalFee") as fees, sum ("b_reward") as rewards, count (*) as count',
+      'SELECT sum ("b_totalFee") as fees, sum ("b_reward") as rewards, count (1) as count',
 		  'FROM blocks_list',
       (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
     ].filter(Boolean).join(' ');


### PR DESCRIPTION
This pull request will implement the feature described in: #318 

Insted of creating a new API, I extended the getForgedByAccount api with two optional parameters:
- start: start time in unixtime
- end: end time in unixtime

If start and end are both present, it returns the forged amount in the specified timeslice.

Example call: forged by my delegate in the last 24h
http://localhost:8000/api/delegates/forging/getForgedByAccount?generatorPublicKey=120d1c3847bd272237ee712ae83de59bbeae127263196fc0f16934bcfa82d8a4&start=1481109600&end=1481196006