### PR TITLE
Add API call to get transactions count

### DIFF
--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -49,6 +49,7 @@ __private.attachApi = function () {
 	router.map(shared, {
 		'get /': 'getTransactions',
 		'get /get': 'getTransaction',
+		'get /count': 'getTransactionsCount',
 		'get /queued/get': 'getQueuedTransaction',
 		'get /queued': 'getQueuedTransactions',
 		'get /multisignatures/get': 'getMultisignatureTransaction',
@@ -415,6 +416,20 @@ shared.getTransaction = function (req, cb) {
 			}
 		});
 	});
+};
+
+shared.getTransactionsCount = function (req, cb) {
+    library.db.query(sql.count).then(function (transactionsCount) {
+		return setImmediate(cb, null, {
+            confirmed: transactionsCount[0].count,
+            multisignature: __private.transactionPool.multisignature.transactions.length,
+            unconfirmed: __private.transactionPool.unconfirmed.transactions.length,
+            queued: __private.transactionPool.queued.transactions.length
+        });
+
+    }, function (err) {
+        return setImmediate(cb, 'Unable to count transactions');
+    });
 };
 
 shared.getQueuedTransaction = function (req, cb) {

--- a/sql/transactions.js
+++ b/sql/transactions.js
@@ -15,6 +15,8 @@ var TransactionsSql = {
     'height'
   ],
 
+  count: 'SELECT COUNT("id")::int AS "count" FROM trs',
+
   countById: 'SELECT COUNT("id")::int AS "count" FROM trs WHERE "id" = ${id}',
 
   countList: function (params) {

--- a/test/api/transactions.js
+++ b/test/api/transactions.js
@@ -247,6 +247,20 @@ describe('GET /api/transactions/get?id=', function () {
 	});
 });
 
+describe('GET /api/transactions/count', function () {
+
+    it('should be ok', function (done) {
+        node.get('/api/transactions/count', function (err, res) {
+            node.expect(res.body).to.have.property('success').to.be.ok;
+            node.expect(res.body).to.have.property('confirmed').that.is.an('number');
+            node.expect(res.body).to.have.property('queued').that.is.an('number');
+            node.expect(res.body).to.have.property('multisignature').that.is.an('number');
+            node.expect(res.body).to.have.property('unconfirmed').that.is.an('number');
+            done();
+        });
+    });
+});
+
 describe('GET /api/transactions/queued/get?id=', function () {
 
 	it('using unknown id should be ok', function (done) {


### PR DESCRIPTION
Allows to see how many confirmed, unconfirmed, multisignature and queued transactions exists in particular moment via API call.

closes #341