### PR TITLE
ignore versionChar, check only version

### DIFF
--- a/modules/system.js
+++ b/modules/system.js
@@ -78,6 +78,12 @@ System.prototype.versionCompatible = function (version) {
 		version = version.replace(rcRegExp, '');
 	}
 
+	// if no range specifier is used for minVersion, check the complete version string (inclusive versionChar)
+	var rangeRegExp = /[\^\~\*]/;
+	if (this.minVersionChar && versionChar && !rangeRegExp.test(this.minVersion)) {
+		return (version + versionChar) === (this.minVersion + this.minVersionChar);
+	}
+
 	// ignore versionChar, check only version
 	return semver.satisfies(version, this.minVersion);
 };

--- a/modules/system.js
+++ b/modules/system.js
@@ -79,7 +79,7 @@ System.prototype.versionCompatible = function (version) {
 	}
 
 	// if no range specifier is used for minVersion, check the complete version string (inclusive versionChar)
-	var rangeRegExp = /[\^\~\*]/;
+	var rangeRegExp = /[\^~\*]/;
 	if (this.minVersionChar && versionChar && !rangeRegExp.test(this.minVersion)) {
 		return (version + versionChar) === (this.minVersion + this.minVersionChar);
 	}

--- a/modules/system.js
+++ b/modules/system.js
@@ -78,11 +78,8 @@ System.prototype.versionCompatible = function (version) {
 		version = version.replace(rcRegExp, '');
 	}
 
-	if (this.minVersionChar && versionChar) {
-		return (version + versionChar) === (this.minVersion + this.minVersionChar);
-	} else {
-		return semver.satisfies(version, this.minVersion);
-	}
+	// ignore versionChar, check only version
+	return semver.satisfies(version, this.minVersion);
 };
 
 System.prototype.getBroadhash = function (cb) {


### PR DESCRIPTION
this.minVersion can contain range specifier (^ ~ *) which cannot compared directly

this PR is a bugfix for https://github.com/LiskHQ/lisk/issues/387
