### PR TITLE
Improve /api/transactions endpoint

### DIFF
--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -124,6 +124,13 @@ __private.list = function (filter, cb) {
 			throw new Error('Invalid parameter supplied: ' + key);
 		}
 
+		// Mutating parametres when unix timestamp is supplied
+		if (_.includes(['fromUnixTime', 'toUnixTime'], field[1])) {
+			// Lisk epoch is 1464109200 as unix timestamp
+			value = value - constants.epochTime.getTime() / 1000;
+			field[1] = field[1].replace('UnixTime', 'Timestamp');
+		}
+
 		if (!_.includes(_.keys(allowedFieldsMap), field[1])) {
 			throw new Error('Parameter is not supported: ' + field[1]);
 		}
@@ -134,9 +141,6 @@ __private.list = function (filter, cb) {
 		}
 
 		if (allowedFieldsMap[field[1]]) {
-			if (_.includes(['fromTimestamp', 'toTimestamp'], field[1])) {
-				value = value - constants.epochTime.getTime() / 1000;
-			}
 			where.push((!isFirstWhere ? (field[0] + ' ') : '') + allowedFieldsMap[field[1]]);
 			params[field[1]] = value;
 			isFirstWhere = false;

--- a/schema/transactions.js
+++ b/schema/transactions.js
@@ -106,6 +106,14 @@ module.exports = {
 				type: 'integer',
 				minimum: 1
 			},
+			fromUnixTime: {
+				type: 'integer',
+				minimum: (constants.epochTime.getTime() / 1000)
+			},
+			toUnixTime: {
+				type: 'integer',
+				minimum: (constants.epochTime.getTime() / 1000 + 1)
+			},
 			minAmount: {
 				type: 'integer',
 				minimum: 0

--- a/test/api/transactions.js
+++ b/test/api/transactions.js
@@ -268,6 +268,26 @@ describe('GET /api/transactions', function () {
 		});
 	});
 
+	it('using too small fromUnixTime should fail', function (done) {
+		var params = 'fromUnixTime=1464109199';
+
+		node.get('/api/transactions?' + params, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error');
+			done();
+		});
+	});
+
+	it('using too small toUnixTime should fail', function (done) {
+		var params = 'toUnixTime=1464109200';
+
+		node.get('/api/transactions?' + params, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error');
+			done();
+		});
+	});
+
 	it('using limit > 1000 should fail', function (done) {
 		var limit = 1001;
 		var params = 'limit=' + limit;


### PR DESCRIPTION
- Changed `fromTimestamp` and `toTimestamp` behavior, now referencing Lisk epoch instead of unix time (closes https://github.com/LiskHQ/lisk/issues/432)
- Added `fromUnixTime` and `toUnixTime` params, referencing unix time (closes https://github.com/LiskHQ/lisk/issues/431)