### PR TITLE
Reducing limit of GET /peer/blocks from 1440 to 34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: 'trusty'
 language: node_js
 node_js:
-  - '6.9.4'
+  - '6.9.5'
 cache:
   directories:
     - test/lisk-js

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -137,9 +137,12 @@ __private.attachApi = function () {
 			if (err) { return next(err); }
 			if (!report.isValid) { return res.json({success: false, error: report.issues}); }
 
-			// Get 101 blocks with all data (joins) from provided block id
+			// Get 34 blocks with all data (joins) from provided block id
+			// According to maxium payload of 58150 bytes per block with every transaction being a vote
+			// Discounting maxium compression setting used in middleware
+			// Maximum transport payload = 2000000 bytes
 			modules.blocks.loadBlocksData({
-				limit: 101, // 1 round
+				limit: 34, // 1977100 bytes
 				lastId: query.lastBlockId
 			}, function (err, data) {
 				res.status(200);

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -137,9 +137,9 @@ __private.attachApi = function () {
 			if (err) { return next(err); }
 			if (!report.isValid) { return res.json({success: false, error: report.issues}); }
 
-			// Get 1400+ blocks with all data (joins) from provided block id
+			// Get 101 blocks with all data (joins) from provided block id
 			modules.blocks.loadBlocksData({
-				limit: 1440,
+				limit: 101, // 1 round
 				lastId: query.lastBlockId
 			}, function (err, data) {
 				res.status(200);


### PR DESCRIPTION
Reducing number of blocks yielded to requesting peers from 1440 to 34. Fixes maximum payload problem when all 1440 blocks are full.

Bumping node_js version used by travis.