### PR TITLE
Performance fix for counting all blocks - Closes #342

### DIFF
--- a/sql/blocks.js
+++ b/sql/blocks.js
@@ -18,10 +18,11 @@ var BlocksSql = {
   deleteBlock: 'DELETE FROM blocks WHERE "id" = ${id};',
 
   countList: function (params) {
-    return [
-      'SELECT COUNT("b_id")::int FROM blocks_list',
-      (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
-    ].filter(Boolean).join(' ');
+    if (params.where.length) {
+      return 'SELECT COUNT("b_id")::int FROM blocks_list WHERE ' + params.where.join(' AND ');
+    } else {
+      return 'SELECT COALESCE((SELECT height FROM blocks ORDER BY height DESC LIMIT 1), 0)';
+    }
   },
 
   aggregateBlocksReward: function (params) {


### PR DESCRIPTION
`COUNT` on `blocks` table uses seq scan and takes 500ms-1sec, we can use height of last block as a count for counting all blocks (when no `where` is supplied, so most of the time). Such query takes less than 1ms to exec.

Closes #342