### PR TITLE
Extend test timeout - Closes #400

### DIFF
--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -773,16 +773,18 @@ describe('PUT /api/dapps/withdrawal', function () {
 
 			putWithdrawal(validParams, function (err, res) {
 				node.expect(res.body).to.have.property('success').to.be.not.ok;
-				node.get('/api/transactions/queued', function (err, trsRes) {
-					node.expect(trsRes.body).to.have.property('success').to.be.ok;
-					node.expect(trsRes.body.transactions).to.be.an('array').and.to.have.length.of.at.least(1);
-					var trsQueued = trsRes.body.transactions.find(function (t) {
-						return t.asset.outTransfer.transactionId === validParams.transactionId;
+				if (res.body.error !== 'Transaction is already processed: ' + validParams.transactionId) {
+					node.get('/api/transactions/queued', function (err, trsRes) {
+						node.expect(trsRes.body).to.have.property('success').to.be.ok;
+						node.expect(trsRes.body.transactions).to.be.an('array').and.to.have.length.of.at.least(1);
+						var trsQueued = trsRes.body.transactions.find(function (t) {
+							return t.asset.outTransfer.transactionId === validParams.transactionId;
+						});
+						node.expect(trsQueued).to.be.not.empty;
+						node.expect(res.body).to.have.property('error').to.equal('Transaction is already processed: ' + trsQueued.id);
+						done();
 					});
-					node.expect(trsQueued).to.be.not.empty;
-					node.expect(res.body).to.have.property('error').to.equal('Transaction is already processed: ' + trsQueued.id);
-					done();
-				});
+				}
 			});
 		});
 	});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---timeout 500s
+--timeout 1200s


### PR DESCRIPTION
Extend max execution time of a mocha test to 20 min. Fix dapp doubled transaction test stability.