### PR TITLE
Provide mechanisms to disable APIs and toggle Whitelists

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,0 @@
-helpers/bignum.js

--- a/app.js
+++ b/app.js
@@ -327,7 +327,7 @@ d.run(function () {
 
 				if (parts.length > 1) {
 					if (parts[1] === 'api') {
-						if (scope.config.api.open === true) {
+						if (scope.config.api.access.public === true) {
 							next();
 						} else {
 							if (checkIpInList(scope.config.api.access.whiteList, ip, false)) {

--- a/config.json
+++ b/config.json
@@ -37,6 +37,7 @@
         }
     },
     "peers": {
+        "enabled": true,
         "list": [
             {
                 "ip": "40.68.214.86",
@@ -80,7 +81,6 @@
             }
         ],
         "access": {
-            "enabled": true,
             "blackList": []
         },
         "options": {

--- a/config.json
+++ b/config.json
@@ -78,7 +78,10 @@
                 "port": 8000
             }
         ],
-        "blackList": [],
+        "access": {
+            "enabled": true,
+            "blackList": []
+        },
         "options": {
             "limits": {
                 "max": 0,

--- a/config.json
+++ b/config.json
@@ -23,7 +23,8 @@
     },
     "api": {
         "access": {
-            "whiteList": []
+            "enabled": true,
+            "whiteList": ["127.0.0.1"]
         },
         "options": {
             "limits": {

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
         ]
     },
     "api": {
-      "enabled": true,
+        "enabled": true,
         "access": {
             "public": false,
             "whiteList": ["127.0.0.1"]

--- a/config.json
+++ b/config.json
@@ -22,9 +22,9 @@
         ]
     },
     "api": {
-      "open": false,
+      "enabled": true,
         "access": {
-            "enabled": true,
+            "public": false,
             "whiteList": ["127.0.0.1"]
         },
         "options": {

--- a/helpers/router.js
+++ b/helpers/router.js
@@ -27,7 +27,7 @@ function Map (root, config) {
  * @overview Router stub
  * @returns {*}
  */
-var Router = function () {
+var Router = function (config) {
 	var router = require('express').Router();
 
 	router.use(function (req, res, next) {
@@ -37,6 +37,12 @@ var Router = function () {
 	});
 
 	router.map = Map;
+
+	if (config.access && config.access.enabled === false) {
+		router.use(function (req, res, next) {
+			res.status(500).send({success: false, error: 'API endpoint disabled'});
+		});
+	}
 
 	return router;
 };

--- a/helpers/router.js
+++ b/helpers/router.js
@@ -38,7 +38,7 @@ var Router = function (config) {
 
 	router.map = Map;
 
-	if (config.access && config.access.enabled === false) {
+	if (config.enabled === false) {
 		router.use(function (req, res, next) {
 			res.status(500).send({success: false, error: 'API endpoint disabled'});
 		});

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -34,7 +34,7 @@ function Accounts (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -89,7 +89,7 @@ function Blocks (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/dapps.js
+++ b/modules/dapps.js
@@ -94,7 +94,7 @@ function DApps (cb, scope) {
 }
 
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -42,7 +42,7 @@ function Delegates (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules && __private.loaded) { return next(); }

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -45,7 +45,7 @@ __private.initalize = function () {
 };
 
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.get('/status/ping', function (req, res) {
 		__private.ping(function (status, body) {

--- a/modules/multisignatures.js
+++ b/modules/multisignatures.js
@@ -34,7 +34,7 @@ function Multisignatures (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -30,7 +30,7 @@ function Peers (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/server.js
+++ b/modules/server.js
@@ -22,7 +22,7 @@ function Server (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router({});
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/signatures.js
+++ b/modules/signatures.js
@@ -32,7 +32,7 @@ function Signatures (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -44,7 +44,7 @@ function Transactions (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.api);
 
 	router.use(function (req, res, next) {
 		if (modules) { return next(); }

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -35,7 +35,7 @@ function Transport (cb, scope) {
 
 // Private methods
 __private.attachApi = function () {
-	var router = new Router();
+	var router = new Router(library.config.peers);
 
 	router.use(function (req, res, next) {
 		res.set(__private.headers);

--- a/schema/config.js
+++ b/schema/config.js
@@ -79,11 +79,14 @@ module.exports = {
 					access: {
 						type: 'object',
 						properties: {
+							enabled: {
+								type: 'boolean'
+							},
 							whiteList: {
 								type: 'array'
 							}
 						},
-						required: ['whiteList']
+						required: ['enabled', 'whiteList']
 					},
 					options: {
 						type: 'object',

--- a/schema/config.js
+++ b/schema/config.js
@@ -121,8 +121,17 @@ module.exports = {
 					list: {
 						type: 'array'
 					},
-					blackList: {
-						type: 'array'
+					access: {
+						type: 'object',
+						properties: {
+							enabled: {
+								type: 'boolean'
+							},
+							blackList: {
+								type: 'array'
+							}
+						},
+						required: ['enabled', 'blackList']
 					},
 					options: {
 						properties: {
@@ -151,7 +160,7 @@ module.exports = {
 						required: ['limits', 'timeout']
 					}
 				},
-				required: ['list', 'blackList', 'options']
+				required: ['list', 'access', 'options']
 			},
 			broadcasts: {
 				type: 'object',

--- a/schema/config.js
+++ b/schema/config.js
@@ -76,17 +76,20 @@ module.exports = {
 			api: {
 				type: 'object',
 				properties: {
+					enabled: {
+						type: 'boolean'
+					},
 					access: {
 						type: 'object',
 						properties: {
-							enabled: {
-								type: 'boolean'
+							public: {
+								type: 'boolean',
 							},
 							whiteList: {
 								type: 'array'
 							}
 						},
-						required: ['enabled', 'whiteList']
+						required: ['public', 'whiteList']
 					},
 					options: {
 						type: 'object',
@@ -113,25 +116,25 @@ module.exports = {
 						required: ['limits']
 					}
 				},
-				required: ['open', 'access', 'options']
+				required: ['enabled', 'access', 'options']
 			},
 			peers: {
 				type: 'object',
 				properties: {
+					enabled: {
+						type: 'boolean'
+					},
 					list: {
 						type: 'array'
 					},
 					access: {
 						type: 'object',
 						properties: {
-							enabled: {
-								type: 'boolean'
-							},
 							blackList: {
 								type: 'array'
 							}
 						},
-						required: ['enabled', 'blackList']
+						required: ['blackList']
 					},
 					options: {
 						properties: {
@@ -160,7 +163,7 @@ module.exports = {
 						required: ['limits', 'timeout']
 					}
 				},
-				required: ['list', 'access', 'options']
+				required: ['enabled', 'list', 'access', 'options']
 			},
 			broadcasts: {
 				type: 'object',

--- a/schema/config.js
+++ b/schema/config.js
@@ -83,7 +83,7 @@ module.exports = {
 						type: 'object',
 						properties: {
 							public: {
-								type: 'boolean',
+								type: 'boolean'
 							},
 							whiteList: {
 								type: 'array'

--- a/test/config.json
+++ b/test/config.json
@@ -37,7 +37,10 @@
     },
     "peers": {
         "list": [],
-        "blackList": [],
+        "access": {
+            "enabled": true,
+            "blackList": []
+        },
         "options": {
             "limits": {
                 "max": 0,

--- a/test/config.json
+++ b/test/config.json
@@ -37,9 +37,9 @@
         }
     },
     "peers": {
+	"enabled": true,
         "list": [],
         "access": {
-            "enabled": true,
             "blackList": []
         },
         "options": {

--- a/test/config.json
+++ b/test/config.json
@@ -22,9 +22,9 @@
         ]
     },
     "api": {
-      "open": true,
+        "enabled": true,
         "access": {
-            "enabled": true,
+            "public": true,
             "whiteList": ["127.0.0.1"]
         },
         "options": {

--- a/test/config.json
+++ b/test/config.json
@@ -23,7 +23,8 @@
     },
     "api": {
         "access": {
-            "whiteList": []
+            "enabled": true,
+            "whiteList": ["127.0.0.1"]
         },
         "options": {
             "limits": {


### PR DESCRIPTION
This PR Addresses issues #472 and fulfills the following:

Provides end users a flag to disable access to Peers and API functions
Provides a flag to toggle public status of the api
Defaults the whitelist to include localhost
Defaults public API to be closed but enabled

Closes #472