### PR TITLE
Remove ignored default value in ColumnConfig

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -211,7 +211,7 @@ __private.dbSave = function (cb) {
 	// Creating set of columns
 	var cs = new pgp.helpers.ColumnSet([
 		'ip', 'port', 'state', 'height', 'os', 'version', 'clock',
-		{name: 'broadhash', def: null, init: function (col) {
+		{name: 'broadhash', init: function (col) {
 			return col.value ? new Buffer(col.value, 'hex') : null;
 		}}
 	], {table: 'peers'});

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -216,11 +216,11 @@ __private.dbSave = function (cb) {
 		}}
 	], {table: 'peers'});
 
-	// Generating insert query
-	var insert_peers = pgp.helpers.insert(peers, cs);
-
 	// Wrap sql queries in transaction and execute
 	library.db.tx(function (t) {
+		// Generating insert query
+		var insert_peers = pgp.helpers.insert(peers, cs);
+		
 		var queries = [
 			// Clear peers table
 			t.none(sql.clear),


### PR DESCRIPTION
because of the way you define `init` there, it becomes pointless to use `def` at all. When you do not have `def`, means for an undefined property you will get `undefined`, which passing through your `init` logic will create identical result ;)

It is mostly pointless to use `def` when you use `init` :wink:, which overrides the value anyway. You normally supply `def` when you do not use `init` :wink:

In that context you can think of `init` as an advanced/dynamic approach to providing the default value :wink:

See: [ColumnConfig](http://vitaly-t.github.io/pg-promise/helpers.html#.ColumnConfig)
