### PR TITLE
Trigger sync faster when node is missing blocks

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -4,7 +4,7 @@ module.exports = {
 	activeDelegates: 101,
 	addressLength: 208,
 	blockHeaderLength: 248,
-	blockReceiptTimeOut: 120, // 12 blocks
+	blockReceiptTimeOut: 20, // 2 blocks
 	confirmationLength: 77,
 	epochTime: new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0)),
 	fees: {


### PR DESCRIPTION
When we know that node is missing blocks (stale `lastReceipt`) - we should trigger sync immediately to catch-up.