### PR TITLE
Updating README.md and .travis.yml - Closes #513

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: 'trusty'
 language: node_js
 node_js:
-  - '6.9.5'
+  - '6.10.1'
 cache:
   directories:
     - test/lisk-js

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Lisk is a next generation crypto-currency and decentralized application platform
 
   ```
   curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-  nvm install v6.9.5
+  nvm install v6.10.1
   ```
 
 - Install PostgreSQL (version 9.6.2):


### PR DESCRIPTION
- Bumping node_js version used by travis
- Bumping version installed via nvm

Closes #513.