### PR TITLE
Improving block reward and dapps test stability - Addresses #400

### DIFF
--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -773,7 +773,7 @@ describe('PUT /api/dapps/withdrawal', function () {
 
 			putWithdrawal(validParams, function (err, res) {
 				node.expect(res.body).to.have.property('success').to.be.not.ok;
-				node.expect(res.body).to.have.propety('error').to.contain('Transaction is already processed');
+				node.expect(res.body).to.have.property('error').to.contain('Transaction is already processed');
 				done();
 			});
 		});

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -773,18 +773,8 @@ describe('PUT /api/dapps/withdrawal', function () {
 
 			putWithdrawal(validParams, function (err, res) {
 				node.expect(res.body).to.have.property('success').to.be.not.ok;
-				if (res.body.error !== 'Transaction is already processed: ' + validParams.transactionId) {
-					node.get('/api/transactions/queued', function (err, trsRes) {
-						node.expect(trsRes.body).to.have.property('success').to.be.ok;
-						node.expect(trsRes.body.transactions).to.be.an('array').and.to.have.length.of.at.least(1);
-						var trsQueued = trsRes.body.transactions.find(function (t) {
-							return t.asset.outTransfer.transactionId === validParams.transactionId;
-						});
-						node.expect(trsQueued).to.be.not.empty;
-						node.expect(res.body).to.have.property('error').to.equal('Transaction is already processed: ' + trsQueued.id);
-						done();
-					});
-				}
+				node.expect(res.body).to.have.propety('error').to.contain('Transaction is already processed');
+				done();
 			});
 		});
 	});

--- a/test/unit/logic/blockReward.js
+++ b/test/unit/logic/blockReward.js
@@ -434,6 +434,7 @@ describe('BlockReward', function () {
 				it('should be ok', function () {
 					var supply = blockReward.calcSupply(13451519);
 					var prev = supply;
+
 					for (var i = 13451520; i < (13451520 + 100); i++) {
 						supply = blockReward.calcSupply(i);
 						expect(supply).to.equal(prev + constants.rewards.milestones[4]);

--- a/test/unit/logic/blockReward.js
+++ b/test/unit/logic/blockReward.js
@@ -434,8 +434,7 @@ describe('BlockReward', function () {
 				it('should be ok', function () {
 					var supply = blockReward.calcSupply(13451519);
 					var prev = supply;
-
-					for (var i = 13451520; i < (13451520 * 2); i++) {
+					for (var i = 13451520; i < (13451520 + 100); i++) {
 						supply = blockReward.calcSupply(i);
 						expect(supply).to.equal(prev + constants.rewards.milestones[4]);
 						prev = supply;


### PR DESCRIPTION
- Change double withdrawal test expectation. As unable to control when transaction changes state from queued to confirmed, change test expectation so it not includes transaction id.
- Reducing heights tested past milestone 4 in block reward unit tests.

Addresses #482