### PR TITLE
Fix emptying config.json - Closes #521

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,9 +162,9 @@ d.run(function () {
 					delete appConfig.loading.snapshot;
 				}
 
-				fs.writeFile('./config.json', JSON.stringify(appConfig, null, 4), 'utf8', function (err) {
-					cb(err, appConfig);
-				});
+				fs.writeFileSync('./config.json', JSON.stringify(appConfig, null, 4));
+
+				cb(null, appConfig);
 			} else {
 				cb(null, appConfig);
 			}


### PR DESCRIPTION
Eliminates emptying the file, when config.json is used by other processes.

Closes #521