### PR TITLE
Improve API 'delegates/search' endpoint - Closes #533

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -615,7 +615,7 @@ Delegates.prototype.shared = {
 
 			library.db.query(sql.search({
 				q: req.body.q,
-				limit: req.body.limit || 100,
+				limit: req.body.limit || 101,
 				sortField: orderBy.sortField,
 				sortMethod: orderBy.sortMethod
 			})).then(function (rows) {

--- a/schema/delegates.js
+++ b/schema/delegates.js
@@ -72,7 +72,7 @@ module.exports = {
 			limit: {
 				type: 'integer',
 				minimum: 1,
-				maximum: 100
+				maximum: 1000
 			}
 		},
 		required: ['q']

--- a/sql/delegates.js
+++ b/sql/delegates.js
@@ -9,18 +9,39 @@ var DelegatesSql = {
     'publicKey',
     'vote',
     'missedblocks',
-    'producedblocks'
+    'producedblocks',
+    'approval',
+    'productivity',
+    'voters_cnt',
+    'register_timestamp'
   ],
 
   count: 'SELECT COUNT(*)::int FROM delegates',
 
   search: function (params) {
     var sql = [
-      'SELECT m."username", m."address", ENCODE(m."publicKey", \'hex\') AS "publicKey", m."vote", m."producedblocks", m."missedblocks"',
-      'FROM mem_accounts m',
-      'WHERE m."isDelegate" = 1 AND m."username" LIKE ${q}',
-      'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') + ' NULLS LAST',
-      'LIMIT ${limit}'
+      'WITH',
+      'supply AS (SELECT calcSupply()::numeric),',
+      'delegates AS (SELECT row_number() OVER (ORDER BY vote DESC, m."publicKey" ASC)::int AS rank,',
+        'm.username,',
+        'm.address,',
+        'ENCODE(m."publicKey", \'hex\') AS "publicKey",',
+        'm.vote,',
+        'm.producedblocks,',
+        'm.missedblocks,',
+        'ROUND(vote / (SELECT * FROM supply) * 100, 2) AS approval,',
+        '(CASE WHEN producedblocks+missedblocks = 0 THEN 0.00 ELSE',
+          'ROUND(100 - (missedblocks::numeric / (producedblocks+missedblocks) * 100), 2)',
+        'END) AS productivity,',
+        'COALESCE(v.voters_cnt, 0) AS voters_cnt,',
+        't.timestamp AS register_timestamp',
+      'FROM delegates d',
+      'LEFT JOIN mem_accounts m ON d.username = m.username',
+      'LEFT JOIN trs t ON d."transactionId" = t.id',
+      'LEFT JOIN (SELECT "dependentId", COUNT(1)::int AS voters_cnt from mem_accounts2delegates GROUP BY "dependentId") v ON v."dependentId" = ENCODE(m."publicKey", \'hex\')',
+      'WHERE m."isDelegate" = 1',
+      'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') + ')',
+      'SELECT * FROM delegates WHERE username LIKE ${q} LIMIT ${limit}'
     ].join(' ');
 
     params.q = '%' + String(params.q).toLowerCase() + '%';

--- a/sql/migrations/20170408001337_createIndex.sql
+++ b/sql/migrations/20170408001337_createIndex.sql
@@ -1,0 +1,10 @@
+/*
+ * Add index for performance
+ */
+
+BEGIN;
+
+-- Add 'mem_accounts2delegates_depId' index for fast delegates voters counting
+CREATE INDEX IF NOT EXISTS "mem_accounts2delegates_depId" ON mem_accounts2delegates ("dependentId");
+
+COMMIT;

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -861,12 +861,12 @@ describe('GET /api/delegates/search', function () {
 		node.get('/api/delegates/search?q=' + q, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('delegates').that.is.an('array');
-			node.expect(res.body.delegates).to.have.length(100);
+			node.expect(res.body.delegates).to.have.length(101);
 			done();
 		});
 	});
 
-	it('using string limit should be ok', function (done) {
+	it('using string limit should fail', function (done) {
 		var q = 'genesis_';
 		var limit = 'one';
 

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -760,6 +760,16 @@ describe('GET /api/delegates/search', function () {
 		});
 	});
 
+	it('using wildcard criteria should be ok', function (done) {
+		var q = '%'; // 1 character
+
+		node.get('/api/delegates/search?q=' + q, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('delegates').that.is.an('array');
+			done();
+		});
+	});
+
 	it('using criteria with length == 1 should be ok', function (done) {
 		var q = 'g'; // 1 character
 
@@ -830,12 +840,17 @@ describe('GET /api/delegates/search', function () {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('delegates').that.is.an('array');
 			node.expect(res.body.delegates).to.have.length(1);
+			node.expect(res.body.delegates[0]).to.have.property('rank').that.is.an('number');
 			node.expect(res.body.delegates[0]).to.have.property('username').that.is.an('string');
 			node.expect(res.body.delegates[0]).to.have.property('address').that.is.an('string');
 			node.expect(res.body.delegates[0]).to.have.property('publicKey').that.is.an('string');
 			node.expect(res.body.delegates[0]).to.have.property('vote').that.is.an('string');
 			node.expect(res.body.delegates[0]).to.have.property('producedblocks').that.is.an('number');
 			node.expect(res.body.delegates[0]).to.have.property('missedblocks').that.is.an('number');
+			node.expect(res.body.delegates[0]).to.have.property('approval').that.is.an('string');
+			node.expect(res.body.delegates[0]).to.have.property('productivity').that.is.an('string');
+			node.expect(res.body.delegates[0]).to.have.property('voters_cnt').that.is.an('number');
+			node.expect(res.body.delegates[0]).to.have.property('register_timestamp').that.is.an('number');
 			done();
 		});
 	});
@@ -907,21 +922,21 @@ describe('GET /api/delegates/search', function () {
 		});
 	});
 
-	it('using limit == 100 should be ok', function (done) {
+	it('using limit == 1000 should be ok', function (done) {
 		var q = 'genesis_';
-		var limit = 100;
+		var limit = 1000;
 
 		node.get('/api/delegates/search?q=' + q + '&limit=' + limit, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('delegates').that.is.an('array');
-			node.expect(res.body.delegates).to.have.length(100);
+			node.expect(res.body.delegates).to.have.length(101);
 			done();
 		});
 	});
 
-	it('using limit > 100 should fail', function (done) {
+	it('using limit > 1000 should fail', function (done) {
 		var q = 'genesis_';
-		var limit = 101;
+		var limit = 1001;
 
 		node.get('/api/delegates/search?q=' + q + '&limit=' + limit, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.not.ok;
@@ -946,7 +961,7 @@ describe('GET /api/delegates/search', function () {
 		node.get('/api/delegates/search?q=' + q, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('delegates').that.is.an('array');
-			node.expect(res.body.delegates).to.have.length(100);
+			node.expect(res.body.delegates).to.have.length(101);
 			node.expect(res.body.delegates[0]).to.have.property('username');
 			node.expect(res.body.delegates[0].username).to.equal('genesis_1');
 			node.expect(res.body.delegates[24]).to.have.property('username');
@@ -961,7 +976,7 @@ describe('GET /api/delegates/search', function () {
 		node.get('/api/delegates/search?q=' + q + '&orderBy=username:asc', function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('delegates').that.is.an('array');
-			node.expect(res.body.delegates).to.have.length(100);
+			node.expect(res.body.delegates).to.have.length(101);
 			node.expect(res.body.delegates[0]).to.have.property('username');
 			node.expect(res.body.delegates[0].username).to.equal('genesis_1');
 			node.expect(res.body.delegates[24]).to.have.property('username');
@@ -976,7 +991,7 @@ describe('GET /api/delegates/search', function () {
 		node.get('/api/delegates/search?q=' + q + '&orderBy=username:desc', function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('delegates').that.is.an('array');
-			node.expect(res.body.delegates).to.have.length(100);
+			node.expect(res.body.delegates).to.have.length(101);
 			node.expect(res.body.delegates[0]).to.have.property('username');
 			node.expect(res.body.delegates[0].username).to.equal('genesis_99');
 			node.expect(res.body.delegates[24]).to.have.property('username');


### PR DESCRIPTION
Improve API `delegates/search` endpoint:
- Refactored SQL query
- Uses new `calcSupply()` SQL function
- Return new properties for every delegate: `rank`, `approval`, `productivity`, `voters_cnt`, `register_timestamp` with ability to order by those fields
- Increased limit of max returned delegates from `100` to `1000`

Closes https://github.com/LiskHQ/lisk/issues/533