### PR TITLE
Cover SQL functions with tests - Closes #562

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     # Longest duration first
     - TEST=test/api/peer.transactions.stress.js TEST_TYPE='FUNC'
     - TEST=test/api/peer.transactions.votes.js TEST_TYPE='FUNC'
+    - TEST=test/unit/sql TEST_TYPE='UNIT'
     - TEST=test/unit/logic TEST_TYPE='UNIT'
     - TEST=test/api/delegates.js TEST_TYPE='FUNC'
     - TEST=test/api/accounts.js TEST_TYPE='FUNC'

--- a/sql/delegates.js
+++ b/sql/delegates.js
@@ -21,7 +21,7 @@ var DelegatesSql = {
   search: function (params) {
     var sql = [
       'WITH',
-      'supply AS (SELECT calcSupply()::numeric),',
+      'supply AS (SELECT calcSupply((SELECT height FROM blocks ORDER BY height DESC LIMIT 1))::numeric),',
       'delegates AS (SELECT row_number() OVER (ORDER BY vote DESC, m."publicKey" ASC)::int AS rank,',
         'm.username,',
         'm.address,',

--- a/sql/migrations/20170422001337_recreateCalculateBlocksRewards.sql
+++ b/sql/migrations/20170422001337_recreateCalculateBlocksRewards.sql
@@ -1,0 +1,148 @@
+/*
+ * - Recreate blockRewards data type and function getBlockRewards (simplify milestones)
+ * - Recreate calcBlockReward function, improved performance
+ * - Create calcSupply_test function - for testing calcSupply
+ * - Recreate calcSupply, improved performance, change type to IMMUTABLE
+ */
+
+BEGIN;
+
+-- Drop old functions and data type
+DROP FUNCTION IF EXISTS getBlockRewards();
+DROP FUNCTION IF EXISTS calcBlockReward(int);
+DROP FUNCTION If EXISTS calcSupply(int);
+DROP TYPE IF EXISTS blockRewards;
+
+-- Create new data type which will store block rewards info
+CREATE TYPE blockRewards AS (supply bigint, start int, distance bigint, milestones bigint[]);
+
+-- Create function that returns blocks rewards data
+-- @IMMUTABLE - always returns the same result
+CREATE FUNCTION getBlockRewards() RETURNS blockRewards LANGUAGE PLPGSQL IMMUTABLE AS $$
+	DECLARE
+		res        blockRewards;
+		supply     bigint     = 10000000000000000; -- Initial supply
+		start      int        = 1451520; -- Start rewards at block (n)
+		distance   bigint     = 3000000; -- Distance between each milestone
+		milestones bigint[] = ARRAY[   -- Milestones
+			500000000, -- Initial Reward
+			400000000, -- Milestone 1
+			300000000, -- Milestone 2
+			200000000, -- Milestone 3
+			100000000  -- Milestone 4
+		];
+	BEGIN
+		res.supply     = supply;
+		res.start      = start;
+		res.distance   = distance;
+		res.milestones = milestones;
+	RETURN res;
+END $$;
+
+-- Create function that returns blocks rewards data
+-- @IMMUTABLE - always returns the same result for the same argument
+CREATE FUNCTION calcBlockReward(block_height int) RETURNS bigint LANGUAGE PLPGSQL IMMUTABLE AS $$
+	DECLARE
+		r blockRewards;
+		mile int;
+	BEGIN
+		-- Return NULL if supplied height is invalid
+		IF block_height IS NULL OR block_height <= 0 THEN RETURN NULL; END IF;
+
+		-- Get blocks rewards data
+		SELECT * FROM getBlockRewards() INTO r;
+
+		-- If height is below rewards start - return 0
+		IF block_height < r.start THEN
+			RETURN 0;
+		END IF;
+
+		-- Calculate milestone for height (we use +1 here because array indexes by default begins from 1 in postgres)
+		mile := FLOOR((block_height-r.start)/r.distance)+1;
+
+		-- If calculated milestone exceed last milestone
+		IF mile > array_length(r.milestones, 1) THEN
+			-- Use last milestone
+			mile := array_length(r.milestones, 1);
+		END IF;
+
+		-- Return calculated reward
+		RETURN r.milestones[mile];
+END $$;
+
+
+
+-- Create function that calculate current supply
+-- @IMMUTABLE - always returns the same result for the same argument
+CREATE FUNCTION calcSupply(block_height int) RETURNS bigint LANGUAGE PLPGSQL IMMUTABLE AS $$
+	DECLARE
+		r blockRewards;
+		mile   int;
+	BEGIN
+		-- Return NULL if supplied height is invalid
+		IF block_height IS NULL OR block_height <= 0 THEN RETURN NULL; END IF;
+
+		-- Get blocks rewards data
+		SELECT * FROM getBlockRewards() INTO r;
+
+		-- If height is below rewards start - return initial supply
+		IF block_height < r.start THEN
+			RETURN r.supply;
+		END IF;
+
+		-- Calculate milestone for height (we use +1 here because array indexes by default begins from 1 in postgres)
+		mile := FLOOR((block_height-r.start)/r.distance)+1;
+
+		-- If calculated milestone exceed last milestone
+		IF mile > array_length(r.milestones, 1) THEN
+			-- Use last milestone
+			mile := array_length(r.milestones, 1);
+		END IF;
+
+		-- Iterate over milestones
+		FOR m IN 1..mile LOOP
+			IF m = mile THEN
+				-- Not completed milestone
+				-- Calculate amount of blocks in milestone, calculate rewards and add to supply
+				r.supply := r.supply + (block_height-r.start+1-r.distance*(m-1))*r.milestones[m];
+			ELSE
+				-- Completed milestone
+				-- Use distance for calculate rewards for blocks in milestone and add to supply
+				r.supply := r.supply + r.distance*r.milestones[m];
+			END IF;
+		END LOOP;
+
+	-- Return calculated supply
+	RETURN r.supply;
+END $$;
+
+-- Create function for testing calcSupply(int) function
+-- @IMMUTABLE - always returns the same result for the same arguments
+CREATE FUNCTION calcSupply_test(height_start int, height_end int, expected_reward bigint) RETURNS boolean LANGUAGE PLPGSQL IMMUTABLE AS $$
+	DECLARE
+		supply bigint;
+		prev_supply bigint;
+	BEGIN
+		-- Calculate supply for previous height
+		SELECT calcSupply(height_start-1) INTO prev_supply;
+
+		-- Iteratating over heights
+		FOR height IN height_start..height_end LOOP
+			-- Calculate supply for current height
+			SELECT calcSupply(height) INTO supply;
+
+			-- If supply for previous height + expected block reward is different than supply for current height
+			IF (prev_supply+expected_reward) <> supply THEN
+				-- Break and retun false
+				RETURN false;
+			END IF;
+
+			-- Update supply for previous height
+			prev_supply := supply;
+		END LOOP;
+
+		-- All tests passed - return true
+		RETURN true;
+END $$;
+
+COMMIT;

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 require('./unit/helpers/request-limiter.js');
 require('./unit/logic/blockReward.js');
+require('./unit/sql/blockRewards.js');
 require('./unit/modules/peers.js');
 require('./unit/modules/blocks.js');
 

--- a/test/sql/blockRewards.js
+++ b/test/sql/blockRewards.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var BlockRewards = {
+
+	getBlockRewards: 'SELECT * FROM getBlockRewards();',
+
+	calcBlockReward: 'SELECT calcBlockReward AS reward FROM calcBlockReward(${height});',
+
+	calcSupply: 'SELECT calcSupply AS supply FROM calcSupply(${height});',
+
+	calcSupply_test: 'SELECT calcSupply_test AS result FROM calcSupply_test(${height_start}, ${height_end}, ${expected_reward});',
+
+	calcBlockReward_test: 'WITH heights AS (SELECT generate_series(${height_start}, ${height_end}) AS height), results AS (SELECT height, ${expected_reward} AS expected_reward, calcBlockReward(height) AS reward FROM heights) SELECT COUNT(1) AS result FROM results WHERE reward <> expected_reward;'
+
+};
+
+module.exports = BlockRewards;

--- a/test/unit/sql/blockRewards.js
+++ b/test/unit/sql/blockRewards.js
@@ -65,6 +65,18 @@ function calcSupply_test (height_start, height_end, expected_reward, done) {
 	});
 };
 
+function calcSupply_test_fail (height_start, height_end, expected_reward, done) {
+	return db.query(sql.calcSupply_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
+		expect(rows).to.be.array;
+		expect(rows.length).to.equal(1);
+		expect(rows[0]).to.be.object;
+		expect(rows[0].result).to.equal(false);
+		done();
+	}).catch(function (err) {
+		done(err);
+	});
+};
+
 function calcBlockReward_test (height_start, height_end, expected_reward, done) {
 	return db.query(sql.calcBlockReward_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
 		expect(rows).to.be.array;
@@ -76,7 +88,6 @@ function calcBlockReward_test (height_start, height_end, expected_reward, done) 
 		done(err);
 	});
 };
-
 
 describe('BlockRewardsSQL', function () {
 
@@ -340,12 +351,29 @@ describe('BlockRewardsSQL', function () {
 
 	describe('checking completely SQL functions calcSupply(int) and calcBlockReward(int)', function () {
 
+		describe('check if calcBlockReward_test can fail', function () {
+			it('calcBlockReward_test should return 1000 for 1000 not matching block rewards', function (done) {
+				db.query(sql.calcBlockReward_test, {height_start: 1, height_end: 1000, expected_reward: 1}).then(function (rows) {
+					expect(rows).to.be.array;
+					expect(rows.length).to.equal(1);
+					expect(rows[0]).to.be.object;
+					expect(Number(rows[0].result)).to.equal(1000);
+					done();
+				}).catch(function (err) {
+					done(err);
+				});
+			});
+		});
+
 		describe('before reward offset', function () {
 			it('calcBlockReward_test should return 0', function (done) {
 				calcBlockReward_test(1, 1451519, 0, done);
 			});
 			it('calcSupply_test should return true', function (done) {
 				calcSupply_test(1, 1451519, 0, done);
+			});
+			it('calcSupply_test_fail should return false', function (done) {
+				calcSupply_test_fail(1, 1451519, 1, done);
 			});
 		});
 
@@ -356,6 +384,9 @@ describe('BlockRewardsSQL', function () {
 			it('calcSupply_test should return true', function (done) {
 				calcSupply_test(1451520, 4451519, constants.rewards.milestones[0], done);
 			});
+			it('calcSupply_test_fail should return false', function (done) {
+				calcSupply_test_fail(1451520, 4451519, 1, done);
+			});
 		});
 
 		describe('for milestone 1', function () {
@@ -364,6 +395,9 @@ describe('BlockRewardsSQL', function () {
 			});
 			it('calcSupply_test should return true', function (done) {
 				calcSupply_test(4451520, 7451519, constants.rewards.milestones[1], done);
+			});
+			it('calcSupply_test_fail should return false', function (done) {
+				calcSupply_test_fail(4451520, 7451519, 1, done);
 			});
 		});
 
@@ -374,6 +408,9 @@ describe('BlockRewardsSQL', function () {
 			it('calcSupply_test should return true', function (done) {
 				calcSupply_test(7451520, 10451519, constants.rewards.milestones[2], done);
 			});
+			it('calcSupply_test_fail should return false', function (done) {
+				calcSupply_test_fail(7451520, 10451519, 1, done);
+			});
 		});
 
 		describe('for milestone 3', function () {
@@ -383,6 +420,9 @@ describe('BlockRewardsSQL', function () {
 			it('calcSupply_test should return true', function (done) {
 				calcSupply_test(10451520, 13451519, constants.rewards.milestones[3], done);
 			});
+			it('calcSupply_test_fail should return false', function (done) {
+				calcSupply_test_fail(10451520, 13451519, 1, done);
+			});
 		});
 
 		describe('for milestone 4 and beyond', function () {
@@ -391,6 +431,9 @@ describe('BlockRewardsSQL', function () {
 			});
 			it('calcSupply_test should return true', function (done) {
 				calcSupply_test(13451520, (13451520 + 100), constants.rewards.milestones[4], done);
+			});
+			it('calcSupply_test_fail should return false', function (done) {
+				calcSupply_test_fail(13451520, (13451520 + 100), 1, done);
 			});
 		});
 	});

--- a/test/unit/sql/blockRewards.js
+++ b/test/unit/sql/blockRewards.js
@@ -1,0 +1,398 @@
+'use strict';
+
+var chai = require('chai');
+var expect = require('chai').expect;
+
+var sql = require('../../sql/blockRewards.js');
+var constants = require('../../../helpers/constants.js');
+var modulesLoader = require('../../common/initModule').modulesLoader;
+var db;
+
+before(function (done) {
+	modulesLoader.getDbConnection(function (err, db_handle) {
+		if (err) {
+			return done(err);
+		}
+		db = db_handle;
+		done();
+	});
+});
+
+constants.rewards.distance = 3000000;
+constants.rewards.offset = 1451520;
+
+function calcBlockReward (height, reward, done) {
+	return db.query(sql.calcBlockReward, {height: height}).then(function (rows) {
+		expect(rows).to.be.array;
+		expect(rows.length).to.equal(1);
+		expect(rows[0]).to.be.object;
+		if (rows[0].reward == null) {
+			expect(rows[0].reward).to.equal(reward);
+		} else {
+			expect(Number(rows[0].reward)).to.equal(reward);
+		}
+		done();
+	}).catch(function (err) {
+		done(err);
+	});
+};
+
+function calcSupply (height, supply, done) {
+	return db.query(sql.calcSupply, {height: height}).then(function (rows) {
+		expect(rows).to.be.array;
+		expect(rows.length).to.equal(1);
+		expect(rows[0]).to.be.object;
+		if (rows[0].supply == null) {
+			expect(rows[0].supply).to.equal(supply);
+		} else {
+			expect(Number(rows[0].supply)).to.equal(supply);
+		}
+		done();
+	}).catch(function (err) {
+		done(err);
+	});
+};
+
+function calcSupply_test (height_start, height_end, expected_reward, done) {
+	return db.query(sql.calcSupply_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
+		expect(rows).to.be.array;
+		expect(rows.length).to.equal(1);
+		expect(rows[0]).to.be.object;
+		expect(rows[0].result).to.equal(true);
+		done();
+	}).catch(function (err) {
+		done(err);
+	});
+};
+
+function calcBlockReward_test (height_start, height_end, expected_reward, done) {
+	return db.query(sql.calcBlockReward_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
+		expect(rows).to.be.array;
+		expect(rows.length).to.equal(1);
+		expect(rows[0]).to.be.object;
+		expect(Number(rows[0].result)).to.equal(0);
+		done();
+	}).catch(function (err) {
+		done(err);
+	});
+};
+
+
+describe('BlockRewardsSQL', function () {
+
+	describe('checking SQL function getBlockRewards()', function () {
+		it('SQL rewards should be equal to those in constants', function (done) {
+			db.query(sql.getBlockRewards).then(function (rows) {
+				expect(rows).to.be.array;
+				expect(rows.length).to.equal(1);
+				expect(rows[0]).to.be.object;
+				// Checking supply
+				expect(Number(rows[0].supply)).to.equal(constants.totalAmount);
+				// Checking reward start
+				expect(Number(rows[0].start)).to.equal(constants.rewards.offset);
+				// Checking distance between milestones
+				expect(Number(rows[0].distance)).to.equal(constants.rewards.distance);
+				// Checking milestones
+				expect(Number(rows[0].milestones[0])).to.equal(constants.rewards.milestones[0]);
+				expect(Number(rows[0].milestones[1])).to.equal(constants.rewards.milestones[1]);
+				expect(Number(rows[0].milestones[2])).to.equal(constants.rewards.milestones[2]);
+				expect(Number(rows[0].milestones[3])).to.equal(constants.rewards.milestones[3]);
+				expect(Number(rows[0].milestones[4])).to.equal(constants.rewards.milestones[4]);
+				done();
+			}).catch(function (err) {
+				done(err);
+			});
+		});
+	});
+
+	describe('checking SQL function calcBlockReward(int)', function () {
+
+		it('when height is undefined should return null', function (done) {
+			// Height, expected reward, callback
+			calcBlockReward(undefined, null, done);
+		});
+
+		it('when height == 0 should return null', function (done) {
+			calcBlockReward(0, null, done);
+		});
+
+		it('when height == 1 should return 0', function (done) {
+			calcBlockReward(1, 0, done);
+		});
+
+		it('when height == (offset - 1) should return 0', function (done) {
+			calcBlockReward(1451519, 0, done);
+		});
+
+		it('when height == (offset) should return 500000000', function (done) {
+			calcBlockReward(1451520, 500000000, done);
+		});
+
+		it('when height == (offset + 1) should return 500000000', function (done) {
+			calcBlockReward(1451521, 500000000, done);
+		});
+
+		it('when height == (offset + 2) should return 500000000', function (done) {
+			calcBlockReward(1451522, 500000000, done);
+		});
+
+		it('when height == (distance) should return 500000000', function (done) {
+			calcBlockReward(3000000, 500000000, done);
+		});
+
+		it('when height == (distance + 1) should return 500000000', function (done) {
+			calcBlockReward(3000001, 500000000, done);
+		});
+
+		it('when height == (distance + 2) should return 500000000', function (done) {
+			calcBlockReward(3000002, 500000000, done);
+		});
+
+		it('when height == (milestoneOne - 1) should return 500000000', function (done) {
+			calcBlockReward(4451519, 500000000, done);
+		});
+
+		it('when height == (milestoneOne) should return 400000000', function (done) {
+			calcBlockReward(4451520, 400000000, done);
+		});
+
+		it('when height == (milestoneOne + 1) should return 400000000', function (done) {
+			calcBlockReward(4451521, 400000000, done);
+		});
+
+		it('when height == (milestoneTwo - 1) should return 400000000', function (done) {
+			calcBlockReward(7451519, 400000000, done);
+		});
+
+		it('when height == (milestoneTwo) should return 300000000', function (done) {
+			calcBlockReward(7451521, 300000000, done);
+		});
+
+		it('when height == (milestoneTwo + 1) should return 300000000', function (done) {
+			calcBlockReward(7451522, 300000000, done);
+		});
+
+		it('when height == (milestoneThree - 1) should return 300000000', function (done) {
+			calcBlockReward(10451519, 300000000, done);
+		});
+
+		it('when height == (milestoneThree) should return 200000000', function (done) {
+			calcBlockReward(10451520, 200000000, done);
+		});
+
+		it('when height == (milestoneThree + 1) should return 200000000', function (done) {
+			calcBlockReward(10451521, 200000000, done);
+		});
+
+		it('when height == (milestoneFour - 1) should return 200000000', function (done) {
+			calcBlockReward(13451519, 200000000, done);
+		});
+
+		it('when height == (milestoneFour) should return 100000000', function (done) {
+			calcBlockReward(13451520, 100000000, done);
+		});
+
+		it('when height == (milestoneFour + 1) should return 100000000', function (done) {
+			calcBlockReward(13451521, 100000000, done);
+		});
+
+		it('when height == (milestoneFour * 2) should return 100000000', function (done) {
+			calcBlockReward((13451520 * 2), 100000000, done);
+		});
+
+		it('when height == (milestoneFour * 10) should return 100000000', function (done) {
+			calcBlockReward((13451520 * 10), 100000000, done);
+		});
+
+		it('when height == (milestoneFour * 100) should return 100000000', function (done) {
+			// Height, expected reward, callback
+			calcBlockReward((13451520 * 100), 100000000, done);
+		});
+
+		// That query expect to fail because height is int and (milestoneFour * 1000) is bigint
+		// However, it will take 400+ years to reach height of last passing test, so is safe to ignore
+		it('when height == (milestoneFour * 1000) should overflow int and return error', function (done) {
+			db.query(sql.calcBlockReward, {height: (13451520 * 1000)}).then(function (rows) {
+				done('Should not pass');
+			}).catch(function (err) {
+				expect(err).to.be.an('error');
+				expect(err.message).to.contain('function calcblockreward(bigint) does not exist');
+				done();
+			});
+		});
+	});
+
+	describe('checking SQL function calcSupply(int)', function () {
+
+		it('when height is undefined should return null', function (done) {
+			calcSupply(undefined, null, done);
+		});
+
+		it('when height == 0 should return null', function (done) {
+			calcSupply(0, null, done);
+		});
+
+		it('when height == 1 should return 10000000000000000', function (done) {
+			calcSupply(1, 10000000000000000, done);
+		});
+
+		it('when height == (offset - 1) should return 10000000000000000', function (done) {
+			calcSupply(1451519, 10000000000000000, done);
+		});
+
+		it('when height == (offset) should return 10000000500000000', function (done) {
+			calcSupply(1451520, 10000000500000000, done);
+		});
+
+		it('when height == (offset + 1) should return 10000001000000000', function (done) {
+			calcSupply(1451521, 10000001000000000, done);
+		});
+
+		it('when height == (offset + 2) should return 10000001500000000', function (done) {
+			calcSupply(1451522, 10000001500000000, done);
+		});
+
+		it('when height == (distance) should return 10774240500000000', function (done) {
+			calcSupply(3000000, 10774240500000000, done);
+		});
+
+		it('when height == (distance + 1) should return 10774241000000000', function (done) {
+			calcSupply(3000001, 10774241000000000, done);
+		});
+
+		it('when height == (distance + 2) should return 10774241500000000', function (done) {
+			calcSupply(3000002, 10774241500000000, done);
+		});
+
+		it('when height == (milestoneOne - 1) should return 11500000000000000', function (done) {
+			calcSupply(4451519, 11500000000000000, done);
+		});
+
+		it('when height == (milestoneOne) should return 11500000400000000', function (done) {
+			calcSupply(4451520, 11500000400000000, done);
+		});
+
+		it('when height == (milestoneOne + 1) should return 11500000800000000', function (done) {
+			calcSupply(4451521, 11500000800000000, done);
+		});
+
+		it('when height == (milestoneTwo - 1) should return 12700000000000000', function (done) {
+			calcSupply(7451519, 12700000000000000, done);
+		});
+
+		it('when height == (milestoneTwo) should return 12700000300000000', function (done) {
+			calcSupply(7451520, 12700000300000000, done);
+		});
+
+		it('when height == (milestoneTwo + 1) should return 12700000600000000', function (done) {
+			calcSupply(7451521, 12700000600000000, done);
+		});
+
+		it('when height == (milestoneThree - 1) should return 13600000000000000', function (done) {
+			calcSupply(10451519, 13600000000000000, done);
+		});
+
+		it('when height == (milestoneThree) should return 13600000200000000', function (done) {
+			calcSupply(10451520, 13600000200000000, done);
+		});
+
+		it('when height == (milestoneThree + 1) should return 13600000400000000', function (done) {
+			calcSupply(10451521, 13600000400000000, done);
+		});
+
+		it('when height == (milestoneFour - 1) should return 14200000000000000', function (done) {
+			calcSupply(13451519, 14200000000000000, done);
+		});
+
+		it('when height == (milestoneFour) should return 14200000100000000', function (done) {
+			calcSupply(13451520, 14200000100000000, done);
+		});
+
+		it('when height == (milestoneFour + 1) should return 14200000200000000', function (done) {
+			calcSupply(13451521, 14200000200000000, done);
+		});
+
+		it('when height == (milestoneFour * 2) should return 15545152100000000', function (done) {
+			calcSupply((13451520 * 2), 15545152100000000, done);
+		});
+
+		it('when height == (milestoneFour * 10) should return 26306368100000000', function (done) {
+			calcSupply((13451520 * 10), 26306368100000000, done);
+		});
+
+		it('when height == (milestoneFour * 100) should return 147370048100000000', function (done) {
+			calcSupply((13451520 * 100), 147370048100000000, done);
+		});
+
+		// That query expect to fail because height is int and (milestoneFour * 1000) is bigint
+		// However, it will take 400+ years to reach height of last passing test, so is safe to ignore
+		it('when height == (milestoneFour * 1000) should overflow int and return error', function (done) {
+			db.query(sql.calcSupply, {height: (13451520 * 1000)}).then(function (rows) {
+				done('Should not pass');
+			}).catch(function (err) {
+				expect(err).to.be.an('error');
+				expect(err.message).to.contain('function calcsupply(bigint) does not exist');
+				done();
+			});
+		});
+
+	});
+
+	describe('checking completely SQL functions calcSupply(int) and calcBlockReward(int)', function () {
+
+		describe('before reward offset', function () {
+			it('calcBlockReward_test should return 0', function (done) {
+				calcBlockReward_test(1, 1451519, 0, done);
+			});
+			it('calcSupply_test should return true', function (done) {
+				calcSupply_test(1, 1451519, 0, done);
+			});
+		});
+
+		describe('for milestone 0', function () {
+			it('calcBlockReward_test should return 0', function (done) {
+				calcBlockReward_test(1451520, 4451519, constants.rewards.milestones[0], done);
+			});
+			it('calcSupply_test should return true', function (done) {
+				calcSupply_test(1451520, 4451519, constants.rewards.milestones[0], done);
+			});
+		});
+
+		describe('for milestone 1', function () {
+			it('calcBlockReward_test should return 0', function (done) {
+				calcBlockReward_test(4451520, 7451519, constants.rewards.milestones[1], done);
+			});
+			it('calcSupply_test should return true', function (done) {
+				calcSupply_test(4451520, 7451519, constants.rewards.milestones[1], done);
+			});
+		});
+
+		describe('for milestone 2', function () {
+			it('calcBlockReward_test should return 0', function (done) {
+				calcBlockReward_test(7451520, 10451519, constants.rewards.milestones[2], done);
+			});
+			it('calcSupply_test should return true', function (done) {
+				calcSupply_test(7451520, 10451519, constants.rewards.milestones[2], done);
+			});
+		});
+
+		describe('for milestone 3', function () {
+			it('calcBlockReward_test should return 0', function (done) {
+				calcBlockReward_test(10451520, 13451519, constants.rewards.milestones[3], done);
+			});
+			it('calcSupply_test should return true', function (done) {
+				calcSupply_test(10451520, 13451519, constants.rewards.milestones[3], done);
+			});
+		});
+
+		describe('for milestone 4 and beyond', function () {
+			it('calcBlockReward_test should return 0', function (done) {
+				calcBlockReward_test(13451520, (13451520 + 100), constants.rewards.milestones[4], done);
+			});
+			it('calcSupply_test should return true', function (done) {
+				calcSupply_test(13451520, (13451520 + 100), constants.rewards.milestones[4], done);
+			});
+		});
+	});
+
+});


### PR DESCRIPTION
- Recreate functions for calculating blocks rewards (improved performance)
- Cover `getBlockRewards`, `calcBlockReward`, `calcSupply` with tests