### PR TITLE
Timestamps performance - Closes #448

### DIFF
--- a/helpers/slots.js
+++ b/helpers/slots.js
@@ -16,7 +16,7 @@ function beginEpochTime () {
 
 function getEpochTime (time) {
 	if (time === undefined) {
-		time = (new Date()).getTime();
+		time = Date.now();
 	}
 
 	var d = beginEpochTime();

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -521,9 +521,10 @@ __private.expireTransactions = function (transactions, parentIds, cb) {
 			return setImmediate(eachSeriesCb);
 		}
 
-		var timeNow = new Date();
+		var timeNow = Date.now();
 		var timeOut = __private.transactionTimeOut(transaction);
-		var seconds = Math.floor((timeNow.getTime() - new Date(transaction.receivedAt).getTime()) / 1000);
+		// transaction.receivedAt is instance of Date
+		var seconds = Math.floor((timeNow - transaction.receivedAt.getTime()) / 1000);
 
 		if (seconds > timeOut) {
 			ids.push(transaction.id);

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -521,10 +521,10 @@ __private.expireTransactions = function (transactions, parentIds, cb) {
 			return setImmediate(eachSeriesCb);
 		}
 
-		var timeNow = Date.now();
+		var timeNow = Math.floor(Date.now() / 1000);
 		var timeOut = __private.transactionTimeOut(transaction);
 		// transaction.receivedAt is instance of Date
-		var seconds = Math.floor(timeNow / 1000) - Math.floor(transaction.receivedAt.getTime() / 1000);
+		var seconds = timeNow - Math.floor(transaction.receivedAt.getTime() / 1000);
 
 		if (seconds > timeOut) {
 			ids.push(transaction.id);

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -524,7 +524,7 @@ __private.expireTransactions = function (transactions, parentIds, cb) {
 		var timeNow = Date.now();
 		var timeOut = __private.transactionTimeOut(transaction);
 		// transaction.receivedAt is instance of Date
-		var seconds = Math.floor((timeNow - transaction.receivedAt.getTime()) / 1000);
+		var seconds = Math.floor(timeNow / 1000) - Math.floor(transaction.receivedAt.getTime() / 1000);
 
 		if (seconds > timeOut) {
 			ids.push(transaction.id);

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -729,8 +729,7 @@ Blocks.prototype.getLastBlock = function () {
 
 Blocks.prototype.lastReceipt = function (lastReceipt) {
 	if (lastReceipt) {
-		__private.lastReceipt = lastReceipt;
-		__private.lastReceipt.timestamp = Math.floor(lastReceipt / 1000);
+		__private.lastReceipt = {timestamp: Math.floor(lastReceipt / 1000)};
 	}
 
 	if (__private.lastReceipt) {

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -683,7 +683,7 @@ __private.receiveBlock = function (block, cb) {
 		'reward:', modules.blocks.getLastBlock().reward
 	].join(' '));
 
-	self.lastReceipt(new Date());
+	self.lastReceipt(Date.now());
 	self.processBlock(block, true, cb, true);
 };
 
@@ -703,7 +703,7 @@ Blocks.prototype.getLastBlock = function () {
 	if (__private.lastBlock) {
 		var epoch = constants.epochTime / 1000;
 		var lastBlockTime = epoch + __private.lastBlock.timestamp;
-		var currentTime = new Date().getTime() / 1000;
+		var currentTime =Date.now() / 1000;
 
 		__private.lastBlock.secondsAgo = Math.round((currentTime - lastBlockTime) * 1e2) / 1e2;
 		__private.lastBlock.fresh = (__private.lastBlock.secondsAgo < constants.blockReceiptTimeOut);
@@ -718,8 +718,8 @@ Blocks.prototype.lastReceipt = function (lastReceipt) {
 	}
 
 	if (__private.lastReceipt) {
-		var timeNow = new Date();
-		__private.lastReceipt.secondsAgo = Math.floor((timeNow.getTime() - __private.lastReceipt.getTime()) / 1000);
+		var timeNow = Date.now();
+		__private.lastReceipt.secondsAgo = Math.floor((timeNow - __private.lastReceipt) / 1000);
 		__private.lastReceipt.secondsAgo = Math.round(__private.lastReceipt.secondsAgo * 1e2) / 1e2;
 		__private.lastReceipt.stale = (__private.lastReceipt.secondsAgo > constants.blockReceiptTimeOut);
 	}

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -730,11 +730,11 @@ Blocks.prototype.getLastBlock = function () {
 Blocks.prototype.lastReceipt = function (lastReceipt) {
 	if (lastReceipt) {
 		__private.lastReceipt = lastReceipt;
+		__private.lastReceipt.timestamp = Math.floor(lastReceipt / 1000);
 	}
 
 	if (__private.lastReceipt) {
 		var timeNow = Math.floor(Date.now() / 1000);
-		__private.lastReceipt.timestamp = Math.floor(__private.lastReceipt / 1000);
 		__private.lastReceipt.secondsAgo = timeNow - __private.lastReceipt.timestamp;
 		__private.lastReceipt.stale = (__private.lastReceipt.secondsAgo > constants.blockReceiptTimeOut);
 	}

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -63,6 +63,12 @@ Blocks.prototype.lastBlock = {
 	set: function (lastBlock) {
 		__private.lastBlock = lastBlock;
 		return __private.lastBlock;
+	},
+	isFresh: function () {
+		if (!__private.lastBlock) { return false; }
+		// Current time in seconds - (epoch start in seconds + block timestamp)
+		var secondsAgo = Math.floor(Date.now() / 1000) - (Math.floor(constants.epochTime / 1000) + __private.lastBlock.timestamp);
+		return (secondsAgo < constants.blockReceiptTimeOut);
 	}
 };
 
@@ -85,28 +91,6 @@ Blocks.prototype.isCleaning = {
 /**
  * PUBLIC METHODS
  */
-
-/**
- * Get last block with additional 'secondsAgo' and 'fresh' properties
- *
- * @public
- * @method getLastBlock
- * @return {Object} lastBlock Modified last block
- */
-Blocks.prototype.getLastBlock = function () {
-	if (__private.lastBlock) {
-		var epoch = Math.floor(constants.epochTime / 1000);
-		var lastBlockTime = epoch + __private.lastBlock.timestamp;
-		var currentTime = Math.floor(Date.now() / 1000);
-
-		//FIXME: That function modify global last block object - not good, for what we need those properties?
-		// 'fresh' is used in modules.loader.internal.statusPing
-		__private.lastBlock.secondsAgo = (currentTime - lastBlockTime);
-		__private.lastBlock.fresh = (__private.lastBlock.secondsAgo < constants.blockReceiptTimeOut);
-	}
-
-	return __private.lastBlock;
-};
 
 /**
  * Returns last receipt - indicator how long ago last block was received

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -88,7 +88,7 @@ Blocks.prototype.lastReceipt = {
 		return __private.lastReceipt;
 	},
 	update: function () {
-		__private.lastReceipt = Math.floor(Date.now / 1000);
+		__private.lastReceipt = Math.floor(Date.now() / 1000);
 		return __private.lastReceipt;
 	},
 	/**

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -90,7 +90,7 @@ Blocks.prototype.lastReceipt = {
 	update: function () {
 		__private.lastReceipt = Math.floor(Date.now / 1000);
 		return __private.lastReceipt;
-	}
+	},
 	/**
 	 * Returns status of last receipt - if it stale or not
 	 *

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -719,6 +719,7 @@ Blocks.prototype.lastReceipt = function (lastReceipt) {
 
 	if (__private.lastReceipt) {
 		var timeNow = Date.now();
+		__private.lastReceipt.timestamp = Math.floor( __private.lastReceipt / 1000);
 		__private.lastReceipt.secondsAgo = Math.floor((timeNow - __private.lastReceipt) / 1000);
 		__private.lastReceipt.secondsAgo = Math.round(__private.lastReceipt.secondsAgo * 1e2) / 1e2;
 		__private.lastReceipt.stale = (__private.lastReceipt.secondsAgo > constants.blockReceiptTimeOut);

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -716,11 +716,11 @@ Blocks.prototype.count = function (cb) {
 
 Blocks.prototype.getLastBlock = function () {
 	if (__private.lastBlock) {
-		var epoch = constants.epochTime / 1000;
+		var epoch = Math.floor(constants.epochTime / 1000);
 		var lastBlockTime = epoch + __private.lastBlock.timestamp;
-		var currentTime =Date.now() / 1000;
+		var currentTime = Math.floor(Date.now() / 1000);
 
-		__private.lastBlock.secondsAgo = Math.round((currentTime - lastBlockTime) * 1e2) / 1e2;
+		__private.lastBlock.secondsAgo = (currentTime - lastBlockTime);
 		__private.lastBlock.fresh = (__private.lastBlock.secondsAgo < constants.blockReceiptTimeOut);
 	}
 
@@ -733,10 +733,9 @@ Blocks.prototype.lastReceipt = function (lastReceipt) {
 	}
 
 	if (__private.lastReceipt) {
-		var timeNow = Date.now();
+		var timeNow = Math.floor(Date.now() / 1000);
 		__private.lastReceipt.timestamp = Math.floor( __private.lastReceipt / 1000);
-		__private.lastReceipt.secondsAgo = Math.floor((timeNow - __private.lastReceipt) / 1000);
-		__private.lastReceipt.secondsAgo = Math.round(__private.lastReceipt.secondsAgo * 1e2) / 1e2;
+		__private.lastReceipt.secondsAgo = timeNow - __private.lastReceipt.timestamp;
 		__private.lastReceipt.stale = (__private.lastReceipt.secondsAgo > constants.blockReceiptTimeOut);
 	}
 

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -734,7 +734,7 @@ Blocks.prototype.lastReceipt = function (lastReceipt) {
 
 	if (__private.lastReceipt) {
 		var timeNow = Math.floor(Date.now() / 1000);
-		__private.lastReceipt.timestamp = Math.floor( __private.lastReceipt / 1000);
+		__private.lastReceipt.timestamp = Math.floor(__private.lastReceipt / 1000);
 		__private.lastReceipt.secondsAgo = timeNow - __private.lastReceipt.timestamp;
 		__private.lastReceipt.stale = (__private.lastReceipt.secondsAgo > constants.blockReceiptTimeOut);
 	}

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -56,6 +56,10 @@ function Blocks (cb, scope) {
 	});
 }
 
+/**
+ * PUBLIC METHODS
+ */
+
 Blocks.prototype.lastBlock = {
 	get: function () {
 		return __private.lastBlock;
@@ -64,11 +68,41 @@ Blocks.prototype.lastBlock = {
 		__private.lastBlock = lastBlock;
 		return __private.lastBlock;
 	},
+	/**
+	 * Returns status of last block - if it fresh or not
+	 *
+	 * @public
+	 * @method lastBlock.isFresh
+	 * @return {Boolean} Fresh status of last block
+	 */
 	isFresh: function () {
 		if (!__private.lastBlock) { return false; }
 		// Current time in seconds - (epoch start in seconds + block timestamp)
 		var secondsAgo = Math.floor(Date.now() / 1000) - (Math.floor(constants.epochTime / 1000) + __private.lastBlock.timestamp);
 		return (secondsAgo < constants.blockReceiptTimeOut);
+	}
+};
+
+Blocks.prototype.lastReceipt = {
+	get: function () {
+		return __private.lastReceipt;
+	},
+	update: function () {
+		__private.lastReceipt = Math.floor(Date.now / 1000);
+		return __private.lastReceipt;
+	}
+	/**
+	 * Returns status of last receipt - if it stale or not
+	 *
+	 * @public
+	 * @method lastReceipt.isStale
+	 * @return {Boolean} Stale status of last receipt
+	 */
+	isStale: function () {
+		if (!__private.lastReceipt) { return true; }
+		// Current time in seconds - lastReceipt (seconds)
+		var secondsAgo = Math.floor(Date.now() / 1000) - __private.lastReceipt;
+		return (secondsAgo > constants.blockReceiptTimeOut);
 	}
 };
 
@@ -86,35 +120,6 @@ Blocks.prototype.isCleaning = {
 	get: function () {
 		return __private.cleanup;
 	}
-};
-
-/**
- * PUBLIC METHODS
- */
-
-/**
- * Returns last receipt - indicator how long ago last block was received
- *
- * @public
- * @method lastReceipt
- * @param  {Object} [lastReceipt] Last receipt, if supplied - global one will be overwritten
- * @return {Object} lastReceipt Last receipt
- */
-Blocks.prototype.lastReceipt = function (lastReceipt) {
-	//TODO: Should public methods modify module's global object directly?
-	if (lastReceipt) {
-		__private.lastReceipt = {timestamp: Math.floor(lastReceipt / 1000)};
-	}
-
-	if (__private.lastReceipt) {
-		// Recalculate how long ago we received a block
-		var timeNow = Math.floor(Date.now() / 1000);
-		__private.lastReceipt.secondsAgo = timeNow - __private.lastReceipt.timestamp;
-		// Mark if last receipt is stale - that is used to trigger sync in case we not received a block for long
-		__private.lastReceipt.stale = (__private.lastReceipt.secondsAgo > constants.blockReceiptTimeOut);
-	}
-
-	return __private.lastReceipt;
 };
 
 /**

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -418,7 +418,7 @@ __private.receiveBlock = function (block, cb) {
 	].join(' '));
 
 	// Update last receipt
-	modules.blocks.lastReceipt(Date.now());
+	modules.blocks.lastReceipt.update();
 	// Start block processing - broadcast: true, saveBlock: true
 	modules.blocks.verify.processBlock(block, true, cb, true);
 };

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -131,7 +131,7 @@ __private.forge = function (cb) {
 			if (err) {
 				library.logger.error('Failed to generate block within delegate slot', err);
 			} else {
-				modules.blocks.lastReceipt(new Date());
+				modules.blocks.lastReceipt(Date.now());
 
 				library.logger.info([
 					'Forged new block id:',

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -163,7 +163,7 @@ __private.forge = function (cb) {
 				library.logger.error('Failed to generate block within delegate slot', err);
 			} else {
 				var forgedBlock = modules.blocks.lastBlock.get();
-				modules.blocks.lastReceipt(Date.now());
+				modules.blocks.lastReceipt.update();
 
 				library.logger.info([
 					'Forged new block id:', forgedBlock.id,

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -120,7 +120,7 @@ __private.forge = function (cb) {
 	}
 
 	var currentSlot = slots.getSlotNumber();
-	var lastBlock = modules.blocks.getLastBlock();
+	var lastBlock = modules.blocks.lastBlock.get();
 
 	if (currentSlot === slots.getSlotNumber(lastBlock.timestamp)) {
 		library.logger.debug('Waiting for next delegate slot');
@@ -162,15 +162,15 @@ __private.forge = function (cb) {
 			if (err) {
 				library.logger.error('Failed to generate block within delegate slot', err);
 			} else {
+				var forgedBlock = modules.blocks.lastBlock.get();
 				modules.blocks.lastReceipt(Date.now());
 
 				library.logger.info([
-					'Forged new block id:',
-					modules.blocks.getLastBlock().id,
-					'height:', modules.blocks.getLastBlock().height,
-					'round:', modules.rounds.calc(modules.blocks.getLastBlock().height),
+					'Forged new block id:', forgedBlock.id,
+					'height:', forgedBlock.height,
+					'round:', modules.rounds.calc(forgedBlock.height),
 					'slot:', slots.getSlotNumber(currentBlockData.time),
-					'reward:' + modules.blocks.getLastBlock().reward
+					'reward:' + forgedBlock.reward
 				].join(' '));
 			}
 
@@ -375,7 +375,7 @@ Delegates.prototype.getDelegates = function (query, cb) {
 		var length = Math.min(limit, count);
 		var realLimit = Math.min(offset + limit, count);
 
-		var lastBlock   = modules.blocks.getLastBlock(),
+		var lastBlock   = modules.blocks.lastBlock.get(),
 		    totalSupply = __private.blockReward.calcSupply(lastBlock.height);
 
 		for (var i = 0; i < delegates.length; i++) {
@@ -696,7 +696,7 @@ Delegates.prototype.shared = {
 	},
 
 	getNextForgers: function (req, cb) {
-		var currentBlock = modules.blocks.getLastBlock ();
+		var currentBlock = modules.blocks.lastBlock.get();
 		var limit = req.body.limit || 10;
 
 		modules.delegates.generateDelegateList(currentBlock.height, function (err, activeDelegates) {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -87,7 +87,8 @@ __private.syncTrigger = function (turnOn) {
 /**
  * Syncs timer trigger.
  * @private
- * @implements {modules.blocks.lastReceipt}
+ * @implements {modules.blocks.lastReceipt.get}
+ * @implements {modules.blocks.lastReceipt.isStale}
  * @implements {Loader.syncing}
  * @implements {library.sequence.add}
  * @implements {async.retry}
@@ -96,10 +97,9 @@ __private.syncTrigger = function (turnOn) {
 __private.syncTimer = function () {
 	library.logger.trace('Setting sync timer');
 	setImmediate(function nextSync () {
-		var lastReceipt = modules.blocks.lastReceipt();
-		library.logger.trace('Sync timer trigger', {loaded: __private.loaded, syncing: self.syncing(), last_receipt: lastReceipt});
+		library.logger.trace('Sync timer trigger', {loaded: __private.loaded, syncing: self.syncing(), last_receipt: modules.blocks.lastReceipt.get()});
 
-		if (__private.loaded && !self.syncing() && (!lastReceipt || lastReceipt.stale)) {
+		if (__private.loaded && !self.syncing() && modules.blocks.lastReceipt.isStale()) {
 			library.sequence.add(function (cb) {
 				async.retry(__private.retries, __private.sync, cb);
 			}, function (err) {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -61,7 +61,7 @@ __private.initialize = function () {
  * next sync with 1000 milliseconds.
  * @private
  * @implements {library.network.io.sockets.emit}
- * @implements {modules.blocks.getLastBlock}
+ * @implements {modules.blocks.lastBlock.get}
  * @param {boolean} turnOn
  * @emits loader/sync
  */
@@ -77,7 +77,7 @@ __private.syncTrigger = function (turnOn) {
 			library.logger.trace('Sync trigger');
 			library.network.io.sockets.emit('loader/sync', {
 				blocks: __private.blocksToSync,
-				height: modules.blocks.getLastBlock().height
+				height: modules.blocks.lastBlock.get().height
 			});
 			__private.syncIntervalId = setTimeout(nextSyncTrigger, 1000);
 		});
@@ -484,7 +484,7 @@ __private.loadBlockChain = function () {
  * @private
  * @implements {Loader.getNetwork}
  * @implements {async.whilst}
- * @implements {modules.blocks.getLastBlock}
+ * @implements {modules.blocks.lastBlock.get}
  * @implements {modules.blocks.loadBlocksFromPeer}
  * @implements {modules.blocks.getCommonBlock}
  * @param {function} cb
@@ -504,7 +504,7 @@ __private.loadBlocksFromNetwork = function (cb) {
 				},
 				function (next) {
 					var peer = network.peers[Math.floor(Math.random() * network.peers.length)];
-					var lastBlock = modules.blocks.getLastBlock();
+					var lastBlock = modules.blocks.lastBlock.get();
 
 					function loadBlocks () {
 						__private.blocksToSync = peer.height;
@@ -620,13 +620,13 @@ __private.sync = function (cb) {
 /**
  * Gets the list of good peers. 
  * @private
- * @implements {modules.blocks.getLastBlock}
+ * @implements {modules.blocks.lastBlock.get}
  * @implements {library.logic.peers.create}
  * @param {number} heights
  * @return {Object} {height number, peers array}
  */
 __private.findGoodPeers = function (heights) {
-	var lastBlockHeight = modules.blocks.getLastBlock().height;
+	var lastBlockHeight = modules.blocks.lastBlock.get().height;
 	library.logger.trace('Good peers - received', {count: heights.length});
 
 	heights = heights.filter(function (item) {
@@ -685,14 +685,14 @@ __private.findGoodPeers = function (heights) {
 // - With this list we try to get a peer with sensibly good blockchain height (see __private.findGoodPeers for actual strategy).
 /**
  * Gets good peers.
- * @implements {modules.blocks.getLastBlock}
+ * @implements {modules.blocks.lastBlock.get}
  * @implements {modules.peers.list}
  * @implements {__private.findGoodPeers}
  * @param {function} cb
  * @return {setImmediateCallback} err | __private.network (good peers)
  */
 Loader.prototype.getNetwork = function (cb) {
-	if (__private.network.height > 0 && Math.abs(__private.network.height - modules.blocks.getLastBlock().height) === 1) {
+	if (__private.network.height > 0 && Math.abs(__private.network.height - modules.blocks.lastBlock.get().height) === 1) {
 		return setImmediate(cb, null, __private.network);
 	}
 
@@ -829,8 +829,7 @@ Loader.prototype.cleanup = function (cb) {
  */
 Loader.prototype.internal = {
 	statusPing: function () {
-		var lastBlock = modules.blocks.getLastBlock();
-		return lastBlock && lastBlock.fresh;
+		return modules.blocks.lastBlock.isFresh();
 	}
 };
 
@@ -852,7 +851,7 @@ Loader.prototype.shared = {
 		return setImmediate(cb, null, {
 			syncing: self.syncing(),
 			blocks: __private.blocksToSync,
-			height: modules.blocks.getLastBlock().height,
+			height: modules.blocks.lastBlock.get().height,
 			broadhash: modules.system.getBroadhash(),
 			consensus: modules.transport.consensus()
 		});

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -272,10 +272,12 @@ Rounds.prototype.onBind = function (scope) {
 };
 
 /**
- * Calculates round and calls sumRound.
- * @implements {calc}
- * @implements {modules.blocks.getLastBlock}
- * @implements {__private.sumRound}
+ * Sets private variable loaded to true.
+ *
+ * @public
+ * @method  onBlockchainReady
+ * @listens module:loader~event:blockchainReady
+ * @param   {block}   block New block
  */
 Rounds.prototype.onBlockchainReady = function () {
 	__private.loaded = true;

--- a/modules/system.js
+++ b/modules/system.js
@@ -173,7 +173,7 @@ System.prototype.getBroadhash = function (cb) {
  * Updates private broadhash and height values.
  * @implements {async.series}
  * @implements {System.getBroadhash}
- * @implements {modules.blocks.getLastBlock}
+ * @implements {modules.blocks.lastBlock.get}
  * @implements {modules.transport.headers}
  * @param {function} cb Callback function
  * @return {setImmediateCallback} cb, err
@@ -190,7 +190,7 @@ System.prototype.update = function (cb) {
 			});
 		},
 		getHeight: function (seriesCb) {
-			__private.height = modules.blocks.getLastBlock().height;
+			__private.height = modules.blocks.lastBlock.get().height;
 			return setImmediate(seriesCb);
 		}
 	}, function (err) {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -604,7 +604,7 @@ Transport.prototype.internal = {
 
 // Shared API
 shared.message = function (msg, cb) {
-	msg.timestamp = Date.now();
+	msg.timestamp = Math.floor(Date.now() / 1000);
 	msg.hash = __private.hashsum(msg.body, msg.timestamp);
 
 	__private.broadcaster.enqueue({dappid: msg.dappid}, {api: '/dapp/message', data: msg, method: 'POST'});
@@ -613,7 +613,7 @@ shared.message = function (msg, cb) {
 };
 
 shared.request = function (msg, cb) {
-	msg.timestamp = Date.now();
+	msg.timestamp = Math.floor(Date.now() / 1000);
 	msg.hash = __private.hashsum(msg.body, msg.timestamp);
 
 	if (msg.body.peer) {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -603,7 +603,7 @@ Transport.prototype.internal = {
 	},
 
 	height: function (req, cb) {
-		return setImmediate(cb, null, {success: true, height: modules.blocks.getLastBlock().height});
+		return setImmediate(cb, null, {success: true, height: modules.blocks.lastBlock.get().height});
 	},
 
 	ping: function (req, cb) {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -604,7 +604,7 @@ Transport.prototype.internal = {
 
 // Shared API
 shared.message = function (msg, cb) {
-	msg.timestamp = (new Date()).getTime();
+	msg.timestamp = Date.now();
 	msg.hash = __private.hashsum(msg.body, msg.timestamp);
 
 	__private.broadcaster.enqueue({dappid: msg.dappid}, {api: '/dapp/message', data: msg, method: 'POST'});
@@ -613,7 +613,7 @@ shared.message = function (msg, cb) {
 };
 
 shared.request = function (msg, cb) {
-	msg.timestamp = (new Date()).getTime();
+	msg.timestamp = Date.now();
 	msg.hash = __private.hashsum(msg.body, msg.timestamp);
 
 	if (msg.body.peer) {

--- a/test/api/peer.transactions.delegates.js
+++ b/test/api/peer.transactions.delegates.js
@@ -85,7 +85,7 @@ describe('POST /peer/transactions', function () {
 			});
 
 			it('using uppercase username should fail', function (done) {
-				account.username = node.randomDelegateName().toUpperCase();
+				account.username = 'UPPER_DELEGATE';
 				var transaction = node.lisk.delegate.createDelegate(account.password, account.username);
 
 				postTransaction(transaction, function (err, res) {

--- a/test/node.js
+++ b/test/node.js
@@ -334,7 +334,11 @@ function abstractRequest (options, done) {
 		request.send(options.params);
 	}
 
-	node.debug(['> Path:'.grey, options.verb.toUpperCase(), options.path].join(' '));
+	var verb = options.verb.toUpperCase();
+	node.debug(['> Path:'.grey, verb, options.path].join(' '));
+	if (verb === 'POST' || verb === 'PUT') {
+		node.debug(['> Data:'.grey, JSON.stringify(options.params)].join(' '));
+	}
 
 	if (done) {
 		request.end(function (err, res) {


### PR DESCRIPTION
Replacement of new Date() with Date.now() when possible:
> Date.now() === new Date().getTime()

**Pendings**:
* logger.js
`timestamp: strftime('%F %T', new Date())` because **strftime** uses `date.getTime`.
* transactionPool.js
`transaction.receivedAt = new Date();` because later it uses `receivedAt.toUTCString()` to log.

Closes #448