### PR TITLE
Replace new Buffer with .from or .alloc - Closes #559

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,7 +143,7 @@ d.run(function () {
 	async.auto({
 		config: function (cb) {
 			try {
-				appConfig.nethash = new Buffer(genesisblock.payloadHash, 'hex').toString('hex');
+				appConfig.nethash = Buffer.from(genesisblock.payloadHash, 'hex').toString('hex');
 			} catch (e) {
 				logger.error('Failed to assign nethash from genesis block');
 				throw Error(e);

--- a/helpers/bignum.js
+++ b/helpers/bignum.js
@@ -50,7 +50,7 @@ BigNumber.prototype.toBuffer = function ( opts ) {
 		var len = buf.length === 1 && buf[0] === 0 ? 0 : buf.length;
 		if (buf[0] & 0x80) len ++;
 
-		var ret = new Buffer(4 + len);
+		var ret = Buffer.alloc(4 + len);
 		if (len > 0) buf.copy(ret, 4 + (buf[0] & 0x80 ? 1 : 0));
 		if (buf[0] & 0x80) ret[4] = 0;
 
@@ -84,7 +84,7 @@ BigNumber.prototype.toBuffer = function ( opts ) {
 	var size = opts.size === 'auto' ? Math.ceil(hex.length / 2) : (opts.size || 1);
 
 	var len = Math.ceil(hex.length / (2 * size)) * size;
-	var buf = new Buffer(len);
+	var buf = Buffer.alloc(len);
 
 	// Zero-pad the hex string so the chunks are all `size` long
 	while (hex.length < 2 * len) hex = '0' + hex;

--- a/helpers/ed.js
+++ b/helpers/ed.js
@@ -13,7 +13,7 @@ ed.makeKeypair = function (hash) {
 };
 
 ed.sign = function (hash, keypair) {
-	return sodium.crypto_sign_detached(hash, new Buffer(keypair.privateKey, 'hex'));
+	return sodium.crypto_sign_detached(hash, Buffer.from(keypair.privateKey, 'hex'));
 };
 
 ed.verify = function (hash, signatureBuffer, publicKeyBuffer) {

--- a/helpers/z_schema.js
+++ b/helpers/z_schema.js
@@ -29,7 +29,7 @@ z_schema.registerFormat('username', function (str) {
 
 z_schema.registerFormat('hex', function (str) {
 	try {
-		new Buffer(str, 'hex');
+		Buffer.from(str, 'hex');
 	} catch (e) {
 		return false;
 	}
@@ -43,7 +43,7 @@ z_schema.registerFormat('publicKey', function (str) {
 	}
 
 	try {
-		var publicKey = new Buffer(str, 'hex');
+		var publicKey = Buffer.from(str, 'hex');
 
 		return publicKey.length === 32;
 	} catch (e) {
@@ -70,7 +70,7 @@ z_schema.registerFormat('signature', function (str) {
 	}
 
 	try {
-		var signature = new Buffer(str, 'hex');
+		var signature = Buffer.from(str, 'hex');
 		return signature.length === 64;
 	} catch (e) {
 		return false;

--- a/logic/account.js
+++ b/logic/account.js
@@ -420,7 +420,7 @@ Account.prototype.verifyPublicKey = function (publicKey) {
 		}
 		// Check format
 		try {
-			new Buffer(publicKey, 'hex');
+			Buffer.from(publicKey, 'hex');
 		} catch (e) {
 			throw 'Invalid public key, must be a hex string';
 		}
@@ -430,7 +430,7 @@ Account.prototype.verifyPublicKey = function (publicKey) {
 Account.prototype.toDB = function (raw) {
 	this.binary.forEach(function (field) {
 		if (raw[field]) {
-			raw[field] = new Buffer(raw[field], 'hex');
+			raw[field] = Buffer.from(raw[field], 'hex');
 		}
 	});
 

--- a/logic/block.js
+++ b/logic/block.js
@@ -24,7 +24,7 @@ __private.blockReward = new BlockReward();
 
 __private.getAddressByPublicKey = function (publicKey) {
 	var publicKeyHash = crypto.createHash('sha256').update(publicKey, 'hex').digest();
-	var temp = new Buffer(8);
+	var temp = Buffer.alloc(8);
 
 	for (var i = 0; i < 8; i++) {
 		temp[i] = publicKeyHash[7 - i];
@@ -128,18 +128,18 @@ Block.prototype.getBytes = function (block) {
 
 		bb.writeInt(block.payloadLength);
 
-		var payloadHashBuffer = new Buffer(block.payloadHash, 'hex');
+		var payloadHashBuffer = Buffer.from(block.payloadHash, 'hex');
 		for (i = 0; i < payloadHashBuffer.length; i++) {
 			bb.writeByte(payloadHashBuffer[i]);
 		}
 
-		var generatorPublicKeyBuffer = new Buffer(block.generatorPublicKey, 'hex');
+		var generatorPublicKeyBuffer = Buffer.from(block.generatorPublicKey, 'hex');
 		for (i = 0; i < generatorPublicKeyBuffer.length; i++) {
 			bb.writeByte(generatorPublicKeyBuffer[i]);
 		}
 
 		if (block.blockSignature) {
-			var blockSignatureBuffer = new Buffer(block.blockSignature, 'hex');
+			var blockSignatureBuffer = Buffer.from(block.blockSignature, 'hex');
 			for (i = 0; i < blockSignatureBuffer.length; i++) {
 				bb.writeByte(blockSignatureBuffer[i]);
 			}
@@ -160,14 +160,14 @@ Block.prototype.verifySignature = function (block) {
 
 	try {
 		var data = this.getBytes(block);
-		var data2 = new Buffer(data.length - remove);
+		var data2 = Buffer.alloc(data.length - remove);
 
 		for (var i = 0; i < data2.length; i++) {
 			data2[i] = data[i];
 		}
 		var hash = crypto.createHash('sha256').update(data2).digest();
-		var blockSignatureBuffer = new Buffer(block.blockSignature, 'hex');
-		var generatorPublicKeyBuffer = new Buffer(block.generatorPublicKey, 'hex');
+		var blockSignatureBuffer = Buffer.from(block.blockSignature, 'hex');
+		var generatorPublicKeyBuffer = Buffer.from(block.generatorPublicKey, 'hex');
 		res = this.scope.ed.verify(hash, blockSignatureBuffer || ' ', generatorPublicKeyBuffer || ' ');
 	} catch (e) {
 		throw e;
@@ -198,9 +198,9 @@ Block.prototype.dbSave = function (block) {
 	var payloadHash, generatorPublicKey, blockSignature;
 
 	try {
-		payloadHash = new Buffer(block.payloadHash, 'hex');
-		generatorPublicKey = new Buffer(block.generatorPublicKey, 'hex');
-		blockSignature = new Buffer(block.blockSignature, 'hex');
+		payloadHash = Buffer.from(block.payloadHash, 'hex');
+		generatorPublicKey = Buffer.from(block.generatorPublicKey, 'hex');
+		blockSignature = Buffer.from(block.blockSignature, 'hex');
 	} catch (e) {
 		throw e;
 	}
@@ -320,7 +320,7 @@ Block.prototype.objectNormalize = function (block) {
 
 Block.prototype.getId = function (block) {
 	var hash = crypto.createHash('sha256').update(this.getBytes(block)).digest();
-	var temp = new Buffer(8);
+	var temp = Buffer.alloc(8);
 	for (var i = 0; i < 8; i++) {
 		temp[i] = hash[7 - i];
 	}

--- a/logic/dapp.js
+++ b/logic/dapp.js
@@ -163,26 +163,26 @@ DApp.prototype.getBytes = function (trs) {
 	var buf;
 
 	try {
-		buf = new Buffer([]);
-		var nameBuf = new Buffer(trs.asset.dapp.name, 'utf8');
+		buf = Buffer.from([]);
+		var nameBuf = Buffer.from(trs.asset.dapp.name, 'utf8');
 		buf = Buffer.concat([buf, nameBuf]);
 
 		if (trs.asset.dapp.description) {
-			var descriptionBuf = new Buffer(trs.asset.dapp.description, 'utf8');
+			var descriptionBuf = Buffer.from(trs.asset.dapp.description, 'utf8');
 			buf = Buffer.concat([buf, descriptionBuf]);
 		}
 
 		if (trs.asset.dapp.tags) {
-			var tagsBuf = new Buffer(trs.asset.dapp.tags, 'utf8');
+			var tagsBuf = Buffer.from(trs.asset.dapp.tags, 'utf8');
 			buf = Buffer.concat([buf, tagsBuf]);
 		}
 
 		if (trs.asset.dapp.link) {
-			buf = Buffer.concat([buf, new Buffer(trs.asset.dapp.link, 'utf8')]);
+			buf = Buffer.concat([buf, Buffer.from(trs.asset.dapp.link, 'utf8')]);
 		}
 
 		if (trs.asset.dapp.icon) {
-			buf = Buffer.concat([buf, new Buffer(trs.asset.dapp.icon, 'utf8')]);
+			buf = Buffer.concat([buf, Buffer.from(trs.asset.dapp.icon, 'utf8')]);
 		}
 
 		var bb = new ByteBuffer(4 + 4, true);

--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -106,7 +106,7 @@ Delegate.prototype.getBytes = function (trs) {
 	var buf;
 
 	try {
-		buf = new Buffer(trs.asset.delegate.username, 'utf8');
+		buf = Buffer.from(trs.asset.delegate.username, 'utf8');
 	} catch (e) {
 		throw e;
 	}

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -65,8 +65,8 @@ InTransfer.prototype.getBytes = function (trs) {
 	var buf;
 
 	try {
-		buf = new Buffer([]);
-		var nameBuf = new Buffer(trs.asset.inTransfer.dappId, 'utf8');
+		buf = Buffer.from([]);
+		var nameBuf = Buffer.from(trs.asset.inTransfer.dappId, 'utf8');
 		buf = Buffer.concat([buf, nameBuf]);
 	} catch (e) {
 		throw e;

--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -110,7 +110,7 @@ Multisignature.prototype.verify = function (trs, sender, cb) {
 		}
 
 		try {
-			var b = new Buffer(publicKey, 'hex');
+			var b = Buffer.from(publicKey, 'hex');
 			if (b.length !== 32) {
 				return setImmediate(cb, 'Invalid public key in multisignature keysgroup');
 			}
@@ -143,7 +143,7 @@ Multisignature.prototype.process = function (trs, sender, cb) {
 };
 
 Multisignature.prototype.getBytes = function (trs, skip) {
-	var keysgroupBuffer = new Buffer(trs.asset.multisignature.keysgroup.join(''), 'utf8');
+	var keysgroupBuffer = Buffer.from(trs.asset.multisignature.keysgroup.join(''), 'utf8');
 
 	var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
 	bb.writeByte(trs.asset.multisignature.min);

--- a/logic/outTransfer.js
+++ b/logic/outTransfer.js
@@ -89,9 +89,9 @@ OutTransfer.prototype.getBytes = function (trs) {
 	var buf;
 
 	try {
-		buf = new Buffer([]);
-		var dappIdBuf = new Buffer(trs.asset.outTransfer.dappId, 'utf8');
-		var transactionIdBuff = new Buffer(trs.asset.outTransfer.transactionId, 'utf8');
+		buf = Buffer.from([]);
+		var dappIdBuf = Buffer.from(trs.asset.outTransfer.dappId, 'utf8');
+		var transactionIdBuff = Buffer.from(trs.asset.outTransfer.transactionId, 'utf8');
 		buf = Buffer.concat([buf, dappIdBuf, transactionIdBuff]);
 	} catch (e) {
 		throw e;

--- a/logic/signature.js
+++ b/logic/signature.js
@@ -38,7 +38,7 @@ Signature.prototype.verify = function (trs, sender, cb) {
 	}
 
 	try {
-		if (!trs.asset.signature.publicKey || new Buffer(trs.asset.signature.publicKey, 'hex').length !== 32) {
+		if (!trs.asset.signature.publicKey || Buffer.from(trs.asset.signature.publicKey, 'hex').length !== 32) {
 			return setImmediate(cb, 'Invalid public key');
 		}
 	} catch (e) {
@@ -58,7 +58,7 @@ Signature.prototype.getBytes = function (trs) {
 
 	try {
 		bb = new ByteBuffer(32, true);
-		var publicKeyBuffer = new Buffer(trs.asset.signature.publicKey, 'hex');
+		var publicKeyBuffer = Buffer.from(trs.asset.signature.publicKey, 'hex');
 
 		for (var i = 0; i < publicKeyBuffer.length; i++) {
 			bb.writeByte(publicKeyBuffer[i]);
@@ -149,7 +149,7 @@ Signature.prototype.dbSave = function (trs) {
 	var publicKey;
 
 	try {
-		publicKey = new Buffer(trs.asset.signature.publicKey, 'hex');
+		publicKey = Buffer.from(trs.asset.signature.publicKey, 'hex');
 	} catch (e) {
 		throw e;
 	}

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -90,7 +90,7 @@ Transaction.prototype.multisign = function (keypair, trs) {
 
 Transaction.prototype.getId = function (trs) {
 	var hash = this.getHash(trs);
-	var temp = new Buffer(8);
+	var temp = Buffer.alloc(8);
 	for (var i = 0; i < 8; i++) {
 		temp[i] = hash[7 - i];
 	}
@@ -119,13 +119,13 @@ Transaction.prototype.getBytes = function (trs, skipSignature, skipSecondSignatu
 		bb.writeByte(trs.type);
 		bb.writeInt(trs.timestamp);
 
-		var senderPublicKeyBuffer = new Buffer(trs.senderPublicKey, 'hex');
+		var senderPublicKeyBuffer = Buffer.from(trs.senderPublicKey, 'hex');
 		for (i = 0; i < senderPublicKeyBuffer.length; i++) {
 			bb.writeByte(senderPublicKeyBuffer[i]);
 		}
 
 		if (trs.requesterPublicKey) {
-			var requesterPublicKey = new Buffer(trs.requesterPublicKey, 'hex');
+			var requesterPublicKey = Buffer.from(trs.requesterPublicKey, 'hex');
 			for (i = 0; i < requesterPublicKey.length; i++) {
 				bb.writeByte(requesterPublicKey[i]);
 			}
@@ -153,14 +153,14 @@ Transaction.prototype.getBytes = function (trs, skipSignature, skipSecondSignatu
 		}
 
 		if (!skipSignature && trs.signature) {
-			var signatureBuffer = new Buffer(trs.signature, 'hex');
+			var signatureBuffer = Buffer.from(trs.signature, 'hex');
 			for (i = 0; i < signatureBuffer.length; i++) {
 				bb.writeByte(signatureBuffer[i]);
 			}
 		}
 
 		if (!skipSecondSignature && trs.signSignature) {
-			var signSignatureBuffer = new Buffer(trs.signSignature, 'hex');
+			var signSignatureBuffer = Buffer.from(trs.signSignature, 'hex');
 			for (i = 0; i < signSignatureBuffer.length; i++) {
 				bb.writeByte(signSignatureBuffer[i]);
 			}
@@ -495,15 +495,15 @@ Transaction.prototype.verifyBytes = function (bytes, publicKey, signature) {
 	var res;
 
 	try {
-		var data2 = new Buffer(bytes.length);
+		var data2 = Buffer.alloc(bytes.length);
 
 		for (var i = 0; i < data2.length; i++) {
 			data2[i] = bytes[i];
 		}
 
 		var hash = crypto.createHash('sha256').update(data2).digest();
-		var signatureBuffer = new Buffer(signature, 'hex');
-		var publicKeyBuffer = new Buffer(publicKey, 'hex');
+		var signatureBuffer = Buffer.from(signature, 'hex');
+		var publicKeyBuffer = Buffer.from(publicKey, 'hex');
 
 		res = this.scope.ed.verify(hash, signatureBuffer || ' ', publicKeyBuffer || ' ');
 	} catch (e) {
@@ -663,10 +663,10 @@ Transaction.prototype.dbSave = function (trs) {
 	var senderPublicKey, signature, signSignature, requesterPublicKey;
 
 	try {
-		senderPublicKey = new Buffer(trs.senderPublicKey, 'hex');
-		signature = new Buffer(trs.signature, 'hex');
-		signSignature = trs.signSignature ? new Buffer(trs.signSignature, 'hex') : null;
-		requesterPublicKey = trs.requesterPublicKey ? new Buffer(trs.requesterPublicKey, 'hex') : null;
+		senderPublicKey = Buffer.from(trs.senderPublicKey, 'hex');
+		signature = Buffer.from(trs.signature, 'hex');
+		signSignature = trs.signSignature ? Buffer.from(trs.signSignature, 'hex') : null;
+		requesterPublicKey = trs.requesterPublicKey ? Buffer.from(trs.requesterPublicKey, 'hex') : null;
 	} catch (e) {
 		throw e;
 	}

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -116,7 +116,7 @@ Vote.prototype.getBytes = function (trs) {
 	var buf;
 
 	try {
-		buf = trs.asset.votes ? new Buffer(trs.asset.votes.join(''), 'utf8') : null;
+		buf = trs.asset.votes ? Buffer.from(trs.asset.votes.join(''), 'utf8') : null;
 	} catch (e) {
 		throw e;
 	}

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -63,7 +63,7 @@ __private.openAccount = function (secret, cb) {
 // Public methods
 Accounts.prototype.generateAddressByPublicKey = function (publicKey) {
 	var publicKeyHash = crypto.createHash('sha256').update(publicKey, 'hex').digest();
-	var temp = new Buffer(8);
+	var temp = Buffer.alloc(8);
 
 	for (var i = 0; i < 8; i++) {
 		temp[i] = publicKeyHash[7 - i];

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -180,7 +180,7 @@ __private.checkDelegates = function (publicKey, votes, state, cb) {
 			var publicKey = action.slice(1);
 
 			try {
-				new Buffer(publicKey, 'hex');
+				Buffer.from(publicKey, 'hex');
 			} catch (e) {
 				library.logger.error(e.stack);
 				return setImmediate(cb, 'Invalid public key');

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -183,7 +183,7 @@ __private.dbSave = function (cb) {
 	var cs = new pgp.helpers.ColumnSet([
 		'ip', 'port', 'state', 'height', 'os', 'version', 'clock',
 		{name: 'broadhash', init: function (col) {
-			return col.value ? new Buffer(col.value, 'hex') : null;
+			return col.value ? Buffer.from(col.value, 'hex') : null;
 		}}
 	], {table: 'peers'});
 

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -33,9 +33,9 @@ function Transport (cb, scope) {
 
 // Private methods
 __private.hashsum = function (obj) {
-	var buf = new Buffer(JSON.stringify(obj), 'utf8');
+	var buf = Buffer.from(JSON.stringify(obj), 'utf8');
 	var hashdig = crypto.createHash('sha256').update(buf).digest();
-	var temp = new Buffer(8);
+	var temp = Buffer.alloc(8);
 	for (var i = 0; i < 8; i++) {
 		temp[i] = hashdig[7 - i];
 	}


### PR DESCRIPTION
* `new Buffer(array)` - Deprecated: Use `Buffer.from(array)` instead.
* `new Buffer(buffer)` - Deprecated: Use `Buffer.from(buffer`) instead.
* `new Buffer(arrayBuffer[, byteOffset [, length]])`  - Deprecated: Use `Buffer.from(arrayBuffer[, byteOffset [, length]])` instead.
* `new Buffer(size)` - Deprecated: Use `Buffer.alloc()` instead (also see `Buffer.allocUnsafe()`).

**Note**: `alloc` instead of `allocUnsafe` because pre-fills the new Buffer with `0`.

Closes #559