### PR TITLE
Split scope (closure reduction) - Closes #555

### DIFF
--- a/app.js
+++ b/app.js
@@ -472,18 +472,18 @@ d.run(function () {
 						block: genesisblock
 					});
 				},
-				account: ['db', 'bus', 'ed', 'schema', 'genesisblock', function (scope, cb) {
+				account: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'logger', function (scope, cb) {
 					new Account(scope.db, scope.schema, scope.logger, cb);
 				}],
-				transaction: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', function (scope, cb) {
+				transaction: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', 'logger', function (scope, cb) {
 					new Transaction(scope.db, scope.ed, scope.schema, scope.genesisblock, scope.account, scope.logger, cb);
 				}],
 				block: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', 'transaction', function (scope, cb) {
 					new Block(scope.ed, scope.schema, scope.transaction, cb);
 				}],
-				peers: function (cb) {
+				peers: ['logger', function (scope, cb) {
 					new Peers(scope.logger, cb);
-				}
+				}]
 			}, cb);
 		}],
 

--- a/app.js
+++ b/app.js
@@ -548,7 +548,7 @@ d.run(function () {
 
 		ready: ['modules', 'bus', 'logic', function (scope, cb) {
 			scope.bus.message('bind', scope.modules);
-			scope.logic.transaction.bindModules(scope.modules);
+			scope.logic.transaction.bindModules(scope.modules.rounds);
 			scope.logic.peers.bind(scope);
 			cb();
 		}],

--- a/app.js
+++ b/app.js
@@ -479,10 +479,10 @@ d.run(function () {
 					new Transaction(scope.db, scope.ed, scope.schema, scope.genesisblock, scope.account, scope.logger, cb);
 				}],
 				block: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', 'transaction', function (scope, cb) {
-					new Block(scope, cb);
+					new Block(scope.ed, scope.schema, scope.transaction, cb);
 				}],
 				peers: function (cb) {
-					new Peers(scope, cb);
+					new Peers(scope.logger, cb);
 				}
 			}, cb);
 		}],

--- a/app.js
+++ b/app.js
@@ -473,10 +473,10 @@ d.run(function () {
 					});
 				},
 				account: ['db', 'bus', 'ed', 'schema', 'genesisblock', function (scope, cb) {
-					new Account(scope, cb);
+					new Account(scope.db, scope.schema, scope.genesisblock, scope.logger, cb);
 				}],
 				transaction: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', function (scope, cb) {
-					new Transaction(scope, cb);
+					new Transaction(scope.db, scope.ed, scope.schema, scope.genesisblock, scope.account, scope.logger, cb);
 				}],
 				block: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', 'transaction', function (scope, cb) {
 					new Block(scope, cb);

--- a/app.js
+++ b/app.js
@@ -473,7 +473,7 @@ d.run(function () {
 					});
 				},
 				account: ['db', 'bus', 'ed', 'schema', 'genesisblock', function (scope, cb) {
-					new Account(scope.db, scope.schema, scope.genesisblock, scope.logger, cb);
+					new Account(scope.db, scope.schema, scope.logger, cb);
 				}],
 				transaction: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', function (scope, cb) {
 					new Transaction(scope.db, scope.ed, scope.schema, scope.genesisblock, scope.account, scope.logger, cb);

--- a/docs/typedef/components.js
+++ b/docs/typedef/components.js
@@ -1,0 +1,19 @@
+/**
+ * Handles module content
+ * @typedef {Object} modules
+ * @property {Accounts} accounts
+ * @property {Blocks} blocks
+ * @property {Crypto} crypto
+ * @property {DApps} dapps
+ * @property {Delegates} delegates
+ * @property {Loader} loader
+ * @property {Multisignatures} multisignatures
+ * @property {Peers} peers
+ * @property {Rounds} rounds
+ * @property {Server} server
+ * @property {Signatures} signatures
+ * @property {Sql} sql
+ * @property {System} system
+ * @property {Transactions} transactions
+ * @property {transport} Transport
+ */

--- a/logic/account.js
+++ b/logic/account.js
@@ -24,13 +24,13 @@ var self, library, __private = {};
  */
 function Account (db, schema, logger, cb) {
 	this.scope = {
-		db,
-		schema,
+		db: db,
+		schema: schema,
 	};
 
 	self = this;
 	library = {
-		logger,
+		logger: logger,
 	};
 
 	this.table = 'mem_accounts';

--- a/logic/account.js
+++ b/logic/account.js
@@ -9,7 +9,7 @@ var constants = require('../helpers/constants.js');
 var slots = require('../helpers/slots.js');
 
 // Private fields
-var self, db, library, __private = {}, genesisBlock = null;
+var self, library, __private = {};
 
 /**
  * Main account logic.
@@ -31,11 +31,9 @@ function Account (db, schema, genesisblock, logger, cb) {
 	};
 
 	self = this;
-	db = this.scope.db;
 	library = {
 		logger,
 	};
-	genesisBlock = this.scope.genesisblock.block;
 
 	this.table = 'mem_accounts';
 	/**
@@ -424,7 +422,7 @@ function Account (db, schema, genesisblock, logger, cb) {
 Account.prototype.createTables = function (cb) {
 	var sql = new pgp.QueryFile(path.join(process.cwd(), 'sql', 'memoryTables.sql'), {minify: true});
 
-	db.query(sql).then(function () {
+	this.scope.db.query(sql).then(function () {
 		return setImmediate(cb);
 	}).catch(function (err) {
 		library.logger.error(err.stack);
@@ -458,7 +456,7 @@ Account.prototype.removeTables = function (cb) {
 			sqles.push(sql.query);
 		});
 
-	db.query(sqles.join('')).then(function () {
+	this.scope.db.query(sqles.join('')).then(function () {
 		return setImmediate(cb);
 	}).catch(function (err) {
 		library.logger.error(err.stack);
@@ -610,7 +608,7 @@ Account.prototype.getAll = function (filter, fields, cb) {
 		fields: realFields
 	});
 
-	db.query(sql.query, sql.values).then(function (rows) {
+	this.scope.db.query(sql.query, sql.values).then(function (rows) {
 		return setImmediate(cb, null, rows);
 	}).catch(function (err) {
 		library.logger.error(err.stack);
@@ -641,7 +639,7 @@ Account.prototype.set = function (address, fields, cb) {
 		modifier: this.toDB(fields)
 	});
 
-	db.none(sql.query, sql.values).then(function () {
+	this.scope.db.none(sql.query, sql.values).then(function () {
 		return setImmediate(cb);
 	}).catch(function (err) {
 		library.logger.error(err.stack);
@@ -883,7 +881,7 @@ Account.prototype.merge = function (address, diff, cb) {
 		return done();
 	}
 
-	db.none(queries).then(function () {
+	this.scope.db.none(queries).then(function () {
 		return done();
 	}).catch(function (err) {
 		library.logger.error(err.stack);
@@ -905,7 +903,7 @@ Account.prototype.remove = function (address, cb) {
 			address: address
 		}
 	});
-	db.none(sql.query, sql.values).then(function () {
+	this.scope.db.none(sql.query, sql.values).then(function () {
 		return setImmediate(cb, null, address);
 	}).catch(function (err) {
 		library.logger.error(err.stack);

--- a/logic/account.js
+++ b/logic/account.js
@@ -16,16 +16,25 @@ var self, db, library, __private = {}, genesisBlock = null;
  * @memberof module:accounts
  * @class
  * @classdesc Main account logic.
- * @param {scope} scope - App instance.
+ * @param {function} db
+ * @param {function} schema
+ * @param {function} genesisblock
+ * @param {function} logger
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */
-function Account (scope, cb) {
-	this.scope = scope;
+function Account (db, schema, genesisblock, logger, cb) {
+	this.scope = {
+		db,
+		schema,
+		genesisblock,
+	};
 
 	self = this;
 	db = this.scope.db;
-	library = this.scope.library;
+	library = {
+		logger,
+	};
 	genesisBlock = this.scope.genesisblock.block;
 
 	this.table = 'mem_accounts';

--- a/logic/account.js
+++ b/logic/account.js
@@ -18,16 +18,14 @@ var self, library, __private = {};
  * @classdesc Main account logic.
  * @param {function} db
  * @param {function} schema
- * @param {function} genesisblock
  * @param {function} logger
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */
-function Account (db, schema, genesisblock, logger, cb) {
+function Account (db, schema, logger, cb) {
 	this.scope = {
 		db,
 		schema,
-		genesisblock,
 	};
 
 	self = this;

--- a/logic/account.js
+++ b/logic/account.js
@@ -16,9 +16,9 @@ var self, library, __private = {};
  * @memberof module:accounts
  * @class
  * @classdesc Main account logic.
- * @param {function} db
- * @param {function} schema
- * @param {function} logger
+ * @param {Database} db
+ * @param {ZSchema} schema
+ * @param {Object} logger
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */

--- a/logic/block.js
+++ b/logic/block.js
@@ -24,9 +24,9 @@ var __private = {};
 // Constructor
 function Block (ed, schema, transaction, cb) {
 	this.scope = {
-		ed,
-		schema,
-		transaction,
+		ed: ed,
+		schema: schema,
+		transaction: transaction,
 	};
 	if (cb) {
 		return setImmediate(cb, null, this);

--- a/logic/block.js
+++ b/logic/block.js
@@ -8,21 +8,26 @@ var BlockReward = require('../logic/blockReward.js');
 var constants = require('../helpers/constants.js');
 
 // Private fields
-var __private = {}, genesisblock = null;
+var __private = {};
 
 /**
  * Main Block logic.
  * @memberof module:blocks
  * @class
  * @classdesc Main Block logic.
- * @param {scope} scope - App instance.
+ * @param {function} ed
+ * @param {function} schema
+ * @param {function} transaction
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */
 // Constructor
-function Block (scope, cb) {
-	this.scope = scope;
-	genesisblock = this.scope.genesisblock;
+function Block (ed, schema, transaction, cb) {
+	this.scope = {
+		ed,
+		schema,
+		transaction,
+	};
 	if (cb) {
 		return setImmediate(cb, null, this);
 	}

--- a/logic/block.js
+++ b/logic/block.js
@@ -15,9 +15,9 @@ var __private = {};
  * @memberof module:blocks
  * @class
  * @classdesc Main Block logic.
- * @param {function} ed
- * @param {function} schema
- * @param {function} transaction
+ * @param {Object} ed
+ * @param {ZSchema} schema
+ * @param {Transaction} transaction
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */

--- a/logic/blockReward.js
+++ b/logic/blockReward.js
@@ -6,13 +6,13 @@ var constants = require('../helpers/constants.js');
 var __private = {};
 
 /**
- * Main BlockReward logic.
- * @memberof module:blocks
- * @class
- * @classdesc Initializes variables:
+ * Initializes variables:
  * - milestones
  * - distance
  * - rewardOffset
+ * @memberof module:blocks
+ * @class
+ * @classdesc Main BlockReward logic.
  */
 // Constructor
 function BlockReward () {

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -15,11 +15,27 @@ var modules, library, self, __private = {};
  * @classdesc Initializes variables, sets Broadcast routes and timer based on
  * broadcast interval from config file.
  * @implements {__private.releaseQueue}
- * @param {scope} scope - App instance.
+ * @param {Object} broadcasts
+ * @param {boolean} force
+ * @param {Peers} peers - from logic, Peers instance
+ * @param {Transaction} transaction - from logic, Transaction instance
+ * @param {Object} logger
  */
 // Constructor
-function Broadcaster (scope) {
-	library = scope;
+function Broadcaster (broadcasts, force, peers, transaction, logger) {
+	library = {
+		config: {
+			broadcasts,
+			forging: {
+				force,
+			},
+		},
+		logic: {
+			peers,
+			transaction,
+		},
+		logger,
+	};
 	self = this;
 
 	self.queue = [];

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -9,11 +9,11 @@ var _ = require('lodash');
 var modules, library, self, __private = {};
 
 /**
- * Main Broadcaster logic.
+ * Initializes variables, sets Broadcast routes and timer based on
+ * broadcast interval from config file.
  * @memberof module:transport
  * @class
- * @classdesc Initializes variables, sets Broadcast routes and timer based on
- * broadcast interval from config file.
+ * @classdesc Main Broadcaster logic.
  * @implements {__private.releaseQueue}
  * @param {Object} broadcasts
  * @param {boolean} force

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -25,15 +25,15 @@ var modules, library, self, __private = {};
 function Broadcaster (broadcasts, force, peers, transaction, logger) {
 	library = {
 		logger,
+		logic: {
+			peers,
+			transaction,
+		},
 		config: {
 			broadcasts,
 			forging: {
 				force,
 			},
-		},
-		logic: {
-			peers,
-			transaction,
 		},
 	};
 	self = this;

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -78,11 +78,17 @@ function Broadcaster (broadcasts, force, peers, transaction, logger) {
 
 // Public methods
 /**
- * Binds scope to private variable modules.
- * @param {scope} scope - App instance.
+ * Binds input parameters to private variables modules.
+ * @param {Peers} peers
+ * @param {Transport} transport
+ * @param {Transactions} transactions
  */
-Broadcaster.prototype.bind = function (scope) {
-	modules = scope;
+Broadcaster.prototype.bind = function (peers, transport, transactions) {
+	modules = {
+		peers,
+		transport,
+		transactions,
+	};
 };
 
 /**

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -24,6 +24,7 @@ var modules, library, self, __private = {};
 // Constructor
 function Broadcaster (broadcasts, force, peers, transaction, logger) {
 	library = {
+		logger,
 		config: {
 			broadcasts,
 			forging: {
@@ -34,7 +35,6 @@ function Broadcaster (broadcasts, force, peers, transaction, logger) {
 			peers,
 			transaction,
 		},
-		logger,
 	};
 	self = this;
 

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -24,15 +24,15 @@ var modules, library, self, __private = {};
 // Constructor
 function Broadcaster (broadcasts, force, peers, transaction, logger) {
 	library = {
-		logger,
+		logger: logger,
 		logic: {
-			peers,
-			transaction,
+			peers: peers,
+			transaction: transaction,
 		},
 		config: {
-			broadcasts,
+			broadcasts: broadcasts,
 			forging: {
-				force,
+				force: force,
 			},
 		},
 	};
@@ -85,9 +85,9 @@ function Broadcaster (broadcasts, force, peers, transaction, logger) {
  */
 Broadcaster.prototype.bind = function (peers, transport, transactions) {
 	modules = {
-		peers,
-		transport,
-		transactions,
+		peers: peers,
+		transport: transport,
+		transactions: transactions,
 	};
 };
 

--- a/logic/dapp.js
+++ b/logic/dapp.js
@@ -26,10 +26,10 @@ __private.unconfirmedAscii = {};
 // Constructor
 function DApp (db, logger, schema, network) {
 	library = {
-		db,
-		logger,
-		schema,
-		network,
+		db: db,
+		logger: logger,
+		schema: schema,
+		network: network,
 	};
 }
 

--- a/logic/dapp.js
+++ b/logic/dapp.js
@@ -17,19 +17,27 @@ __private.unconfirmedAscii = {};
  * Main dapp logic.
  * @memberof module:dapps
  * @class
- * @classdesc Main dapp logic.
+ * @classdesc Initializes library.
+ * @param {Database} db
+ * @param {Object} logger
+ * @param {ZSchema} schema
+ * @param {Object} network
  */
 // Constructor
-function DApp () {}
+function DApp (db, logger, schema, network) {
+	library = {
+		db,
+		logger,
+		schema,
+		network,
+	};
+}
 
 // Public methods
 /**
- * Binds scope.library to private variable library.
- * @param {scope} scope - App instance.
+ * Binds scope.modules to private variable modules.
  */
-DApp.prototype.bind = function (scope) {
-	library = scope.library;
-};
+DApp.prototype.bind = function () {};
 
 /**
  * Creates transaction.asset.dapp based on data.

--- a/logic/dapp.js
+++ b/logic/dapp.js
@@ -14,10 +14,10 @@ __private.unconfirmedLinks = {};
 __private.unconfirmedAscii = {};
 
 /**
- * Main dapp logic.
+ * Initializes library.
  * @memberof module:dapps
  * @class
- * @classdesc Initializes library.
+ * @classdesc Main dapp logic.
  * @param {Database} db
  * @param {Object} logger
  * @param {ZSchema} schema

--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -6,12 +6,17 @@ var constants = require('../helpers/constants.js');
 var modules, library;
 
 /**
- * Main delegate logic.
+ * Initializes library.
  * @memberof module:delegates
  * @class
  * @classdesc Main delegate logic.
+ * @param {ZSchema} schema
  */
-function Delegate () {}
+function Delegate (schema) {
+	library = {
+		schema,
+	};
+}
 
 // Public methods
 /**
@@ -19,7 +24,6 @@ function Delegate () {}
  */
 Delegate.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 };
 
 /**

--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -14,7 +14,7 @@ var modules, library;
  */
 function Delegate (schema) {
 	library = {
-		schema,
+		schema: schema,
 	};
 }
 
@@ -25,7 +25,7 @@ function Delegate (schema) {
  */
 Delegate.prototype.bind = function (accounts) {
 	modules = {
-		accounts,
+		accounts: accounts,
 	};
 };
 

--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -20,10 +20,13 @@ function Delegate (schema) {
 
 // Public methods
 /**
- * @param {scope} scope - App instance.
+ * Binds input parameters to private variables modules.
+ * @param {Accounts} accounts
  */
-Delegate.prototype.bind = function (scope) {
-	modules = scope.modules;
+Delegate.prototype.bind = function (accounts) {
+	modules = {
+		accounts,
+	};
 };
 
 /**

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -27,14 +27,14 @@ function InTransfer (db, schema) {
  * Binds input parameters to private variables modules and shared.
  * @param {Accounts} accounts
  * @param {Rounds} rounds
- * @param {Object} shared
+ * @param {Object} sharedApi
  */
-InTransfer.prototype.bind = function (accounts, rounds, shared) {
+InTransfer.prototype.bind = function (accounts, rounds, sharedApi) {
 	modules = {
 		accounts,
 		rounds,
 	};
-	shared = shared;
+	shared = sharedApi;
 };
 
 /**

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -10,19 +10,25 @@ var modules, library, shared;
  * Main InTransfer logic.
  * @memberof module:dapps
  * @class
- * @classdesc Main InTransfer logic.
+ * @classdesc Initializes library.
+ * @param {Database} db
+ * @param {ZSchema} schema
  */
 // Constructor
-function InTransfer () {}
+function InTransfer (db, schema) {
+	library = {
+		db,
+		schema,
+	};
+}
 
 // Public methods
 /**
- * Binds scope content to private variables modules, library and shared.
+ * Binds scope content to private variables modules and shared.
  * @param {scope} scope - App instance.
  */
 InTransfer.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 	shared = scope.shared;
 };
 

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -7,10 +7,10 @@ var sql = require('../sql/dapps.js');
 var modules, library, shared;
 
 /**
- * Main InTransfer logic.
+ * Initializes library.
  * @memberof module:dapps
  * @class
- * @classdesc Initializes library.
+ * @classdesc Main InTransfer logic.
  * @param {Database} db
  * @param {ZSchema} schema
  */

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -17,8 +17,8 @@ var modules, library, shared;
 // Constructor
 function InTransfer (db, schema) {
 	library = {
-		db,
-		schema,
+		db: db,
+		schem: schema,
 	};
 }
 
@@ -31,8 +31,8 @@ function InTransfer (db, schema) {
  */
 InTransfer.prototype.bind = function (accounts, rounds, sharedApi) {
 	modules = {
-		accounts,
-		rounds,
+		accounts: accounts,
+		rounds: rounds,
 	};
 	shared = sharedApi;
 };

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -18,7 +18,7 @@ var modules, library, shared;
 function InTransfer (db, schema) {
 	library = {
 		db: db,
-		schem: schema,
+		schema: schema,
 	};
 }
 

--- a/logic/inTransfer.js
+++ b/logic/inTransfer.js
@@ -24,12 +24,17 @@ function InTransfer (db, schema) {
 
 // Public methods
 /**
- * Binds scope content to private variables modules and shared.
- * @param {scope} scope - App instance.
+ * Binds input parameters to private variables modules and shared.
+ * @param {Accounts} accounts
+ * @param {Rounds} rounds
+ * @param {Object} shared
  */
-InTransfer.prototype.bind = function (scope) {
-	modules = scope.modules;
-	shared = scope.shared;
+InTransfer.prototype.bind = function (accounts, rounds, shared) {
+	modules = {
+		accounts,
+		rounds,
+	};
+	shared = shared;
 };
 
 /**

--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -12,13 +12,26 @@ var modules, library, __private = {};
 __private.unconfirmedSignatures = {};
 
 /**
- * Main multisignature logic.
+ * Initializes library.
  * @memberof module:multisignatures
  * @class
  * @classdesc Main multisignature logic.
+ * @param {ZSchema} schema
+ * @param {Object} network
+ * @param {Transaction} transaction
+ * @param {Object} logger
  */
 // Constructor
-function Multisignature () {}
+function Multisignature (schema, network, transaction, logger) {
+	library = {
+		logic: {
+			transaction,
+		},
+		schema,
+		network,
+		logger,
+	};
+}
 
 // Public methods
 /**
@@ -26,7 +39,6 @@ function Multisignature () {}
  */
 Multisignature.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 };
 
 /**

--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -24,11 +24,11 @@ __private.unconfirmedSignatures = {};
 // Constructor
 function Multisignature (schema, network, transaction, logger) {
 	library = {
-		schema,
-		network,
-		logger,
+		schema: schema,
+		network: network,
+		logger: logger,
 		logic: {
-			transaction,
+			transaction: transaction,
 		},
 	};
 }
@@ -41,8 +41,8 @@ function Multisignature (schema, network, transaction, logger) {
  */
 Multisignature.prototype.bind = function (rounds, accounts) {
 	modules = {
-		rounds,
-		accounts,
+		rounds: rounds,
+		accounts: accounts,
 	};
 };
 

--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -24,21 +24,26 @@ __private.unconfirmedSignatures = {};
 // Constructor
 function Multisignature (schema, network, transaction, logger) {
 	library = {
-		logic: {
-			transaction,
-		},
 		schema,
 		network,
 		logger,
+		logic: {
+			transaction,
+		},
 	};
 }
 
 // Public methods
 /**
- * @param {scope} scope - App instance.
+ * Binds input parameters to private variable modules
+ * @param {Rounds} rounds
+ * @param {Accounts} accounts
  */
-Multisignature.prototype.bind = function (scope) {
-	modules = scope.modules;
+Multisignature.prototype.bind = function (rounds, accounts) {
+	modules = {
+		rounds,
+		accounts,
+	};
 };
 
 /**

--- a/logic/outTransfer.js
+++ b/logic/outTransfer.js
@@ -9,10 +9,10 @@ var modules, library, __private = {};
 __private.unconfirmedOutTansfers = {};
 
 /**
- * Main OutTransfer logic.
+ * Initializes library.
  * @memberof module:dapps
  * @class
- * @classdesc Initializes library.
+ * @classdesc Main OutTransfer logic.
  * @param {Database} db
  * @param {ZSchema} schema
  * @param {Object} logger

--- a/logic/outTransfer.js
+++ b/logic/outTransfer.js
@@ -28,11 +28,17 @@ function OutTransfer (db, schema, logger) {
 
 // Public methods
 /**
- * Binds scope content to private variables modules and library.
- * @param {scope} scope - App instance.
+ * Binds input modules to private variable module.
+ * @param {Accounts} accounts
+ * @param {Rounds} rounds
+ * @param {Dapps} dapps
  */
-OutTransfer.prototype.bind = function (scope) {
-	modules = scope.modules;
+OutTransfer.prototype.bind = function (accounts, rounds, dapps) {
+	modules = {
+		accounts,
+		rounds,
+		dapps,
+	};
 };
 
 /**

--- a/logic/outTransfer.js
+++ b/logic/outTransfer.js
@@ -12,10 +12,19 @@ __private.unconfirmedOutTansfers = {};
  * Main OutTransfer logic.
  * @memberof module:dapps
  * @class
- * @classdesc Main OutTransfer logic.
+ * @classdesc Initializes library.
+ * @param {Database} db
+ * @param {ZSchema} schema
+ * @param {Object} logger
  */
 // Constructor
-function OutTransfer () {}
+function OutTransfer (db, schema, logger) {
+	library = {
+		db,
+		schema,
+		logger,
+	};
+}
 
 // Public methods
 /**
@@ -24,7 +33,6 @@ function OutTransfer () {}
  */
 OutTransfer.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 };
 
 /**

--- a/logic/outTransfer.js
+++ b/logic/outTransfer.js
@@ -20,9 +20,9 @@ __private.unconfirmedOutTansfers = {};
 // Constructor
 function OutTransfer (db, schema, logger) {
 	library = {
-		db,
-		schema,
-		logger,
+		db: db,
+		schema: schema,
+		logger: logger,
 	};
 }
 
@@ -35,9 +35,9 @@ function OutTransfer (db, schema, logger) {
  */
 OutTransfer.prototype.bind = function (accounts, rounds, dapps) {
 	modules = {
-		accounts,
-		rounds,
-		dapps,
+		accounts: accounts,
+		rounds: rounds,
+		dapps: dapps,
 	};
 };
 

--- a/logic/peer.js
+++ b/logic/peer.js
@@ -4,10 +4,11 @@ var _ = require('lodash');
 var ip = require('ip');
 
 /**
- * Main peer logic.
+ * Creates a peer.
  * @memberof module:peers
  * @class
  * @classdesc Main peer logic.
+ * @implements {Peer.accept}
  * @param {peer} peer
  * @return calls accept method
  */

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -8,11 +8,10 @@ var schema = require('../schema/peers.js');
 // Private fields
 var __private = {};
 var self;
-var modules;
 var library;
 
 /**
- * Main peers logic.
+ * Initializes library.
  * @memberof module:peers
  * @class
  * @classdesc Main peers logic.
@@ -217,11 +216,10 @@ Peers.prototype.list = function (normalize) {
 
 // Public methods
 /**
- * @param {scope} scope - App instance.
+ * Modules are not required in this file.
+ * @param {modules} scope - Loaded modules.
  */
 Peers.prototype.bind = function (scope) {
-	modules = scope.modules;
-	library.logger.trace('Logic/Peers->bind');
 };
 
 // Export

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -16,7 +16,7 @@ var library;
  * @memberof module:peers
  * @class
  * @classdesc Main peers logic.
- * @param {scope} scope - App instance.
+ * @param {Object} logger
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} Callback function with `this` as data.
  */

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -21,8 +21,10 @@ var library;
  * @return {setImmediateCallback} Callback function with `this` as data.
  */
 // Constructor
-function Peers (scope, cb) {
-	library = scope;
+function Peers (logger, cb) {
+	library = {
+		logger,
+	};
 	self = this;
 	__private.peers = {};
 	return setImmediate(cb, null, this);

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -22,7 +22,7 @@ var library;
 // Constructor
 function Peers (logger, cb) {
 	library = {
-		logger,
+		logger: logger,
 	};
 	self = this;
 	__private.peers = {};

--- a/logic/round.js
+++ b/logic/round.js
@@ -20,6 +20,8 @@ function Round (scope, t) {
 		round: scope.round,
 		roundOutsiders: scope.roundOutsiders,
 		roundDelegates: scope.roundDelegates,
+		roundFees: scope.roundFees,
+		roundRewards: scope.roundRewards,
 		library: {
 			logger: scope.library.logger,
 		},

--- a/logic/round.js
+++ b/logic/round.js
@@ -5,17 +5,33 @@ var RoundChanges = require('../helpers/RoundChanges.js');
 var sql = require('../sql/rounds.js');
 
 /**
- * Main Round logic.
+ * Validates required scope properties.
  * @memberof module:rounds
  * @class
  * @classdesc Main Round logic.
  * @param {Object} scope
- * @param {} t
+ * @param {Task} t
  * @constructor
  */
 // Constructor
 function Round (scope, t) {
-	this.scope = scope;
+	this.scope = {
+		backwards: scope.backwards,
+		round: scope.round,
+		roundOutsiders: scope.roundOutsiders,
+		roundDelegates: scope.roundDelegates,
+		library: {
+			logger: scope.library.logger,
+		},
+		modules: {
+			accounts: scope.modules.accounts,
+		},
+		block: {
+			generatorPublicKey: scope.block.generatorPublicKey,
+			id: scope.block.id,
+			height: scope.block.height,
+		},
+	};
 	this.t = t;
 
 	// List of required scope properties

--- a/logic/signature.js
+++ b/logic/signature.js
@@ -23,10 +23,13 @@ function Signature (schema, logger) {
 }
 
 /**
- * @param {scope} scope - App instance.
+ * Binds input parameters to private variable modules
+ * @param {Accounts} accounts
  */
-Signature.prototype.bind = function (scope) {
-	modules = scope.modules;
+Signature.prototype.bind = function (accounts) {
+	modules = {
+		accounts,
+	};
 };
 
 /**

--- a/logic/signature.js
+++ b/logic/signature.js
@@ -17,8 +17,8 @@ var modules, library;
 // Constructor
 function Signature (schema, logger) {
 	library ={
-		schema,
-		logger,
+		schema: schema,
+		logger: logger,
 	};
 }
 
@@ -28,7 +28,7 @@ function Signature (schema, logger) {
  */
 Signature.prototype.bind = function (accounts) {
 	modules = {
-		accounts,
+		accounts: accounts,
 	};
 };
 

--- a/logic/signature.js
+++ b/logic/signature.js
@@ -7,20 +7,26 @@ var constants = require('../helpers/constants.js');
 var modules, library;
 
 /**
- * Main signature logic.
+ * Initializes library.
  * @memberof module:signatures
  * @class
  * @classdesc Main signature logic.
+ * @param {ZSchema} schema
+ * @param {Object} logger
  */
 // Constructor
-function Signature () {}
+function Signature (schema, logger) {
+	library ={
+		schema,
+		logger,
+	};
+}
 
 /**
  * @param {scope} scope - App instance.
  */
 Signature.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 };
 
 /**

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -31,13 +31,25 @@ __private.types = {};
  * @memberof module:transactions
  * @class
  * @classdesc Main transaction logic.
- * @param {scope} scope - App instance.
+ * @param {function} db
+ * @param {function} ed
+ * @param {function} schema
+ * @param {function} genesisblock
+ * @param {function} account
+ * @param {function} logger
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */
 // Constructor
-function Transaction (scope, cb) {
-	this.scope = scope;
+function Transaction (db, ed, schema, genesisblock, account, logger, cb) {
+	this.scope = {
+		db,
+		ed,
+		schema,
+		genesisblock,
+		account,
+		logger,
+	};
 	genesisblock = this.scope.genesisblock;
 	self = this;
 	if (cb) {

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -11,7 +11,7 @@ var slots = require('../helpers/slots.js');
 var sql = require('../sql/transactions.js');
 
 // Private fields
-var self, modules, __private = {}, genesisblock = null;
+var self, modules, __private = {};
 
 /**
  * @typedef {Object} privateTypes
@@ -50,7 +50,6 @@ function Transaction (db, ed, schema, genesisblock, account, logger, cb) {
 		account,
 		logger,
 	};
-	genesisblock = this.scope.genesisblock;
 	self = this;
 	if (cb) {
 		return setImmediate(cb, null, this);
@@ -329,7 +328,7 @@ Transaction.prototype.checkConfirmed = function (trs, cb) {
  */
 Transaction.prototype.checkBalance = function (amount, balance, trs, sender) {
 	var exceededBalance = new bignum(sender[balance].toString()).lessThan(amount);
-	var exceeded = (trs.blockId !== genesisblock.block.id && exceededBalance);
+	var exceeded = (trs.blockId !== this.scope.genesisblock.block.id && exceededBalance);
 
 	return {
 		exceeded: exceeded,
@@ -430,7 +429,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	}
 
 	// Check for missing sender second signature
-	if (!trs.requesterPublicKey && sender.secondSignature && !trs.signSignature && trs.blockId !== genesisblock.block.id) {
+	if (!trs.requesterPublicKey && sender.secondSignature && !trs.signSignature && trs.blockId !== this.scope.genesisblock.block.id) {
 		return setImmediate(cb, 'Missing sender second signature');
 	}
 
@@ -462,7 +461,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	}
 
 	// Check sender is not genesis account unless block id equals genesis
-	if ([exceptions.genesisPublicKey.mainnet, exceptions.genesisPublicKey.testnet].indexOf(sender.publicKey) !== -1 && trs.blockId !== genesisblock.block.id) {
+	if ([exceptions.genesisPublicKey.mainnet, exceptions.genesisPublicKey.testnet].indexOf(sender.publicKey) !== -1 && trs.blockId !== this.scope.genesisblock.block.id) {
 		return setImmediate(cb, 'Invalid sender. Can not send from genesis account');
 	}
 

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1132,12 +1132,14 @@ Transaction.prototype.dbRead = function (raw) {
 
 // Events
 /**
- * Binds scope to modules.
- * @param {scope} scope - App instance
+ * Binds input parameters to private variables modules.
+ * @param {Rounds} rounds
  */
-Transaction.prototype.bindModules = function (scope) {
+Transaction.prototype.bindModules = function (rounds) {
 	this.scope.logger.trace('Logic/Transaction->bindModules');
-	modules = scope;
+	modules = {
+		rounds,
+	};
 };
 
 // Export

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -43,12 +43,12 @@ __private.types = {};
 // Constructor
 function Transaction (db, ed, schema, genesisblock, account, logger, cb) {
 	this.scope = {
-		db,
-		ed,
-		schema,
-		genesisblock,
-		account,
-		logger,
+		db: db,
+		ed: ed,
+		schema: schema,
+		genesisblock: genesisblock,
+		account: account,
+		logger: logger,
 	};
 	self = this;
 	if (cb) {
@@ -1138,7 +1138,7 @@ Transaction.prototype.dbRead = function (raw) {
 Transaction.prototype.bindModules = function (rounds) {
 	this.scope.logger.trace('Logic/Transaction->bindModules');
 	modules = {
-		rounds,
+		rounds: rounds,
 	};
 };
 

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -31,12 +31,12 @@ __private.types = {};
  * @memberof module:transactions
  * @class
  * @classdesc Main transaction logic.
- * @param {function} db
- * @param {function} ed
- * @param {function} schema
- * @param {function} genesisblock
- * @param {function} account
- * @param {function} logger
+ * @param {Database} db
+ * @param {Object} ed
+ * @param {ZSchema} schema
+ * @param {Object} genesisblock
+ * @param {Account} account
+ * @param {Object} logger
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -25,17 +25,17 @@ var modules, library, self, __private = {};
 // Constructor
 function TransactionPool (broadcastInterval, releaseLimit, transaction, bus, logger) {
 	library = {
+		logger,
+		bus,
+		logic: {
+			transaction
+		},
 		config: {
 			broadcasts: {
 				broadcastInterval,
 				releaseLimit
 			}
 		},
-		logic: {
-			transaction
-		},
-		bus,
-		logger,
 	};
 	self = this;
 
@@ -77,11 +77,17 @@ function TransactionPool (broadcastInterval, releaseLimit, transaction, bus, log
 
 // Public methods
 /**
- * Bounds scope to private modules variable
- * @param {scope} scope - App instance.
+ * Bounds input parameters to private variable modules.
+ * @param {Accounts} accounts
+ * @param {Transactions} transactions
+ * @param {Loader} loader
  */
-TransactionPool.prototype.bind = function (scope) {
-	modules = scope;
+TransactionPool.prototype.bind = function (accounts, transactions, loader) {
+	modules = {
+		accounts,
+		transactions,
+		loader,
+	};
 };
 
 /**

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -16,11 +16,27 @@ var modules, library, self, __private = {};
  * transaction expiry timer.
  * @implements {processBundled}
  * @implements {expireTransactions}
- * @param {scope} scope - App instance.
+ * @param {number} broadcastInterval
+ * @param {number} releaseLimit
+ * @param {Transaction} transaction - Logic instance
+ * @param {bus} bus
+ * @param {Object} logger
  */
 // Constructor
-function TransactionPool (scope) {
-	library = scope;
+function TransactionPool (broadcastInterval, releaseLimit, transaction, bus, logger) {
+	library = {
+		config: {
+			broadcasts: {
+				broadcastInterval,
+				releaseLimit
+			}
+		},
+		logic: {
+			transaction
+		},
+		bus,
+		logger,
+	};
 	self = this;
 
 	self.unconfirmed = { transactions: [], index: {} };

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -25,16 +25,16 @@ var modules, library, self, __private = {};
 // Constructor
 function TransactionPool (broadcastInterval, releaseLimit, transaction, bus, logger) {
 	library = {
-		logger,
-		bus,
+		logger: logger,
+		bus: bus,
 		logic: {
-			transaction
+			transaction: transaction,
 		},
 		config: {
 			broadcasts: {
-				broadcastInterval,
-				releaseLimit
-			}
+				broadcastInterval: broadcastInterval,
+				releaseLimit: releaseLimit,
+			},
 		},
 	};
 	self = this;
@@ -84,9 +84,9 @@ function TransactionPool (broadcastInterval, releaseLimit, transaction, bus, log
  */
 TransactionPool.prototype.bind = function (accounts, transactions, loader) {
 	modules = {
-		accounts,
-		transactions,
-		loader,
+		accounts: accounts,
+		transactions: transactions,
+		loader: loader,
 	};
 };
 

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -9,11 +9,11 @@ var transactionTypes = require('../helpers/transactionTypes.js');
 var modules, library, self, __private = {};
 
 /**
- * Main transactionPool logic.
+ * Initializes variables, sets bundled transaction timer and
+ * transaction expiry timer.
  * @memberof module:transactions
  * @class
- * @classdesc Initializes variables, sets bundled transaction timer and
- * transaction expiry timer.
+ * @classdesc Main transactionPool logic.
  * @implements {processBundled}
  * @implements {expireTransactions}
  * @param {number} broadcastInterval

--- a/logic/transfer.js
+++ b/logic/transfer.js
@@ -22,8 +22,8 @@ function Transfer () {}
  */
 Transfer.prototype.bind = function (accounts, rounds) {
 	modules = {
-		accounts,
-		rounds,
+		accounts: accounts,
+		rounds: rounds,
 	};
 };
 

--- a/logic/transfer.js
+++ b/logic/transfer.js
@@ -3,7 +3,7 @@
 var constants = require('../helpers/constants.js');
 
 // Private fields
-var modules, library;
+var modules;
 
 /**
  * Main transfer logic.
@@ -16,12 +16,11 @@ function Transfer () {}
 
 // Public methods
 /**
- * Binds scope to private variables modules and library.
+ * Binds scope to private variable modules.
  * @param {scope} scope - App instance.
  */
 Transfer.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 };
 
 /**

--- a/logic/transfer.js
+++ b/logic/transfer.js
@@ -16,11 +16,15 @@ function Transfer () {}
 
 // Public methods
 /**
- * Binds scope to private variable modules.
- * @param {scope} scope - App instance.
+ * Binds input parameters to private variable modules.
+ * @param {Accounts} accounts
+ * @param {Rounds} rounds
  */
-Transfer.prototype.bind = function (scope) {
-	modules = scope.modules;
+Transfer.prototype.bind = function (accounts, rounds) {
+	modules = {
+		accounts,
+		rounds,
+	};
 };
 
 /**

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -10,11 +10,14 @@ var modules, library, self;
 
 // Constructor
 /**
- * Initializes library
+ * Initializes library.
+ * @memberof module:accounts
  * @class
- * @classdesc Main vote logic
+ * @classdesc Main vote logic.
  * Allows validate and undo transactions, verify votes.
  * @constructor
+ * @param {Object} logger
+ * @param {ZSchema} schema
  */
 function Vote (logger, schema) {
 	self = this;
@@ -27,11 +30,15 @@ function Vote (logger, schema) {
 
 // Public methods
 /**
- * Binds scope content to private variable module.
- * @param {scope} scope - App instance.
+ * Binds module content to private object modules.
+ * @param {Delegates} delegates
+ * @param {Rounds} rounds
  */
-Vote.prototype.bind = function (scope) {
-	modules = scope.modules;
+Vote.prototype.bind = function (delegates, rounds) {
+	modules = {
+		delegates,
+		rounds
+	};
 };
 
 /**

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -22,8 +22,8 @@ var modules, library, self;
 function Vote (logger, schema) {
 	self = this;
 	library = {
-		logger,
-		schema,
+		logger: logger,
+		schema: schema,
 	};
 
 }
@@ -36,8 +36,8 @@ function Vote (logger, schema) {
  */
 Vote.prototype.bind = function (delegates, rounds) {
 	modules = {
-		delegates,
-		rounds
+		delegates: delegates,
+		rounds: rounds,
 	};
 };
 

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -10,23 +10,28 @@ var modules, library, self;
 
 // Constructor
 /**
+ * Initializes library
  * @class
  * @classdesc Main vote logic
  * Allows validate and undo transactions, verify votes.
  * @constructor
  */
-function Vote () {
+function Vote (logger, schema) {
 	self = this;
+	library = {
+		logger,
+		schema,
+	};
+
 }
 
 // Public methods
 /**
- * Binds scope content to private variables modules and library.
+ * Binds scope content to private variable module.
  * @param {scope} scope - App instance.
  */
 Vote.prototype.bind = function (scope) {
 	modules = scope.modules;
-	library = scope.library;
 };
 
 /**

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -28,7 +28,15 @@ __private.blockReward = new BlockReward();
  * @return {setImmediateCallback} Callback function with `self` as data.
  */
 function Accounts (cb, scope) {
-	library = scope;
+	library = {
+		logic: {
+			account: scope.logic.account,
+			transaction: scope.logic.transaction,
+		},
+		ed: scope.ed,
+		schema: scope.schema,
+		balancesSequence: scope.balancesSequence,
+	};
 	self = this;
 
 	__private.assetTypes[transactionTypes.VOTE] = library.logic.transaction.attachAssetType(
@@ -228,11 +236,16 @@ Accounts.prototype.sandboxApi = function (call, args, cb) {
  * @param {scope} scope - Loaded modules.
  */
 Accounts.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		delegates: scope.delegates,
+		accounts: scope.accounts,
+		transactions: scope.transactions,
+	};
 
-	__private.assetTypes[transactionTypes.VOTE].bind({
-		modules: modules
-	});
+	__private.assetTypes[transactionTypes.VOTE].bind(
+		scope.delegates,
+		scope.rounds
+	);
 };
 /**
  * Checks if modules is loaded.

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -233,7 +233,7 @@ Accounts.prototype.sandboxApi = function (call, args, cb) {
 /**
  * Calls Vote.bind() with scope.
  * @implements module:accounts#Vote~bind
- * @param {scope} scope - Loaded modules.
+ * @param {modules} scope - Loaded modules.
  */
 Accounts.prototype.onBind = function (scope) {
 	modules = {

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -29,13 +29,13 @@ __private.blockReward = new BlockReward();
  */
 function Accounts (cb, scope) {
 	library = {
+		ed: scope.ed,
+		schema: scope.schema,
+		balancesSequence: scope.balancesSequence,
 		logic: {
 			account: scope.logic.account,
 			transaction: scope.logic.transaction,
 		},
-		ed: scope.ed,
-		schema: scope.schema,
-		balancesSequence: scope.balancesSequence,
 	};
 	self = this;
 

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -32,7 +32,11 @@ function Accounts (cb, scope) {
 	self = this;
 
 	__private.assetTypes[transactionTypes.VOTE] = library.logic.transaction.attachAssetType(
-		transactionTypes.VOTE, new Vote()
+		transactionTypes.VOTE,
+		new Vote(
+			scope.logger,
+			scope.schema
+		)
 	);
 
 	setImmediate(cb, null, self);
@@ -227,7 +231,7 @@ Accounts.prototype.onBind = function (scope) {
 	modules = scope;
 
 	__private.assetTypes[transactionTypes.VOTE].bind({
-		modules: modules, library: library
+		modules: modules
 	});
 };
 /**

--- a/modules/blocks/api.js
+++ b/modules/blocks/api.js
@@ -25,12 +25,12 @@ __private.blockReward = new BlockReward();
  */
 function API (logger, db, block, schema, dbSequence) {
 	library = {
-		logger,
-		db,
-		schema,
-		dbSequence,
+		logger: logger,
+		db: db,
+		schema: schema,
+		dbSequence: dbSequence,
 		logic: {
-			block,
+			block: block,
 		},
 	};
 	self = this;

--- a/modules/blocks/api.js
+++ b/modules/blocks/api.js
@@ -11,8 +11,28 @@ var modules, library, self, __private = {};
 
 __private.blockReward = new BlockReward();
 
-function API (scope) {
-	library = scope;
+/**
+ * Initializes library.
+ * @memberof module:blocks
+ * @class
+ * @classdesc Main API logic.
+ * Allows get information.
+ * @param {Object} logger
+ * @param {Database} db
+ * @param {Block} block
+ * @param {ZSchema} schema
+ * @param {Sequence} dbSequence
+ */
+function API (logger, db, block, schema, dbSequence) {
+	library = {
+		logger,
+		db,
+		schema,
+		dbSequence,
+		logic: {
+			block,
+		},
+	};
 	self = this;
 
 	library.logger.trace('Blocks->API: Submodule initialized.');
@@ -307,16 +327,17 @@ API.prototype.getStatus = function (req, cb) {
 };
 
 /**
- * Handle modules initialization
- *
- * @public
- * @method onBind
- * @listens module:app~event:bind
- * @param  {scope}   scope Exposed modules
+ * Handle modules initialization:
+ * - blocks
+ * - system
+ * @param {modules} scope Exposed modules
  */
 API.prototype.onBind = function (scope) {
 	library.logger.trace('Blocks->API: Shared modules bind.');
-	modules = scope;
+	modules = {
+		blocks: scope.blocks,
+		system: scope.system,
+	};
 
 	// Set module as loaded
 	__private.loaded = true;

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -9,8 +9,32 @@ var transactionTypes = require('../../helpers/transactionTypes.js');
 
 var modules, library, self, __private = {};
 
-function Chain (scope) {
-	library = scope;
+/**
+ * Initializes library.
+ * @memberof module:blocks
+ * @class
+ * @classdesc Main Chain logic.
+ * Allows set information.
+ * @param {Object} logger
+ * @param {Block} block
+ * @param {Transaction} transaction
+ * @param {Database} db
+ * @param {Object} genesisblock
+ * @param {bus} bus
+ * @param {Sequence} balancesSequence
+ */
+function Chain (logger, block, transaction, db, genesisblock, bus, balancesSequence) {
+	library = {
+		logger,
+		db,
+		genesisblock,
+		bus,
+		balancesSequence,
+		logic: {
+			block,
+			transaction,
+		},
+	};
 	self = this;
 
 	library.logger.trace('Blocks->Chain: Submodule initialized.');
@@ -20,10 +44,7 @@ function Chain (scope) {
 /**
  * Save genesis block to database
  *
- * @private
  * @async
- * @method saveGenesisBlock
- * @param  {Object}   block Full normalized genesis block
  * @param  {Function} cb Callback function
  * @return {Function} cb Callback function from params (through setImmediate)
  * @return {Object}   cb.err Error if occurred
@@ -52,9 +73,7 @@ Chain.prototype.saveGenesisBlock = function (cb) {
 /**
  * Save block with transactions to database
  *
- * @private
  * @async
- * @method saveBlock
  * @param  {Object}   block Full normalized block
  * @param  {Function} cb Callback function
  * @return {Function|afterSave} cb If SQL transaction was OK - returns safterSave execution,
@@ -639,16 +658,21 @@ Chain.prototype.recoverChain = function (cb) {
 };
 
 /**
- * Handle modules initialization
- *
- * @public
- * @method onBind
- * @listens module:app~event:bind
- * @param  {scope}   scope Exposed modules
+ * Handle modules initialization:
+ * - accounts
+ * - blocks
+ * - rounds
+ * - transactions
+ * @param {modules} scope Exposed modules
  */
 Chain.prototype.onBind = function (scope) {
 	library.logger.trace('Blocks->Chain: Shared modules bind.');
-	modules = scope;
+	modules = {
+		accounts: scope.accounts,
+		blocks: scope.blocks,
+		rounds: scope.rounds,
+		transactions: scope.transactions,
+	};
 
 	// Set module as loaded
 	__private.loaded = true;

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -25,14 +25,14 @@ var modules, library, self, __private = {};
  */
 function Chain (logger, block, transaction, db, genesisblock, bus, balancesSequence) {
 	library = {
-		logger,
-		db,
-		genesisblock,
-		bus,
-		balancesSequence,
+		logger: logger,
+		db: db,
+		genesisblock: genesisblock,
+		bus: bus,
+		balancesSequence: balancesSequence,
 		logic: {
-			block,
-			transaction,
+			block: block,
+			transaction: transaction,
 		},
 	};
 	self = this;

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -26,16 +26,16 @@ var modules, library, self, __private = {};
  */
 function Process (logger, block, peers, transaction, schema, db, dbSequence, sequence, genesisblock) {
 	library = {
-		logger,
-		schema,
-		db,
-		dbSequence,
-		sequence,
-		genesisblock,
+		logger: logger,
+		schema: schema,
+		db: db,
+		dbSequence: dbSequence,
+		sequence: sequence,
+		genesisblock: genesisblock,
 		logic: {
-			block,
-			peers,
-			transaction,
+			block: block,
+			peers: peers,
+			transaction: transaction,
 		},
 	};
 	self = this;

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -8,8 +8,36 @@ var sql = require('../../sql/blocks.js');
 
 var modules, library, self, __private = {};
 
-function Process (scope) {
-	library = scope;
+/**
+ * Initializes library.
+ * @memberof module:blocks
+ * @class
+ * @classdesc Main Process logic.
+ * Allows process blocks.
+ * @param {Object} logger
+ * @param {Block} block
+ * @param {Peers} peers
+ * @param {Transaction} transaction
+ * @param {ZSchema} schema
+ * @param {Database} db
+ * @param {Sequence} dbSequence
+ * @param {Sequence} sequence
+ * @param {Object} genesisblock
+ */
+function Process (logger, block, peers, transaction, schema, db, dbSequence, sequence, genesisblock) {
+	library = {
+		logger,
+		schema,
+		db,
+		dbSequence,
+		sequence,
+		genesisblock,
+		logic: {
+			block,
+			peers,
+			transaction,
+		},
+	};
 	self = this;
 
 	library.logger.trace('Blocks->Process: Submodule initialized.');
@@ -425,15 +453,26 @@ __private.receiveBlock = function (block, cb) {
 
 /**
  * Handle modules initialization
- *
- * @public
- * @method onBind
- * @listens module:app~event:bind
- * @param  {scope}   scope Exposed modules
+ * - accounts
+ * - blocks
+ * - delegates
+ * - loader
+ * - rounds
+ * - transactions
+ * - transport
+ * @param {modules} scope Exposed modules
  */
 Process.prototype.onBind = function (scope) {
 	library.logger.trace('Blocks->Process: Shared modules bind.');
-	modules = scope;
+	modules = {
+		accounts: scope.accounts,
+		blocks: scope.blocks,
+		delegates: scope.delegates,
+		loader: scope.loader,
+		rounds: scope.rounds,
+		transactions: scope.transactions,
+		transport: scope.transport,
+	};
 
 	// Set module as loaded
 	__private.loaded = true;

--- a/modules/blocks/utils.js
+++ b/modules/blocks/utils.js
@@ -7,8 +7,30 @@ var transactionTypes = require('../../helpers/transactionTypes.js');
 
 var modules, library, self, __private = {};
 
-function Utils (scope) {
-	library = scope;
+/**
+ * Initializes library.
+ * @memberof module:blocks
+ * @class
+ * @classdesc Main Utils logic.
+ * Allows utils functions for blocks.
+ * @param {Object} logger
+ * @param {Block} block
+ * @param {Transaction} transaction
+ * @param {Database} db
+ * @param {Sequence} dbSequence
+ * @param {Object} genesisblock
+ */
+function Utils (logger, block, transaction, db, dbSequence, genesisblock) {
+	library = {
+		logger,
+		db,
+		dbSequence,
+		genesisblock,
+		logic: {
+			block,
+			transaction,
+		},
+	};
 	self = this;
 
 	library.logger.trace('Blocks->Utils: Submodule initialized.');
@@ -358,16 +380,15 @@ Utils.prototype.aggregateBlocksReward = function (filter, cb) {
 };
 
 /**
- * Handle modules initialization
- *
- * @public
- * @method onBind
- * @listens module:app~event:bind
- * @param  {scope}   scope Exposed modules
+ * Handle modules initialization:
+ * - blocks
+ * @param {modules} scope Exposed modules
  */
 Utils.prototype.onBind = function (scope) {
 	library.logger.trace('Blocks->Utils: Shared modules bind.');
-	modules = scope;
+	modules = {
+		blocks: scope.blocks
+	};
 
 	// Set module as loaded
 	__private.loaded = true;

--- a/modules/blocks/utils.js
+++ b/modules/blocks/utils.js
@@ -22,13 +22,13 @@ var modules, library, self, __private = {};
  */
 function Utils (logger, block, transaction, db, dbSequence, genesisblock) {
 	library = {
-		logger,
-		db,
-		dbSequence,
-		genesisblock,
+		logger: logger,
+		db: db,
+		dbSequence: dbSequence,
+		genesisblock: genesisblock,
 		logic: {
-			block,
-			transaction,
+			block: block,
+			transaction: transaction,
 		},
 	};
 	self = this;

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -13,11 +13,11 @@ __private.blockReward = new BlockReward();
 
 function Verify (logger, block, transaction, db) {
 	library = {
-		logger,
-		db,
+		logger: logger,
+		db: db,
 		logic: {
-			block,
-			transaction,
+			block: block,
+			transaction: transaction,
 		},
 	};
 	self = this;

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -11,8 +11,15 @@ var modules, library, self, __private = {};
 
 __private.blockReward = new BlockReward();
 
-function Verify (scope) {
-	library = scope;
+function Verify (logger, block, transaction, db) {
+	library = {
+		logger,
+		db,
+		logic: {
+			block,
+			transaction,
+		},
+	};
 	self = this;
 
 	library.logger.trace('Blocks->Verify: Submodule initialized.');
@@ -292,15 +299,21 @@ Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock) {
 
 /**
  * Handle modules initialization
- *
- * @public
- * @method onBind
- * @listens module:app~event:bind
- * @param  {scope}   scope Exposed modules
+ * - accounts
+ * - blocks
+ * - delegates
+ * - transactions
+ * @param {modules} scope Exposed modules
  */
 Verify.prototype.onBind = function (scope) {
 	library.logger.trace('Blocks->Verify: Shared modules bind.');
-	modules = scope;
+	modules = {
+		accounts: scope.accounts,
+		blocks: scope.blocks,
+		delegates: scope.delegates,
+		transactions: scope.transactions,
+	};
+
 
 	// Set module as loaded
 	__private.loaded = true;

--- a/modules/crypto.js
+++ b/modules/crypto.js
@@ -5,12 +5,11 @@ var fs = require('fs');
 var sandboxHelper = require('../helpers/sandbox.js');
 
 // Private fields
-var modules, library, self, __private = {}, shared = {};
+var self, __private = {}, shared = {};
 
 __private.loaded = false;
 
 /**
- * Initializes library with scope content.
  * @class
  * @classdesc Main Crypto methods.
  * @param {setImmediateCallback} cb - Callback function.
@@ -18,7 +17,6 @@ __private.loaded = false;
  */
 // Constructor
 function Crypto (cb, scope) {
-	library = scope;
 	self = this;
 
 	setImmediate(cb, null, self);
@@ -38,11 +36,10 @@ Crypto.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Assigns scope to modules variable.
- * @param {scope} scope - Loaded modules.
+ * Modules are not required in this file.
+ * @param {modules} scope - Loaded modules.
  */
 Crypto.prototype.onBind = function (scope) {
-	modules = scope;
 };
 
 /**

--- a/modules/dapps.js
+++ b/modules/dapps.js
@@ -56,7 +56,21 @@ __private.routes = {};
  */
 // Constructor
 function DApps (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		public: scope.public,
+		network: scope.network,
+		schema: scope.schema,
+		ed: scope.ed,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			transaction: scope.logic.transaction,
+		},
+		config: {
+			dapp: scope.config.dapp,
+		},
+	};
 	self = this;
 
 	__private.assetTypes[transactionTypes.DAPP] = library.logic.transaction.attachAssetType(
@@ -933,21 +947,30 @@ DApps.prototype.request = function (dappid, method, path, query, cb) {
 
 // Events
 /**
- * Bounds scope to private modules variable and modules and library
+ * Bounds used scope modules to private modules variable and sets params
  * to private Dapp, InTransfer and OutTransfer instances.
  * @implements module:transactions#Transfer~bind
  * @param {scope} scope - Loaded modules.
  */
 DApps.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		transactions: scope.transactions,
+		accounts: scope.accounts,
+		peers: scope.peers,
+		sql: scope.sql,
+	};
 
-	__private.assetTypes[transactionTypes.IN_TRANSFER].bind({
-		modules: modules, library: library, shared: shared
-	});
+	__private.assetTypes[transactionTypes.IN_TRANSFER].bind(
+		scope.accounts,
+		scope.rounds,
+		shared
+	);
 
-	__private.assetTypes[transactionTypes.OUT_TRANSFER].bind({
-		modules: modules, library: library
-	});
+	__private.assetTypes[transactionTypes.OUT_TRANSFER].bind(
+		scope.accounts,
+		scope.rounds,
+		scope.dapps
+	);
 };
 
 /**

--- a/modules/dapps.js
+++ b/modules/dapps.js
@@ -60,15 +60,30 @@ function DApps (cb, scope) {
 	self = this;
 
 	__private.assetTypes[transactionTypes.DAPP] = library.logic.transaction.attachAssetType(
-		transactionTypes.DAPP, new DApp()
+		transactionTypes.DAPP,
+		new DApp(
+			scope.db, 
+			scope.logger, 
+			scope.schema, 
+			scope.network
+		)
 	);
 
 	__private.assetTypes[transactionTypes.IN_TRANSFER] = library.logic.transaction.attachAssetType(
-		transactionTypes.IN_TRANSFER, new InTransfer()
+		transactionTypes.IN_TRANSFER, 
+		new InTransfer(
+			scope.db,
+			scope.schema
+		)
 	);
 
 	__private.assetTypes[transactionTypes.OUT_TRANSFER] = library.logic.transaction.attachAssetType(
-		transactionTypes.OUT_TRANSFER, new OutTransfer()
+		transactionTypes.OUT_TRANSFER, 
+		new OutTransfer(
+			scope.db,
+			scope.schema,
+			scope.logger
+		)
 	);
 	/**
 	 * Receives an 'exit' signal and calls stopDApp for each launched app.
@@ -925,10 +940,6 @@ DApps.prototype.request = function (dappid, method, path, query, cb) {
  */
 DApps.prototype.onBind = function (scope) {
 	modules = scope;
-
-	__private.assetTypes[transactionTypes.DAPP].bind({
-		library: library
-	});
 
 	__private.assetTypes[transactionTypes.IN_TRANSFER].bind({
 		modules: modules, library: library, shared: shared

--- a/modules/dapps.js
+++ b/modules/dapps.js
@@ -950,7 +950,7 @@ DApps.prototype.request = function (dappid, method, path, query, cb) {
  * Bounds used scope modules to private modules variable and sets params
  * to private Dapp, InTransfer and OutTransfer instances.
  * @implements module:transactions#Transfer~bind
- * @param {scope} scope - Loaded modules.
+ * @param {modules} scope - Loaded modules.
  */
 DApps.prototype.onBind = function (scope) {
 	modules = {

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -37,7 +37,26 @@ __private.tmpKeypairs = {};
  */
 // Constructor
 function Delegates (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		sequence: scope.sequence,
+		ed: scope.ed,
+		db: scope.db,
+		network: scope.network,
+		schema: scope.schema,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			transaction: scope.logic.transaction,
+		},
+		config: {
+			forging: {
+				secret: scope.config.forging.secret,
+				access: {
+					whiteList: scope.config.forging.access.whiteList,
+				},
+			},
+		},
+	};
 	self = this;
 
 	__private.assetTypes[transactionTypes.DELEGATE] = library.logic.transaction.attachAssetType(
@@ -504,11 +523,19 @@ Delegates.prototype.sandboxApi = function (call, args, cb) {
  * @param {scope} scope - Loaded modules.
  */
 Delegates.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		loader: scope.loader,
+		rounds: scope.rounds,
+		accounts: scope.accounts,
+		blocks: scope.blocks,
+		transport: scope.transport,
+		transactions: scope.transactions,
+		delegates: scope.delegates,
+	};
 
-	__private.assetTypes[transactionTypes.DELEGATE].bind({
-		modules: modules, library: library
-	});
+	__private.assetTypes[transactionTypes.DELEGATE].bind(
+		scope.accounts
+	);
 };
 
 /**

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -520,7 +520,7 @@ Delegates.prototype.sandboxApi = function (call, args, cb) {
 /**
  * Calls Delegate.bind() with scope.
  * @implements module:delegates#Delegate~bind
- * @param {scope} scope - Loaded modules.
+ * @param {modules} scope - Loaded modules.
  */
 Delegates.prototype.onBind = function (scope) {
 	modules = {

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -41,7 +41,10 @@ function Delegates (cb, scope) {
 	self = this;
 
 	__private.assetTypes[transactionTypes.DELEGATE] = library.logic.transaction.attachAssetType(
-		transactionTypes.DELEGATE, new Delegate()
+		transactionTypes.DELEGATE, 
+		new Delegate(
+			scope.schema
+		)
 	);
 
 	setImmediate(cb, null, self);

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -34,7 +34,27 @@ __private.retries = 5;
  */
 // Constructor
 function Loader (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		network: scope.network,
+		schema: scope.schema,
+		sequence: scope.sequence,
+		bus: scope.bus,
+		genesisblock: scope.genesisblock,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			transaction: scope.logic.transaction,
+			account: scope.logic.account,
+			peers: scope.logic.peers,
+		},
+		config: {
+			loading: {
+				verifyOnLoading: scope.config.loading.verifyOnLoading,
+				snapshot: scope.config.loading.snapshot,
+			},
+		},
+	};
 	self = this;
 
 	__private.initialize();
@@ -795,12 +815,20 @@ Loader.prototype.onPeersReady = function () {
 };
 
 /**
- * Assigns scope to modules variable.
+ * Assigns needed modules from scope to private modules variable.
  * Calls __private.loadBlockChain
- * @param {scope} scope
+ * @param {modules} scope
  */
 Loader.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		transactions: scope.transactions,
+		blocks: scope.blocks,
+		peers: scope.peers,
+		rounds: scope.rounds,
+		transport: scope.transport,
+		multisignatures: scope.multisignatures,
+		system: scope.system,
+	};
 
 	__private.loadBlockChain();
 };

--- a/modules/multisignatures.js
+++ b/modules/multisignatures.js
@@ -27,12 +27,24 @@ __private.assetTypes = {};
  */
 // Constructor
 function Multisignatures (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		network: scope.network,
+		schema: scope.schema,
+		ed: scope.ed,
+		bus: scope.bus,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			transaction: scope.logic.transaction,
+		},
+	};
 	genesisblock = library.genesisblock;
 	self = this;
 
 	__private.assetTypes[transactionTypes.MULTI] = library.logic.transaction.attachAssetType(
-		transactionTypes.MULTI, new Multisignature(
+		transactionTypes.MULTI,
+		new Multisignature(
 			scope.schema,
 			scope.network,
 			scope.logic.transaction,
@@ -167,16 +179,20 @@ Multisignatures.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Calls Multisignature.bind() with scope.
+ * Calls Multisignature.bind() with modules params.
  * @implements module:multisignatures#Multisignature~bind
- * @param {scope} scope - Loaded modules.
+ * @param {modules} scope - Loaded modules.
  */
 Multisignatures.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		transactions: scope.transactions,
+		accounts: scope.accounts,
+	};
 
-	__private.assetTypes[transactionTypes.MULTI].bind({
-		modules: modules
-	});
+	__private.assetTypes[transactionTypes.MULTI].bind(
+		scope.rounds,
+		scope.accounts
+	);
 };
 
 /**

--- a/modules/multisignatures.js
+++ b/modules/multisignatures.js
@@ -32,7 +32,12 @@ function Multisignatures (cb, scope) {
 	self = this;
 
 	__private.assetTypes[transactionTypes.MULTI] = library.logic.transaction.attachAssetType(
-		transactionTypes.MULTI, new Multisignature()
+		transactionTypes.MULTI, new Multisignature(
+			scope.schema,
+			scope.network,
+			scope.logic.transaction,
+			scope.logger
+		)
 	);
 
 	setImmediate(cb, null, self);
@@ -170,7 +175,7 @@ Multisignatures.prototype.onBind = function (scope) {
 	modules = scope;
 
 	__private.assetTypes[transactionTypes.MULTI].bind({
-		modules: modules, library: library
+		modules: modules
 	});
 };
 

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -519,8 +519,8 @@ Peers.prototype.list = function (options, cb) {
 
 // Events
 /**
- * assign scope to modules variable
- * @param {scope} scope
+ * assigns scope to modules variable
+ * @param {modules} scope
  */
 Peers.prototype.onBind = function (scope) {
 	modules = {

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -27,7 +27,22 @@ var modules, library, self, __private = {}, shared = {};
  */
 // Constructor
 function Peers (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		schema: scope.schema,
+		bus: scope.bus,
+		nonce: scope.nonce,
+		build: scope.build,
+		lastCommit: scope.lastCommit,
+		logic: {
+			peers: scope.logic.peers,
+		},
+		config: {
+			peers: scope.config.peers,
+			version: scope.config.version,
+		},
+	};
 	self = this;
 
 	setImmediate(cb, null, self);
@@ -508,7 +523,10 @@ Peers.prototype.list = function (options, cb) {
  * @param {scope} scope
  */
 Peers.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		transport: scope.transport,
+		system: scope.system,
+	};
 };
 
 /**

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -274,8 +274,8 @@ Rounds.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Assigns scope app to private variable `modules`.
- * @param {scope} scope - Loaded App.
+ * Assigns modules to private variable `modules`.
+ * @param {modules} scope - Loaded modules.
  */
 Rounds.prototype.onBind = function (scope) {
 	modules = {

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -25,7 +25,17 @@ __private.ticking = false;
  */
 // Constructor
 function Rounds (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		bus: scope.bus,
+		network: scope.network,
+		config: {
+			loading: {
+				snapshot: scope.config.loading.snapshot,
+			},
+		},
+	};
 	self = this;
 
 	setImmediate(cb, null, self);
@@ -268,7 +278,11 @@ Rounds.prototype.sandboxApi = function (call, args, cb) {
  * @param {scope} scope - Loaded App.
  */
 Rounds.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		blocks: scope.blocks,
+		accounts: scope.accounts,
+		delegates: scope.delegates,
+	};
 };
 
 /**

--- a/modules/server.js
+++ b/modules/server.js
@@ -5,12 +5,12 @@ var path = require('path');
 var sandboxHelper = require('../helpers/sandbox.js');
 
 // Private fields
-var modules, library, self, __private = {}, shared = {};
+var modules, self, __private = {}, shared = {};
 
 __private.loaded = false;
 
 /**
- * Initializes library with scope content.
+ * Initializes Server.
  * @memberof module:server
  * @class
  * @classdesc Main server methods.
@@ -20,7 +20,6 @@ __private.loaded = false;
  */
 // Constructor
 function Server (cb, scope) {
-	library = scope;
 	self = this;
 
 	setImmediate(cb, null, self);
@@ -40,11 +39,11 @@ Server.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Loads scope into private variable modules.
- * @param {scope} scope - Loaded App.
+ * Modules are not required in this file.
+ * @param {modules} scope - Loaded modules.
  */
 Server.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = true;
 };
 
 /**

--- a/modules/signatures.js
+++ b/modules/signatures.js
@@ -25,7 +25,14 @@ __private.assetTypes = {};
  */
 // Constructor
 function Signatures (cb, scope) {
-	library = scope;
+	library = {
+		schema: scope.schema,
+		ed: scope.ed,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			transaction: scope.logic.transaction,
+		},
+	};
 	self = this;
 
 	__private.assetTypes[transactionTypes.SIGNATURE] = library.logic.transaction.attachAssetType(
@@ -61,16 +68,19 @@ Signatures.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Calls Signature.bind() with scope to create closure.
+ * Calls Signature.bind() with modules params.
  * @implements module:signatures#Signature~bind
- * @param {scope} scope - Loaded modules.
+ * @param {modules} scope - Loaded modules.
  */
 Signatures.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		accounts: scope.accounts,
+		transactions: scope.transactions,
+	};
 
-	__private.assetTypes[transactionTypes.SIGNATURE].bind({
-		modules: modules, library: library
-	});
+	__private.assetTypes[transactionTypes.SIGNATURE].bind(
+		scope.accounts
+	);
 };
 
 // Shared API

--- a/modules/signatures.js
+++ b/modules/signatures.js
@@ -29,7 +29,11 @@ function Signatures (cb, scope) {
 	self = this;
 
 	__private.assetTypes[transactionTypes.SIGNATURE] = library.logic.transaction.attachAssetType(
-		transactionTypes.SIGNATURE, new Signature()
+		transactionTypes.SIGNATURE,
+		new Signature(
+			scope.schema,
+			scope.logger
+		)
 	);
 
 	setImmediate(cb, null, self);

--- a/modules/sql.js
+++ b/modules/sql.js
@@ -7,7 +7,7 @@ jsonSql.setDialect('postgresql');
 var sandboxHelper = require('../helpers/sandbox.js');
 
 // Private fields
-var modules, library, self, __private = {}, shared = {};
+var library, self, __private = {}, shared = {};
 
 __private.loaded = false;
 __private.SINGLE_QUOTES = /'/g;
@@ -24,7 +24,10 @@ __private.DOUBLE_QUOTES_DOUBLED = '""';
  */
 // Constructor
 function Sql (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+	};
 	self = this;
 
 	setImmediate(cb, null, self);
@@ -284,11 +287,10 @@ Sql.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Assigns scope to modules variable.
- * @param {scope} scope - Loaded modules.
+ * Modules are not required in this file.
+ * @param {modules} scope - Loaded modules.
  */
 Sql.prototype.onBind = function (scope) {
-	modules = scope;
 };
 
 /**

--- a/modules/system.js
+++ b/modules/system.js
@@ -30,7 +30,17 @@ var rcRegExp = /[a-z]+$/;
  */
 // Constructor
 function System (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		nonce: scope.nonce,
+		config: {
+			version: scope.config.version,
+			port: scope.config.port,
+			nethash: scope.config.nethash,
+			minVersion: scope.config.minVersion,
+		},
+	};
 	self = this;
 
 	__private.os = os.platform() + os.release();
@@ -213,11 +223,14 @@ System.prototype.sandboxApi = function (call, args, cb) {
 
 // Events
 /**
- * Assigns scope to modules variable.
- * @param {scope} scope - Loaded modules.
+ * Assigns used modules to modules variable.
+ * @param {modules} scope - Loaded modules.
  */
 System.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		blocks: scope.blocks,
+		transport: scope.transport,
+	};
 };
 
 // Export

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -40,7 +40,13 @@ function Transactions (cb, scope) {
 	genesisblock = library.genesisblock;
 	self = this;
 
-	__private.transactionPool = new TransactionPool(library);
+	__private.transactionPool = new TransactionPool(
+		scope.config.broadcasts.broadcastInterval,
+		scope.config.broadcasts.releaseLimit,
+		scope.logic.transaction,
+		scope.bus,
+		scope.logger
+	);
 
 	__private.assetTypes[transactionTypes.SEND] = library.logic.transaction.attachAssetType(
 		transactionTypes.SEND, new Transfer()
@@ -567,7 +573,7 @@ Transactions.prototype.isLoaded = function () {
 
 // Events
 /**
- * Bounds scope to private transactionPool and modules and library
+ * Bounds scope to private transactionPool and modules
  * to private Transfer instance.
  * @implements module:transactions#Transfer~bind
  * @param {scope} scope - Loaded modules.
@@ -577,7 +583,7 @@ Transactions.prototype.onBind = function (scope) {
 
 	__private.transactionPool.bind(modules);
 	__private.assetTypes[transactionTypes.SEND].bind({
-		modules: modules, library: library
+		modules: modules
 	});
 };
 

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -36,7 +36,16 @@ __private.assetTypes = {};
  */
 // Constructor
 function Transactions (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		schema: scope.schema,
+		ed: scope.ed,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			transaction: scope.logic.transaction,
+		},
+	};
 	genesisblock = library.genesisblock;
 	self = this;
 
@@ -579,12 +588,20 @@ Transactions.prototype.isLoaded = function () {
  * @param {scope} scope - Loaded modules.
  */
 Transactions.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		accounts: scope.accounts,
+		transactions: scope.transactions,
+	};
 
-	__private.transactionPool.bind(modules);
-	__private.assetTypes[transactionTypes.SEND].bind({
-		modules: modules
-	});
+	__private.transactionPool.bind(
+		scope.accounts,
+		scope.transactions,
+		scope.loader
+	);
+	__private.assetTypes[transactionTypes.SEND].bind(
+		scope.accounts,
+		scope.rounds
+	);
 };
 
 // Shared API

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -35,7 +35,13 @@ function Transport (cb, scope) {
 	library = scope;
 	self = this;
 
-	__private.broadcaster = new Broadcaster(library);
+	__private.broadcaster = new Broadcaster(
+		library.config.broadcasts,
+		library.config.forging.force,
+		library.logic.peers,
+		library.logic.transaction,
+		library.logger
+	);
 
 	setImmediate(cb, null, self);
 }

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -32,15 +32,34 @@ __private.messages = {};
  */
 // Constructor
 function Transport (cb, scope) {
-	library = scope;
+	library = {
+		logger: scope.logger,
+		db: scope.db,
+		bus: scope.bus,
+		schema: scope.schema,
+		network: scope.network,
+		balancesSequence: scope.balancesSequence,
+		logic: {
+			block: scope.logic.block,
+			transaction: scope.logic.transaction,
+			peers: scope.logic.peers,
+		},
+		config: {
+			peers: {
+				options: {
+					timeout: scope.config.peers.options.timeout,
+				},
+			},
+		},
+	};
 	self = this;
 
 	__private.broadcaster = new Broadcaster(
-		library.config.broadcasts,
-		library.config.forging.force,
-		library.logic.peers,
-		library.logic.transaction,
-		library.logger
+		scope.config.broadcasts,
+		scope.config.forging.force,
+		scope.logic.peers,
+		scope.logic.transaction,
+		scope.logger
 	);
 
 	setImmediate(cb, null, self);
@@ -431,13 +450,24 @@ Transport.prototype.sandboxApi = function (call, args, cb) {
  * Bounds scope to private broadcaster amd initialize headers.
  * @implements {modules.system.headers}
  * @implements {broadcaster.bind}
- * @param {scope} scope - Loaded modules.
+ * @param {modules} scope - Loaded modules.
  */
 Transport.prototype.onBind = function (scope) {
-	modules = scope;
+	modules = {
+		blocks: scope.blocks,
+		dapps: scope.dapps,
+		peers: scope.peers,
+		multisignatures: scope.multisignatures,
+		transactions: scope.transactions,
+		system: scope.system,
+	};
 
 	__private.headers = modules.system.headers();
-	__private.broadcaster.bind(modules);
+	__private.broadcaster.bind(
+		scope.peers,
+		scope.transport,
+		scope.transactions
+	);
 };
 
 /**

--- a/test/common/initModule.js
+++ b/test/common/initModule.js
@@ -41,7 +41,22 @@ var modulesLoader = new function () {
 	 * @param {Function} cb
 	 */
 	this.initLogic = function (Logic, scope, cb) {
-		new Logic(scope, cb);
+		switch (Logic.name) {
+		 case 'Account':
+			new Logic(scope.db, scope.schema, scope.logger, cb);
+			break;
+		 case 'Transaction':
+			new Logic(scope.db, scope.ed, scope.schema, scope.genesisblock, scope.account, scope.logger, cb);
+			break;
+		 case 'Block':
+			new Logic(scope.ed, scope.schema, scope.transaction, cb);
+			break;
+		 case 'Peers':
+			new Logic(scope.logger, cb);
+			break;
+		 default:
+		 	console.log('no Logic case initLogic');
+		}
 	};
 
 	/**

--- a/test/common/initModule.js
+++ b/test/common/initModule.js
@@ -54,8 +54,8 @@ var modulesLoader = new function () {
 				account: function (cb) {
 					new Account(scope.db, scope.schema, scope.logger, cb);
 				}
-			 }, function(err, result){
-					new Logic(scope.db, scope.ed, scope.schema, scope.genesisblock, result.account, scope.logger, cb);
+			 }, function (err, result) {
+				 new Logic(scope.db, scope.ed, scope.schema, scope.genesisblock, result.account, scope.logger, cb);
 			 });
 			break;
 		 case 'Block':
@@ -65,9 +65,9 @@ var modulesLoader = new function () {
 				},
 				function (account, waterCb) {
 					return new Transaction(scope.db, scope.ed, scope.schema, scope.genesisblock, account, scope.logger, waterCb);
-				}		
-			 ], function(err, transaction) {
-					new Logic(scope.ed, scope.schema, transaction, cb);
+				}
+			 ], function (err, transaction) {
+				 new Logic(scope.ed, scope.schema, transaction, cb);
 			});
 			break;
 		 case 'Peers':

--- a/test/unit/modules/blocks.js
+++ b/test/unit/modules/blocks.js
@@ -7,18 +7,23 @@ var express = require('express');
 var sinon = require('sinon');
 
 var modulesLoader = require('../../common/initModule').modulesLoader;
-var Blocks = require('../../../modules/blocks');
 
 describe('blocks', function () {
 
 	var blocks;
 
 	before(function (done) {
-		modulesLoader.initModuleWithDb(Blocks, function (err, __blocks) {
+		modulesLoader.initModules([
+			{blocks: require('../../../modules/blocks')}
+		], [
+			{'transaction': require('../../../logic/transaction')},
+			{'block': require('../../../logic/block')},
+			{'peers': require('../../../logic/peers.js')}
+		], {}, function (err, __blocks) {
 			if (err) {
 				return done(err);
 			}
-			blocks = __blocks;
+			blocks = __blocks.blocks;
 			done();
 		});
 	});

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -5,16 +5,20 @@ var express = require('express');
 var _  = require('lodash');
 var node = require('../../node.js');
 var Rounds = require('../../../modules/rounds.js');
+var modulesLoader = require('../../common/initModule').modulesLoader;
 
 describe('rounds', function () {
 
 	var rounds;
 
 	before(function (done) {
-		new Rounds(function (err, __rounds) {
+		modulesLoader.initModuleWithDb(Rounds, function (err, __rounds) {
+			if (err) {
+				return done(err);
+			}
 			rounds = __rounds;
 			done();
-		}, {});
+		});
 	});
 
 	describe('calc', function () {


### PR DESCRIPTION
Instead of introduce specific variables, we will reuse private variables `modules` and `library` and load them only with the content needed in order to reduce closures and keep the division.

**Approach**: 
1. Use parameters when available.
2. create object (`library` or `modules`) with all functions and objects needed. Keep full path in order to mirror the source.

Closes #555