### PR TITLE
Add declaration for blocks folder in Gruntfile - Closes #589

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
 		'logger.js',
 		'api/**/*.js',
 		'helpers/**/*.js',
-		'modules/*.js',
+		'modules/**/*.js',
 		'logic/*.js',
 		'schema/**/*.js',
 		'sql/**/*.js',


### PR DESCRIPTION
The missing declaration breaks binary builds. This pull request properly addresses the new folder in `modules`


Closes #589