### PR TITLE
Fix rounds module init, improved tests

### DIFF
--- a/test/api/peer.transactions.stress.js
+++ b/test/api/peer.transactions.stress.js
@@ -50,7 +50,7 @@ describe('POST /peer/transactions', function () {
 		});
 
 		it('should confirm all transactions', function (done) {
-			var blocksToWait = maximum / node.constants.maxTxsPerBlock + 1;
+			var blocksToWait = Math.ceil(maximum / node.constants.maxTxsPerBlock);
 			node.waitForBlocks(blocksToWait, function (err) {
 				node.async.eachSeries(transactions, function (transaction, eachSeriesCb) {
 					node.get('/api/transactions/get?id=' + transaction.id, function (err, res) {
@@ -92,7 +92,7 @@ describe('POST /peer/transactions', function () {
 		});
 
 		it('should confirm all transactions', function (done) {
-			var blocksToWait = maximum / node.constants.maxTxsPerBlock + 1;
+			var blocksToWait = Math.ceil(maximum / node.constants.maxTxsPerBlock);
 			node.waitForBlocks(blocksToWait, function (err) {
 				node.async.eachSeries(transactions, function (transaction, eachSeriesCb) {
 					node.get('/api/transactions/get?id=' + transaction.id, function (err, res) {

--- a/test/api/peer.transactions.votes.js
+++ b/test/api/peer.transactions.votes.js
@@ -26,7 +26,7 @@ function getVotes (address, done) {
 
 function postVotes (params, done) {
 	var count = 0;
-	var blocksToWait = Math.ceil(params.delegates.length / 25);
+	var blocksToWait = Math.ceil(params.delegates.length / node.constants.maxTxsPerBlock);
 
 	node.async.eachSeries(params.delegates, function (delegate, eachCb) {
 		var transaction = node.lisk.vote.createVote(params.passphrase, [params.action + delegate]);

--- a/test/api/peer.transactions.votes.js
+++ b/test/api/peer.transactions.votes.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var async = require('async');
 var node = require('./../node.js');
 
 var account = node.randomAccount();
@@ -27,31 +26,20 @@ function getVotes (address, done) {
 
 function postVotes (params, done) {
 	var count = 0;
-	var limit = Math.ceil(params.delegates.length / 25);
+	var blocksToWait = Math.ceil(params.delegates.length / 25);
 
-	async.whilst(
-		function () {
-			return count <= limit;
-		}, function (untilCb) {
-		node.onNewBlock(function (err) {
-			count++;
-			return untilCb();
+	node.async.eachSeries(params.delegates, function (delegate, eachCb) {
+		var transaction = node.lisk.vote.createVote(params.passphrase, [params.action + delegate]);
+
+		postVote(transaction, function (err, res) {
+			params.voteCb(err, res);
+			return eachCb();
 		});
 	}, function (err) {
-		async.eachSeries(params.delegates, function (delegate, eachCb) {
-			var transaction = node.lisk.vote.createVote(params.passphrase, [params.action + delegate]);
-
-			postVote(transaction, function (err, res) {
-				params.voteCb(err, res);
-				return eachCb();
-			});
-		}, function (err) {
-			node.onNewBlock(function (err) {
-				return done(err);
-			});
+		node.waitForBlocks(blocksToWait, function (err) {
+			return done(err);
 		});
-	}
-	);
+	});
 }
 
 function postVote (transaction, done) {
@@ -185,14 +173,12 @@ describe('POST /peer/transactions', function () {
 	});
 
 	it('voting twice for a delegate should fail', function (done) {
-		async.series([
+		node.async.series([
 			function (seriesCb) {
-				node.onNewBlock(function (err) {
-					var transaction = node.lisk.vote.createVote(account.password, ['+' + delegate]);
-					postVote(transaction, function (err, res) {
-						node.expect(res.body).to.have.property('success').to.be.ok;
-						seriesCb();
-					});
+				var transaction = node.lisk.vote.createVote(account.password, ['+' + delegate]);
+				postVote(transaction, function (err, res) {
+					node.expect(res.body).to.have.property('success').to.be.ok;
+					return seriesCb();
 				});
 			},
 			function (seriesCb) {
@@ -202,7 +188,7 @@ describe('POST /peer/transactions', function () {
 				var transaction2 = node.lisk.vote.createVote(account.password, ['+' + delegate]);
 				postVote(transaction2, function (err, res) {
 					node.expect(res.body).to.have.property('success').to.be.ok;
-					seriesCb();
+					return seriesCb();
 				});
 			},
 			function (seriesCb) {
@@ -212,13 +198,13 @@ describe('POST /peer/transactions', function () {
 				var transaction2 = node.lisk.vote.createVote(account.password, ['+' + delegate]);
 				postVote(transaction2, function (err, res) {
 					node.expect(res.body).to.have.property('success').to.be.not.ok;
-					seriesCb();
+					return seriesCb();
 				});
 			},
 			function (seriesCb) {
 				getVotes(account.address, function (err, res) {
 					node.expect(res.body).to.have.property('delegates').that.has.lengthOf(1);
-					seriesCb(err);
+					return seriesCb(err);
 				});
 			}
 		], function (err) {
@@ -227,98 +213,94 @@ describe('POST /peer/transactions', function () {
 	});
 
 	it('removing votes from a delegate should be ok', function (done) {
-		node.onNewBlock(function (err) {
-			var transaction = node.lisk.vote.createVote(account.password, ['-' + delegate]);
-			postVote(transaction, function (err, res) {
-				node.expect(res.body).to.have.property('success').to.be.ok;
-				node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
-				done();
+		var transaction = node.lisk.vote.createVote(account.password, ['-' + delegate]);
+		postVote(transaction, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
+			node.onNewBlock(function (err) {
+				return done(err);
 			});
 		});
 	});
 
 	it('voting for 33 delegates at once should be ok', function (done) {
-		node.onNewBlock(function (err) {
-			var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 33).map(function (delegate) {
-				return '+' + delegate;
-			}));
+		var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 33).map(function (delegate) {
+			return '+' + delegate;
+		}));
 
-			postVote(transaction, function (err, res) {
-				node.expect(res.body).to.have.property('success').to.be.ok;
-				node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
-				done();
+		postVote(transaction, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
+			node.onNewBlock(function (err) {
+				return done(err);
 			});
 		});
 	});
 
 	it('removing votes from 33 delegates at once should be ok', function (done) {
-		node.onNewBlock(function (err) {
-			var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 33).map(function (delegate) {
-				return '-' + delegate;
-			}));
+		var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 33).map(function (delegate) {
+			return '-' + delegate;
+		}));
 
-			postVote(transaction, function (err, res) {
-				node.expect(res.body).to.have.property('success').to.be.ok;
-				node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
-				done();
+		postVote(transaction, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
+			node.onNewBlock(function (err) {
+				return done(err);
 			});
 		});
 	});
 
 	it('voting for 34 delegates at once should fail', function (done) {
-		node.onNewBlock(function (err) {
-			var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 34).map(function (delegate) {
-				return '+' + delegate;
-			}));
+		var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 34).map(function (delegate) {
+			return '+' + delegate;
+		}));
 
-			postVote(transaction, function (err, res) {
-				node.expect(res.body).to.have.property('success').to.be.not.ok;
-				node.expect(res.body).to.have.property('message').to.equal('Voting limit exceeded. Maximum is 33 votes per transaction');
-				done();
+		postVote(transaction, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('message').to.equal('Voting limit exceeded. Maximum is 33 votes per transaction');
+			node.onNewBlock(function (err) {
+				return done(err);
 			});
 		});
 	});
 
 	it('voting for 101 delegates separately should be ok', function (done) {
-		node.onNewBlock(function (err) {
-			postVotes({
-				delegates: delegates,
-				passphrase: account.password,
-				action: '+',
-				voteCb: function (err, res) {
-					node.expect(res.body).to.have.property('success').to.be.ok;
-					node.expect(res.body).to.have.property('transactionId').that.is.a('string');
-				}
-			}, done);
-		});
+		postVotes({
+			delegates: delegates,
+			passphrase: account.password,
+			action: '+',
+			voteCb: function (err, res) {
+				node.expect(res.body).to.have.property('success').to.be.ok;
+				node.expect(res.body).to.have.property('transactionId').that.is.a('string');
+			}
+		}, done);
 	});
 
 	it('removing votes from 34 delegates at once should fail', function (done) {
-		node.onNewBlock(function (err) {
-			var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 34).map(function (delegate) {
-				return '-' + delegate;
-			}));
+		var transaction = node.lisk.vote.createVote(account.password, delegates.slice(0, 34).map(function (delegate) {
+			return '-' + delegate;
+		}));
 
-			postVote(transaction, function (err, res) {
-				node.expect(res.body).to.have.property('success').to.be.not.ok;
-				node.expect(res.body).to.have.property('message').to.equal('Voting limit exceeded. Maximum is 33 votes per transaction');
-				done();
+		postVote(transaction, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('message').to.equal('Voting limit exceeded. Maximum is 33 votes per transaction');
+			node.onNewBlock(function (err) {
+				return done(err);
 			});
 		});
 	});
 
 	it('removing votes from 101 delegates separately should be ok', function (done) {
-		node.onNewBlock(function (err) {
-			postVotes({
-				delegates: delegates,
-				passphrase: account.password,
-				action: '-',
-				voteCb: function (err, res) {
-					node.expect(res.body).to.have.property('success').to.be.ok;
-					node.expect(res.body).to.have.property('transactionId').that.is.a('string');
-				}
-			}, done);
-		});
+		postVotes({
+			delegates: delegates,
+			passphrase: account.password,
+			action: '-',
+			voteCb: function (err, res) {
+				node.expect(res.body).to.have.property('success').to.be.ok;
+				node.expect(res.body).to.have.property('transactionId').that.is.a('string');
+			}
+		}, done);
 	});
 });
 
@@ -359,7 +341,7 @@ describe('POST /peer/transactions after registering a new delegate', function ()
 	});
 
 	it('exceeding maximum of 101 votes should fail', function (done) {
-		async.series([
+		node.async.series([
 			function (seriesCb) {
 				getVotes(account.address, function (err, res) {
 					node.expect(res.body).to.have.property('delegates').that.has.lengthOf(1);
@@ -378,9 +360,6 @@ describe('POST /peer/transactions after registering a new delegate', function ()
 						node.expect(res.body).to.have.property('success').to.be.ok;
 					}
 				}, seriesCb);
-			},
-			function (seriesCb) {
-				return node.onNewBlock(seriesCb);
 			},
 			function (seriesCb) {
 				var slicedDelegates = delegates.slice(-25);
@@ -413,7 +392,9 @@ describe('POST /peer/transactions after registering a new delegate', function ()
 		postVote(transaction, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
-			done();
+			node.onNewBlock(function (err) {
+				return done(err);
+			});
 		});
 	});
 });

--- a/test/node.js
+++ b/test/node.js
@@ -4,7 +4,6 @@
 var node = {};
 var Rounds = require('../modules/rounds.js');
 var slots = require('../helpers/slots.js');
-var modulesLoader = require('./common/initModule').modulesLoader;
 
 // Requires
 node.bignum = require('../helpers/bignum.js');
@@ -131,15 +130,10 @@ node.onNewRound = function (cb) {
 		if (err) {
 			return cb(err);
 		} else {
-			modulesLoader.initModuleWithDb(Rounds, function (err, rounds) {
-				if (err) {
-					return cb(err);
-				}
-				var nextRound = rounds.calc(height);
-				var blocksToWait = nextRound * slots.delegates - height;
-				node.debug('blocks to wait: '.grey, blocksToWait);
-				node.waitForNewBlock(height, blocksToWait, cb);
-			});
+			var nextRound = Math.ceil(height / slots.delegates);
+			var blocksToWait = nextRound * slots.delegates - height;
+			node.debug('blocks to wait: '.grey, blocksToWait);
+			node.waitForNewBlock(height, blocksToWait, cb);
 		}
 	});
 };
@@ -168,6 +162,10 @@ node.waitForBlocks = function (blocksToWait, cb) {
 
 // Waits for a new block to be created
 node.waitForNewBlock = function (height, blocksToWait, cb) {
+	if (blocksToWait === 0) {
+		return setImmediate(cb, null, height);
+	}
+
 	var actualHeight = height;
 	var counter = 1;
 	var target = height + blocksToWait;

--- a/test/node.js
+++ b/test/node.js
@@ -150,7 +150,7 @@ node.onNewBlock = function (cb) {
 		if (err) {
 			return cb(err);
 		} else {
-			node.waitForNewBlock(height, 2, cb);
+			node.waitForNewBlock(height, 1, cb);
 		}
 	});
 };


### PR DESCRIPTION
- Fix rounds module init (module is skipped, instead we use function for calc round) for tests
- Wait for 1 blocks instead of 2 in `onNewBlock` function
- Refactored `peers.transactions.votes` for compatibility with 1 block wait, improved performance