### PR TITLE
Improve "Invalid transaction timestamp" error message - Closes #614

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -580,7 +580,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 
 	// Check timestamp
 	if (slots.getSlotNumber(trs.timestamp) > slots.getSlotNumber()) {
-		return setImmediate(cb, 'Invalid transaction timestamp');
+		return setImmediate(cb, 'Transaction timestamp in future. Your system time is ahead of the time on the server.');
 	}
 
 	// Call verify on transaction type


### PR DESCRIPTION
This is how it helps Lisk Nano:
Before:
![old-message](https://user-images.githubusercontent.com/1254342/27176173-dd0990fa-51c1-11e7-847d-53dcd2fb374b.png)

After:
![new-message](https://user-images.githubusercontent.com/1254342/27176178-dfec684c-51c1-11e7-96fa-b75d2cf259e1.png)
