### PR TITLE
Improve verbosity of timestamp failure - Closes #614

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -580,7 +580,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 
 	// Check timestamp
 	if (slots.getSlotNumber(trs.timestamp) > slots.getSlotNumber()) {
-		return setImmediate(cb, 'Invalid transaction timestamp. Timestamp is in the future.');
+		return setImmediate(cb, 'Invalid transaction timestamp. Timestamp is in the future');
 	}
 
 	// Call verify on transaction type

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -580,7 +580,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 
 	// Check timestamp
 	if (slots.getSlotNumber(trs.timestamp) > slots.getSlotNumber()) {
-		return setImmediate(cb, 'Invalid transaction timestamp');
+		return setImmediate(cb, 'Invalid transaction timestamp. Timestamp is in the future.');
 	}
 
 	// Call verify on transaction type


### PR DESCRIPTION
The time stamp error message on transactions in the future is too vague. This PR corrects the text to provide better understanding of why a TX failed.

Closes #614 