### PR TITLE
Disable console logging for production - Closes #620

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
     "minVersion": ">=0.5.0",
     "fileLogLevel": "info",
     "logFileName": "logs/lisk.log",
-    "consoleLogLevel": "info",
+    "consoleLogLevel": "none",
     "trustProxy": false,
     "topAccounts": false,
     "cacheEnabled": false,

--- a/logger.js
+++ b/logger.js
@@ -10,6 +10,7 @@ module.exports = function (config) {
 	var exports = {};
 
 	config.levels = config.levels || {
+		none: 99,
 		trace: 0,
 		debug: 1,
 		log: 2,


### PR DESCRIPTION
Disable console logging by using level "none"

```
  "consoleLogLevel": "debug"
```