### PR TITLE
Verify snapshot - Closes #637

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -423,6 +423,8 @@ __private.loadBlockChain = function () {
 				if ((count === 1) || (count % constants.activeDelegates > 0)) {
 					library.config.loading.snapshot = (round > 1) ? (round - 1) : 1;
 				}
+
+				modules.rounds.setSnapshotRounds(library.config.loading.snapshot);
 			}
 
 			library.logger.info('Snapshotting to end of round: ' + library.config.loading.snapshot);

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -165,6 +165,13 @@ Rounds.prototype.backwardTick = function (block, previousBlock, done) {
 		return done(err);
 	});
 };
+/**
+ * Sets snapshot rounds
+ * @param {number} rounds
+*/
+Rounds.prototype.setSnapshotRounds = function (rounds) {
+	library.config.loading.snapshot = rounds;
+};
 
 /**
  * Generates snapshot round

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -165,10 +165,11 @@ Rounds.prototype.backwardTick = function (block, previousBlock, done) {
 		return done(err);
 	});
 };
+
 /**
  * Sets snapshot rounds
  * @param {number} rounds
-*/
+ */
 Rounds.prototype.setSnapshotRounds = function (rounds) {
 	library.config.loading.snapshot = rounds;
 };


### PR DESCRIPTION
Properly terminates the node at the end of the specified snapshot round.

Closes #637 