### PR TITLE
Improve handling of invalid peers - Closes #645

### DIFF
--- a/logic/peer.js
+++ b/logic/peer.js
@@ -164,8 +164,8 @@ Peer.prototype.update = function (peer) {
 
 	// Accept only supported properties
 	_.each(this.properties, function (key) {
-		// Change value only when is defined, also prevent release ban when banned peer connect to our node
-		if (peer[key] !== null && peer[key] !== undefined && !(key === 'state' && this.state === Peer.STATE.BANNED && peer.state === Peer.STATE.CONNECTED) && !_.includes(this.immutable, key)) {
+		// Change value only when is defined
+		if (peer[key] !== null && peer[key] !== undefined && !_.includes(this.immutable, key)) {
 			this[key] = peer[key];
 		}
 	}.bind(this));

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -148,42 +148,6 @@ Peers.prototype.upsert = function (peer, insertOnly) {
 };
 
 /**
- * Upserts peer with banned state `0` and clock with current time + seconds.
- * @param {string} pip - Peer ip
- * @param {number} port
- * @param {number} seconds
- * @return {function} Calls upsert
- */
-Peers.prototype.ban = function (ip, port, seconds) {
-	return self.upsert({
-		ip: ip,
-		port: port,
-		// State 0 for banned peer
-		state: 0,
-		clock: Date.now() + (seconds || 1) * 1000
-	});
-};
-
-/**
- * Upserts peer with unbanned state `1` and deletes clock.
- * @param {string} pip - Peer ip
- * @param {number} port
- * @param {number} seconds
- * @return {peer}
- */
-Peers.prototype.unban = function (peer) {
-	peer = self.get(peer);
-	if (peer) {
-		delete peer.clock;
-		peer.state = 1;
-		library.logger.debug('Released ban for peer', peer.string);
-	} else {
-		library.logger.debug('Failed to release ban for peer', {err: 'INVALID', peer: peer});
-	}
-	return peer;
-};
-
-/**
  * Deletes peer from peers list.
  * @param {peer} peer
  * @return {boolean} True if peer exists

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -201,7 +201,7 @@ __private.loadSignatures = function (cb) {
 
 /**
  * Gets a random peer and loads transactions calling the api.
- * Validates each transaction from peer and bans peer if invalid.
+ * Validates each transaction from peer and remove peer if invalid.
  * Calls processUnconfirmedTransaction for each transaction.
  * @private
  * @implements {Loader.getNetwork}
@@ -209,7 +209,7 @@ __private.loadSignatures = function (cb) {
  * @implements {library.schema.validate}
  * @implements {async.eachSeries}
  * @implements {library.logic.transaction.objectNormalize}
- * @implements {modules.peers.ban}
+ * @implements {modules.peers.remove}
  * @implements {library.balancesSequence.add}
  * @implements {modules.transactions.processUnconfirmedTransaction}
  * @param {function} cb
@@ -257,8 +257,8 @@ __private.loadTransactions = function (cb) {
 				} catch (e) {
 					library.logger.debug('Transaction normalization failed', {id: id, err: e.toString(), module: 'loader', tx: transaction});
 
-					library.logger.warn(['Transaction', id, 'is not valid, ban 10 min'].join(' '), peer.string);
-					modules.peers.ban(peer.ip, peer.port, 600);
+					library.logger.warn(['Transaction', id, 'is not valid, peer removed'].join(' '), peer.string);
+					modules.peers.remove(peer.ip, peer.port);
 
 					return setImmediate(eachSeriesCb, e);
 				}

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -415,7 +415,7 @@ Peers.prototype.acceptable = function (peers) {
 			if ((process.env['NODE_ENV'] || '').toUpperCase() === 'TEST') {
 				return peer.nonce !== modules.system.getNonce();
 			}
-			return !ip.isPrivate(peer.ip) && peer.nonce !== modules.system.getNonce();
+			return !ip.isPrivate(peer.ip) && peer.nonce !== modules.system.getNonce() && (peer.os !== 'lisk-js-api');
 		}).value();
 };
 

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -413,7 +413,7 @@ Peers.prototype.acceptable = function (peers) {
 		.filter(function (peer) {
 			// Removing peers with private address or nonce equal to self
 			if ((process.env['NODE_ENV'] || '').toUpperCase() === 'TEST') {
-				return peer.nonce !== modules.system.getNonce();
+				return peer.nonce !== modules.system.getNonce() && (peer.os !== 'lisk-js-api');
 			}
 			return !ip.isPrivate(peer.ip) && peer.nonce !== modules.system.getNonce() && (peer.os !== 'lisk-js-api');
 		}).value();

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -152,22 +152,6 @@ __private.getByFilter = function (filter, cb) {
 };
 
 /**
- * Remove bans from peers list if clock period time has been pass.
- * @private
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} cb
- */
-__private.removeBans = function (cb) {
-	var now = Date.now();
-	_.each(library.logic.peers.list(), function (peer, index) {
-		if (peer.clock && peer.clock <= now) {
-			library.logic.peers.unban(peer);
-		}
-	});
-	return setImmediate(cb);
-};
-
-/**
  * Pings to every member of peers list.
  * @private
  * @param {function} cb - Callback function.
@@ -329,26 +313,6 @@ Peers.prototype.remove = function (pip, port) {
 		library.logger.debug('Cannot remove frozen peer', pip + ':' + port);
 	} else {
 		return library.logic.peers.remove ({ip: pip, port: port});
-	}
-};
-
-/**
- * Bans peer in peers list if it is not a peer from config file list.
- * @implements logic.peers.ban
- * @param {string} pip - Peer ip
- * @param {number} port
- * @param {number} seconds
- * @return {function} Calls peers.ban
- */
-Peers.prototype.ban = function (pip, port, seconds) {
-	var frozenPeer = _.find(library.config.peers.list, function (peer) {
-		return peer.ip === pip && peer.port === port;
-	});
-	if (frozenPeer) {
-		// FIXME: Keeping peer frozen is bad idea at all
-		library.logger.debug('Cannot ban frozen peer', pip + ':' + port);
-	} else {
-		return library.logic.peers.ban (pip, port, seconds);
 	}
 };
 
@@ -567,7 +531,7 @@ Peers.prototype.onBlockchainReady = function () {
 };
 
 /**
- * Discovers peers, updates them and removes bans in 10sec intervals loop.
+ * Discovers peers and updates them in 10sec intervals loop.
  */
 Peers.prototype.onPeersReady = function () {
 	library.logger.trace('Peers ready');
@@ -601,13 +565,6 @@ Peers.prototype.onPeersReady = function () {
 					}
 				}, function () {
 					library.logger.trace('Peers updated', {updated: updated, total: peers.length});
-					return setImmediate(seriesCb);
-				});
-			},
-			removeBans: function (seriesCb) {
-				library.logger.trace('Checking peers bans...');
-
-				__private.removeBans(function (err) {
 					return setImmediate(seriesCb);
 				});
 			}

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -87,23 +87,6 @@ __private.hashsum = function (obj) {
 };
 
 /**
- * Bans a peer based on ip, port and clock options.
- * @private
- * @implements {modules.peers.ban}
- * @param {Object} options - Contains code, clock and peer.
- * @param {string} extraMessage
- * @return {boolean} False if there is no peer object
- */
-__private.banPeer = function (options, extraMessage) {
-	if (!options.peer || !options.peer.ip || !options.peer.port) {
-		library.logger.trace('Peer ban skipped', {options: options});
-		return false;
-	}
-	library.logger.debug([options.code, ['Ban', options.peer.string, (options.clock / 60), 'minutes'].join(' '), extraMessage].join(' '));
-	modules.peers.ban(options.peer.ip, options.peer.port, options.clock);
-};
-
-/**
  * Removes a peer based on ip and port.
  * @private
  * @implements {modules.peers.remove}
@@ -225,12 +208,12 @@ __private.receiveTransactions = function (query, peer, extraLogMessage, cb) {
 };
 
 /**
- * Normalizes transaction and bans peer if it fails.
+ * Normalizes transaction and remove peer if it fails.
  * Calls balancesSequence.add to receive transaction and 
  * processUnconfirmedTransaction to confirm it.
  * @private
  * @implements {library.logic.transaction.objectNormalize}
- * @implements {__private.banPeer}
+ * @implements {__private.removePeer}
  * @implements {library.balancesSequence.add}
  * @implements {modules.transactions.processUnconfirmedTransaction}
  * @param {transaction} transaction
@@ -247,8 +230,7 @@ __private.receiveTransaction = function (transaction, peer, extraLogMessage, cb)
 	} catch (e) {
 		library.logger.debug('Transaction normalization failed', {id: id, err: e.toString(), module: 'transport', tx: transaction});
 
-		// Ban peer for 10 minutes
-		__private.banPeer({peer: peer, code: 'ETRANSACTION', clock: 600}, extraLogMessage);
+		__private.removePeer({peer: peer, code: 'ETRANSACTION'}, extraLogMessage);
 
 		return setImmediate(cb, 'Invalid transaction body - ' + e.toString());
 	}
@@ -355,7 +337,6 @@ Transport.prototype.getFromRandomPeer = function (config, options, cb) {
  * @implements {modules.system.versionCompatible}
  * @implements {modules.peers.update}
  * @implements {__private.removePeer}
- * @implements {__private.banPeer}
  * @param {peer} peer
  * @param {Object} options
  * @param {function} cb
@@ -423,13 +404,7 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
 			}
 		}).catch(function (err) {
 			if (peer) {
-				if (err.code === 'EUNAVAILABLE') {
-				// Remove peer
-					__private.removePeer({peer: peer, code: err.code}, req.method + ' ' + req.url);
-				} else {
-				// Ban peer for 1 minute
-					__private.banPeer({peer: peer, code: err.code, clock: 60}, req.method + ' ' + req.url);
-				}
+				__private.removePeer({peer: peer, code: err.code}, req.method + ' ' + req.url);
 			}
 
 			return setImmediate(cb, [err.code, 'Request failed', req.method, req.url].join(' '));
@@ -585,8 +560,7 @@ Transport.prototype.internal = {
 		if (!escapedIds.length) {
 			library.logger.debug('Common block request validation failed', {err: 'ESCAPE', req: ids});
 
-			// Ban peer for 10 minutes
-			__private.banPeer({peer: peer, code: 'ECOMMON', clock: 600}, extraLogMessage);
+			__private.removePeer({peer: peer, code: 'ECOMMON'}, extraLogMessage);
 
 			return setImmediate(cb, 'Invalid block id sequence');
 		}
@@ -622,8 +596,7 @@ Transport.prototype.internal = {
 		} catch (e) {
 			library.logger.debug('Block normalization failed', {err: e.toString(), module: 'transport', block: block });
 
-			// Ban peer for 10 minutes
-			__private.banPeer({peer: peer, code: 'EBLOCK', clock: 600}, extraLogMessage);
+			__private.removePeer({peer: peer, code: 'EBLOCK'}, extraLogMessage);
 
 			return setImmediate(cb, null, {success: false, error: e.toString()});
 		}

--- a/test/unit/logic/peer.js
+++ b/test/unit/logic/peer.js
@@ -121,13 +121,13 @@ describe('peer', function () {
 			expect(peer.someProp).to.not.exist;
 		});
 
-		it('should not change state of banned peer', function () {
+		it('should change state of banned peer', function () {
 			var initialState = peer.state;
 			// Ban peer
 			peer.state = 0;
 			// Try to unban peer
 			peer.update({state: 2});
-			expect(peer.state).to.equal(0);
+			expect(peer.state).to.equal(2);
 			peer.state = initialState;
 		});
 

--- a/test/unit/logic/peers.js
+++ b/test/unit/logic/peers.js
@@ -99,6 +99,15 @@ describe('peers', function () {
 			removeAll();
 		});
 
+		it('should not insert new peer with lisk-js-api os', function () {
+			removeAll();
+			var modifiedPeer = _.clone(randomPeer);
+			modifiedPeer.os = 'lisk-js-api';
+			peers.upsert(modifiedPeer);
+			expect(peers.list().length).equal(0);
+			removeAll();
+		});
+
 		it('should update height of existing peer', function () {
 			removeAll();
 

--- a/test/unit/logic/peers.js
+++ b/test/unit/logic/peers.js
@@ -222,56 +222,6 @@ describe('peers', function () {
 		});
 	});
 
-	describe('ban', function () {
-
-		it('should change the peer state to banned', function () {
-			removeAll();
-			peers.upsert(randomPeer);
-			expect(peers.list().length).equal(1);
-			expect(peers.list()[0].state).equal(2);
-
-			var result = peers.ban(randomPeer.ip, randomPeer.port, 10);
-			expect(result).to.be.ok;
-			expect(peers.list().length).equal(1);
-			expect(peers.list()[0].state).equal(0);
-		});
-
-	});
-
-	describe('unban', function () {
-
-		it('should change the peer state to unbanned', function () {
-			removeAll();
-			peers.upsert(randomPeer);
-			expect(peers.list().length).equal(1);
-			expect(peers.list()[0].state).equal(2);
-
-			var result = peers.ban(randomPeer.ip, randomPeer.port, 10);
-			expect(result).to.be.ok;
-			expect(peers.list().length).equal(1);
-			expect(peers.list()[0].state).equal(0);
-
-			peers.unban(randomPeer);
-			expect(peers.list().length).equal(1);
-			expect(peers.list()[0].state).equal(1);
-		});
-
-		it('should do nothing when unbanning non inserted peer', function () {
-			removeAll();
-			peers.upsert(randomPeer);
-			expect(peers.list().length).equal(1);
-			expect(peers.list()[0].state).equal(2);
-
-			var differentPeer = _.clone(randomPeer);
-			differentPeer.port += 1;
-
-			peers.unban(differentPeer);
-			expect(peers.list().length).equal(1);
-			expect(arePeersEqual(peers.list()[0], randomPeer)).to.be.ok;
-		});
-
-	});
-
 	describe('remove', function () {
 
 		it('should remove added peer', function () {

--- a/test/unit/logic/peers.js
+++ b/test/unit/logic/peers.js
@@ -16,15 +16,18 @@ describe('peers', function () {
 	var peers;
 
 	before(function (done) {
-		modulesLoader.initLogic(Peers, modulesLoader.scope, function (err, __peers) {
-			peers = __peers;
-			var peersModuleMock = {
-				acceptable: function (peers) {
-					return peers;
-				}
-			};
-			peers.bindModules({peers: peersModuleMock});
-			done();
+		modulesLoader.initAllModules(function (err, __modules) {
+			if (err) {
+				return done(err);
+			}
+
+			__modules.peers.onBind(__modules);
+
+			modulesLoader.initLogic(Peers, modulesLoader.scope, function (err, __peers) {
+				peers = __peers;
+				peers.bindModules({peers: __modules.peers});
+				done();
+			});
 		});
 	});
 

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -170,36 +170,6 @@ describe('peers', function () {
 		});
 	});
 
-	describe('ban', function () {
-
-		var peerToBan;
-
-		before(function (done) {
-			peerToBan = _.clone(randomPeer);
-			peerToBan.port += 1;
-			peers.update(peerToBan);
-			done();
-		});
-
-		it('should ban active peer', function (done) {
-			getPeers(function (err, __peers) {
-				currentPeers = __peers;
-				peerToBan = __peers.find(function (p) {
-					return p.ip + ':' + p.port === peerToBan.ip + ':' + peerToBan.port;
-				});
-				expect(peerToBan).to.be.an('object').and.not.to.be.empty;
-				expect(peerToBan.state).that.equals(2);
-
-				expect(peers.ban(peerToBan.ip, peerToBan.port, 1)).to.be.ok;
-				getPeers(function (err, __peers) {
-					expect(currentPeers.length - 1).that.equals(__peers.length);
-					currentPeers = __peers;
-					done();
-				});
-			});
-		});
-	});
-
 	describe('remove', function () {
 
 		before(function (done) {

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -214,6 +214,12 @@ describe('peers', function () {
 			expect(peers.acceptable([privatePeer])).that.is.an('array').and.to.be.empty;
 		});
 
+		it('should not accept peer with lisk-js-api os', function () {
+			var privatePeer = _.clone(randomPeer);
+			privatePeer.os = 'lisk-js-api';
+			expect(peers.acceptable([privatePeer])).that.is.an('array').and.to.be.empty;
+		});
+
 		it('should not accept peer with host\'s nonce', function () {
 			var peer = _.clone(randomPeer);
 			peer.nonce = NONCE;


### PR DESCRIPTION
- Remove peers instead of ban
- Drop ban mechanism
- Don't allow peers with `os` header equal `lisk-js-api` to be accepted as peers

Closes #645 