### PR TITLE
Fix coveralls unit test reporting - Closes #666

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,9 @@ module.exports = function (grunt) {
 			fetchCoverage: {
 				command: 'rm -rf ./test/.coverage-func.zip; curl -o ./test/.coverage-func.zip $HOST/coverage/download',
 				maxBuffer: maxBufferSize
+			},
+			coverageReport: {
+				command: 'rm -f ./test/.coverage-unit/lcov.info; ./node_modules/.bin/istanbul report --root ./test/.coverage-unit/ --dir ./test/.coverage-unit'
 			}
 		},
 
@@ -118,6 +121,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', ['release']);
 	grunt.registerTask('release', ['exec:folder', 'obfuscator', 'exec:package', 'exec:build', 'compress']);
 	grunt.registerTask('jenkins', ['exec:coverageSingle']);
+	grunt.registerTask('coverageReport', ['exec:coverateReport']);
 	grunt.registerTask('eslint-nofix', ['eslint']);
 	grunt.registerTask('test', ['eslint', 'exec:coverage']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', ['release']);
 	grunt.registerTask('release', ['exec:folder', 'obfuscator', 'exec:package', 'exec:build', 'compress']);
 	grunt.registerTask('jenkins', ['exec:coverageSingle']);
-	grunt.registerTask('coverageReport', ['exec:coverateReport']);
+	grunt.registerTask('coverageReport', ['exec:coverageReport']);
 	grunt.registerTask('eslint-nofix', ['eslint']);
 	grunt.registerTask('test', ['eslint', 'exec:coverage']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function (grunt) {
 			},
 
 			coverageSingle: {
-				command: 'export NODE_ENV=TEST && node_modules/.bin/istanbul cover --dir test/.coverage-unit ./node_modules/.bin/_mocha $TEST',
+				command: 'export NODE_ENV=TEST && node_modules/.bin/istanbul cover --dir test/.coverage-unit --include-pid ./node_modules/.bin/_mocha $TEST',
 				maxBuffer: maxBufferSize
 			},
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -350,6 +350,8 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
         node('node-02'){
           sh '''#!/bin/bash
           export HOST=127.0.0.1:4000
+	  # Gathers unit test into single lcov.info
+	  npm run coverageReport
           npm run fetchCoverage
           # Submit coverage reports to Master
           scp test/.coverage-func.zip jenkins@master-01:/var/lib/jenkins/coverage/coverage-func-node-02.zip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -350,8 +350,8 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
         node('node-02'){
           sh '''#!/bin/bash
           export HOST=127.0.0.1:4000
-	  # Gathers unit test into single lcov.info
-	  npm run coverageReport
+          # Gathers unit test into single lcov.info
+          npm run coverageReport
           npm run fetchCoverage
           # Submit coverage reports to Master
           scp test/.coverage-func.zip jenkins@master-01:/var/lib/jenkins/coverage/coverage-func-node-02.zip
@@ -420,8 +420,8 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
         rm -rf coverage-unit/*
         rm -f merged-lcov.info
         rm -rf lisk/*
-	rm -f coverage.json
-	rm -f lcov.info
+        rm -f coverage.json
+        rm -f lcov.info
         '''
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -418,6 +418,8 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
         rm -rf coverage-unit/*
         rm -f merged-lcov.info
         rm -rf lisk/*
+	rm -f coverage.json
+	rm -f lcov.info
         '''
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "jenkins": "./node_modules/.bin/grunt jenkins --verbose",
     "eslint": "./node_modules/.bin/grunt eslint-nofix --verbose",
     "fetchCoverage": "./node_modules/.bin/grunt exec:fetchCoverage --verbose",
+    "coverageReport": "./node_modules/.bin/grunt coverageReport --verbose",
     "jsdoc": "jsdoc -c docs/conf.json --verbose --pedantic",
     "server-docs": "npm run jsdoc && http-server docs/jsdoc/"
   },


### PR DESCRIPTION
LCOV files were being overwritten by each other. This pr creates unique coverage.json for each test and then merges them all for submission at the end of the job.