### PR TITLE
Improving dapps API test coverage - Closes #560

### DIFF
--- a/api/http/dapps.js
+++ b/api/http/dapps.js
@@ -30,7 +30,7 @@ function DappsHttpApi (dappsModule, app) {
 	});
 
 	router.get('/', httpApi.middleware.sanitize('query', schema.list, dappsModule.internal.list));
-	router.get('/:id', httpApi.middleware.sanitize('param', schema.get, dappsModule.internal.get));
+	router.get('/get', httpApi.middleware.sanitize('query', schema.get, dappsModule.internal.get));
 
 	httpApi.registerEndpoint('/api/dapps', app, router, dappsModule.isLoaded);
 }

--- a/helpers/httpApi.js
+++ b/helpers/httpApi.js
@@ -156,7 +156,7 @@ var middleware = {
 
 		var key = req.originalUrl;
 		cache.getJsonForKey(key, function (err, cachedValue) {
-			//there was an error or value doesn't exist for key
+			// There was an error or value doesn't exist for key
 			if (err || !cachedValue) {
 				// Monkey patching res.json function only if we expect to cache response
 				var expressSendJson = res.json;

--- a/modules/dapps.js
+++ b/modules/dapps.js
@@ -239,7 +239,7 @@ DApps.prototype.internal = {
 	list: function (query, cb) {
 		__private.list(query, function (err, dapps) {
 			if (err) {
-				return setImmediate(cb, 'Application not found');
+				return setImmediate(cb, err);
 			} else {
 				return setImmediate(cb, null, {success: true, dapps: dapps});
 			}

--- a/modules/dapps.js
+++ b/modules/dapps.js
@@ -129,7 +129,8 @@ __private.list = function (filter, cb) {
 
 	if (filter.category) {
 		var category = dappCategories[filter.category];
-		if (category != null && category !== undefined) {
+
+		if (category != null) {
 			where.push('"category" = ${category}');
 			params.category = category;
 		} else {

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -4,7 +4,11 @@ var node = require('./../node.js');
 var clearDatabaseTable = require('../common/globalBefore').clearDatabaseTable;
 var modulesLoader = require('../common/initModule').modulesLoader;
 
-var dapp = {};
+function postTransaction (transaction, done) {
+	node.post('/peer/transactions', {
+		transaction: transaction
+	}, done);
+}
 
 before(function (done) {
 	modulesLoader.getDbConnection(function (err, db) {
@@ -18,200 +22,65 @@ before(function (done) {
 	});
 });
 
-describe('GET /dapps', function () {
+before(function (done) {
+	var account = node.randomAccount();
+	var options = node.guestbookDapp;
+	var transaction = node.lisk.dapp.createDapp(node.gAccount.password, null, options);
+	node.guestbookDapp.transactionId = transaction.id;
 
-	before(function (done) {
-		node.onNewBlock(done);
-	});
-
-	function getDapps (params, done) {
-		node.get('/api/dapps?' + params, done);
-	}
-
-	it('user orderBy == "category:asc" should be ok', function (done) {
-		getDapps('orderBy=' + 'category:asc', function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			if (res.body.dapps[0] != null) {
-				for (var i = 0; i < res.body.dapps.length; i++) {
-					if (res.body.dapps[i + 1] != null) {
-						node.expect(res.body.dapps[i].category).to.be.at.most(res.body.dapps[i + 1].category);
-					}
-				}
-			}
-			done();
-		});
-	});
-
-	it('user orderBy == "category:desc" should be ok', function (done) {
-		getDapps('orderBy=' + 'category:desc', function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			if (res.body.dapps[0] != null) {
-				for (var i = 0; i < res.body.dapps.length; i++) {
-					if (res.body.dapps[i + 1] != null) {
-						node.expect(res.body.dapps[i].category).to.be.at.least(res.body.dapps[i + 1].category);
-					}
-				}
-			}
-			done();
-		});
-	});
-
-	it('using category should be ok', function (done) {
-		var randomCategory = node.randomProperty(node.dappCategories, true);
-
-		getDapps('category=' + randomCategory, function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			if (res.body.dapps.length > 0) {
-				node.expect(res.body.dapps[0].category).to.equal(node.dappCategories[randomCategory]);
-			}
-			done();
-		});
-	});
-
-	it.skip('using name should be ok', function (done) {
-		var name = '';
-
-		if (dapp !== {} && dapp != null) {
-			name = dapp.name;
-		} else {
-			name = 'test';
-		}
-
-		getDapps('name=' + name, function (err, res) {
-			node.expect(res.body).to.have.property('success');
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			if (name !== 'test') {
-				node.expect(res.body.dapps).to.have.length.above(0);
-				node.expect(res.body.dapps[0].name).to.equal(name);
-			}
-			done();
-		});
-	});
-
-	it('using type should be ok', function (done) {
-		var type = node.randomProperty(node.dappTypes);
-
-		getDapps('type=' + type, function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			for (var i = 0; i < res.body.dapps.length; i++) {
-				if (res.body.dapps[i] != null) {
-					node.expect(res.body.dapps[i].type).to.equal(type);
-				}
-			}
-			done();
-		});
-	});
-
-	it('using numeric link should fail', function (done) {
-		var link = 12345;
-
-		getDapps('link=' + link, function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.not.ok;
-			node.expect(res.body).to.have.property('error');
-			done();
-		});
-	});
-
-	it('using string link should be ok', function (done) {
-		var link = node.guestbookDapp.link;
-
-		getDapps('link=' + link, function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			for (var i = 0; i < res.body.dapps.length; i++) {
-				if (res.body.dapps[i] != null) {
-					node.expect(res.body.dapps[i].link).to.equal(link);
-				}
-			}
-			done();
-		});
-	});
-
-	it('using no limit should be ok', function (done) {
-		getDapps('', function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			if (res.body.dapps.length > 0) {
-				dapp = res.body.dapps[0];
-				dapp = dapp;
-			}
-			done();
-		});
-	});
-
-	it('using limit == 3 should be ok', function (done) {
-		var limit = 3;
-
-		getDapps('limit=' + limit, function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			node.expect(res.body.dapps).to.have.length.at.most(limit);
-			done();
-		});
-	});
-
-	it('using offset should be ok', function (done) {
-		var offset = 1;
-		var secondDapp;
-
-		getDapps('', function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			if (res.body.dapps[1] != null) {
-				secondDapp = res.body.dapps[1];
-
-				getDapps('offset=' + 1, function (err, res) {
-					node.expect(res.body).to.have.property('success').to.be.ok;
-					node.expect(res.body).to.have.property('dapps').that.is.an('array');
-					node.expect(res.body.dapps[0]).to.deep.equal(secondDapp);
-				});
-			}
-			done();
-		});
-	});
+	postTransaction(transaction, done);
 });
 
-describe('GET /dapps?id=', function () {
+before(function (done) {
+	var account = node.randomAccount();
+	var options = node.blockDataDapp;
+	var transaction = node.lisk.dapp.createDapp(node.gAccount.password, null, options);
+	node.blockDataDapp.transactionId = transaction.id;
 
-	function getDapps (id, done) {
-		node.get('/api/dapps?id=' + id, done);
+	postTransaction(transaction, done);
+});
+
+before(function (done) {
+	node.onNewBlock(done);
+});
+
+describe('GET /api/dapps/get?id=', function () {
+
+	function getDapp (id, done) {
+		node.get('/api/dapps/get?id=' + id, done);
 	}
 
 	it('using no id should fail', function (done) {
-		getDapps('', function (err, res) {
+		getDapp('', function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.not.ok;
-			node.expect(res.body).to.have.property('error').to.equal('String is too short (0 chars), minimum 1: #/id');
+			node.expect(res.body).to.have.property('error').that.is.equal('String is too short (0 chars), minimum 1: #/id');
 			done();
 		});
 	});
 
 	it('using id with length > 20 should fail', function (done) {
-		getDapps('012345678901234567890', function (err, res) {
+		getDapp('012345678901234567890', function (err, res) {
 			node.expect(res.body).to.have.property('success').to.not.be.ok;
-			node.expect(res.body).to.have.property('error').to.equal('String is too long (21 chars), maximum 20: #/id');
+			node.expect(res.body).to.have.property('error').that.is.equal('String is too long (21 chars), maximum 20: #/id');
 			done();
 		});
 	});
 
-	it('using unknown id should be ok', function (done) {
+	it('using unknown id should fail', function (done) {
 		var dappId = '8713095156789756398';
 
-		getDapps(dappId, function (err, res) {
-			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
+		getDapp(dappId, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Application not found');
 			done();
 		});
 	});
 
-	it.skip('using valid id should be ok', function (done) {
-		getDapps(dapp.transactionId, function (err, res) {
+	it('using known id should be ok', function (done) {
+		getDapp(node.guestbookDapp.transactionId, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
-			node.expect(res.body).to.have.property('dapps').that.is.an('array');
-			node.expect(res.body.dapps[0].transactionId).to.equal(dapp.transactionId);
+			node.expect(res.body).to.have.property('dapp').that.is.an('object');
+			node.expect(res.body.dapp).to.have.property('name').that.is.equal(node.guestbookDapp.name);
 			done();
 		});
 	});
@@ -226,6 +95,354 @@ describe('GET /api/dapps/categories', function () {
 			for (var i in node.dappCategories) {
 				node.expect(res.body.categories[i]).to.equal(node.dappCategories[i]);
 			}
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?type=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?type=' + params, done);
+	}
+
+	it('using no type should fail', function (done) {
+		var type = node.randomProperty(node.dappTypes);
+
+		getDapps('', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Expected type integer but found type string: #/type');
+			done();
+		});
+	});
+
+	it('using type == -1 should fail', function (done) {
+		var type = node.randomProperty(node.dappTypes);
+
+		getDapps('-1', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Value -1 is less than minimum 0: #/type');
+			done();
+		});
+	});
+
+	it('using type == 0 should be ok', function (done) {
+		var type = node.randomProperty(node.dappTypes);
+
+		getDapps('0', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(2);
+			node.expect(res.body.dapps[0].type).to.equal(0);
+			node.expect(res.body.dapps[1].type).to.equal(0);
+			done();
+		});
+	});
+
+	it('using type == 1 should be ok', function (done) {
+		var type = node.randomProperty(node.dappTypes);
+
+		getDapps('1', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(0);
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?name=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?name=' + params, done);
+	}
+
+	it('using name with length < 1 should fail', function (done) {
+		var name = '';
+
+		getDapps(name, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('String is too short (0 chars), minimum 1: #/name');
+			done();
+		});
+	});
+
+	it('using name with length > 32 should fail', function (done) {
+		var name = 'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFG';
+
+		getDapps(name, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('String is too long (33 chars), maximum 32: #/name');
+			done();
+		});
+	});
+
+	it('using unknown name should be ok', function (done) {
+		var name = 'fooBar';
+
+		getDapps(name, function (err, res) {
+			node.expect(res.body).to.have.property('success');
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(0);
+			done();
+		});
+	});
+
+	it('using name == "Lisk Guestbook" should be ok', function (done) {
+		var name = 'Lisk Guestbook';
+
+		getDapps(name, function (err, res) {
+			node.expect(res.body).to.have.property('success');
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].name).to.equal('Lisk Guestbook');
+			done();
+		});
+	});
+
+	it('using name == "BlockData" should be ok', function (done) {
+		var name = 'BlockData';
+
+		getDapps(name, function (err, res) {
+			node.expect(res.body).to.have.property('success');
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].name).to.equal('BlockData');
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?category=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?category=' + params, done);
+	}
+
+	it('using numeric category should fail', function (done) {
+		var category = 0;
+
+		getDapps(category, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Expected type string but found type integer: #/category');
+			done();
+		});
+	});
+
+	it('using category == "Education" should be ok', function (done) {
+		var category = 'Education';
+
+		getDapps(category, function (err, res) {
+			node.expect(res.body).to.have.property('success');
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].category).to.equal(0);
+			done();
+		});
+	});
+
+	it('using category == "Entertainment" should be ok', function (done) {
+		var category = 'Entertainment';
+
+		getDapps(category, function (err, res) {
+			node.expect(res.body).to.have.property('success');
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].category).to.equal(1);
+			done();
+		});
+	});
+
+	it('using category == "Unknown"', function (done) {
+		var category = 'Unknown';
+
+		getDapps(category, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Invalid application category');
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?link=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?link=' + params, done);
+	}
+
+	it('using numeric link should fail', function (done) {
+		var link = 0;
+
+		getDapps(link, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Expected type string but found type integer: #/link');
+			done();
+		});
+	});
+
+	it('using link with length < 1 should fail', function (done) {
+		var link = '';
+
+		getDapps(link, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('String is too short (0 chars), minimum 1: #/link');
+			done();
+		});
+	});
+
+	it('using link with length > 2000 should fail', function (done) {
+		var link = 'https://github.com/MaxKK/xxxxxx/archive/master.zip'.repeat(40) + '1';
+
+		getDapps(link, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('String is too long (2001 chars), maximum 2000: #/link');
+			done();
+		});
+	});
+
+	it('using known link should be ok', function (done) {
+		var link = node.guestbookDapp.link;
+
+		getDapps(link, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].link).to.equal(link);
+			done();
+		});
+	});
+
+	it('using unknown link should be ok', function (done) {
+		var link = 'https://github.com/MaxKK/xxxxxx/archive/master.zip';
+
+		getDapps(link, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(0);
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?limit=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?limit=' + params, done);
+	}
+
+	it('using limit == 0 should fail', function (done) {
+		var limit = 0;
+
+		getDapps(limit, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Value 0 is less than minimum 1: #/limit');
+			done();
+		});
+	});
+
+	it('using limit > 100 should fail', function (done) {
+		var limit = 101;
+
+		getDapps(limit, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Value 101 is greater than maximum 100: #/limit');
+			done();
+		});
+	});
+
+	it('using limit == 1 should be ok', function (done) {
+		var limit = 1;
+
+		getDapps(limit, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array');
+			node.expect(res.body.dapps).to.have.length.at.most(limit);
+			done();
+		});
+	});
+
+	it('using limit == 100 should be ok', function (done) {
+		var limit = 100;
+
+		getDapps(limit, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array');
+			node.expect(res.body.dapps).to.have.length.at.most(limit);
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?limit=1&offset=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?limit=1&offset=' + params, done);
+	}
+
+	it('using offset < 0 should fail', function (done) {
+		var offset = -1;
+
+		getDapps(offset, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Value -1 is less than minimum 0: #/offset');
+			done();
+		});
+	});
+
+	it('using offset == 0 should be ok', function (done) {
+		var offset = 0;
+
+		getDapps(offset, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].name).to.equal(node.blockDataDapp.name);
+			done();
+		});
+	});
+
+	it('using offset == 1 should be ok', function (done) {
+		var offset = 1;
+
+		getDapps(offset, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
+			node.expect(res.body.dapps[0].name).to.equal(node.guestbookDapp.name);
+			done();
+		});
+	});
+});
+
+describe('GET /api/dapps/?orderBy=', function () {
+
+	function getDapps (params, done) {
+		node.get('/api/dapps?orderBy=' + params, done);
+	}
+
+	it('using orderBy == "category:asc" should be ok', function (done) {
+		getDapps('category:asc', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array');
+			node.expect(res.body.dapps[0].category).to.equal(0);
+			node.expect(res.body.dapps[1].category).to.equal(1);
+			done();
+		});
+	});
+
+	it('using orderBy == "category:desc" should be ok', function (done) {
+		getDapps('category:desc', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array');
+			node.expect(res.body.dapps[0].category).to.equal(1);
+			node.expect(res.body.dapps[1].category).to.equal(0);
+			done();
+		});
+	});
+
+	it('using orderBy == "category:unknown" should be ok', function (done) {
+		getDapps('category:unknown', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.ok;
+			node.expect(res.body).to.have.property('dapps').that.is.an('array');
+			node.expect(res.body.dapps[0].category).to.equal(0);
+			node.expect(res.body.dapps[1].category).to.equal(1);
+			done();
+		});
+	});
+
+	it('using orderBy == "unknown:unknown" should be ok', function (done) {
+		getDapps('unknown:unknown', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Invalid sort field');
 			done();
 		});
 	});

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -186,8 +186,8 @@ describe('GET /api/dapps/?name=', function () {
 		});
 	});
 
-	it('using unknown name should be ok', function (done) {
-		var name = 'fooBar';
+	it('using name == "Unknown" should be ok', function (done) {
+		var name = 'Unknown';
 
 		getDapps(name, function (err, res) {
 			node.expect(res.body).to.have.property('success');

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -23,21 +23,12 @@ before(function (done) {
 });
 
 before(function (done) {
-	var account = node.randomAccount();
-	var options = node.guestbookDapp;
-	var transaction = node.lisk.dapp.createDapp(node.gAccount.password, null, options);
-	node.guestbookDapp.transactionId = transaction.id;
+	node.async.eachSeries([node.guestbookDapp, node.blockDataDapp], function (dapp, eachSeriesCb) {
+		var transaction = node.lisk.dapp.createDapp(node.gAccount.password, null, dapp);
+		dapp.transactionId = transaction.id;
 
-	postTransaction(transaction, done);
-});
-
-before(function (done) {
-	var account = node.randomAccount();
-	var options = node.blockDataDapp;
-	var transaction = node.lisk.dapp.createDapp(node.gAccount.password, null, options);
-	node.blockDataDapp.transactionId = transaction.id;
-
-	postTransaction(transaction, done);
+		postTransaction(transaction, eachSeriesCb);
+	}, done);
 });
 
 before(function (done) {

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -58,6 +58,16 @@ describe('GET /api/dapps/get?id=', function () {
 		});
 	});
 
+	it('using non-numeric id should fail', function (done) {
+		var dappId = 'ABCDEFGHIJKLMNOPQRST';
+
+		getDapp(dappId, function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Object didn\'t pass validation for format id: ABCDEFGHIJKLMNOPQRST: #/id');
+			done();
+		});
+	});
+
 	it('using id with length > 20 should fail', function (done) {
 		getDapp('012345678901234567890', function (err, res) {
 			node.expect(res.body).to.have.property('success').to.not.be.ok;
@@ -110,6 +120,16 @@ describe('GET /api/dapps/?type=', function () {
 		var type = node.randomProperty(node.dappTypes);
 
 		getDapps('', function (err, res) {
+			node.expect(res.body).to.have.property('success').to.be.not.ok;
+			node.expect(res.body).to.have.property('error').that.is.equal('Expected type integer but found type string: #/type');
+			done();
+		});
+	});
+
+	it('using non-numeric type should fail', function (done) {
+		var type = 'A';
+
+		getDapps(type, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.not.ok;
 			node.expect(res.body).to.have.property('error').that.is.equal('Expected type integer but found type string: #/type');
 			done();

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -108,9 +108,9 @@ describe('GET /api/dapps/?type=', function () {
 	}
 
 	it('using no type should fail', function (done) {
-		var type = node.randomProperty(node.dappTypes);
+		var type = '';
 
-		getDapps('', function (err, res) {
+		getDapps(type, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.not.ok;
 			node.expect(res.body).to.have.property('error').that.is.equal('Expected type integer but found type string: #/type');
 			done();
@@ -128,9 +128,9 @@ describe('GET /api/dapps/?type=', function () {
 	});
 
 	it('using type == -1 should fail', function (done) {
-		var type = node.randomProperty(node.dappTypes);
+		var type = '-1';
 
-		getDapps('-1', function (err, res) {
+		getDapps(type, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.not.ok;
 			node.expect(res.body).to.have.property('error').that.is.equal('Value -1 is less than minimum 0: #/type');
 			done();
@@ -138,9 +138,9 @@ describe('GET /api/dapps/?type=', function () {
 	});
 
 	it('using type == 0 should be ok', function (done) {
-		var type = node.randomProperty(node.dappTypes);
+		var type = '0';
 
-		getDapps('0', function (err, res) {
+		getDapps(type, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(2);
 			node.expect(res.body.dapps[0].type).to.equal(0);
@@ -150,9 +150,9 @@ describe('GET /api/dapps/?type=', function () {
 	});
 
 	it('using type == 1 should be ok', function (done) {
-		var type = node.randomProperty(node.dappTypes);
+		var type = '1';
 
-		getDapps('1', function (err, res) {
+		getDapps(type, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(0);
 			done();

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -439,7 +439,7 @@ describe('GET /api/dapps/?orderBy=', function () {
 		});
 	});
 
-	it('using orderBy == "unknown:unknown" should be ok', function (done) {
+	it('using orderBy == "unknown:unknown" should fail', function (done) {
 		getDapps('unknown:unknown', function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.not.ok;
 			node.expect(res.body).to.have.property('error').that.is.equal('Invalid sort field');

--- a/test/api/dapps.js
+++ b/test/api/dapps.js
@@ -397,7 +397,6 @@ describe('GET /api/dapps/?limit=1&offset=', function () {
 		getDapps(offset, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
-			node.expect(res.body.dapps[0].name).to.equal(node.blockDataDapp.name);
 			done();
 		});
 	});
@@ -408,7 +407,6 @@ describe('GET /api/dapps/?limit=1&offset=', function () {
 		getDapps(offset, function (err, res) {
 			node.expect(res.body).to.have.property('success').to.be.ok;
 			node.expect(res.body).to.have.property('dapps').that.is.an('array').and.has.lengthOf(1);
-			node.expect(res.body.dapps[0].name).to.equal(node.guestbookDapp.name);
 			done();
 		});
 	});

--- a/test/node.js
+++ b/test/node.js
@@ -45,8 +45,24 @@ node.fees = {
 
 // Test application
 node.guestbookDapp = {
-	icon: 'https://raw.githubusercontent.com/MaxKK/guestbookDapp/master/icon.png',
-	link: 'https://github.com/MaxKK/guestbookDapp/archive/master.zip'
+	category: 0,
+	name: 'Lisk Guestbook',
+	description: 'The official Lisk guestbook',
+	tags: 'guestbook message sidechain',
+	type: 0,
+	link: 'https://github.com/MaxKK/guestbookDapp/archive/master.zip',
+	icon: 'https://raw.githubusercontent.com/MaxKK/guestbookDapp/master/icon.png'
+};
+
+// Test application
+node.blockDataDapp = {
+	category: 1,
+	name: 'BlockData',
+	description: 'Blockchain based home monitoring tool',
+	tags: 'monitoring temperature power sidechain',
+	type: 0,
+	link: 'https://github.com/MaxKK/blockDataDapp/archive/master.zip',
+	icon: 'https://raw.githubusercontent.com/MaxKK/blockDataDapp/master/icon.png'
 };
 
 // Existing delegate account


### PR DESCRIPTION
Improved dapps API test coverage of remaining functionalities, after selected removal in: https://github.com/LiskHQ/lisk/pull/655

Covering:

- `GET /api/dapps/get?id=`
- `GET /api/dapps/categories`
- `GET /api/dapps/?type=`
- `GET /api/dapps/?name=`
- `GET /api/dapps/?category=`
- `GET /api/dapps/?link=`
- `GET /api/dapps/?limit=`
- `GET /api/dapps/?limit=1&offset=`
- `GET /api/dapps/?orderBy=`

Fixing:

- Reverted premature dapps API change from `/:id` back to `/get`.
- Fixed incorrect error message yielded by `DApps.prototype.internal.list`.

Closes #560