### PR TITLE
List peers as normalised objects - Closes #681

### DIFF
--- a/helpers/z_schema.js
+++ b/helpers/z_schema.js
@@ -138,8 +138,5 @@ z_schema.registerFormat('version', function (str) {
 	return /^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})([a-z]{1})?$/g.test(str);
 });
 
-// var registeredFormats = z_schema.getRegisteredFormats();
-// console.log(registeredFormats);
-
 // Exports
 module.exports = z_schema;

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -100,6 +100,7 @@ Broadcaster.prototype.bind = function (peers, transport, transactions) {
 Broadcaster.prototype.getPeers = function (params, cb) {
 	params.limit = params.limit || self.config.peerLimit;
 	params.broadhash = params.broadhash || null;
+	params.normalized = false;
 
 	var originalLimit = params.limit;
 

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -147,7 +147,7 @@ Process.prototype.loadBlocksOffset = function (limit, offset, verify, cb) {
 	var params = { limit: newLimit, offset: offset || 0 };
 
 	library.logger.debug('Loading blocks offset', {limit: limit, offset: offset, verify: verify});
-	// Execute in sequence via dbSequence]
+	// Execute in sequence via dbSequence
 	library.dbSequence.add(function (cb) {
 		// Loads full blocks from database
 		// FIXME: Weird logic in that SQL query, also ordering used can be performance bottleneck - to rewrite

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -164,7 +164,6 @@ __private.loadSignatures = function (cb) {
 		},
 		function (peer, waterCb) {
 			library.logger.log('Loading signatures from: ' + peer.string);
-			peer = library.logic.peers.create(peer);
 			peer.rpc.getSignatures(function (err, res) {
 				if (err) {
 					return setImmediate(waterCb, err);
@@ -720,7 +719,7 @@ Loader.prototype.getNetwork = function (cb) {
 	if (__private.network.height > 0 && Math.abs(__private.network.height - modules.blocks.lastBlock.get().height) === 1) {
 		return setImmediate(cb, null, __private.network);
 	}
-	modules.peers.list({}, function (err, peers) {
+	modules.peers.list({normalized: false}, function (err, peers) {
 		if (err) {
 			return setImmediate(cb, err);
 		}

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -374,7 +374,7 @@ Transport.prototype.onNewBlock = function (block, broadcast) {
 	if (broadcast) {
 		modules.system.update(function () {
 			if (!__private.broadcaster.maxRelays(block) && !modules.loader.syncing()) {
-				modules.peers.list({}, function (err, peers) {
+				modules.peers.list({normalized: false}, function (err, peers) {
 					async.each(peers.filter(function (peer) { return peer.state === Peer.STATE.CONNECTED; }), function (peer, cb) {
 						peer.rpc.acceptPeer(library.logic.peers.me(), function (err) {
 							if (err) {

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -8,6 +8,7 @@ var _  = require('lodash');
 var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
 
 var config = require('../../config.json');
+var Peer = require('../../../logic/peer');
 var modulesLoader = require('../../common/initModule').modulesLoader;
 var randomPeer = require('../../common/objectStubs').randomPeer;
 var wsRPC = require('../../../api/ws/rpc/wsRPC').wsRPC;
@@ -23,7 +24,7 @@ describe('peers', function () {
 	var peers, modules, NONCE;
 
 	function getPeers (cb) {
-		peers.list({}, function (err, __peers) {
+		peers.list({normalized: false}, function (err, __peers) {
 			expect(err).to.not.exist;
 			expect(__peers).to.be.an('array');
 			return cb(err, __peers);
@@ -162,6 +163,52 @@ describe('peers', function () {
 					expect(peersAddresses.indexOf(secondPeer.ip + ':' + secondPeer.port) !== -1).to.be.ok;
 					done();
 				});
+			});
+		});
+	});
+
+	describe('list', function () {
+
+		beforeEach(function (done) {
+			removeAll(done);
+		});
+
+		it('should list empty peers list when no peers were insterted before', function (done) {
+			peers.list({}, function (err, __peers) {
+				expect(__peers).to.be.an('array').and.to.have.lengthOf(0);
+				done();
+			});
+		});
+
+		it('should list the inserted peer after insert', function (done) {
+			peers.update(randomPeer);
+			peers.list({}, function (err, __peers) {
+				expect(__peers).to.be.an('array').and.to.have.lengthOf(1);
+				done();
+			});
+		});
+
+		it('should list the inserted peer as Peer instance with normalized parameter set to false', function (done) {
+			peers.update(randomPeer);
+			peers.list({normalized: false}, function (err, __peers) {
+				expect(__peers[0]).to.be.an.instanceof(Peer);
+				done();
+			});
+		});
+
+		it('should list the inserted peer as object with normalized parameter set to true', function (done) {
+			peers.update(randomPeer);
+			peers.list({normalized: true}, function (err, __peers) {
+				expect(__peers[0]).to.be.an.instanceof(Object);
+				done();
+			});
+		});
+
+		it('should list the inserted peer as object without set normalized parameter', function (done) {
+			peers.update(randomPeer);
+			peers.list({}, function (err, __peers) {
+				expect(__peers[0]).to.be.an.instanceof(Object);
+				done();
 			});
 		});
 	});

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -173,7 +173,7 @@ describe('peers', function () {
 			removeAll(done);
 		});
 
-		it('should list empty peers list when no peers were insterted before', function (done) {
+		it('should list empty peers list when no peers were inserted before', function (done) {
 			peers.list({}, function (err, __peers) {
 				expect(__peers).to.be.an('array').and.to.have.lengthOf(0);
 				done();


### PR DESCRIPTION
Distinguish usages of list and getByFilter functions in peers module between internal peers listing (normalised = false) and exposing the list for external usage (normalised = true). 
Provide normalisation parameter for peers listings.

Closes #681