### PR TITLE
Replace BUILD_ID with NODE_COOKIE - Closes #698

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def startLisk() {
 		sh '''#!/bin/bash
 		cp test/config.json test/genesisBlock.json .
 		export NODE_ENV=test
-		BUILD_ID=dontKillMe ~/start_lisk.sh
+		JENKINS_NODE_COOKIE=dontKillMe ~/start_lisk.sh
 		'''
 	} catch (err) {
 		currentBuild.result = 'FAILURE'


### PR DESCRIPTION
This is the new way to disable process kill tree in Jenkins between node blocks.

Delicious cookies :) 