### PR TITLE
Load the correct config.json and genesisblock.json based on the NODE_ENV

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,8 @@
     "before": true,
     "beforeEach": true,
     "after": true,
-    "afterEach": true
+    "afterEach": true,
+    "alias": true
   },
   "plugins": []
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ sftp-config.json
 test/integration/logs/
 test/integration/configs/
 !test/integration/configs/config.non-forge.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -100,32 +100,27 @@ pm2 start --name lisk app.js -- -p [port] -a [address] -c [config-path]
 
 Before running any tests, please ensure Lisk is configured to run on the same testnet that is used by the test-suite.
 
-Replace **config.json** and **genesisBlock.json** with the corresponding files under the **test** directory:
-
-```
-cp test/config.json test/genesisBlock.json .
-```
-
-**NOTE:** If the node was started with a different genesis block previous, trauncate the database before running tests.
-
-```
-dropdb lisk_test
-createdb lisk_test
-```
-
 **NOTE:** The master passphrase for this genesis block is as follows:
 
 ```
 wagon stock borrow episode laundry kitten salute link globe zero feed marble
 ```
 
-Launch Lisk (runs on port 4000):
+If you have not yet created the test database, run the following command.
 
 ```
-node app.js
+createdb lisk_test
 ```
 
-Run the test suite:
+Launch Lisk (runs on port 4000). This command will set the NODE_ENV=TEST.
+Additionally, it will load the configuration from the 'test' folder rather than the main folder.
+Finally. it will drop the list_test DB and recreate it.
+
+```
+npm run start-test-server
+```
+
+In a separate command window, from the root directory, run the test suite:
 
 ```
 npm test

--- a/alias.js
+++ b/alias.js
@@ -24,15 +24,28 @@
  * With alias, you will instead be able to do the following:
  * var awesome = alias.require('src/awesome');
  */
+var program = require('commander');
+
+program
+   .option('-c, --config <path>', 'config file path')
+   .parse(process.argv);
+
 var prefix = '';
 if (process.env.NODE_ENV && ( process.env.NODE_ENV.toLowerCase() === 'test')) {
   prefix = 'test/'
 }
 
-/**
- * Setting up our config and genesisblock objects as singletons.
- */
-var config        = require(process.env.PWD + '/' +prefix + 'config.json');
+// You can override the configuration from the command line.
+var config;
+if (program.config) {
+  if (!program.config.startsWith('/')) {
+    program.config = '/' +program.config;
+  }
+  config = require(process.env.PWD + program.config);
+} else {
+  config = require(process.env.PWD + '/' +prefix + 'config.json');
+}
+
 var genesisblock  = require(process.env.PWD + '/' + prefix + 'genesisBlock.json');
 
 /**

--- a/alias.js
+++ b/alias.js
@@ -1,0 +1,48 @@
+'use strict';
+/**
+ * This file is for convinience in setting up dynamic objects (config.json,
+ * genesisBlock.json). If the NODE_ENV.toLowerCase() === 'test', then we change-case
+ * the bootstraping of the config files to the test folder.
+ *
+ * In order to retrieve the config:
+ * var config = alias.config;
+ *
+ * In order to get the genesisblock:
+ * var genesisblock = alias.genesisblock;
+ *
+ * Additionally this class provides a function called require. This allows developers
+ * to access files from the root rather than from their current location.
+ *
+ * As a result, when calling a class somewhere outside of your directory, you
+ * can call it as if it where the root.
+ * For example, you are in test/a/package/somewhere/deep/aspec.js and would like
+ * to 'require' src/awesome.js in it.
+ *
+ * Traditionally, you would write the following:
+ * var awesome = require('../../../../../src/awesome');
+ *
+ * With alias, you will instead be able to do the following:
+ * var awesome = alias.require('src/awesome');
+ */
+var prefix = '';
+if (process.env.NODE_ENV && ( process.env.NODE_ENV.toLowerCase() === 'test')) {
+  prefix = 'test/'
+}
+
+/**
+ * Setting up our config and genesisblock objects as singletons.
+ */
+var config        = require(process.env.PWD + '/' +prefix + 'config.json');
+var genesisblock  = require(process.env.PWD + '/' + prefix + 'genesisBlock.json');
+
+/**
+ * Export alias as a global for now. If we need to refactor it to export should
+ * not be a big deal.
+ */
+global.alias = {
+  config: config,
+  genesisblock: genesisblock,
+  require: function(path) {
+      return require(process.env.PWD + '/' + path);
+  }
+}

--- a/app.js
+++ b/app.js
@@ -24,24 +24,24 @@
  */
 // Must load up the alias as a global before any other file.
 require('./alias');
-var async 						= require('async');
-var extend 						= require('extend');
-var fs 								= require('fs');
-var https 						= require('https');
-var path 							= require('path');
-var SocketCluster 		= require('socketcluster').SocketCluster;
-var util 							= require('util');
+var async = require('async');
+var extend = require('extend');
+var fs = require('fs');
+var https = require('https');
+var path = require('path');
+var SocketCluster = require('socketcluster').SocketCluster;
+var util = require('util');
 
-var Logger 						= alias.require('logger.js');
+var Logger = alias.require('logger.js');
 var workersController = alias.require('workersController');
-var wsRPC 						= alias.require('api/ws/rpc/wsRPC').wsRPC;
+var wsRPC = alias.require('api/ws/rpc/wsRPC').wsRPC;
 
-var AppConfig 				= alias.require('helpers/config.js');
-var git 							= alias.require('helpers/git.js');
-var httpApi 					= alias.require('helpers/httpApi.js');
-var Sequence 					= alias.require('helpers/sequence.js');
-var z_schema 					= alias.require('helpers/z_schema.js');
-var genesisblock 			= alias.genesisblock;
+var AppConfig = alias.require('helpers/config.js');
+var git = alias.require('helpers/git.js');
+var httpApi = alias.require('helpers/httpApi.js');
+var Sequence = alias.require('helpers/sequence.js');
+var z_schema = alias.require('helpers/z_schema.js');
+var genesisblock = alias.genesisblock;
 
 process.stdin.resume();
 

--- a/app.js
+++ b/app.js
@@ -22,25 +22,26 @@
  * CLI options available.
  * @module app
  */
+// Must load up the alias as a global before any other file.
+require('./alias');
+var async 						= require('async');
+var extend 						= require('extend');
+var fs 								= require('fs');
+var https 						= require('https');
+var path 							= require('path');
+var SocketCluster 		= require('socketcluster').SocketCluster;
+var util 							= require('util');
 
-var async = require('async');
-var extend = require('extend');
-var fs = require('fs');
-var https = require('https');
-var path = require('path');
-var SocketCluster = require('socketcluster').SocketCluster;
-var util = require('util');
+var Logger 						= alias.require('logger.js');
+var workersController = alias.require('workersController');
+var wsRPC 						= alias.require('api/ws/rpc/wsRPC').wsRPC;
 
-var genesisblock = require('./genesisBlock.json');
-var Logger = require('./logger.js');
-var workersController = require('./workersController');
-var wsRPC = require('./api/ws/rpc/wsRPC').wsRPC;
-
-var AppConfig = require('./helpers/config.js');
-var git = require('./helpers/git.js');
-var httpApi = require('./helpers/httpApi.js');
-var Sequence = require('./helpers/sequence.js');
-var z_schema = require('./helpers/z_schema.js');
+var AppConfig 				= alias.require('helpers/config.js');
+var git 							= alias.require('helpers/git.js');
+var httpApi 					= alias.require('helpers/httpApi.js');
+var Sequence 					= alias.require('helpers/sequence.js');
+var z_schema 					= alias.require('helpers/z_schema.js');
+var genesisblock 			= alias.genesisblock;
 
 process.stdin.resume();
 
@@ -61,7 +62,7 @@ if (typeof gc !== 'undefined') {
  * @property {object} - The default list of configuration options. Can be updated by CLI.
  * @default 'config.json'
  */
-var appConfig = AppConfig(require('./package.json'));
+var appConfig = AppConfig(alias.require('package.json'));
 
 // Define top endpoint availability
 process.env.TOP = appConfig.topAccounts;
@@ -202,7 +203,7 @@ d.run(function () {
 				app.use('/coverage', im.createHandler());
 			}
 
-			require('./helpers/request-limiter')(app, appConfig);
+			alias.require('helpers/request-limiter')(app, appConfig);
 
 			app.use(compression({ level: 9 }));
 			app.use(cors());
@@ -359,7 +360,7 @@ d.run(function () {
 				}
 			}));
 
-			scope.network.app.use(require('./helpers/z_schema-express.js')(scope.schema));
+			scope.network.app.use(alias.require('helpers/z_schema-express.js')(scope.schema));
 
 			scope.network.app.use(httpApi.middleware.logClientConnections.bind(null, scope.logger));
 
@@ -382,7 +383,7 @@ d.run(function () {
 		}],
 
 		ed: function (cb) {
-			cb(null, require('./helpers/ed.js'));
+			cb(null, alias.require('helpers/ed.js'));
 		},
 
 		bus: ['ed', function (scope, cb) {
@@ -412,11 +413,11 @@ d.run(function () {
 			cb(null, new bus());
 		}],
 		db: function (cb) {
-			var db = require('./helpers/database.js');
+			var db = alias.require('helpers/database.js');
 			db.connect(config.db, logger, cb);
 		},
 		pg_notify: ['db', 'bus', 'logger', function (scope, cb) {
-			var pg_notify = require('./helpers/pg-notify.js');
+			var pg_notify = alias.require('helpers/pg-notify.js');
 			pg_notify.init(scope.db, scope.bus, scope.logger, cb);
 		}],
 		/**
@@ -424,7 +425,7 @@ d.run(function () {
 		 * @param {function} cb
 		 */
 		cache: function (cb) {
-			var cache = require('./helpers/cache.js');
+			var cache = alias.require('helpers/cache.js');
 			cache.connect(config.cacheEnabled, config.cache, logger, cb);
 		},
 		/**
@@ -436,10 +437,10 @@ d.run(function () {
 		 * @param {function} cb - Callback function.
 		 */
 		logic: ['db', 'bus', 'schema', 'genesisblock', function (scope, cb) {
-			var Transaction = require('./logic/transaction.js');
-			var Block = require('./logic/block.js');
-			var Account = require('./logic/account.js');
-			var Peers = require('./logic/peers.js');
+			var Transaction = alias.require('logic/transaction.js');
+			var Block = alias.require('logic/block.js');
+			var Account = alias.require('logic/account.js');
+			var Peers = alias.require('logic/peers.js');
 
 			async.auto({
 				bus: function (cb) {

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -18,7 +18,6 @@ function Config (packageJson) {
 
 	program
 		.version(packageJson.version)
-		.option('-c, --config <path>', 'config file path')
 		.option('-p, --port <port>', 'listening port number')
 		.option('-h, --http-port <httpPort>', 'listening HTTP port number')
 		.option('-d, --database <database>', 'database name')
@@ -28,7 +27,6 @@ function Config (packageJson) {
 		.option('-s, --snapshot <round>', 'verify snapshot')
 		.parse(process.argv);
 
-	var configPath = program.config;
 	var appConfig = alias.config;
 
 	if (program.port) {

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -29,14 +29,7 @@ function Config (packageJson) {
 		.parse(process.argv);
 
 	var configPath = program.config;
-	var appConfig = fs.readFileSync(path.resolve(process.cwd(), (configPath || 'config.json')), 'utf8');
-
-	if (!appConfig.length) {
-		console.log('Failed to read config file');
-		process.exit(1);
-	} else {
-		appConfig = JSON.parse(appConfig);
-	}
+	var appConfig = alias.config;
 
 	if (program.port) {
 		appConfig.port = +program.port;

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var async = require('async');
-var config = require('../config.json');
 var constants = require('../helpers/constants.js');
 var jobsQueue = require('../helpers/jobsQueue.js');
 var transactionTypes = require('../helpers/transactionTypes.js');
 
+var config = alias.config;
 // Private fields
 var modules, library, self, __private = {};
 
@@ -314,7 +314,7 @@ TransactionPool.prototype.addQueuedTransaction = function (transaction) {
 };
 
 /**
- * Removes id from queued index and transactions. 
+ * Removes id from queued index and transactions.
  * @param {string} id
  */
 TransactionPool.prototype.removeQueuedTransaction = function (id) {
@@ -347,7 +347,7 @@ TransactionPool.prototype.addMultisignatureTransaction = function (transaction) 
 };
 
 /**
- * Removes id from multisignature index and transactions. 
+ * Removes id from multisignature index and transactions.
  * @param {string} id
  */
 TransactionPool.prototype.removeMultisignatureTransaction = function (id) {

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var constants     = require('../helpers/constants.js');
+var constants = require('../helpers/constants.js');
 // Submodules
-var blocksAPI     = require('./blocks/api');
-var blocksVerify  = require('./blocks/verify');
+var blocksAPI = require('./blocks/api');
+var blocksVerify = require('./blocks/verify');
 var blocksProcess = require('./blocks/process');
-var blocksUtils   = require('./blocks/utils');
-var blocksChain   = require('./blocks/chain');
+var blocksUtils = require('./blocks/utils');
+var blocksChain = require('./blocks/chain');
 
 // Private fields
 var modules, library, self, __private = {};

--- a/package.json
+++ b/package.json
@@ -3,45 +3,58 @@
   "version": "0.9.2",
   "private": true,
   "scripts": {
-    "start":            "better-npm-run start",
-    "jenkins":          "better-npm-run jenkins",
-    "eslint":           "./node_modules/.bin/grunt eslint-nofix --verbose",
-    "fetchCoverage":    "./node_modules/.bin/grunt exec:fetchCoverage --verbose",
-    "coverageReport":   "./node_modules/.bin/grunt coverageReport --verbose",
-    "test":             "better-npm-run test",
-    "start-test-server":"better-npm-run start-test-server",
-    "test-unit":        "better-npm-run test-unit",
+    "start": "better-npm-run start",
+    "jenkins": "better-npm-run jenkins",
+    "eslint": "./node_modules/.bin/grunt eslint-nofix --verbose",
+    "fetchCoverage": "./node_modules/.bin/grunt exec:fetchCoverage --verbose",
+    "coverageReport": "./node_modules/.bin/grunt coverageReport --verbose",
+    "test": "better-npm-run test",
+    "start-test-server": "better-npm-run start-test-server",
+    "test-unit": "better-npm-run test-unit",
     "test-integration": "better-npm-run test-integration",
-    "test-functional":  "grunt test-functional",
-    "jsdoc":            "jsdoc -c docs/conf.json --verbose --pedantic",
-    "create-bundles":   "webpack",
-    "server-docs":      "npm run jsdoc && http-server docs/jsdoc/",
-    "precommit":        "npm run eslint"
+    "test-functional": "grunt test-functional",
+    "jsdoc": "jsdoc -c docs/conf.json --verbose --pedantic",
+    "create-bundles": "webpack",
+    "server-docs": "npm run jsdoc && http-server docs/jsdoc/",
+    "precommit": "npm run eslint"
   },
   "betterScripts": {
     "start": {
       "command": "node app.js",
-      "env": {"NODE_ENV": "PROD"}
+      "env": {
+        "NODE_ENV": "PROD"
+      }
     },
     "jenkins": {
       "command": "./node_modules/.bin/grunt jenkins",
-      "env": {"NODE_ENV": "TEST"}
+      "env": {
+        "NODE_ENV": "TEST"
+      }
     },
     "start-test-server": {
       "command": "dropdb lisk_test && createdb lisk_test && node app.js",
-      "env": {"NODE_ENV": "TEST"}
+      "env": {
+        "NODE_ENV": "TEST"
+      }
     },
     "test": {
       "command": "./node_modules/.bin/grunt test --verbose",
-      "env": {"NODE_ENV": "TEST"}
+      "env": {
+        "NODE_ENV": "TEST"
+      }
     },
     "test-unit": {
       "command": "./node_modules/.bin/grunt test-unit --verbose",
-      "env": {"NODE_ENV": "TEST"}
+      "env": {
+        "NODE_ENV": "TEST"
+      }
     },
     "test-integration": {
       "command": "./node_modules/.bin/grunt jenkins",
-      "env": {"TEST": "test/integration/peers.integration.js","NODE_ENV": "TEST"}
+      "env": {
+        "TEST": "test/integration/peers.integration.js",
+        "NODE_ENV": "TEST"
+      }
     }
   },
   "author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",

--- a/package.json
+++ b/package.json
@@ -3,19 +3,46 @@
   "version": "0.9.2",
   "private": true,
   "scripts": {
-    "start": "node app.js",
-    "jenkins": "./node_modules/.bin/grunt jenkins --verbose",
-    "eslint": "./node_modules/.bin/grunt eslint-nofix --verbose",
-    "fetchCoverage": "./node_modules/.bin/grunt exec:fetchCoverage --verbose",
-    "coverageReport": "./node_modules/.bin/grunt coverageReport --verbose",
-    "test": "./node_modules/.bin/grunt test --verbose",
-    "test-unit": "./node_modules/.bin/grunt test-unit --verbose",
-    "test-integration": "export TEST=test/integration/peers.integration.js && export NODE_ENV=TEST && ./node_modules/.bin/grunt jenkins",
-    "test-functional": "grunt test-functional",
-    "jsdoc": "jsdoc -c docs/conf.json --verbose --pedantic",
-    "create-bundles": "webpack",
-    "server-docs": "npm run jsdoc && http-server docs/jsdoc/",
-    "precommit": "npm run eslint"
+    "start":            "better-npm-run start",
+    "jenkins":          "better-npm-run jenkins",
+    "eslint":           "./node_modules/.bin/grunt eslint-nofix --verbose",
+    "fetchCoverage":    "./node_modules/.bin/grunt exec:fetchCoverage --verbose",
+    "coverageReport":   "./node_modules/.bin/grunt coverageReport --verbose",
+    "test":             "better-npm-run test",
+    "start-test-server":"better-npm-run start-test-server",
+    "test-unit":        "better-npm-run test-unit",
+    "test-integration": "better-npm-run test-integration",
+    "test-functional":  "grunt test-functional",
+    "jsdoc":            "jsdoc -c docs/conf.json --verbose --pedantic",
+    "create-bundles":   "webpack",
+    "server-docs":      "npm run jsdoc && http-server docs/jsdoc/",
+    "precommit":        "npm run eslint"
+  },
+  "betterScripts": {
+    "start": {
+      "command": "node app.js",
+      "env": {"NODE_ENV": "PROD"}
+    },
+    "jenkins": {
+      "command": "./node_modules/.bin/grunt jenkins",
+      "env": {"NODE_ENV": "TEST"}
+    },
+    "start-test-server": {
+      "command": "dropdb lisk_test && createdb lisk_test && node app.js",
+      "env": {"NODE_ENV": "TEST"}
+    },
+    "test": {
+      "command": "./node_modules/.bin/grunt test --verbose",
+      "env": {"NODE_ENV": "TEST"}
+    },
+    "test-unit": {
+      "command": "./node_modules/.bin/grunt test-unit --verbose",
+      "env": {"NODE_ENV": "TEST"}
+    },
+    "test-integration": {
+      "command": "./node_modules/.bin/grunt jenkins",
+      "env": {"TEST": "test/integration/peers.integration.js","NODE_ENV": "TEST"}
+    }
   },
   "author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
   "license": "GPL-3.0",
@@ -63,6 +90,7 @@
     "z-schema": "=3.18.2"
   },
   "devDependencies": {
+    "better-npm-run": "~0.0.1",
     "bitcore-mnemonic": "=1.2.5",
     "browserify-bignum": "=1.3.0-2",
     "chai": "=4.0.2",

--- a/test/api/__loadalias.js
+++ b/test/api/__loadalias.js
@@ -1,0 +1,24 @@
+'use strict';
+require.main.require('alias.js');
+var chai = require('chai');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+
+describe('alias for the test api package', function () {
+
+	describe('has alias loaded into the global setting', function () {
+
+		it('should load config as a global', function () {
+			expect(alias.config).to.have.a.property('version');
+		});
+
+		it('should load genesisblock as a global', function () {
+			expect(alias.genesisblock).to.have.a.property('version');
+		});
+
+		it('should load a dynamic file from the root', function () {
+			var bignum = alias.require('helpers/bignum');
+			expect(new bignum(1234).toString()).eq('1234');
+		});
+	});
+});

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -1,3 +1,4 @@
+require('./__loadalias.js');
 require('./accounts');
 require('./blocks');
 require('./dapps');

--- a/test/api/transactions.js
+++ b/test/api/transactions.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var node 										= alias.require('test/node.js');
-var http 										= alias.require('test/common/httpCommunication.js');
-var ws 											= alias.require('test/common/wsCommunication');
-var sendLiskTrs 						= alias.require('test/common/complexTransactions.js').sendLISK;
-var transactionSortFields 	= alias.require('sql/transactions').sortFields;
-var modulesLoader 					= alias.require('test/common/initModule').modulesLoader;
-var transactionTypes 				= alias.require('helpers/transactionTypes.js');
-var genesisblock 						= alias.genesisblock;
+var node = alias.require('test/node.js');
+var http = alias.require('test/common/httpCommunication.js');
+var ws = alias.require('test/common/wsCommunication');
+var sendLiskTrs = alias.require('test/common/complexTransactions.js').sendLISK;
+var transactionSortFields = alias.require('sql/transactions').sortFields;
+var modulesLoader = alias.require('test/common/initModule').modulesLoader;
+var transactionTypes = alias.require('helpers/transactionTypes.js');
+var genesisblock = alias.genesisblock;
 
 var account = node.randomTxAccount();
 var account2 = node.randomTxAccount();

--- a/test/api/transactions.js
+++ b/test/api/transactions.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var node = require('../node.js');
-var http = require('../common/httpCommunication.js');
-var ws = require('../common/wsCommunication');
-var sendLiskTrs = require('../common/complexTransactions.js').sendLISK;
-var transactionSortFields = require('../../sql/transactions').sortFields;
-var modulesLoader = require('../common/initModule').modulesLoader;
-var transactionTypes = require('../../helpers/transactionTypes.js');
-var genesisblock = require('../genesisBlock.json');
+var node 										= alias.require('test/node.js');
+var http 										= alias.require('test/common/httpCommunication.js');
+var ws 											= alias.require('test/common/wsCommunication');
+var sendLiskTrs 						= alias.require('test/common/complexTransactions.js').sendLISK;
+var transactionSortFields 	= alias.require('sql/transactions').sortFields;
+var modulesLoader 					= alias.require('test/common/initModule').modulesLoader;
+var transactionTypes 				= alias.require('helpers/transactionTypes.js');
+var genesisblock 						= alias.genesisblock;
 
 var account = node.randomTxAccount();
 var account2 = node.randomTxAccount();

--- a/test/api/transport/transport.blocks.js
+++ b/test/api/transport/transport.blocks.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var node 					= alias.require('test/node.js');
-var ws 						= alias.require('test/common/wsCommunication');
-var verify 				= alias.require('modules/blocks/verify.js');
-var bson 					= alias.require('helpers/bson.js');
+var node = alias.require('test/node.js');
+var ws = alias.require('test/common/wsCommunication');
+var verify = alias.require('modules/blocks/verify.js');
+var bson = alias.require('helpers/bson.js');
 var genesisblock 	= alias.genesisblock;
 
 describe('blocks', function () {

--- a/test/api/transport/transport.blocks.js
+++ b/test/api/transport/transport.blocks.js
@@ -1,11 +1,10 @@
 'use strict';
 
-var node = require('../../node.js');
-var ws = require('../../common/wsCommunication');
-
-var genesisblock = require('../../genesisBlock.json');
-var verify = require('../../../modules/blocks/verify.js');
-var bson = require('../../../helpers/bson.js');
+var node 					= alias.require('test/node.js');
+var ws 						= alias.require('test/common/wsCommunication');
+var verify 				= alias.require('modules/blocks/verify.js');
+var bson 					= alias.require('helpers/bson.js');
+var genesisblock 	= alias.genesisblock;
 
 describe('blocks', function () {
 
@@ -84,7 +83,7 @@ describe('blocksCommon', function () {
 	it('using ids == \'\',\'\',\'\' should fail', function (done) {
 		ws.call('blocksCommon',  {ids: '\'\',\'\',\'\''}, function (err, res) {
 			node.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-			
+
 			node.expect(err).to.equal('Invalid block id sequence');
 			done();
 		});
@@ -109,7 +108,7 @@ describe('blocksCommon', function () {
 	it('using ids == "1","2","3" should be ok and return null common block', function (done) {
 		ws.call('blocksCommon', {ids: '"1","2","3"'}, function (err, res) {
 			node.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-			
+
 			node.expect(res).to.have.property('common').to.be.null;
 			done();
 		});
@@ -118,7 +117,7 @@ describe('blocksCommon', function () {
 	it('using ids == \'1\',\'2\',\'3\' should be ok and return null common block', function (done) {
 		ws.call('blocksCommon', {ids: '\'1\',\'2\',\'3\''}, function (err, res) {
 			node.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-			
+
 			node.expect(res).to.have.property('common').to.be.null;
 			done();
 		});
@@ -127,7 +126,7 @@ describe('blocksCommon', function () {
 	it('using ids == 1,2,3 should be ok and return null common block', function (done) {
 		ws.call('blocksCommon', {ids: '1,2,3'}, function (err, res) {
 			node.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-			
+
 			node.expect(res).to.have.property('common').to.be.null;
 			done();
 		});
@@ -136,7 +135,7 @@ describe('blocksCommon', function () {
 	it('using ids which include genesisblock.id should be ok', function (done) {
 		ws.call('blocksCommon', {ids: [genesisblock.id.toString(),'2','3'].join(',')}, function (err, res) {
 			node.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-			
+
 			node.expect(res).to.have.property('common').to.be.an('object');
 			node.expect(res.common).to.have.property('height').that.is.a('number');
 			node.expect(res.common).to.have.property('id').that.is.a('string');
@@ -148,7 +147,7 @@ describe('blocksCommon', function () {
 });
 
 describe('postBlock', function () {
-	
+
 	it('using no block should fail', function (done) {
 		ws.call('postBlock', function (err, res) {
 			node.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));

--- a/test/common/globalBefore.js
+++ b/test/common/globalBefore.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var popsicle = require('popsicle');
-var config = require('../../config.json');
+var config = alias.config;
 
 
 /**

--- a/test/common/initModule.js
+++ b/test/common/initModule.js
@@ -1,26 +1,22 @@
 'use strict';
+var express 			= require('express');
+var randomString 	= require('randomstring');
+var _ 						= require('lodash');
+var async 				= require('async');
 
-var express = require('express');
-var path = require('path');
-var randomString = require('randomstring');
-
-var _ = require('lodash');
-
-var async = require('async');
-var dirname = path.join(__dirname, '..', '..');
-var config = require(path.join(dirname, '/config.json'));
-var Sequence = require(path.join(dirname, '/helpers', 'sequence.js'));
-var database = require(path.join(dirname, '/helpers', 'database.js'));
-var genesisblock = require(path.join(dirname, '/genesisBlock.json'));
-var Logger = require(dirname + '/logger.js');
-var z_schema = require('../../helpers/z_schema.js');
-var cacheHelper = require('../../helpers/cache.js');
-var Cache = require('../../modules/cache.js');
-var ed = require('../../helpers/ed');
-var jobsQueue = require('../../helpers/jobsQueue');
-var Transaction = require('../../logic/transaction.js');
-var Account = require('../../logic/account.js');
-var Sequence = require('../../helpers/sequence.js');
+var Sequence 			= alias.require('helpers/sequence.js');
+var database 			= alias.require('helpers/database.js');
+var genesisblock 	= alias.genesisblock;
+var Logger 				= alias.require('logger.js');
+var z_schema 			= alias.require('helpers/z_schema.js');
+var cacheHelper 	= alias.require('helpers/cache.js');
+var Cache 				= alias.require('modules/cache.js');
+var ed 						= alias.require('helpers/ed');
+var jobsQueue 		= alias.require('helpers/jobsQueue');
+var Transaction 	= alias.require('logic/transaction.js');
+var Account 			= alias.require('logic/account.js');
+var Sequence 			= alias.require('helpers/sequence.js');
+var config 				= alias.config;
 
 var modulesLoader = new function () {
 
@@ -182,22 +178,22 @@ var modulesLoader = new function () {
 	this.initAllModules = function (cb, scope) {
 		this.clear();
 		this.initModules([
-			{accounts: require('../../modules/accounts')},
-			{blocks: require('../../modules/blocks')},
-			{crypto: require('../../modules/crypto')},
-			{delegates: require('../../modules/delegates')},
-			{loader: require('../../modules/loader')},
-			{multisignatures: require('../../modules/multisignatures')},
-			{peers: require('../../modules/peers')},
-			{signatures: require('../../modules/signatures')},
-			{system: require('../../modules/system')},
-			{transactions: require('../../modules/transactions')},
-			{transport: require('../../modules/transport')}
+			{accounts: 					alias.require('modules/accounts')},
+			{blocks: 						alias.require('modules/blocks')},
+			{crypto: 						alias.require('modules/crypto')},
+			{delegates: 				alias.require('modules/delegates')},
+			{loader: 						alias.require('modules/loader')},
+			{multisignatures: 	alias.require('modules/multisignatures')},
+			{peers: 						alias.require('modules/peers')},
+			{signatures: 				alias.require('modules/signatures')},
+			{system: 						alias.require('modules/system')},
+			{transactions: 			alias.require('modules/transactions')},
+			{transport: 				alias.require('modules/transport')}
 		], [
-			{'transaction': require('../../logic/transaction')},
-			{'account': require('../../logic/account')},
-			{'block': require('../../logic/block')},
-			{'peers': require('../../logic/peers.js')}
+			{'transaction': 		alias.require('logic/transaction')},
+			{'account': 				alias.require('logic/account')},
+			{'block': 					alias.require('logic/block')},
+			{'peers': 					alias.require('logic/peers.js')}
 		], scope || {}, cb);
 	};
 

--- a/test/common/initModule.js
+++ b/test/common/initModule.js
@@ -1,22 +1,22 @@
 'use strict';
-var express 			= require('express');
-var randomString 	= require('randomstring');
-var _ 						= require('lodash');
-var async 				= require('async');
+var express = require('express');
+var randomString = require('randomstring');
+var _ = require('lodash');
+var async = require('async');
 
-var Sequence 			= alias.require('helpers/sequence.js');
-var database 			= alias.require('helpers/database.js');
-var genesisblock 	= alias.genesisblock;
-var Logger 				= alias.require('logger.js');
-var z_schema 			= alias.require('helpers/z_schema.js');
-var cacheHelper 	= alias.require('helpers/cache.js');
-var Cache 				= alias.require('modules/cache.js');
-var ed 						= alias.require('helpers/ed');
-var jobsQueue 		= alias.require('helpers/jobsQueue');
-var Transaction 	= alias.require('logic/transaction.js');
-var Account 			= alias.require('logic/account.js');
-var Sequence 			= alias.require('helpers/sequence.js');
-var config 				= alias.config;
+var Sequence = alias.require('helpers/sequence.js');
+var database = alias.require('helpers/database.js');
+var genesisblock = alias.genesisblock;
+var Logger = alias.require('logger.js');
+var z_schema = alias.require('helpers/z_schema.js');
+var cacheHelper = alias.require('helpers/cache.js');
+var Cache = alias.require('modules/cache.js');
+var ed = alias.require('helpers/ed');
+var jobsQueue = alias.require('helpers/jobsQueue');
+var Transaction = alias.require('logic/transaction.js');
+var Account = alias.require('logic/account.js');
+var Sequence = alias.require('helpers/sequence.js');
+var config = alias.config;
 
 var modulesLoader = new function () {
 
@@ -178,22 +178,22 @@ var modulesLoader = new function () {
 	this.initAllModules = function (cb, scope) {
 		this.clear();
 		this.initModules([
-			{accounts: 					alias.require('modules/accounts')},
-			{blocks: 						alias.require('modules/blocks')},
-			{crypto: 						alias.require('modules/crypto')},
-			{delegates: 				alias.require('modules/delegates')},
-			{loader: 						alias.require('modules/loader')},
-			{multisignatures: 	alias.require('modules/multisignatures')},
-			{peers: 						alias.require('modules/peers')},
-			{signatures: 				alias.require('modules/signatures')},
-			{system: 						alias.require('modules/system')},
-			{transactions: 			alias.require('modules/transactions')},
-			{transport: 				alias.require('modules/transport')}
+			{accounts: alias.require('modules/accounts')},
+			{blocks: alias.require('modules/blocks')},
+			{crypto: alias.require('modules/crypto')},
+			{delegates: alias.require('modules/delegates')},
+			{loader: alias.require('modules/loader')},
+			{multisignatures: alias.require('modules/multisignatures')},
+			{peers: alias.require('modules/peers')},
+			{signatures: alias.require('modules/signatures')},
+			{system: alias.require('modules/system')},
+			{transactions: alias.require('modules/transactions')},
+			{transport: alias.require('modules/transport')}
 		], [
-			{'transaction': 		alias.require('logic/transaction')},
-			{'account': 				alias.require('logic/account')},
-			{'block': 					alias.require('logic/block')},
-			{'peers': 					alias.require('logic/peers.js')}
+			{'transaction': alias.require('logic/transaction')},
+			{'account': alias.require('logic/account')},
+			{'block': alias.require('logic/block')},
+			{'peers': alias.require('logic/peers.js')}
 		], scope || {}, cb);
 	};
 

--- a/test/integration/peers.integration.js
+++ b/test/integration/peers.integration.js
@@ -10,7 +10,7 @@ var scClient = require('socketcluster-client');
 var waitUntilBlockchainReady = require('../common/globalBefore').waitUntilBlockchainReady;
 var WAMPClient = require('wamp-socket-cluster/WAMPClient');
 
-var baseConfig = require('../../test/config.json');
+var baseConfig = alias.config;
 var Logger = require('../../logger');
 
 var SYNC_MODE = {
@@ -485,4 +485,3 @@ describe('integration', function () {
 		});
 	});
 });
-

--- a/test/node.js
+++ b/test/node.js
@@ -1,33 +1,34 @@
 'use strict';
 
 // Root object
+require('../alias');
 var node = {};
 
-var Promise = require('bluebird');
-var rewire  = require('rewire');
-var sinon   = require('sinon');
+var Promise 									= require('bluebird');
+var rewire  									= require('rewire');
+var sinon   									= require('sinon');
 
 // Application specific
-var Sequence  = require('../helpers/sequence.js');
-var slots     = require('../helpers/slots.js');
+var Sequence  								= alias.require('helpers/sequence.js');
+var slots     								= alias.require('helpers/slots.js');
 
 // Requires
-node.bignum = require('../helpers/bignum.js');
-node.config = require('../config.json');
-node.constants = require('../helpers/constants.js');
-node.dappCategories = require('../helpers/dappCategories.js');
-node.dappTypes = require('../helpers/dappTypes.js');
-node.txTypes = require('../helpers/transactionTypes.js');
-node._ = require('lodash');
-node.async = require('async');
-node.popsicle = require('popsicle');
-node.expect = require('chai').expect;
-node.chai = require('chai');
-node.chai.config.includeStack = true;
+node.bignum 									= alias.require('helpers/bignum.js');
+node.config 									= alias.config;
+node.constants 								= alias.require('helpers/constants.js');
+node.dappCategories 					= alias.require('helpers/dappCategories.js');
+node.dappTypes 								= alias.require('helpers/dappTypes.js');
+node.txTypes 									= alias.require('helpers/transactionTypes.js');
+node._ 												= require('lodash');
+node.async 										= require('async');
+node.popsicle 								= require('popsicle');
+node.expect 									= require('chai').expect;
+node.chai 										= require('chai');
+node.chai.config.includeStack	= true;
 node.chai.use(require('chai-bignumber')(node.bignum));
-node.lisk = require('lisk-js');
-node.supertest = require('supertest');
-var randomString = require('randomstring');
+node.lisk 										= require('lisk-js');
+node.supertest 								= require('supertest');
+var randomString 							= require('randomstring');
 require('colors');
 
 // Node configuration
@@ -394,7 +395,7 @@ node.initApplication = function (cb) {
 				cb(null, node.config);
 			},
 			genesisblock: function (cb) {
-				var genesisblock = require('../genesisBlock.json');
+				var genesisblock = alias.genesisblock;
 				cb(null, {block: genesisblock});
 			},
 

--- a/test/node.js
+++ b/test/node.js
@@ -4,31 +4,31 @@
 require('../alias');
 var node = {};
 
-var Promise 									= require('bluebird');
-var rewire  									= require('rewire');
-var sinon   									= require('sinon');
+var Promise = require('bluebird');
+var rewire = require('rewire');
+var sinon = require('sinon');
 
 // Application specific
-var Sequence  								= alias.require('helpers/sequence.js');
-var slots     								= alias.require('helpers/slots.js');
+var Sequence = alias.require('helpers/sequence.js');
+var slots = alias.require('helpers/slots.js');
 
 // Requires
-node.bignum 									= alias.require('helpers/bignum.js');
-node.config 									= alias.config;
-node.constants 								= alias.require('helpers/constants.js');
-node.dappCategories 					= alias.require('helpers/dappCategories.js');
-node.dappTypes 								= alias.require('helpers/dappTypes.js');
-node.txTypes 									= alias.require('helpers/transactionTypes.js');
-node._ 												= require('lodash');
-node.async 										= require('async');
-node.popsicle 								= require('popsicle');
-node.expect 									= require('chai').expect;
-node.chai 										= require('chai');
+node.bignum = alias.require('helpers/bignum.js');
+node.config = alias.config;
+node.constants = alias.require('helpers/constants.js');
+node.dappCategories = alias.require('helpers/dappCategories.js');
+node.dappTypes = alias.require('helpers/dappTypes.js');
+node.txTypes = alias.require('helpers/transactionTypes.js');
+node._ = require('lodash');
+node.async = require('async');
+node.popsicle = require('popsicle');
+node.expect = require('chai').expect;
+node.chai = require('chai');
 node.chai.config.includeStack	= true;
 node.chai.use(require('chai-bignumber')(node.bignum));
-node.lisk 										= require('lisk-js');
-node.supertest 								= require('supertest');
-var randomString 							= require('randomstring');
+node.lisk = require('lisk-js');
+node.supertest = require('supertest');
+var randomString = require('randomstring');
 require('colors');
 
 // Node configuration

--- a/test/unit/__loadalias.js
+++ b/test/unit/__loadalias.js
@@ -1,0 +1,24 @@
+'use strict';
+require.main.require('alias.js');
+var chai = require('chai');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+
+describe('alias', function () {
+
+	describe('hasvaluesloaded', function () {
+
+		it('should load config as a global', function () {
+			expect(alias.config).to.have.a.property('version');
+		});
+
+		it('should load genesisblock as a global', function () {
+			expect(alias.genesisblock).to.have.a.property('version');
+		});
+
+		it('should load a dynamic file from the root', function () {
+			var bignum = alias.require('helpers/bignum');
+			expect(new bignum(1234).toString()).eq('1234');
+		});
+	});
+});

--- a/test/unit/helpers/RPC.js
+++ b/test/unit/helpers/RPC.js
@@ -5,12 +5,12 @@ var expect = require('chai').expect;
 var express = require('express');
 var sinon = require('sinon');
 
-var constants 				= alias.require('helpers/constants');
-var WAMPClient 				= require('wamp-socket-cluster/WAMPClient');
+var constants = alias.require('helpers/constants');
+var WAMPClient = require('wamp-socket-cluster/WAMPClient');
 
-var wsRPC 						= alias.require('api/ws/rpc/wsRPC').wsRPC;
-var ClientRPCStub 		= alias.require('api/ws/rpc/wsRPC').ClientRPCStub;
-var ConnectionState 	= alias.require('api/ws/rpc/wsRPC').ConnectionState;
+var wsRPC = alias.require('api/ws/rpc/wsRPC').wsRPC;
+var ClientRPCStub = alias.require('api/ws/rpc/wsRPC').ClientRPCStub;
+var ConnectionState = alias.require('api/ws/rpc/wsRPC').ConnectionState;
 
 var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
 

--- a/test/unit/helpers/RPC.js
+++ b/test/unit/helpers/RPC.js
@@ -1,18 +1,16 @@
 'use strict';
 
-var config = require('../../../config.json');
-
 var chai = require('chai');
 var expect = require('chai').expect;
 var express = require('express');
 var sinon = require('sinon');
 
-var constants = require('../../../helpers/constants');
-var WAMPClient = require('wamp-socket-cluster/WAMPClient');
+var constants 				= alias.require('helpers/constants');
+var WAMPClient 				= require('wamp-socket-cluster/WAMPClient');
 
-var wsRPC = require('../../../api/ws/rpc/wsRPC').wsRPC;
-var ClientRPCStub = require('../../../api/ws/rpc/wsRPC').ClientRPCStub;
-var ConnectionState = require('../../../api/ws/rpc/wsRPC').ConnectionState;
+var wsRPC 						= alias.require('api/ws/rpc/wsRPC').wsRPC;
+var ClientRPCStub 		= alias.require('api/ws/rpc/wsRPC').ClientRPCStub;
+var ConnectionState 	= alias.require('api/ws/rpc/wsRPC').ConnectionState;
 
 var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
 

--- a/test/unit/helpers/pg-notify.js
+++ b/test/unit/helpers/pg-notify.js
@@ -6,13 +6,13 @@ var expect = require('chai').expect;
 var sinon  = require('sinon');
 var rewire = require('rewire');
 
-// Load config file - global (not one from test directory)
-var config = require('../../../config.json');
-var sql    = require('../../sql/pgNotify.js');
-var slots  = require('../../../helpers/slots.js');
+var config = alias.config;
+var sql    = alias.require('test/sql/pgNotify.js');
+var slots  = alias.require('helpers/slots.js');
 
 // Init tests subject
 var pg_notify = rewire('../../../helpers/pg-notify.js');
+
 
 // Init global variables
 var db, invalid_db, logger, bus;
@@ -199,7 +199,7 @@ describe('helpers/pg-notify', function () {
 
 					// Last error - function should fail to reconnect
 					expect(logger.error.args[11][0]).to.equal('pg-notify: Failed to reconnect - connection lost');
-					
+
 					// Connection should be cleared
 					connection = pg_notify.__get__('connection');
 					expect(connection).to.be.an('null');

--- a/test/unit/helpers/pg-notify.js
+++ b/test/unit/helpers/pg-notify.js
@@ -1,14 +1,14 @@
 'use strict';
 
 // Init tests dependencies
-var chai   = require('chai');
+var chai = require('chai');
 var expect = require('chai').expect;
-var sinon  = require('sinon');
+var sinon = require('sinon');
 var rewire = require('rewire');
 
 var config = alias.config;
-var sql    = alias.require('test/sql/pgNotify.js');
-var slots  = alias.require('helpers/slots.js');
+var sql = alias.require('test/sql/pgNotify.js');
+var slots = alias.require('helpers/slots.js');
 
 // Init tests subject
 var pg_notify = rewire('../../../helpers/pg-notify.js');

--- a/test/unit/helpers/wsApi.js
+++ b/test/unit/helpers/wsApi.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var config = require('../../../config.json');
+var config = alias.config;
 
 var chai = require('chai');
 var expect = require('chai').expect;
@@ -8,9 +8,8 @@ var express = require('express');
 var _  = require('lodash');
 var sinon = require('sinon');
 
-var wsApi = require('../../../helpers/wsApi');
-
-var System = require('../../../modules/system');
+var wsApi = alias.require('helpers/wsApi');
+var System = alias.require('modules/system');
 
 describe('handshake', function () {
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,3 +1,4 @@
+require('./__loadalias.js');
 require('./helpers/RPC');
 require('./helpers/request-limiter.js');
 require('./helpers/wsApi');
@@ -18,4 +19,5 @@ require('./modules/peers.js');
 
 require('./sql/blockRewards.js');
 require('./sql/delegatesList.js');
+
 require('./sql/rounds.js');

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -1,17 +1,18 @@
 'use strict';
 
-var expect = require('chai').expect;
-var async = require('async');
+var expect 							= require('chai').expect;
+var async 							= require('async');
 
-var modulesLoader = require('../../../common/initModule').modulesLoader;
-var BlockLogic = require('../../../../logic/block.js');
-var VoteLogic = require('../../../../logic/vote.js');
-var genesisBlock = require('../../../../genesisBlock.json');
-var loadTables = require('./processTablesData.json');
-var clearDatabaseTable = require('../../../common/globalBefore').clearDatabaseTable;
+var modulesLoader 			= alias.require('test/common/initModule').modulesLoader;
+var BlockLogic 					= alias.require('logic/block.js');
+var VoteLogic 					= alias.require('logic/vote.js');
+
+var loadTables 					= require('./processTablesData.json');
+var clearDatabaseTable 	= alias.require('test/common/globalBefore').clearDatabaseTable;
+var genesisblock 				= alias.genesisblock;
 
 describe('blocks/process', function () {
-	
+
 	var blocksProcess;
 	var blockLogic;
 	var blocks;
@@ -23,7 +24,7 @@ describe('blocks/process', function () {
 		modulesLoader.initLogic(BlockLogic, modulesLoader.scope, function (err, __blockLogic) {
 			if (err) {
 				return done(err);
-			}			
+			}
 			blockLogic = __blockLogic;
 
 			modulesLoader.initModules([
@@ -103,14 +104,14 @@ describe('blocks/process', function () {
 	});
 
 	describe('loadBlocksOffset {verify: true} - no errors', function () {
-		
+
 		it('should load block 2 from database: block without transactions', function (done) {
-			blocks.lastBlock.set(genesisBlock);
+			blocks.lastBlock.set(genesisblock);
 			blocksProcess.loadBlocksOffset(1, 2, true, function (err, loadedBlock) {
 				if (err) {
 					return done(err);
 				}
-				
+
 				blocks.lastBlock.set(loadedBlock);
 				expect(loadedBlock.height).to.be.equal(2);
 				done();
@@ -131,14 +132,14 @@ describe('blocks/process', function () {
 	});
 
 	describe('loadBlocksOffset {verify: true} - block/trs errors', function () {
-		
+
 		it('should load block 4 from db and return blockSignature error', function (done) {
 			blocksProcess.loadBlocksOffset(1, 4, true, function (err, loadedBlock) {
 				if (err) {
 					expect(err).equal('Failed to verify block signature');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -151,7 +152,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Invalid payload hash');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -164,7 +165,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Invalid block timestamp');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -177,7 +178,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Blocks#loadBlocksOffset error: Unknown transaction type 99');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -190,7 +191,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Invalid block version');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -203,7 +204,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Invalid previous block: 15335393038826825161 expected: 13068833527549895884');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -216,7 +217,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Failed to validate vote schema: Array items are not unique (indexes 0 and 4)');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -244,7 +245,7 @@ describe('blocks/process', function () {
 				if (err) {
 					return done(err);
 				}
-				
+
 				expect(loadedBlock.id).equal(loadTables[0].data[2].id);
 				expect(loadedBlock.previousBlock).equal(loadTables[0].data[2].previousBlock);
 				done();
@@ -287,7 +288,7 @@ describe('blocks/process', function () {
 					expect(err).equal('Blocks#loadBlocksOffset error: Unknown transaction type 99');
 					return done();
 				}
-				
+
 				done(loadedBlock);
 			});
 		});
@@ -299,7 +300,7 @@ describe('blocks/process', function () {
 				if (err) {
 					done(err);
 				}
-				
+
 				expect(loadedBlock.id).equal(loadTables[0].data[6].id);
 				expect(loadedBlock.previousBlock).equal(loadTables[0].data[6].previousBlock);
 				done();
@@ -313,7 +314,7 @@ describe('blocks/process', function () {
 				if (err) {
 					done(err);
 				}
-				
+
 				expect(loadedBlock.id).equal(loadTables[0].data[7].id);
 				expect(loadedBlock.previousBlock).equal(loadTables[0].data[7].previousBlock);
 				done();
@@ -327,7 +328,7 @@ describe('blocks/process', function () {
 				if (err) {
 					done(err);
 				}
-				
+
 				expect(loadedBlock.id).equal(loadTables[0].data[8].id);
 				expect(loadedBlock.previousBlock).equal(loadTables[0].data[8].previousBlock);
 				done();

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var expect 							= require('chai').expect;
-var async 							= require('async');
+var expect = require('chai').expect;
+var async = require('async');
 
-var modulesLoader 			= alias.require('test/common/initModule').modulesLoader;
-var BlockLogic 					= alias.require('logic/block.js');
-var VoteLogic 					= alias.require('logic/vote.js');
+var modulesLoader = alias.require('test/common/initModule').modulesLoader;
+var BlockLogic = alias.require('logic/block.js');
+var VoteLogic = alias.require('logic/vote.js');
 
-var loadTables 					= require('./processTablesData.json');
-var clearDatabaseTable 	= alias.require('test/common/globalBefore').clearDatabaseTable;
-var genesisblock 				= alias.genesisblock;
+var loadTables = require('./processTablesData.json');
+var clearDatabaseTable = alias.require('test/common/globalBefore').clearDatabaseTable;
+var genesisblock = alias.genesisblock;
 
 describe('blocks/process', function () {
 

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -218,7 +218,7 @@ describe('blocks/verify', function () {
 		modulesLoader.initLogic(BlockLogic, modulesLoader.scope, function (err, __blockLogic) {
 			if (err) {
 				return done(err);
-			}			
+			}
 			blockLogic = __blockLogic;
 
 			modulesLoader.initModules([
@@ -255,16 +255,16 @@ describe('blocks/verify', function () {
 
 		it('should be ok', function (done) {
 			blocks.lastBlock.set(previousBlock);
-			
+
 			blocksVerify.verifyBlock(validBlock, function (err) {
 				expect(err).to.be.null;
 				done();
 			});
 		});
-		
+
 		it('should be ok when block is invalid but block id is excepted for having invalid block reward', function (done) {
 			exceptions.blockRewards.push(blockRewardInvalid.id);
-			
+
 			blocksVerify.verifyBlock(blockRewardInvalid, function (err) {
 				expect(err).to.be.null;
 				done();
@@ -273,7 +273,7 @@ describe('blocks/verify', function () {
 	});
 
 	describe('verifyBlock() for invalid block', function () {
-		
+
 		describe('base validations', function () {
 
 			it('should fail when block version != 0', function (done) {
@@ -297,7 +297,7 @@ describe('blocks/verify', function () {
 					done();
 				});
 			});
-			
+
 			it('should fail when previousBlock property is missing', function (done) {
 				var previousBlock = validBlock.previousBlock;
 				delete validBlock.previousBlock;
@@ -333,7 +333,7 @@ describe('blocks/verify', function () {
 
 			it('should fail when transactions length is not equal to numberOfTransactions property', function (done) {
 				validBlock.numberOfTransactions = validBlock.transactions.length + 1;
-				
+
 				blocksVerify.verifyBlock(validBlock, function (err) {
 					expect(err).to.equal('Included transactions do not match block transactions count');
 					validBlock.numberOfTransactions = validBlock.transactions.length;
@@ -345,7 +345,7 @@ describe('blocks/verify', function () {
 				var transactions = validBlock.transactions;
 				validBlock.transactions = new Array(26);
 				validBlock.numberOfTransactions = validBlock.transactions.length;
-				
+
 				blocksVerify.verifyBlock(validBlock, function (err) {
 					expect(err).to.equal('Number of transactions exceeds maximum per block');
 					validBlock.transactions = transactions;
@@ -446,7 +446,7 @@ describe('blocks/verify', function () {
 					validBlock.generatorPublicKey = generatorPublicKey;
 					done();
 				});
-			});		
+			});
 
 			it('should fail when generatorPublicKey property is an invalid hex string', function (done) {
 				var generatorPublicKey = validBlock.generatorPublicKey;
@@ -459,7 +459,7 @@ describe('blocks/verify', function () {
 				});
 			});
 		});
-		
+
 		describe('setBlockId validations', function () {
 
 			it('should reset block id when block id is an invalid alpha-numeric string value', function (done) {
@@ -530,7 +530,7 @@ describe('blocks/verify', function () {
 
 	// Sends a block to network, save it locally.
 	describe('processBlock() for valid block {broadcast: true, saveBlock: true}', function () {
-		
+
 		it('should clear database', function (done) {
 			async.every([
 				'blocks where height > 1',
@@ -560,7 +560,7 @@ describe('blocks/verify', function () {
 
 		it('should generate block 1', function (done) {
 			var secret = 'lend crime turkey diary muscle donkey arena street industry innocent network lunar';
-			
+
 			block1 = createBlock(blocks, blockLogic, secret, 32578370, transactionsBlock1, previousBlock1);
 			expect(block1.version).to.equal(0);
 			expect(block1.timestamp).to.equal(32578370);
@@ -595,7 +595,7 @@ describe('blocks/verify', function () {
 	});
 
 	describe('processBlock() for invalid block {broadcast: true, saveBlock: true}', function () {
-		
+
 		it('should fail when process block 1 again (checkExists)', function (done) {
 			blocks.lastBlock.set(previousBlock1);
 
@@ -606,15 +606,15 @@ describe('blocks/verify', function () {
 			}, true);
 		});
 	});
-	
+
 	// Receives a block from network, save it locally.
 	describe('processBlock() for invalid block {broadcast: false, saveBlock: true}', function () {
-		
+
 		var invalidBlock2;
 
 		it('should generate block 2 with invalid generator slot', function (done) {
 			var secret = 'latin swamp simple bridge pilot become topic summer budget dentist hollow seed';
-			
+
 			block2 = createBlock(blocks, blockLogic, secret, 33772882, transactionsBlock2, block1);
 			expect(block2.version).to.equal(0);
 			expect(block2.timestamp).to.equal(33772882);
@@ -695,7 +695,7 @@ describe('blocks/verify', function () {
 
 		it('should generate block 2 with valid generator slot and processed trs', function (done) {
 			var secret = 'latin swamp simple bridge pilot become topic summer budget dentist hollow seed';
-			
+
 			block2 = createBlock(blocks, blockLogic, secret, 33772862, transactionsBlock1, block1);
 			expect(block2.version).to.equal(0);
 			expect(block2.timestamp).to.equal(33772862);
@@ -725,7 +725,7 @@ describe('blocks/verify', function () {
 
 		it('should generate block 2 with valid generator slot', function (done) {
 			var secret = 'latin swamp simple bridge pilot become topic summer budget dentist hollow seed';
-			
+
 			block2 = createBlock(blocks, blockLogic, secret, 33772862, transactionsBlock2, block1);
 			expect(block2.version).to.equal(0);
 			expect(block2.timestamp).to.equal(33772862);
@@ -780,7 +780,7 @@ describe('blocks/verify', function () {
 
 		it('should generate block 3', function (done) {
 			var secret = 'term stable snap size half hotel unique biology amateur fortune easily tribe';
-			
+
 			block3 = createBlock(blocks, blockLogic, secret, 33942637, [], block2);
 			expect(block3.version).to.equal(0);
 			done();
@@ -811,7 +811,7 @@ describe('blocks/verify', function () {
 
 		it('should be ok when broadcast block 3 again (checkExists)', function (done) {
 			blocks.lastBlock.set(block2);
-			
+
 			blocksVerify.processBlock(block3, true, function (err, result) {
 				if (err) {
 					return done(err);

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var chai 							= require('chai');
-var expect 						= require('chai').expect;
-var express 					= require('express');
-var sinon 						= require('sinon');
-var _  								= require('lodash');
-var MasterWAMPServer 	= require('wamp-socket-cluster/MasterWAMPServer');
+var chai = require('chai');
+var expect = require('chai').expect;
+var express = require('express');
+var sinon = require('sinon');
+var _ = require('lodash');
+var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
 
-var Peer 							= alias.require('logic/peer');
-var modulesLoader 		= alias.require('test/common/initModule').modulesLoader;
-var randomPeer 				= alias.require('test/common/objectStubs').randomPeer;
-var wsRPC 						= alias.require('api/ws/rpc/wsRPC').wsRPC;
+var Peer = alias.require('logic/peer');
+var modulesLoader = alias.require('test/common/initModule').modulesLoader;
+var randomPeer = alias.require('test/common/objectStubs').randomPeer;
+var wsRPC = alias.require('api/ws/rpc/wsRPC').wsRPC;
 
 var currentPeers = [];
 

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -1,17 +1,16 @@
 'use strict';
 
-var chai = require('chai');
-var expect = require('chai').expect;
-var express = require('express');
-var sinon = require('sinon');
-var _  = require('lodash');
-var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
+var chai 							= require('chai');
+var expect 						= require('chai').expect;
+var express 					= require('express');
+var sinon 						= require('sinon');
+var _  								= require('lodash');
+var MasterWAMPServer 	= require('wamp-socket-cluster/MasterWAMPServer');
 
-var config = require('../../config.json');
-var Peer = require('../../../logic/peer');
-var modulesLoader = require('../../common/initModule').modulesLoader;
-var randomPeer = require('../../common/objectStubs').randomPeer;
-var wsRPC = require('../../../api/ws/rpc/wsRPC').wsRPC;
+var Peer 							= alias.require('logic/peer');
+var modulesLoader 		= alias.require('test/common/initModule').modulesLoader;
+var randomPeer 				= alias.require('test/common/objectStubs').randomPeer;
+var wsRPC 						= alias.require('api/ws/rpc/wsRPC').wsRPC;
 
 var currentPeers = [];
 

--- a/test/unit/sql/rounds.js
+++ b/test/unit/sql/rounds.js
@@ -1,21 +1,21 @@
 'use strict';
 
 // Utils
-var _       = require('lodash');
-var async   = require('async');
-var chai    = require('chai');
-var expect  = require('chai').expect;
-var Promise = require('bluebird');
-var rewire  = require('rewire');
-var sinon   = require('sinon');
+var _       	= require('lodash');
+var async   	= require('async');
+var chai    	= require('chai');
+var expect  	= require('chai').expect;
+var Promise 	= require('bluebird');
+var rewire  	= require('rewire');
+var sinon   	= require('sinon');
 
 // Application specific
-var bignum    = require('../../../helpers/bignum.js');
-var config    = require('../../../config.json');
-var constants = require('../../../helpers/constants');
-var node      = require('../../node.js');
-var Sequence  = require('../../../helpers/sequence.js');
-var slots     = require('../../../helpers/slots.js');
+var bignum    = alias.require('helpers/bignum.js');
+var constants = alias.require('helpers/constants');
+var node      = alias.require('test/node.js');
+var Sequence  = alias.require('helpers/sequence.js');
+var slots     = alias.require('helpers/slots.js');
+var config    = alias.config;
 
 describe('Rounds-related SQL triggers', function () {
 	var library;
@@ -120,7 +120,7 @@ describe('Rounds-related SQL triggers', function () {
 		var feesRemaining   = new bignum(feesTotal.toPrecision(15)).minus(feesPerDelegate.times(slots.delegates));
 
 		node.debug('	Total fees: ' + feesTotal.toString() + ' Fees per delegates: ' + feesPerDelegate.toString() + ' Remaining fees: ' + feesRemaining + 'Total rewards: ' + rewardsTotal);
-		
+
 		_.each(blocks, function (block, index) {
 			var pk = block.generatorPublicKey.toString('hex');
 			if (rewards[pk]) {
@@ -203,7 +203,7 @@ describe('Rounds-related SQL triggers', function () {
 					expect(delegate.name).to.equal(found.asset.delegate.username);
 					expect(delegate.address).to.equal(found.senderId);
 					expect(delegate.pk).to.equal(found.senderPublicKey);
-					
+
 					// Data populated by trigger
 					expect(delegate.rank).that.is.an('number');
 					expect(delegate.voters_balance).to.equal(10000000000000000);

--- a/test/unit/sql/rounds.js
+++ b/test/unit/sql/rounds.js
@@ -1,21 +1,21 @@
 'use strict';
 
 // Utils
-var _       	= require('lodash');
-var async   	= require('async');
-var chai    	= require('chai');
-var expect  	= require('chai').expect;
-var Promise 	= require('bluebird');
-var rewire  	= require('rewire');
-var sinon   	= require('sinon');
+var _ = require('lodash');
+var async = require('async');
+var chai = require('chai');
+var expect = require('chai').expect;
+var Promise = require('bluebird');
+var rewire = require('rewire');
+var sinon = require('sinon');
 
 // Application specific
-var bignum    = alias.require('helpers/bignum.js');
+var bignum = alias.require('helpers/bignum.js');
 var constants = alias.require('helpers/constants');
-var node      = alias.require('test/node.js');
-var Sequence  = alias.require('helpers/sequence.js');
-var slots     = alias.require('helpers/slots.js');
-var config    = alias.config;
+var node = alias.require('test/node.js');
+var Sequence = alias.require('helpers/sequence.js');
+var slots = alias.require('helpers/slots.js');
+var config = alias.config;
 
 describe('Rounds-related SQL triggers', function () {
 	var library;

--- a/workersController.js
+++ b/workersController.js
@@ -1,5 +1,4 @@
 'use strict';
-
 var async = require('async');
 var url = require('url');
 
@@ -13,14 +12,15 @@ var PeersUpdateRules = require('./api/ws/workers/peersUpdateRules');
 var Rules = require('./api/ws/workers/rules');
 var failureCodes = require('./api/ws/rpc/failureCodes');
 var Logger = require('./logger');
-var config = require('./config.json');
 
 /**
  * Function is invoked by SocketCluster
  * @param {Worker} worker
  */
 module.exports.run = function (worker) {
-
+	// Needs to be here and not above.
+	require('./alias');
+	var config = alias.config;
 	var scServer = worker.getSCServer();
 
 	async.auto({


### PR DESCRIPTION
Currently, users must cp files from the test package in order to run the test suite. Additionally, before starting the server users must dropdb and createdb before running node app.js.

In this pull request I have created a file, on the root, called alias.js. This file should be called before all others. This file will check the NODE_ENV.toLowercase() var to see if it is of type 'test'. IF it is the file /test/config.json and /test/genesisBlock.json rather than the root directory files. If it is any other type (or not set) it will load up the root files. Once loaded, the files are cached as singletons.

Additionally, I have updated and call to require('<path>/[config || genesisBlock}.json in all files to ensure that they receive the right version of configuration for the environment.

Also, i have added better-npm-run to the project in order to write cleaner npm run commands. This is not required, however, it seems that the file becomes more legible.

Finally. the .eslintignore file I have added alias as a global. This simplifies its use, however, it can easily be created as a module export if that is more inline with your teams opinion. .gitignore has added package-lock.json.

Hope to here from you soon.
Rhys