### PR TITLE
Updating README.md to include information on setting up redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,32 +11,76 @@ Lisk is a next generation crypto-currency and decentralized application platform
 
 ## Prerequisites - In order
 
-- Tool chain components -- Used for compiling dependencies
+This sections provides details on what you need install on your system in order to run Lisk.
 
+### System Install
+
+Tool chain components -- Used for compiling dependencies
+
+- Linux:
   `sudo apt-get install -y python build-essential curl automake autoconf libtool`
 
-- Git (<https://github.com/git/git>) -- Used for cloning and updating Lisk
+- Mac:
+  Make sure that you have both XCode and Brew installed on your machine.
+  Update homebrew:
+  ```
+  brew update
+  brew doctor
+  ```
+  Install Lunchy  for easier starting and stoping of services:
+  `gem install lunchy`
 
+
+Git (<https://github.com/git/git>) -- Used for cloning and updating Lisk
+
+- Linux:
   `sudo apt-get install -y git`
 
-- Node.js (<https://nodejs.org/>) -- Node.js serves as the underlying engine for code execution.
+- Mac:
+  `brew install git`
 
-  System wide via package manager:
+### Nodejs Install
 
+Node.js (<https://nodejs.org/>) -- Node.js serves as the underlying engine for code execution.
+
+- Linux:
   ```
   curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   sudo apt-get install -y nodejs
   ```
 
-  Locally using [nvm](https://github.com/creationix/nvm):
+- Mac:
+  `brew install node`
 
-  ```
-  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-  nvm install v6.10.1
-  ```
+### (Optional) Node Version Manager
 
-- Install PostgreSQL (version 9.6.2):
+[nvm](https://github.com/creationix/nvm)
 
+- Linux
+
+```
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+nvm install v6.10.1
+```
+
+- Mac
+
+You can install the optional NVM from [this tutorial.](http://dev.topheman.com/install-nvm-with-homebrew-to-use-multiple-versions-of-node-and-iojs-easily/)
+
+
+### NPM Installs
+
+- Bower (<http://bower.io/>): Bower helps to install required JavaScript dependencies.
+- Grunt.js (<http://gruntjs.com/>): Grunt is used to compile the frontend code and serves other functions.
+- PM2 (<https://github.com/Unitech/pm2>): PM2 manages the node process for Lisk (Optional)
+
+    `npm install -g bower grunt-cli pm2`
+
+### Install PostgreSQL (version 9.6.2):
+
+**NOTE:** Database user requires privileges to `CREATE EXTENSION pgcrypto`.
+
+- Linux
   ```
   curl -sL "https://downloads.lisk.io/scripts/setup_postgresql.Linux" | bash -
   sudo -u postgres createuser --createdb $USER
@@ -46,19 +90,53 @@ Lisk is a next generation crypto-currency and decentralized application platform
   sudo -u postgres psql -d lisk_main -c "alter user "$USER" with password 'password';"
   ```
 
-  **NOTE:** Database user requires privileges to `CREATE EXTENSION pgcrypto`.
+- Mac
+  ```
+  brew install postgresql
+  initdb /usr/local/var/postgres -E utf8
+  mkdir -p ~/Library/LaunchAgents
+  cp /usr/local/Cellar/postgresql/9.2.1/homebrew.mxcl.postgresql.plist ~/Library/LaunchAgents/
+  lunchy start postgres
+  createdb lisk_test
+  createdb lisk_main
+  ```
+### Installing redis
 
-- Bower (<http://bower.io/>) -- Bower helps to install required JavaScript dependencies.
+- Linux:
+  ```
+  wget http://download.redis.io/redis-stable.tar.gz
+  tar xvzf redis-stable.tar.gz
+  cd redis-stable
+  make
+  redis-server
+  ```
 
-  `npm install -g bower`
+- Mac:
+  ```
+  brew install redis
+  lunchy start redis
+  ```
 
-- Grunt.js (<http://gruntjs.com/>) -- Grunt is used to compile the frontend code and serves other functions.
+**NOTE:** Lisk does not run on the redis default port of 6379. Instead it is configured to run on port: 6380. Because of this, in order for Lisk to run, you have one of two options:
 
-  `npm install -g grunt-cli`
+#### Change The Lisk Configuration
 
-- PM2 (<https://github.com/Unitech/pm2>) -- PM2 manages the node process for Lisk (Optional)
+Update the redis port configuration in both config.json and test/config.json. Note that this is the easiest option, however, be mindfull of reverting the changes should you make a pull request.
 
-  `npm install -g pm2`
+### Change The Redis Launch configuration
+
+Update the launch configuration file on your system. Note that their a number of ways to do this. The following is one way:
+
+1. Stop Redis on your computer. Linux: `redis-server stop` Mac: `lunchy stop redis`
+2. Open the /usr/local/etc/redis.conf file and change this: `port 6379` to `port 6380`
+3. Restart Redis. Linux: `redis-server` Mac: `lunchy start redis`
+
+Now confirm that your is running on port 6380.
+```
+redis-cli -p 6380
+ping
+```
+and you should get the result of 'PONG'
 
 ## Installation Steps
 
@@ -100,7 +178,7 @@ pm2 start --name lisk app.js -- -p [port] -a [address] -c [config-path]
 
 Before running any tests, please ensure Lisk is configured to run on the same testnet that is used by the test-suite.
 
-Replace **config.json** and **genesisBlock.json** with the corresponding files under the **test** directory:
+Replace **config.json** and **genesisBlock.json** with the corresponding files under the **test** directory
 
 ```
 cp test/config.json test/genesisBlock.json .
@@ -112,6 +190,8 @@ cp test/config.json test/genesisBlock.json .
 dropdb lisk_test
 createdb lisk_test
 ```
+
+**NOTE:** Remember to manage the Redis non-default port setting of 6380 as described above.
 
 **NOTE:** The master passphrase for this genesis block is as follows:
 

--- a/README.md
+++ b/README.md
@@ -18,25 +18,33 @@ This sections provides details on what you need install on your system in order 
 Tool chain components -- Used for compiling dependencies
 
 - Linux:
+
   `sudo apt-get install -y python build-essential curl automake autoconf libtool`
 
 - Mac:
+
   Make sure that you have both XCode and Brew installed on your machine.
+
   Update homebrew:
+
   ```
   brew update
   brew doctor
   ```
+
   Install Lunchy  for easier starting and stoping of services:
+
   `gem install lunchy`
 
 
 Git (<https://github.com/git/git>) -- Used for cloning and updating Lisk
 
 - Linux:
+
   `sudo apt-get install -y git`
 
 - Mac:
+
   `brew install git`
 
 ### Nodejs Install
@@ -50,6 +58,7 @@ Node.js (<https://nodejs.org/>) -- Node.js serves as the underlying engine for c
   ```
 
 - Mac:
+
   `brew install node`
 
 ### (Optional) Node Version Manager
@@ -58,14 +67,14 @@ Node.js (<https://nodejs.org/>) -- Node.js serves as the underlying engine for c
 
 - Linux
 
-```
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-nvm install v6.10.1
-```
+  ```
+  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+  nvm install v6.10.1
+  ```
 
 - Mac
 
-You can install the optional NVM from [this tutorial.](http://dev.topheman.com/install-nvm-with-homebrew-to-use-multiple-versions-of-node-and-iojs-easily/)
+  You can install the optional NVM from [this tutorial.](http://dev.topheman.com/install-nvm-with-homebrew-to-use-multiple-versions-of-node-and-iojs-easily/)
 
 
 ### NPM Installs
@@ -123,13 +132,13 @@ You can install the optional NVM from [this tutorial.](http://dev.topheman.com/i
 
 Update the redis port configuration in both config.json and test/config.json. Note that this is the easiest option, however, be mindfull of reverting the changes should you make a pull request.
 
-### Change The Redis Launch configuration
+#### Change The Redis Launch configuration
 
 Update the launch configuration file on your system. Note that their a number of ways to do this. The following is one way:
 
-1. Stop Redis on your computer. Linux: `redis-server stop` Mac: `lunchy stop redis`
+1. Stop Redis on your computer. [{ Linux: `redis-server stop` },{ Mac: `lunchy stop redis` }]
 2. Open the /usr/local/etc/redis.conf file and change this: `port 6379` to `port 6380`
-3. Restart Redis. Linux: `redis-server` Mac: `lunchy start redis`
+3. Restart Redis. [{ Linux: `redis-server` },{ Mac: `lunchy start redis` }]
 
 Now confirm that your is running on port 6380.
 ```


### PR DESCRIPTION
I have added the documentation about setting up redis in the README.md as it was missing. Additionally, since the Lisk redis settings assigns a non-default port ( 6380), i have added documentation one how the developer can manage this.

Finally, since I was in the file, I added documentation on setting up Lisk on a Mac.