### PR TITLE
Switch logger to process.cwd() - Closes #731

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -33,7 +33,7 @@ module.exports = function (config) {
 		fatal: 'FTL'
 	};
 
-	config.filename = __dirname + '/' + (config.filename || 'logs.log');
+	config.filename = process.cwd() + '/' + (config.filename || 'logs.log');
 
 	config.errorLevel = config.errorLevel || 'log';
 


### PR DESCRIPTION
Fixes binary compile issues with workerController logging.