### PR TITLE
FIX: For unit test helpers/config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bytebuffer": "=5.0.1",
     "change-case": "=3.0.1",
     "colors": "=1.1.2",
-    "commander": "=2.9.0",
+    "commander": "=2.11.0",
     "compression": "=1.6.2",
     "cors": "=2.8.3",
     "decompress-zip": "LiskHQ/decompress-zip#f46b0a3",

--- a/test/unit/helpers/config.js
+++ b/test/unit/helpers/config.js
@@ -1,0 +1,192 @@
+'use strict';
+
+var chai = require('chai');
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var commander = require('commander');
+
+var config = require('../../../helpers/config');
+
+describe('config is able to override AppConfig properties from the command line', function () {
+
+	var VERSION = '0.0.0a';
+	var argvcloneStr = JSON.stringify(process.argv);
+	var originalMaxListeners;
+
+	before(function () {
+		originalMaxListeners = commander.getMaxListeners();
+		commander.setMaxListeners(100);
+	});
+
+	after(function () {
+		commander.setMaxListeners(originalMaxListeners);
+	});
+
+	afterEach(function () {
+		process.argv = JSON.parse(argvcloneStr);
+	});
+
+	describe('standard scenarios', function () {
+
+		function standardExpect (result) {
+			describe(result.double.dash , function () {
+
+				it('single dash: [ -' + result.single.dash + ' ]', function () {
+					process.argv.push('-' + result.single.dash);
+					process.argv.push(result.single.value);
+					var appconfig = config({version: VERSION});
+					if (result.expect) {
+						result.expect('single', appconfig);
+					} else {
+						expect(result.appConfigValue(appconfig)).to.eq(result.single.value);
+					}
+				});
+
+				it('double dash: [ --' + result.double.dash + ' ]', function () {
+					process.argv.push('--' + result.double.dash);
+					process.argv.push(result.double.value);
+					var appconfig = config({version: VERSION});
+					if (result.expect) {
+						result.expect('double', appconfig, result);
+					} else {
+						expect(result.appConfigValue(appconfig)).to.eq(result.double.value);
+					}
+				});
+			});
+		}
+
+		[
+			{
+				expect: function (type, appconfig, result) {
+					expect(appconfig.port).to.eq(1234);
+					expect(appconfig.httpPort).to.be.eq(4321);
+					expect(appconfig.address).to.be.eq('0.0.0.0');
+					expect(appconfig.fileLogLevel).to.be.eq('MOCKING');
+					expect(appconfig.db.database).to.eq('MOCKDB');
+					expect(appconfig.peers.list.length).to.eq(1);
+					expect(appconfig.peers.list[0].ip).to.eq('127.0.0.101');
+					expect(appconfig.peers.list[0].port).to.eq('444');
+				},
+				single: {
+					dash: 'c',
+					value: './test/unit/helpers/config.mock.data.json'
+				},
+				double: {
+					dash: 'config',
+					value: './test/unit/helpers/config.mock.data.json'
+				}
+			},{
+				appConfigValue: function (appconfig) {
+					return appconfig.port;
+				},
+				single: {
+					dash: 'p',
+					value: 9999
+				},
+				double: {
+					dash: 'port',
+					value: 9998
+				}
+			},{
+				appConfigValue: function (appconfig) {
+					return appconfig.httpPort;
+				},
+				single: {
+					dash: 'h',
+					value: 1999
+				},
+				double: {
+					dash: 'http-port',
+					value: 1998
+				}
+			},{
+				appConfigValue: function (appconfig) {
+					return appconfig.db.database;
+				},
+				single: {
+					dash: 'd',
+					value: 'database1'
+				},
+				double: {
+					dash: 'database',
+					value: 'database2'
+				}
+			},{
+				appConfigValue: function (appconfig) {
+					return appconfig.address;
+				},
+				single: {
+					dash: 'a',
+					value: '127.0.0.1'
+				},
+				double: {
+					dash: 'address',
+					value: '127.0.0.2'
+				}
+			},{
+				appConfigValue: function (appconfig) {
+					return appconfig.consoleLogLevel;
+				},
+				single: {
+					dash: 'l',
+					value: 'SINGLE_LOG'
+				},
+				double: {
+					dash: 'log',
+					value: 'DOUBLE_LOG'
+				}
+			},{
+				appConfigValue: function (appconfig) {
+					return appconfig.loading.snapshot;
+				},
+				single: {
+					dash: 's',
+					value: 1
+				},
+				double: {
+					dash: 'snapshot',
+					value: 2
+				}
+			},{
+				expect: function (type, appconfig, result) {
+					var startsWith = '127';
+					var ports = ['4008', '4009'];
+					if (type === 'double') {
+						startsWith = '128';
+						ports = ['4010', '4011'];
+					}
+					expect(appconfig.peers.list.length).to.eq(2);
+					expect(appconfig.peers.list[0].ip).to.eq(startsWith + '.0.0.1');
+					expect(appconfig.peers.list[1].ip).to.eq(startsWith + '.0.0.2');
+					expect(appconfig.peers.list[0].port).to.eq(ports[0]);
+					expect(appconfig.peers.list[1].port).to.eq(ports[1]);
+				},
+				single: {
+					dash: 'x',
+					value: '127.0.0.1:4008,127.0.0.2:4009'
+				},
+				double: {
+					dash: 'peers',
+					value: '128.0.0.1:4010,128.0.0.2:4011'
+				}
+			}
+		].forEach( function (result){
+			standardExpect(result);
+		});
+	});
+
+	describe('addition default port for peers if no port is provided', function () {
+
+		it('should override the peers with double dash but defer to the default port', function () {
+			process.argv.push('-p');
+			process.argv.push('9997');
+			process.argv.push('--peers');
+			process.argv.push('127.0.0.19');
+			var appconfig = config({version: VERSION});
+			expect(appconfig).to.not.be.null;
+			expect(appconfig.peers.list.length).to.eq(1);
+			expect(appconfig.peers.list[0].ip).to.eq('127.0.0.19');
+			expect(appconfig.peers.list[0].port).to.eq(9997);
+		});
+	});
+});

--- a/test/unit/helpers/config.mock.data.json
+++ b/test/unit/helpers/config.mock.data.json
@@ -1,0 +1,105 @@
+{
+    "port": 1234,
+    "httpPort": 4321,
+    "address": "0.0.0.0",
+    "version": "0.0.0a",
+    "minVersion": "0.0.0a",
+    "fileLogLevel": "MOCKING",
+    "logFileName": "logs/lisk.log",
+    "consoleLogLevel": "debug",
+    "trustProxy": false,
+    "topAccounts": false,
+    "cacheEnabled": true,
+    "wsWorkers": 1,
+    "db": {
+        "host": "localhost",
+        "port": 5432,
+        "database": "MOCKDB",
+        "user": "",
+        "password": "password",
+        "poolSize": 95,
+        "poolIdleTimeout": 30000,
+        "reapIntervalMillis": 1000,
+        "logEvents": [
+            "error"
+        ]
+    },
+    "redis": {
+        "host": "127.0.0.1",
+        "port": 6380,
+        "db": 0,
+        "password": null
+    },
+    "api": {
+        "enabled": true,
+        "access": {
+            "public": true,
+            "whiteList": ["127.0.0.1"]
+        },
+        "options": {
+            "limits": {
+                "max": 0,
+                "delayMs": 0,
+                "delayAfter": 0,
+                "windowMs": 60000
+            }
+        }
+    },
+    "peers": {
+        "enabled": true,
+        "list": [{
+            "ip": "127.0.0.101",
+            "port": "444"
+        }],
+        "access": {
+            "blackList": []
+        },
+        "options": {
+            "limits": {
+                "max": 0,
+                "delayMs": 0,
+                "delayAfter": 0,
+                "windowMs": 60000
+            },
+            "timeout": 5000
+        }
+    },
+    "broadcasts": {
+        "broadcastInterval": 5000,
+        "broadcastLimit": 20,
+        "parallelLimit": 20,
+        "releaseLimit": 25,
+        "relayLimit": 2
+    },
+    "transactions": {
+        "maxTxsPerQueue": 1000
+    },
+    "forging": {
+        "force": true,
+				"defaultKey": "elephant tree paris dragon chair galaxy",
+				"secret": [{
+  					"encryptedSecret": "19e9f8eee5d9516234a10953669518bf23371d34e114713c8043a98378fd866834946380c4cc0e40f23305643206c1c5be496074f350d09d87735c42eae30c604cabea9862f4fe8f906313c67a7146d54fa844171e6cf925b7c953987082cdd6",
+  					"publicKey": "9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f"
+  				}
+				],
+        "access": {
+            "whiteList": [
+                "127.0.0.1"
+            ]
+        }
+    },
+    "loading": {
+        "verifyOnLoading": false,
+        "loadPerIteration": 5000
+    },
+    "ssl": {
+        "enabled": false,
+        "options": {
+            "port": 443,
+            "address": "0.0.0.0",
+            "key": "./ssl/lisk.key",
+            "cert": "./ssl/lisk.crt"
+        }
+    },
+    "nethash": "198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d"
+}

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -3,6 +3,7 @@ require('./api/ws/workers/peersUpdateRules');
 require('./api/ws/workers/rules');
 require('./api/ws/workers/slaveToMasterSender');
 
+require('./helpers/config');
 require('./helpers/ed');
 require('./helpers/jobs-queue');
 require('./helpers/peersManager');


### PR DESCRIPTION
I have fixed the issue: (node:126470) Warning: Possible EventEmitter memory leak detected. 11 option:peers listeners added. Use emitter.setMaxListeners() to increase limit

I opened a new pull request as the other one was closed... so... I opened this one. Not sure if you would prefer it handled another way?

R