### PR TITLE
Throwable SchemaDynamicTest test - Related to #747

### DIFF
--- a/test/common/schemaDynamicTest.js
+++ b/test/common/schemaDynamicTest.js
@@ -49,7 +49,6 @@ function SchemaDynamicTest (config) {
 	this.customArgumentAssertion = config.customArgumentAssertion;
 	this.customPropertyAssertion = config.customPropertyAssertion;
 	this.customRequiredPropertiesAssertion = config.customRequiredPropertiesAssertion;
-	this.testStyle = config.testStyle || SchemaDynamicTest.TEST_STYLE.ASYNC;
 
 	// TODO: Create argument assertions styles for each testStyle as well.
 	if (config.testStyle === SchemaDynamicTest.TEST_STYLE.THROWABLE) {

--- a/test/common/schemaDynamicTest.js
+++ b/test/common/schemaDynamicTest.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var assign = _.assign;
 var difference = _.difference;
-var setProperty = _.set;
+var set = _.set;
 var chai = require('chai');
 var expect = require('chai').expect;
 var util = require('util');
@@ -129,11 +129,8 @@ SchemaDynamicTest.prototype.testProperty = function (expectedType, invalidInputs
 	var assertion = self.customPropertyAssertion ? self.customPropertyAssertion.bind(self) : self.standardInvalidPropertyAssertion;
 	var test = function (invalidInput, eachCb) {
 		var malformedPart = {};
-		if (property.indexOf('.') === -1) {
-			malformedPart[property] = invalidInput.input;
-		} else {
-			setProperty(malformedPart, property, invalidInput.input);
-		}
+		set(malformedPart, property, invalidInput.input);
+
 		var invalidArgument = assign({}, validArgument, malformedPart);
 		self.testStyle(testedFunction, invalidArgument, function (err) {
 			assertion(invalidInput, expectedType, property, err);

--- a/test/common/schemaDynamicTest.js
+++ b/test/common/schemaDynamicTest.js
@@ -37,7 +37,6 @@ SchemaDynamicTest.TEST_STYLE = {
 
 function SchemaDynamicTest (config) {
 
-	this.customInput = config.customInput;
 	this.customArgumentAssertion = config.customArgumentAssertion;
 	this.customPropertyAssertion = config.customPropertyAssertion;
 	this.customRequiredPropertiesAssertion = config.customRequiredPropertiesAssertion;

--- a/test/common/schemaDynamicTest.js
+++ b/test/common/schemaDynamicTest.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var assign = require('lodash').assign;
-var difference = require('lodash').difference;
+var _ = require('lodash');
+var assign = _.assign;
+var difference = _.difference;
+var setProperty = _.set;
 var chai = require('chai');
 var expect = require('chai').expect;
 var util = require('util');
@@ -19,6 +21,14 @@ var objects = typesRepresentatives.objects;
 var strings = typesRepresentatives.strings;
 
 var self;
+
+function standardInvalidPropertyAssertionForAsyncStyle (input, expectedType, property, err) {
+	self.standardInvalidArgumentAssertion(input, expectedType, err);
+}
+
+function standardInvalidPropertyAssertionForThrowableStyle (input, expectedType, property, err) {
+	expect(err).to.equal(['Failed to validate delegate schema: Expected type', expectedType, 'but found type',  input.expectation].join(' '));
+}
 
 SchemaDynamicTest.TEST_STYLE = {
 	ASYNC: function (testFunction, argument, cb) {
@@ -40,6 +50,18 @@ function SchemaDynamicTest (config) {
 	this.customPropertyAssertion = config.customPropertyAssertion;
 	this.customRequiredPropertiesAssertion = config.customRequiredPropertiesAssertion;
 	this.testStyle = config.testStyle || SchemaDynamicTest.TEST_STYLE.ASYNC;
+
+	// TODO: Create argument assertions styles for each testStyle as well.
+	if (config.testStyle === SchemaDynamicTest.TEST_STYLE.THROWABLE) {
+		this.testStyle = SchemaDynamicTest.TEST_STYLE.THROWABLE;
+		this.standardInvalidPropertyAssertion = standardInvalidPropertyAssertionForThrowableStyle;
+	} else if (config.testStyle === SchemaDynamicTest.TEST_STYLE.ASYNC) {
+		this.testStyle = SchemaDynamicTest.TEST_STYLE.ASYNC;
+		this.standardInvalidPropertyAssertion = standardInvalidPropertyAssertionForAsyncStyle;
+	} else {
+		// We will be required to register a custom property assertion format with this one
+		this.testStyle = config.testStyle;
+	}
 
 	self = this;
 
@@ -118,15 +140,16 @@ SchemaDynamicTest.prototype.testArgument = function (expectedType, invalidInputs
 	self.carpetTesting(test, invalidInputs, 'should return an error when invoked with %s');
 };
 
-SchemaDynamicTest.prototype.standardInvalidPropertyAssertion = function (input, expectedType, property, err) {
-	self.standardInvalidArgumentAssertion(input, expectedType, err);
-};
 
 SchemaDynamicTest.prototype.testProperty = function (expectedType, invalidInputs, testedFunction, validArgument, property) {
 	var assertion = self.customPropertyAssertion ? self.customPropertyAssertion.bind(self) : self.standardInvalidPropertyAssertion;
 	var test = function (invalidInput, eachCb) {
 		var malformedPart = {};
-		malformedPart[property] = invalidInput.input;
+		if (property.indexOf('.') === -1) {
+			malformedPart[property] = invalidInput.input;
+		} else {
+			setProperty(malformedPart, property, invalidInput.input);
+		}
 		var invalidArgument = assign({}, validArgument, malformedPart);
 		self.testStyle(testedFunction, invalidArgument, function (err) {
 			assertion(invalidInput, expectedType, property, err);

--- a/test/common/schemaDynamicTest.js
+++ b/test/common/schemaDynamicTest.js
@@ -41,7 +41,7 @@ function SchemaDynamicTest (config) {
 	this.customArgumentAssertion = config.customArgumentAssertion;
 	this.customPropertyAssertion = config.customPropertyAssertion;
 	this.customRequiredPropertiesAssertion = config.customRequiredPropertiesAssertion;
-	this.testStyle = config.testStyle;
+	this.testStyle = config.testStyle || SchemaDynamicTest.TEST_STYLE.ASYNC;
 
 	self = this;
 

--- a/test/common/schemaDynamicTest.js
+++ b/test/common/schemaDynamicTest.js
@@ -22,14 +22,6 @@ var strings = typesRepresentatives.strings;
 
 var self;
 
-function standardInvalidPropertyAssertionForAsyncStyle (input, expectedType, property, err) {
-	self.standardInvalidArgumentAssertion(input, expectedType, err);
-}
-
-function standardInvalidPropertyAssertionForThrowableStyle (input, expectedType, property, err) {
-	expect(err).to.equal(['Failed to validate delegate schema: Expected type', expectedType, 'but found type',  input.expectation].join(' '));
-}
-
 SchemaDynamicTest.TEST_STYLE = {
 	ASYNC: function (testFunction, argument, cb) {
 		testFunction(argument, cb);
@@ -49,18 +41,7 @@ function SchemaDynamicTest (config) {
 	this.customArgumentAssertion = config.customArgumentAssertion;
 	this.customPropertyAssertion = config.customPropertyAssertion;
 	this.customRequiredPropertiesAssertion = config.customRequiredPropertiesAssertion;
-
-	// TODO: Create argument assertions styles for each testStyle as well.
-	if (config.testStyle === SchemaDynamicTest.TEST_STYLE.THROWABLE) {
-		this.testStyle = SchemaDynamicTest.TEST_STYLE.THROWABLE;
-		this.standardInvalidPropertyAssertion = standardInvalidPropertyAssertionForThrowableStyle;
-	} else if (config.testStyle === SchemaDynamicTest.TEST_STYLE.ASYNC) {
-		this.testStyle = SchemaDynamicTest.TEST_STYLE.ASYNC;
-		this.standardInvalidPropertyAssertion = standardInvalidPropertyAssertionForAsyncStyle;
-	} else {
-		// We will be required to register a custom property assertion format with this one
-		this.testStyle = config.testStyle;
-	}
+	this.testStyle = config.testStyle;
 
 	self = this;
 
@@ -126,6 +107,10 @@ SchemaDynamicTest.prototype.carpetTesting = function (test, inputs, description)
 SchemaDynamicTest.prototype.standardInvalidArgumentAssertion = function (input, expectedType, err) {
 	expect(err).to.be.an('array').and.to.have.nested.property('0.message')
 		.equal('Expected type ' + expectedType + ' but found type ' + input.expectation);
+};
+
+SchemaDynamicTest.prototype.standardInvalidPropertyAssertion = function (input, expectedType, property, err) {
+	self.standardInvalidArgumentAssertion(input, expectedType, err);
 };
 
 SchemaDynamicTest.prototype.testArgument = function (expectedType, invalidInputs, testedFunction) {

--- a/test/unit/helpers/wsApi.js
+++ b/test/unit/helpers/wsApi.js
@@ -93,15 +93,12 @@ describe('handshake', function () {
 		describe('schema', function () {
 
 			var schemaDynamicTests = new SchemaDynamicTests({
-				customInput: {
-					invalidHeadersErrorCode: failureCodes.INVALID_HEADERS
-				},
 				customArgumentAssertion: function (input, expectedType, err) {
-					expect(err).to.have.property('code').equal(this.customInput.invalidHeadersErrorCode);
+					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
 					expect(err).to.have.property('description').equal('#/: Expected type ' + expectedType + ' but found type ' + input.expectation);
 				},
 				customPropertyAssertion: function (input, expectedType, property, err) {
-					expect(err).to.have.property('code').equal(this.customInput.invalidHeadersErrorCode);
+					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
 					expect(err).to.have.property('description').equal('#/' + property + ': Expected type ' + expectedType + ' but found type ' + input.expectation);
 				},
 				customRequiredPropertiesAssertion: function (property, err) {


### PR DESCRIPTION
Every schema check in objectNormalize functions is organized in throwable error manner. The PR makes possible to test them as well.

Related to #747