### PR TITLE
All to all connection in integration tests - Related to #704 

### DIFF
--- a/test/integration/peers.integration.js
+++ b/test/integration/peers.integration.js
@@ -31,7 +31,7 @@ var SYNC_MODE_DEFAULT_ARGS = {
 	}
 };
 
-var WAIT_BEFORE_CONNECT_MS = 25000;
+var WAIT_BEFORE_CONNECT_MS = 40000;
 
 SYNC_MODE_DEFAULT_ARGS.ALL_TO_GROUP.INDICES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 var testNodeConfigs = generateNodesConfig(10, SYNC_MODE.ALL_TO_GROUP, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/test/integration/peers.integration.js
+++ b/test/integration/peers.integration.js
@@ -33,7 +33,8 @@ var SYNC_MODE_DEFAULT_ARGS = {
 
 var WAIT_BEFORE_CONNECT_MS = 25000;
 
-var testNodeConfigs = generateNodesConfig(10, SYNC_MODE.ALL_TO_FIRST, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+SYNC_MODE_DEFAULT_ARGS.ALL_TO_GROUP.INDICES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+var testNodeConfigs = generateNodesConfig(10, SYNC_MODE.ALL_TO_GROUP, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
 var monitorWSClient = {
 	protocol: 'http',
@@ -81,7 +82,17 @@ function generateNodePeers (numOfPeers, syncMode, syncModeArgs) {
 			break;
 
 		case SYNC_MODE.ALL_TO_GROUP:
-			throw new Error('To implement');
+			if (!Array.isArray(syncModeArgs.ALL_TO_GROUP.INDICES)) {
+				throw new Error('Provide peers indices to sync with as an array');
+			}
+			Array.apply(null, new Array(numOfPeers)).forEach(function (val, index) {
+				if (syncModeArgs.ALL_TO_GROUP.INDICES.indexOf(index) !== -1) {
+					peersList.push({
+						ip: '127.0.0.1',
+						port: 5000 + index
+					});
+				}
+			});
 	}
 	return peersList;
 }


### PR DESCRIPTION
Having a full peers list on every peer will allow the network to reach the full connectivity faster.
Also, increase the before connection timeout from 25sec to 40sec. 
Related to #704.