### PR TITLE
Use parameter instead of environment variable - Subtask #809

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,13 +64,13 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 		parallel(
 			"Build cached dependencies" : {
 				node('master-01'){
-					sh '''#!/bin/bash -xe
-					if [ $JENKINS_PROFILE == "jenkins-extensive" ]; then
-						rm -Rf "$WORKSPACE/node_modules/"
+					sh """
+					if [ ${params.JENKINS_PROFILE} = "jenkins-extensive" ]; then
+						rm -Rf "${env.WORKSPACE}/node_modules/"
 						npm install
-						rsync -axl --delete "$WORKSPACE/node_modules/" /var/lib/jenkins/lisk/node_modules/
+						rsync -axl --delete "${env.WORKSPACE}/node_modules/" /var/lib/jenkins/lisk/node_modules/
 					fi
-					'''
+					"""
 				}
 			},
 			"Build Node-01" : {
@@ -172,128 +172,128 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 			},
 			"Functional Accounts" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/accounts.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Blocks" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/blocks.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Dapps" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/dapps.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo $WORKSPACE | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Delegates" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/delegates.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Loader" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/loader.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Multisignatures" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/multisignatures.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Multisignatures post" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/multisignatures.post.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Transactions" : {
 				node('node-01'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/transactions.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Peers" : {
 				node('node-02'){
-					sh '''
+					sh """
 					export TEST=test/functional/http/get/peers.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},  // End node-01 functional tests
 			"Functional Transport - Main" : {
 				node('node-02'){
-					sh '''
+					sh """
 					export TEST=test/functional/ws/transport.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Transport - Blocks" : {
 				node('node-02'){
-					sh '''
+					sh """
 					export TEST=test/functional/ws/transport.blocks.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Transport - Client" : {
 				node('node-02'){
-					sh '''
+					sh """
 					export TEST=test/functional/ws/transport.client.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Transport - Handshake" : {
 				node('node-02'){
-					sh '''
+					sh """
 					export TEST=test/functional/ws/transport.handshake.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Functional Transport - Transactions" : {
 				node('node-02'){
-					sh '''
+					sh """
 					export TEST=test/functional/ws/transport.transactions.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			}, // End Node-02 Tests
 			"Unit Tests" : {
@@ -307,29 +307,29 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 			},
 			"Unit Tests - sql blockRewards" : {
 				node('node-03'){
-					sh '''
+					sh """
 					export TEST=test/unit/sql/blockRewards.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},
 			"Unit Tests - logic blockReward" : {
 				node('node-03'){
-					sh '''
+					sh """
 					export TEST=test/unit/logic/blockReward.js  TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			},// End Node-03 unit tests
 			"Functional Stress - Transactions" : {
 				node('node-04'){
-					sh '''
+					sh """
 					export TEST=test/functional/ws/transport.transactions.stress.js TEST_TYPE='FUNC' NODE_ENV='TEST'
-					cd "$(echo $WORKSPACE | cut -f 1 -d '@')"
-					npm run $JENKINS_PROFILE
-					'''
+					cd "\$(echo ${env.WORKSPACE} | cut -f 1 -d '@')"
+					npm run ${params.JENKINS_PROFILE}
+					"""
 				}
 			} // End Node-04
 		) // End Parallel


### PR DESCRIPTION
Use parameter instead of environment variable which is not set for the first build,
ref. https://issues.jenkins-ci.org/browse/JENKINS-40574

Fix bug from #809 