### PR TITLE
Standardise domain specific variable naming - Closes #826

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 					"""
 				}
 			},
-			"Functional POST tx type 0" : {
+			"Functional POST transaction type 0" : {
 				node('node-01'){
 					sh """
 					export TEST=test/functional/http/post/0.transfer.js TEST_TYPE='FUNC' NODE_ENV='TEST'
@@ -251,7 +251,7 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 					"""
 				}
 			},
-			"Functional POST tx type 1" : {
+			"Functional POST transaction type 1" : {
 				node('node-01'){
 					sh """
 					export TEST=test/functional/http/post/1.second.secret.js TEST_TYPE='FUNC' NODE_ENV='TEST'

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -28,7 +28,7 @@
  * @property {number} maxRequests
  * @property {number} maxSharedTxs
  * @property {number} maxSignaturesLength
- * @property {number} maxTxsPerBlock
+ * @property {number} maxTransactionsPerBlock
  * @property {number} minBroadhashConsensus
  * @property {string[]} nethashes - Mainnet and Testnet.
  * @property {number} numberLength
@@ -69,7 +69,7 @@ var constants = {
 	maxRequests: 10000 * 12,
 	maxSharedTxs: 100,
 	maxSignaturesLength: 196 * 256,
-	maxTxsPerBlock: 25,
+	maxTransactionsPerBlock: 25,
 	minBroadhashConsensus: 51,
 	nethashes: [
 		// Mainnet

--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -33,27 +33,27 @@ Delegate.prototype.bind = function (accounts) {
  * Obtains constant fee delegate.
  * @see {@link module:helpers/constants}
  * @returns {number} constants.fees.delegate
- * @todo delete unnecessary function parameters trs, sender.
+ * @todo delete unnecessary function parameters transaction, sender.
  */
-Delegate.prototype.calculateFee = function (trs, sender) {
+Delegate.prototype.calculateFee = function (transaction, sender) {
 	return constants.fees.delegate;
 };
 
 /**
  * Verifies fields from transaction and sender, calls modules.accounts.getAccount().
  * @implements module:accounts#Account~getAccount
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback|Object} returns error if invalid parameter |
- * trs validated.
+ * transaction validated.
  */
-Delegate.prototype.verify = function (trs, sender, cb) {
-	if (trs.recipientId) {
+Delegate.prototype.verify = function (transaction, sender, cb) {
+	if (transaction.recipientId) {
 		return setImmediate(cb, 'Invalid recipient');
 	}
 
-	if (trs.amount !== 0) {
+	if (transaction.amount !== 0) {
 		return setImmediate(cb, 'Invalid transaction amount');
 	}
 
@@ -61,22 +61,22 @@ Delegate.prototype.verify = function (trs, sender, cb) {
 		return setImmediate(cb, 'Account is already a delegate');
 	}
 
-	if (!trs.asset || !trs.asset.delegate) {
+	if (!transaction.asset || !transaction.asset.delegate) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
 
-	if (!trs.asset.delegate.username) {
+	if (!transaction.asset.delegate.username) {
 		return setImmediate(cb, 'Username is undefined');
 	}
 
-	if (trs.asset.delegate.username !== trs.asset.delegate.username.toLowerCase()) {
+	if (transaction.asset.delegate.username !== transaction.asset.delegate.username.toLowerCase()) {
 		return setImmediate(cb, 'Username must be lowercase');
 	}
 
 	var isAddress = /^[0-9]{1,21}[L|l]$/g;
 	var allowSymbols = /^[a-z0-9!@$&_.]+$/g;
 
-	var username = String(trs.asset.delegate.username).toLowerCase().trim();
+	var username = String(transaction.asset.delegate.username).toLowerCase().trim();
 
 	if (username === '') {
 		return setImmediate(cb, 'Empty username');
@@ -105,37 +105,37 @@ Delegate.prototype.verify = function (trs, sender, cb) {
 			return setImmediate(cb, 'Username already exists');
 		}
 
-		return setImmediate(cb, null, trs);
+		return setImmediate(cb, null, transaction);
 	});
 };
 
 /**
  * Returns transaction with setImmediate.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback} Null error
  * @todo delete extra parameter sender.
  */
-Delegate.prototype.process = function (trs, sender, cb) {
-	return setImmediate(cb, null, trs);
+Delegate.prototype.process = function (transaction, sender, cb) {
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Validates delegate username and returns buffer.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @returns {null|string} Returns null if no delegate| buffer.
  * @throws {error} If buffer fails.
  */
-Delegate.prototype.getBytes = function (trs) {
-	if (!trs.asset.delegate.username) {
+Delegate.prototype.getBytes = function (transaction) {
+	if (!transaction.asset.delegate.username) {
 		return null;
 	}
 
 	var buf;
 
 	try {
-		buf = Buffer.from(trs.asset.delegate.username, 'utf8');
+		buf = Buffer.from(transaction.asset.delegate.username, 'utf8');
 	} catch (e) {
 		throw e;
 	}
@@ -144,75 +144,75 @@ Delegate.prototype.getBytes = function (trs) {
 };
 
 /**
- * Checks trs delegate and calls modules.accounts.setAccountAndGet() with username.
+ * Checks transaction delegate and calls modules.accounts.setAccountAndGet() with username.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @todo delete extra parameter block.
  */
-Delegate.prototype.apply = function (trs, block, sender, cb) {
+Delegate.prototype.apply = function (transaction, block, sender, cb) {
 	var data = {
 		address: sender.address,
 		u_isDelegate: 0,
 		isDelegate: 1,
 		vote: 0,
 		u_username: null,
-		username: trs.asset.delegate.username
+		username: transaction.asset.delegate.username
 	};
 
 	modules.accounts.setAccountAndGet(data, cb);
 };
 
 /**
- * Checks trs delegate and no nameexist and calls modules.accounts.setAccountAndGet() with u_username.
+ * Checks transaction delegate and no nameexist and calls modules.accounts.setAccountAndGet() with u_username.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @todo delete extra parameter block.
  */
-Delegate.prototype.undo = function (trs, block, sender, cb) {
+Delegate.prototype.undo = function (transaction, block, sender, cb) {
 	var data = {
 		address: sender.address,
 		u_isDelegate: 1,
 		isDelegate: 0,
 		vote: 0,
 		username: null,
-		u_username: trs.asset.delegate.username
+		u_username: transaction.asset.delegate.username
 	};
 
 	modules.accounts.setAccountAndGet(data, cb);
 };
 
 /**
- * Checks trs delegate and calls modules.accounts.setAccountAndGet() with u_username.
+ * Checks transaction delegate and calls modules.accounts.setAccountAndGet() with u_username.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  */
-Delegate.prototype.applyUnconfirmed = function (trs, sender, cb) {
+Delegate.prototype.applyUnconfirmed = function (transaction, sender, cb) {
 	var data = {
 		address: sender.address,
 		u_isDelegate: 1,
 		isDelegate: 0,
 		username: null,
-		u_username: trs.asset.delegate.username
+		u_username: transaction.asset.delegate.username
 	};
 
 	modules.accounts.setAccountAndGet(data, cb);
 };
 
 /**
- * Checks trs delegate and calls modules.accounts.setAccountAndGet() with
+ * Checks transaction delegate and calls modules.accounts.setAccountAndGet() with
  * username and u_username both null.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  */
-Delegate.prototype.undoUnconfirmed = function (trs, sender, cb) {
+Delegate.prototype.undoUnconfirmed = function (transaction, sender, cb) {
 	var data = {
 		address: sender.address,
 		u_isDelegate: 0,
@@ -238,12 +238,12 @@ Delegate.prototype.schema = {
 
 /**
  * Validates transaction delegate schema.
- * @param {transaction} trs
- * @returns {err|trs} Error message if fails validation | input parameter.
+ * @param {transaction} transaction
+ * @returns {err|transaction} Error message if fails validation | input parameter.
  * @throws {string} Failed to validate delegate schema.
  */
-Delegate.prototype.objectNormalize = function (trs) {
-	var report = library.schema.validate(trs.asset.delegate, Delegate.prototype.schema);
+Delegate.prototype.objectNormalize = function (transaction) {
+	var report = library.schema.validate(transaction.asset.delegate, Delegate.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate delegate schema: ' + library.schema.getLastErrors().map(function (err) {
@@ -251,7 +251,7 @@ Delegate.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	return trs;
+	return transaction;
 };
 
 /**
@@ -283,35 +283,35 @@ Delegate.prototype.dbFields = [
 ];
 
 /**
- * Creates Object based on trs data.
- * @param {transaction} trs - Contains delegate username.
+ * Creates Object based on transaction data.
+ * @param {transaction} transaction - Contains delegate username.
  * @returns {Object} {table:delegates, username and transaction id}.
  */
-Delegate.prototype.dbSave = function (trs) {
+Delegate.prototype.dbSave = function (transaction) {
 	return {
 		table: this.dbTable,
 		fields: this.dbFields,
 		values: {
-			tx_id: trs.id,
-			name: trs.asset.delegate.username,
-			pk: Buffer.from(trs.senderPublicKey, 'hex'),
-			address: trs.senderId
+			tx_id: transaction.id,
+			name: transaction.asset.delegate.username,
+			pk: Buffer.from(transaction.senderPublicKey, 'hex'),
+			address: transaction.senderId
 		}
 	};
 };
 
 /**
  * Evaluates transaction signatures and sender multisignatures.
- * @param {transaction} trs - signatures.
+ * @param {transaction} transaction - signatures.
  * @param {account} sender
- * @return {boolean} logic based on trs signatures and sender multisignatures.
+ * @return {boolean} logic based on transaction signatures and sender multisignatures.
  */
-Delegate.prototype.ready = function (trs, sender) {
+Delegate.prototype.ready = function (transaction, sender) {
 	if (Array.isArray(sender.multisignatures) && sender.multisignatures.length) {
-		if (!Array.isArray(trs.signatures)) {
+		if (!Array.isArray(transaction.signatures)) {
 			return false;
 		}
-		return trs.signatures.length >= sender.multimin;
+		return transaction.signatures.length >= sender.multimin;
 	} else {
 		return true;
 	}

--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -48,54 +48,54 @@ Multisignature.prototype.bind = function (accounts) {
 /**
  * Obtains constant fee multisignature and multiply by quantity of signatures.
  * @see {@link module:helpers~constants}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender - Unnecessary parameter.
  * @returns {number} Quantity of multisignature keysgroup * multisignature fees.
  */
-Multisignature.prototype.calculateFee = function (trs, sender) {
-	return (trs.asset.multisignature.keysgroup.length + 1) * constants.fees.multisignature;
+Multisignature.prototype.calculateFee = function (transaction, sender) {
+	return (transaction.asset.multisignature.keysgroup.length + 1) * constants.fees.multisignature;
 };
 
 /**
  * Verifies multisignature fields from transaction asset and sender.
  * @implements module:transactions#Transaction~verifySignature
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback|transaction} returns error string if invalid parameter |
- * trs validated.
+ * transaction validated.
  */
-Multisignature.prototype.verify = function (trs, sender, cb) {
-	if (!trs.asset || !trs.asset.multisignature) {
+Multisignature.prototype.verify = function (transaction, sender, cb) {
+	if (!transaction.asset || !transaction.asset.multisignature) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
 
-	if (!Array.isArray(trs.asset.multisignature.keysgroup)) {
+	if (!Array.isArray(transaction.asset.multisignature.keysgroup)) {
 		return setImmediate(cb, 'Invalid multisignature keysgroup. Must be an array');
 	}
 
-	if (trs.asset.multisignature.keysgroup.length === 0) {
+	if (transaction.asset.multisignature.keysgroup.length === 0) {
 		return setImmediate(cb, 'Invalid multisignature keysgroup. Must not be empty');
 	}
 
-	if (trs.asset.multisignature.min < constants.multisigConstraints.min.minimum || trs.asset.multisignature.min > constants.multisigConstraints.min.maximum) {
+	if (transaction.asset.multisignature.min < constants.multisigConstraints.min.minimum || transaction.asset.multisignature.min > constants.multisigConstraints.min.maximum) {
 		return setImmediate(cb, ['Invalid multisignature min. Must be between', constants.multisigConstraints.min.minimum,
 			'and', constants.multisigConstraints.min.maximum].join(' '));
 	}
 
-	if (trs.asset.multisignature.min > trs.asset.multisignature.keysgroup.length) {
+	if (transaction.asset.multisignature.min > transaction.asset.multisignature.keysgroup.length) {
 		var err = 'Invalid multisignature min. Must be less than or equal to keysgroup size';
 
-		if (exceptions.multisignatures.indexOf(trs.id) > -1) {
+		if (exceptions.multisignatures.indexOf(transaction.id) > -1) {
 			this.scope.logger.debug(err);
-			this.scope.logger.debug(JSON.stringify(trs));
+			this.scope.logger.debug(JSON.stringify(transaction));
 		} else {
 			return setImmediate(cb, err);
 		}
 	}
 
-	if (trs.asset.multisignature.lifetime < constants.multisigConstraints.lifetime.minimum  ||
-		trs.asset.multisignature.lifetime > constants.multisigConstraints.lifetime.maximum) {
+	if (transaction.asset.multisignature.lifetime < constants.multisigConstraints.lifetime.minimum  ||
+		transaction.asset.multisignature.lifetime > constants.multisigConstraints.lifetime.maximum) {
 		return setImmediate(cb, ['Invalid multisignature lifetime. Must be between', constants.multisigConstraints.lifetime.minimum, 'and',
 			constants.multisigConstraints.lifetime.maximum].join(' '));
 	}
@@ -104,17 +104,17 @@ Multisignature.prototype.verify = function (trs, sender, cb) {
 		return setImmediate(cb, 'Account already has multisignatures enabled');
 	}
 
-	if (this.ready(trs, sender)) {
+	if (this.ready(transaction, sender)) {
 		try {
-			for (var s = 0; s < trs.asset.multisignature.keysgroup.length; s++) {
+			for (var s = 0; s < transaction.asset.multisignature.keysgroup.length; s++) {
 				var valid = false;
 
-				if (trs.signatures) {
-					for (var d = 0; d < trs.signatures.length && !valid; d++) {
-						if (trs.asset.multisignature.keysgroup[s][0] !== '-' && trs.asset.multisignature.keysgroup[s][0] !== '+') {
+				if (transaction.signatures) {
+					for (var d = 0; d < transaction.signatures.length && !valid; d++) {
+						if (transaction.asset.multisignature.keysgroup[s][0] !== '-' && transaction.asset.multisignature.keysgroup[s][0] !== '+') {
 							valid = false;
 						} else {
-							valid = library.logic.transaction.verifySignature(trs, trs.asset.multisignature.keysgroup[s].substring(1), trs.signatures[d]);
+							valid = library.logic.transaction.verifySignature(transaction, transaction.asset.multisignature.keysgroup[s].substring(1), transaction.signatures[d]);
 						}
 					}
 				}
@@ -129,11 +129,11 @@ Multisignature.prototype.verify = function (trs, sender, cb) {
 		}
 	}
 
-	if (trs.asset.multisignature.keysgroup.indexOf('+' + sender.publicKey) !== -1) {
+	if (transaction.asset.multisignature.keysgroup.indexOf('+' + sender.publicKey) !== -1) {
 		return setImmediate(cb, 'Invalid multisignature keysgroup. Can not contain sender');
 	}
 
-	async.eachSeries(trs.asset.multisignature.keysgroup, function (key, cb) {
+	async.eachSeries(transaction.asset.multisignature.keysgroup, function (key, cb) {
 		if (!key || typeof key !== 'string') {
 			return setImmediate(cb, 'Invalid member in keysgroup');
 		}
@@ -161,45 +161,45 @@ Multisignature.prototype.verify = function (trs, sender, cb) {
 			return setImmediate(cb, err);
 		}
 
-		var keysgroup = trs.asset.multisignature.keysgroup.reduce(function (p, c) {
+		var keysgroup = transaction.asset.multisignature.keysgroup.reduce(function (p, c) {
 			if (p.indexOf(c) < 0) { p.push(c); }
 			return p;
 		}, []);
 
-		if (keysgroup.length !== trs.asset.multisignature.keysgroup.length) {
+		if (keysgroup.length !== transaction.asset.multisignature.keysgroup.length) {
 			return setImmediate(cb, 'Encountered duplicate public key in multisignature keysgroup');
 		}
 
-		return setImmediate(cb, null, trs);
+		return setImmediate(cb, null, transaction);
 	});
 };
 
 /**
  * Returns transaction with setImmediate.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback} Null error
  * @todo check extra parameter sender.
  */
-Multisignature.prototype.process = function (trs, sender, cb) {
-	return setImmediate(cb, null, trs);
+Multisignature.prototype.process = function (transaction, sender, cb) {
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Returns a buffer with bytes from transaction asset information.
  * @requires bytebuffer
  * @see {@link https://github.com/dcodeIO/bytebuffer.js/wiki/API}
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @param {boolean} skip
  * @returns {!Array} Contents as an ArrayBuffer.
  */
-Multisignature.prototype.getBytes = function (trs, skip) {
-	var keysgroupBuffer = Buffer.from(trs.asset.multisignature.keysgroup.join(''), 'utf8');
+Multisignature.prototype.getBytes = function (transaction, skip) {
+	var keysgroupBuffer = Buffer.from(transaction.asset.multisignature.keysgroup.join(''), 'utf8');
 
 	var bb = new ByteBuffer(1 + 1 + keysgroupBuffer.length, true);
-	bb.writeByte(trs.asset.multisignature.min);
-	bb.writeByte(trs.asset.multisignature.lifetime);
+	bb.writeByte(transaction.asset.multisignature.min);
+	bb.writeByte(transaction.asset.multisignature.lifetime);
 	for (var i = 0; i < keysgroupBuffer.length; i++) {
 		bb.writeByte(keysgroupBuffer[i]);
 	}
@@ -212,19 +212,19 @@ Multisignature.prototype.getBytes = function (trs, skip) {
  * Merges transaction data into mem_accounts table.
  * Checks public keys from multisignature and creates accounts.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} for errors
  */
-Multisignature.prototype.apply = function (trs, block, sender, cb) {
+Multisignature.prototype.apply = function (transaction, block, sender, cb) {
 	__private.unconfirmedSignatures[sender.address] = false;
 
 	this.scope.account.merge(sender.address, {
-		multisignatures: trs.asset.multisignature.keysgroup,
-		multimin: trs.asset.multisignature.min,
-		multilifetime: trs.asset.multisignature.lifetime,
+		multisignatures: transaction.asset.multisignature.keysgroup,
+		multimin: transaction.asset.multisignature.min,
+		multilifetime: transaction.asset.multisignature.lifetime,
 		blockId: block.id,
 		round: slots.calcRound(block.height)
 	}, function (err) {
@@ -233,7 +233,7 @@ Multisignature.prototype.apply = function (trs, block, sender, cb) {
 		}
 
 		// Get public keys
-		async.eachSeries(trs.asset.multisignature.keysgroup, function (transaction, cb) {
+		async.eachSeries(transaction.asset.multisignature.keysgroup, function (transaction, cb) {
 			var key = transaction.substring(1);
 			var address = modules.accounts.generateAddressByPublicKey(key);
 
@@ -251,21 +251,21 @@ Multisignature.prototype.apply = function (trs, block, sender, cb) {
 /**
  * Inverts multisignature signs and merges into sender address.
  * Stores sender address into private unconfirmedSignatures.
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} For error.
  */
-Multisignature.prototype.undo = function (trs, block, sender, cb) {
-	var multiInvert = Diff.reverse(trs.asset.multisignature.keysgroup);
+Multisignature.prototype.undo = function (transaction, block, sender, cb) {
+	var multiInvert = Diff.reverse(transaction.asset.multisignature.keysgroup);
 
 	__private.unconfirmedSignatures[sender.address] = true;
 
 	this.scope.account.merge(sender.address, {
 		multisignatures: multiInvert,
-		multimin: -trs.asset.multisignature.min,
-		multilifetime: -trs.asset.multisignature.lifetime,
+		multimin: -transaction.asset.multisignature.min,
+		multilifetime: -transaction.asset.multisignature.lifetime,
 		blockId: block.id,
 		round: slots.calcRound(block.height)
 	}, function (err) {
@@ -276,12 +276,12 @@ Multisignature.prototype.undo = function (trs, block, sender, cb) {
 /**
  * Stores sender address into private unconfirmedSignatures.
  * Merges into sender address transaction asset to unconfirmed fields.
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} For error.
  */
-Multisignature.prototype.applyUnconfirmed = function (trs, sender, cb) {
+Multisignature.prototype.applyUnconfirmed = function (transaction, sender, cb) {
 	if (__private.unconfirmedSignatures[sender.address]) {
 		return setImmediate(cb, 'Signature on this account is pending confirmation');
 	}
@@ -289,9 +289,9 @@ Multisignature.prototype.applyUnconfirmed = function (trs, sender, cb) {
 	__private.unconfirmedSignatures[sender.address] = true;
 
 	this.scope.account.merge(sender.address, {
-		u_multisignatures: trs.asset.multisignature.keysgroup,
-		u_multimin: trs.asset.multisignature.min,
-		u_multilifetime: trs.asset.multisignature.lifetime
+		u_multisignatures: transaction.asset.multisignature.keysgroup,
+		u_multimin: transaction.asset.multisignature.min,
+		u_multilifetime: transaction.asset.multisignature.lifetime
 	}, function (err) {
 		return setImmediate(cb);
 	});
@@ -302,20 +302,20 @@ Multisignature.prototype.applyUnconfirmed = function (trs, sender, cb) {
  * Inverts multisignature signs and merges into sender address
  * to unconfirmed fields.
  *
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} For error.
  */
-Multisignature.prototype.undoUnconfirmed = function (trs, sender, cb) {
-	var multiInvert = Diff.reverse(trs.asset.multisignature.keysgroup);
+Multisignature.prototype.undoUnconfirmed = function (transaction, sender, cb) {
+	var multiInvert = Diff.reverse(transaction.asset.multisignature.keysgroup);
 
 	__private.unconfirmedSignatures[sender.address] = false;
 
 	this.scope.account.merge(sender.address, {
 		u_multisignatures: multiInvert,
-		u_multimin: -trs.asset.multisignature.min,
-		u_multilifetime: -trs.asset.multisignature.lifetime
+		u_multimin: -transaction.asset.multisignature.min,
+		u_multilifetime: -transaction.asset.multisignature.lifetime
 	}, function (err) {
 		return setImmediate(cb, err);
 	});
@@ -352,12 +352,12 @@ Multisignature.prototype.schema = {
 
 /**
  * Validates multisignature schema.
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @return {transaction} Transaction validated.
  * @throws {string} Error message.
  */
-Multisignature.prototype.objectNormalize = function (trs) {
-	var report = library.schema.validate(trs.asset.multisignature, Multisignature.prototype.schema);
+Multisignature.prototype.objectNormalize = function (transaction) {
+	var report = library.schema.validate(transaction.asset.multisignature, Multisignature.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate multisignature schema: ' + library.schema.getLastErrors().map(function (err) {
@@ -365,7 +365,7 @@ Multisignature.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	return trs;
+	return transaction;
 };
 
 /**
@@ -403,50 +403,50 @@ Multisignature.prototype.dbFields = [
 ];
 
 /**
- * Creates database Object based on trs data.
- * @param {transaction} trs - Contains multisignature object.
+ * Creates database Object based on transaction data.
+ * @param {transaction} transaction - Contains multisignature object.
  * @returns {Object} {table:multisignatures, values: multisignature and transaction id}.
  * @todo check if this function is called.
  */
-Multisignature.prototype.dbSave = function (trs) {
+Multisignature.prototype.dbSave = function (transaction) {
 	return {
 		table: this.dbTable,
 		fields: this.dbFields,
 		values: {
-			min: trs.asset.multisignature.min,
-			lifetime: trs.asset.multisignature.lifetime,
-			keysgroup: trs.asset.multisignature.keysgroup.join(','),
-			transactionId: trs.id
+			min: transaction.asset.multisignature.min,
+			lifetime: transaction.asset.multisignature.lifetime,
+			keysgroup: transaction.asset.multisignature.keysgroup.join(','),
+			transactionId: transaction.id
 		}
 	};
 };
 
 /**
  * Emits a 'multisignatures/change' socket signal with transaction info.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {function} cb
  * @return {setImmediateCallback} cb
  */
-Multisignature.prototype.afterSave = function (trs, cb) {
-	library.network.io.sockets.emit('multisignatures/change', trs);
+Multisignature.prototype.afterSave = function (transaction, cb) {
+	library.network.io.sockets.emit('multisignatures/change', transaction);
 	return setImmediate(cb);
 };
 
 /**
  * Evaluates transaction signatures and sender multisignatures.
- * @param {transaction} trs - signatures.
+ * @param {transaction} transaction - signatures.
  * @param {account} sender
- * @return {boolean} logic based on trs signatures and sender multisignatures.
+ * @return {boolean} logic based on transaction signatures and sender multisignatures.
  */
-Multisignature.prototype.ready = function (trs, sender) {
-	if (!Array.isArray(trs.signatures)) {
+Multisignature.prototype.ready = function (transaction, sender) {
+	if (!Array.isArray(transaction.signatures)) {
 		return false;
 	}
 
 	if (!Array.isArray(sender.multisignatures) || !sender.multisignatures.length) {
-		return trs.signatures.length === trs.asset.multisignature.keysgroup.length;
+		return transaction.signatures.length === transaction.asset.multisignature.keysgroup.length;
 	} else {
-		return trs.signatures.length >= sender.multimin;
+		return transaction.signatures.length >= sender.multimin;
 	}
 };
 

--- a/logic/outTransfer.js
+++ b/logic/outTransfer.js
@@ -42,73 +42,73 @@ OutTransfer.prototype.bind = function (accounts, dapps) {
 
 /**
  * Returns send fee from constants.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @return {number} fee
  */
-OutTransfer.prototype.calculateFee = function (trs, sender) {
+OutTransfer.prototype.calculateFee = function (transaction, sender) {
 	return constants.fees.send;
 };
 
 /**
  * Verifies recipientId, amount and outTransfer object content.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
- * @return {setImmediateCallback} errors messages | trs
+ * @return {setImmediateCallback} errors messages | transaction
  */
-OutTransfer.prototype.verify = function (trs, sender, cb) {
-	if (!trs.recipientId) {
+OutTransfer.prototype.verify = function (transaction, sender, cb) {
+	if (!transaction.recipientId) {
 		return setImmediate(cb, 'Invalid recipient');
 	}
 
-	if (!trs.amount) {
+	if (!transaction.amount) {
 		return setImmediate(cb, 'Invalid transaction amount');
 	}
 
-	if (!trs.asset || !trs.asset.outTransfer) {
+	if (!transaction.asset || !transaction.asset.outTransfer) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
 
-	if (!/^[0-9]+$/.test(trs.asset.outTransfer.dappId)) {
+	if (!/^[0-9]+$/.test(transaction.asset.outTransfer.dappId)) {
 		return setImmediate(cb, 'Invalid outTransfer dappId');
 	}
 
-	if (!/^[0-9]+$/.test(trs.asset.outTransfer.transactionId)) {
+	if (!/^[0-9]+$/.test(transaction.asset.outTransfer.transactionId)) {
 		return setImmediate(cb, 'Invalid outTransfer transactionId');
 	}
 
-	return setImmediate(cb, null, trs);
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Finds application into `dapps` table. Checks if transaction is already
  * processed. Checks if transaction is already confirmed.
  * @implements {library.db.one}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
- * @return {setImmediateCallback} errors messages | trs
+ * @return {setImmediateCallback} errors messages | transaction
  */
-OutTransfer.prototype.process = function (trs, sender, cb) {
+OutTransfer.prototype.process = function (transaction, sender, cb) {
 	library.db.one(sql.countByTransactionId, {
-		id: trs.asset.outTransfer.dappId
+		id: transaction.asset.outTransfer.dappId
 	}).then(function (row) {
 		if (row.count === 0) {
-			return setImmediate(cb, 'Application not found: ' + trs.asset.outTransfer.dappId);
+			return setImmediate(cb, 'Application not found: ' + transaction.asset.outTransfer.dappId);
 		}
 
-		if (__private.unconfirmedOutTansfers[trs.asset.outTransfer.transactionId]) {
-			return setImmediate(cb, 'Transaction is already processed: ' + trs.asset.outTransfer.transactionId);
+		if (__private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId]) {
+			return setImmediate(cb, 'Transaction is already processed: ' + transaction.asset.outTransfer.transactionId);
 		}
 
 		library.db.one(sql.countByOutTransactionId, {
-			transactionId: trs.asset.outTransfer.transactionId
+			transactionId: transaction.asset.outTransfer.transactionId
 		}).then(function (row) {
 			if (row.count > 0) {
-				return setImmediate(cb, 'Transaction is already confirmed: ' + trs.asset.outTransfer.transactionId);
+				return setImmediate(cb, 'Transaction is already confirmed: ' + transaction.asset.outTransfer.transactionId);
 			} else {
-				return setImmediate(cb, null, trs);
+				return setImmediate(cb, null, transaction);
 			}
 		}).catch(function (err) {
 			return setImmediate(cb, err);
@@ -122,17 +122,17 @@ OutTransfer.prototype.process = function (trs, sender, cb) {
  * Creates buffer with outTransfer content:
  * - dappId
  * - transactionId
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {Array} Buffer
  * @throws {e} Error
  */
-OutTransfer.prototype.getBytes = function (trs) {
+OutTransfer.prototype.getBytes = function (transaction) {
 	var buf;
 
 	try {
 		buf = Buffer.from([]);
-		var dappIdBuf = Buffer.from(trs.asset.outTransfer.dappId, 'utf8');
-		var transactionIdBuff = Buffer.from(trs.asset.outTransfer.transactionId, 'utf8');
+		var dappIdBuf = Buffer.from(transaction.asset.outTransfer.dappId, 'utf8');
+		var transactionIdBuff = Buffer.from(transaction.asset.outTransfer.transactionId, 'utf8');
 		buf = Buffer.concat([buf, dappIdBuf, transactionIdBuff]);
 	} catch (e) {
 		throw e;
@@ -144,28 +144,28 @@ OutTransfer.prototype.getBytes = function (trs) {
 /**
  * Sets unconfirmed out transfers to false.
  * Calls setAccountAndGet based on transaction recipientId and
- * mergeAccountAndGet with unconfirmed trs amount.
+ * mergeAccountAndGet with unconfirmed transaction amount.
  * @implements {modules.accounts.setAccountAndGet}
  * @implements {modules.accounts.mergeAccountAndGet}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} error, cb
  */
-OutTransfer.prototype.apply = function (trs, block, sender, cb) {
-	__private.unconfirmedOutTansfers[trs.asset.outTransfer.transactionId] = false;
+OutTransfer.prototype.apply = function (transaction, block, sender, cb) {
+	__private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false;
 
-	modules.accounts.setAccountAndGet({address: trs.recipientId}, function (err, recipient) {
+	modules.accounts.setAccountAndGet({address: transaction.recipientId}, function (err, recipient) {
 		if (err) {
 			return setImmediate(cb, err);
 		}
 
 		modules.accounts.mergeAccountAndGet({
-			address: trs.recipientId,
-			balance: trs.amount,
-			u_balance: trs.amount,
+			address: transaction.recipientId,
+			balance: transaction.amount,
+			u_balance: transaction.amount,
 			blockId: block.id,
 			round: slots.calcRound(block.height)
 		}, function (err) {
@@ -177,27 +177,27 @@ OutTransfer.prototype.apply = function (trs, block, sender, cb) {
 /**
  * Sets unconfirmed out transfers to true.
  * Calls setAccountAndGet based on transaction recipientId and
- * mergeAccountAndGet with unconfirmed trs amount and balance both negatives.
+ * mergeAccountAndGet with unconfirmed transaction amount and balance both negatives.
  * @implements {modules.accounts.setAccountAndGet}
  * @implements {modules.accounts.mergeAccountAndGet}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} error, cb
  */
-OutTransfer.prototype.undo = function (trs, block, sender, cb) {
-	__private.unconfirmedOutTansfers[trs.asset.outTransfer.transactionId] = true;
+OutTransfer.prototype.undo = function (transaction, block, sender, cb) {
+	__private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true;
 
-	modules.accounts.setAccountAndGet({address: trs.recipientId}, function (err, recipient) {
+	modules.accounts.setAccountAndGet({address: transaction.recipientId}, function (err, recipient) {
 		if (err) {
 			return setImmediate(cb, err);
 		}
 		modules.accounts.mergeAccountAndGet({
-			address: trs.recipientId,
-			balance: -trs.amount,
-			u_balance: -trs.amount,
+			address: transaction.recipientId,
+			balance: -transaction.amount,
+			u_balance: -transaction.amount,
 			blockId: block.id,
 			round: slots.calcRound(block.height)
 		}, function (err) {
@@ -208,25 +208,25 @@ OutTransfer.prototype.undo = function (trs, block, sender, cb) {
 
 /**
  * Sets unconfirmed OutTansfers to true.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
  * @return {setImmediateCallback} cb
  */
-OutTransfer.prototype.applyUnconfirmed = function (trs, sender, cb) {
-	__private.unconfirmedOutTansfers[trs.asset.outTransfer.transactionId] = true;
+OutTransfer.prototype.applyUnconfirmed = function (transaction, sender, cb) {
+	__private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true;
 	return setImmediate(cb);
 };
 
 /**
  * Sets unconfirmed OutTansfers to false.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
  * @return {setImmediateCallback} cb
  */
-OutTransfer.prototype.undoUnconfirmed = function (trs, sender, cb) {
-	__private.unconfirmedOutTansfers[trs.asset.outTransfer.transactionId] = false;
+OutTransfer.prototype.undoUnconfirmed = function (transaction, sender, cb) {
+	__private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false;
 	return setImmediate(cb);
 };
 
@@ -253,12 +253,12 @@ OutTransfer.prototype.schema = {
 /**
  * Calls `objectNormalize` with asset outTransfer.
  * @implements {library.schema.validate}
- * @param {transaction} trs
- * @return {error|transaction} error string | trs normalized
+ * @param {transaction} transaction
+ * @return {error|transaction} error string | transaction normalized
  * @throws {string} error message
  */
-OutTransfer.prototype.objectNormalize = function (trs) {
-	var report = library.schema.validate(trs.asset.outTransfer, OutTransfer.prototype.schema);
+OutTransfer.prototype.objectNormalize = function (transaction) {
+	var report = library.schema.validate(transaction.asset.outTransfer, OutTransfer.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate outTransfer schema: ' + library.schema.getLastErrors().map(function (err) {
@@ -266,7 +266,7 @@ OutTransfer.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	return trs;
+	return transaction;
 };
 
 /**
@@ -298,34 +298,34 @@ OutTransfer.prototype.dbFields = [
 /**
  * Creates db operation object to 'outtransfer' table based on
  * outTransfer data.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {Object[]} table, fields, values.
  */
-OutTransfer.prototype.dbSave = function (trs) {
+OutTransfer.prototype.dbSave = function (transaction) {
 	return {
 		table: this.dbTable,
 		fields: this.dbFields,
 		values: {
-			dappId: trs.asset.outTransfer.dappId,
-			outTransactionId: trs.asset.outTransfer.transactionId,
-			transactionId: trs.id
+			dappId: transaction.asset.outTransfer.dappId,
+			outTransactionId: transaction.asset.outTransfer.transactionId,
+			transactionId: transaction.id
 		}
 	};
 };
 
 /**
  * Checks sender multisignatures and transaction signatures.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @return {boolean} True if transaction signatures greather than
  * sender multimin or there are not sender multisignatures.
  */
-OutTransfer.prototype.ready = function (trs, sender) {
+OutTransfer.prototype.ready = function (transaction, sender) {
 	if (Array.isArray(sender.multisignatures) && sender.multisignatures.length) {
-		if (!Array.isArray(trs.signatures)) {
+		if (!Array.isArray(transaction.signatures)) {
 			return false;
 		}
-		return trs.signatures.length >= sender.multimin;
+		return transaction.signatures.length >= sender.multimin;
 	} else {
 		return true;
 	}

--- a/logic/signature.js
+++ b/logic/signature.js
@@ -35,34 +35,34 @@ Signature.prototype.bind = function (accounts) {
 /**
  * Obtains constant fee secondsignature.
  * @see {@link module:helpers~constants}
- * @param {transaction} trs - Unnecessary parameter.
+ * @param {transaction} transaction - Unnecessary parameter.
  * @param {account} sender - Unnecessary parameter.
  * @returns {number} Secondsignature fee.
  */
-Signature.prototype.calculateFee = function (trs, sender) {
+Signature.prototype.calculateFee = function (transaction, sender) {
 	return constants.fees.secondsignature;
 };
 
 /**
  * Verifies signature fields from transaction asset and sender.
  * @implements module:transactions#Transaction~verifySignature
- * @param {transaction} trs 
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback|transaction} returns error string if invalid parameter | 
- * trs validated.
+ * transaction validated.
  */
-Signature.prototype.verify = function (trs, sender, cb) {
-	if (!trs.asset || !trs.asset.signature) {
+Signature.prototype.verify = function (transaction, sender, cb) {
+	if (!transaction.asset || !transaction.asset.signature) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
 
-	if (trs.amount !== 0) {
+	if (transaction.amount !== 0) {
 		return setImmediate(cb, 'Invalid transaction amount');
 	}
 
 	try {
-		if (!trs.asset.signature.publicKey || Buffer.from(trs.asset.signature.publicKey, 'hex').length !== 32) {
+		if (!transaction.asset.signature.publicKey || Buffer.from(transaction.asset.signature.publicKey, 'hex').length !== 32) {
 			return setImmediate(cb, 'Invalid public key');
 		}
 	} catch (e) {
@@ -70,36 +70,36 @@ Signature.prototype.verify = function (trs, sender, cb) {
 		return setImmediate(cb, 'Invalid public key');
 	}
 
-	return setImmediate(cb, null, trs);
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Returns transaction with setImmediate.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback} Null error
  * @todo check extra parameter sender.
  */
-Signature.prototype.process = function (trs, sender, cb) {
-	return setImmediate(cb, null, trs);
+Signature.prototype.process = function (transaction, sender, cb) {
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Returns a buffer with bytes from transaction asset information.
  * @requires bytebuffer
  * @see {@link https://github.com/dcodeIO/bytebuffer.js/wiki/API}
- * @param {transaction} trs - Uses multisignature from asset.
+ * @param {transaction} transaction - Uses multisignature from asset.
  * @returns {!Array} Contents as an ArrayBuffer.
  * @throws {error} If buffer fails.
  * @todo check if this function is called.
  */
-Signature.prototype.getBytes = function (trs) {
+Signature.prototype.getBytes = function (transaction) {
 	var bb;
 
 	try {
 		bb = new ByteBuffer(32, true);
-		var publicKeyBuffer = Buffer.from(trs.asset.signature.publicKey, 'hex');
+		var publicKeyBuffer = Buffer.from(transaction.asset.signature.publicKey, 'hex');
 
 		for (var i = 0; i < publicKeyBuffer.length; i++) {
 			bb.writeByte(publicKeyBuffer[i]);
@@ -115,30 +115,30 @@ Signature.prototype.getBytes = function (trs) {
 /**
  * Sets account second signature from transaction asset.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs - Uses publicKey from asset signature.
+ * @param {transaction} transaction - Uses publicKey from asset signature.
  * @param {block} block - Unnecessary parameter.
  * @param {account} sender - Uses the address
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} for errors
  */
-Signature.prototype.apply = function (trs, block, sender, cb) {
+Signature.prototype.apply = function (transaction, block, sender, cb) {
 	modules.accounts.setAccountAndGet({
 		address: sender.address,
 		secondSignature: 1,
 		u_secondSignature: 0,
-		secondPublicKey: trs.asset.signature.publicKey
+		secondPublicKey: transaction.asset.signature.publicKey
 	}, cb);
 };
 
 /**
  * Sets account second signature to null.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs - Unnecessary parameter.
+ * @param {transaction} transaction - Unnecessary parameter.
  * @param {block} block - Unnecessary parameter. 
  * @param {account} sender
  * @param {function} cb - Callback function.
  */
-Signature.prototype.undo = function (trs, block, sender, cb) {
+Signature.prototype.undo = function (transaction, block, sender, cb) {
 	modules.accounts.setAccountAndGet({
 		address: sender.address,
 		secondSignature: 0,
@@ -150,13 +150,13 @@ Signature.prototype.undo = function (trs, block, sender, cb) {
 /**
  * Activates unconfirmed second signature for sender account.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs - Unnecessary parameter.
+ * @param {transaction} transaction - Unnecessary parameter.
  * @param {block} block - Unnecessary parameter. 
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} Error if second signature is already enabled.
  */
-Signature.prototype.applyUnconfirmed = function (trs, sender, cb) {
+Signature.prototype.applyUnconfirmed = function (transaction, sender, cb) {
 	if (sender.u_secondSignature || sender.secondSignature) {
 		return setImmediate(cb, 'Second signature already enabled');
 	}
@@ -167,12 +167,12 @@ Signature.prototype.applyUnconfirmed = function (trs, sender, cb) {
 /**
  * Deactivates unconfirmed second signature for sender account.
  * @implements module:accounts#Accounts~setAccountAndGet
- * @param {transaction} trs - Unnecessary parameter.
+ * @param {transaction} transaction - Unnecessary parameter.
  * @param {block} block - Unnecessary parameter. 
  * @param {account} sender
  * @param {function} cb - Callback function.
  */
-Signature.prototype.undoUnconfirmed = function (trs, sender, cb) {
+Signature.prototype.undoUnconfirmed = function (transaction, sender, cb) {
 	modules.accounts.setAccountAndGet({address: sender.address, u_secondSignature: 0}, cb);
 };
 /**
@@ -193,12 +193,12 @@ Signature.prototype.schema = {
 
 /**
  * Validates signature schema.
- * @param {transaction} trs - Uses signature from asset.
+ * @param {transaction} transaction - Uses signature from asset.
  * @return {transaction} Transaction validated.
  * @throws {string} Error message.
  */
-Signature.prototype.objectNormalize = function (trs) {
-	var report = library.schema.validate(trs.asset.signature, Signature.prototype.schema);
+Signature.prototype.objectNormalize = function (transaction) {
+	var report = library.schema.validate(transaction.asset.signature, Signature.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate signature schema: ' + library.schema.getLastErrors().map(function (err) {
@@ -206,7 +206,7 @@ Signature.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	return trs;
+	return transaction;
 };
 
 /**
@@ -236,16 +236,16 @@ Signature.prototype.dbFields = [
 ];
 
 /**
- * Creates database Object based on trs data.
- * @param {transaction} trs - Contains signature object.
+ * Creates database Object based on transaction data.
+ * @param {transaction} transaction - Contains signature object.
  * @returns {Object} {table:signatures, values: publicKey and transaction id}.
  * @todo check if this function is called.
  */
-Signature.prototype.dbSave = function (trs) {
+Signature.prototype.dbSave = function (transaction) {
 	var publicKey;
 
 	try {
-		publicKey = Buffer.from(trs.asset.signature.publicKey, 'hex');
+		publicKey = Buffer.from(transaction.asset.signature.publicKey, 'hex');
 	} catch (e) {
 		throw e;
 	}
@@ -254,7 +254,7 @@ Signature.prototype.dbSave = function (trs) {
 		table: this.dbTable,
 		fields: this.dbFields,
 		values: {
-			transactionId: trs.id,
+			transactionId: transaction.id,
 			publicKey: publicKey
 		}
 	};
@@ -262,17 +262,17 @@ Signature.prototype.dbSave = function (trs) {
 
 /**
  * Evaluates transaction signatures and sender multisignatures.
- * @param {transaction} trs - signatures.
+ * @param {transaction} transaction - signatures.
  * @param {account} sender
- * @return {boolean} logic based on trs signatures and sender multisignatures.
+ * @return {boolean} logic based on transaction signatures and sender multisignatures.
  * @todo validate this logic, check if this function is called.
  */
-Signature.prototype.ready = function (trs, sender) {
+Signature.prototype.ready = function (transaction, sender) {
 	if (Array.isArray(sender.multisignatures) && sender.multisignatures.length) {
-		if (!Array.isArray(trs.signatures)) {
+		if (!Array.isArray(transaction.signatures)) {
 			return false;
 		}
-		return trs.signatures.length >= sender.multimin;
+		return transaction.signatures.length >= sender.multimin;
 	} else {
 		return true;
 	}

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -84,11 +84,11 @@ Transaction.prototype.attachAssetType = function (typeId, instance) {
  * @implements {getHash}
  * @implements {scope.ed.sign}
  * @param {Object} keypair - Constains privateKey and publicKey
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {signature} sign
  */
-Transaction.prototype.sign = function (keypair, trs) {
-	var hash = this.getHash(trs);
+Transaction.prototype.sign = function (keypair, transaction) {
+	var hash = this.getHash(transaction);
 	return this.scope.ed.sign(hash, keypair.privateKey).toString('hex');
 };
 
@@ -98,11 +98,11 @@ Transaction.prototype.sign = function (keypair, trs) {
  * @implements {crypto.createHash}
  * @implements {scope.ed.sign}
  * @param {Object} keypair - Constains privateKey and publicKey
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {signature} sign
  */
-Transaction.prototype.multisign = function (keypair, trs) {
-	var bytes = this.getBytes(trs, true, true);
+Transaction.prototype.multisign = function (keypair, transaction) {
+	var bytes = this.getBytes(transaction, true, true);
 	var hash = crypto.createHash('sha256').update(bytes).digest();
 	return this.scope.ed.sign(hash, keypair.privateKey).toString('hex');
 };
@@ -111,11 +111,11 @@ Transaction.prototype.multisign = function (keypair, trs) {
  * Calculates transaction id based on transaction
  * @implements {bignum}
  * @implements {getHash}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {string} id
  */
-Transaction.prototype.getId = function (trs) {
-	var hash = this.getHash(trs);
+Transaction.prototype.getId = function (transaction) {
+	var hash = this.getHash(transaction);
 	var temp = Buffer.alloc(8);
 	for (var i = 0; i < 8; i++) {
 		temp[i] = hash[7 - i];
@@ -129,53 +129,53 @@ Transaction.prototype.getId = function (trs) {
  * Creates hash based on transaction bytes.
  * @implements {getBytes}
  * @implements {crypto.createHash}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {hash} sha256 crypto hash
  */
-Transaction.prototype.getHash = function (trs) {
-	return crypto.createHash('sha256').update(this.getBytes(trs)).digest();
+Transaction.prototype.getHash = function (transaction) {
+	return crypto.createHash('sha256').update(this.getBytes(transaction)).digest();
 };
 
 /**
- * Calls `getBytes` based on trs type (see privateTypes)
+ * Calls `getBytes` based on transaction type (see privateTypes)
  * @see privateTypes
  * @implements {ByteBuffer}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {boolean} skipSignature
  * @param {boolean} skipSecondSignature
  * @return {!Array} Contents as an ArrayBuffer.
  * @throws {error} If buffer fails.
  */
-Transaction.prototype.getBytes = function (trs, skipSignature, skipSecondSignature) {
-	if (!__private.types[trs.type]) {
-		throw 'Unknown transaction type ' + trs.type;
+Transaction.prototype.getBytes = function (transaction, skipSignature, skipSecondSignature) {
+	if (!__private.types[transaction.type]) {
+		throw 'Unknown transaction type ' + transaction.type;
 	}
 
 	var bb;
 
 	try {
-		var assetBytes = __private.types[trs.type].getBytes.call(this, trs, skipSignature, skipSecondSignature);
+		var assetBytes = __private.types[transaction.type].getBytes.call(this, transaction, skipSignature, skipSecondSignature);
 		var assetSize = assetBytes ? assetBytes.length : 0;
 		var i;
 
 		bb = new ByteBuffer(1 + 4 + 32 + 32 + 8 + 8 + 64 + 64 + assetSize, true);
-		bb.writeByte(trs.type);
-		bb.writeInt(trs.timestamp);
+		bb.writeByte(transaction.type);
+		bb.writeInt(transaction.timestamp);
 
-		var senderPublicKeyBuffer = Buffer.from(trs.senderPublicKey, 'hex');
+		var senderPublicKeyBuffer = Buffer.from(transaction.senderPublicKey, 'hex');
 		for (i = 0; i < senderPublicKeyBuffer.length; i++) {
 			bb.writeByte(senderPublicKeyBuffer[i]);
 		}
 
-		if (trs.requesterPublicKey) {
-			var requesterPublicKey = Buffer.from(trs.requesterPublicKey, 'hex');
+		if (transaction.requesterPublicKey) {
+			var requesterPublicKey = Buffer.from(transaction.requesterPublicKey, 'hex');
 			for (i = 0; i < requesterPublicKey.length; i++) {
 				bb.writeByte(requesterPublicKey[i]);
 			}
 		}
 
-		if (trs.recipientId) {
-			var recipient = trs.recipientId.slice(0, -1);
+		if (transaction.recipientId) {
+			var recipient = transaction.recipientId.slice(0, -1);
 			recipient = new bignum(recipient).toBuffer({size: 8});
 
 			for (i = 0; i < 8; i++) {
@@ -187,7 +187,7 @@ Transaction.prototype.getBytes = function (trs, skipSignature, skipSecondSignatu
 			}
 		}
 
-		bb.writeLong(trs.amount);
+		bb.writeLong(transaction.amount);
 
 		if (assetSize > 0) {
 			for (i = 0; i < assetSize; i++) {
@@ -195,15 +195,15 @@ Transaction.prototype.getBytes = function (trs, skipSignature, skipSecondSignatu
 			}
 		}
 
-		if (!skipSignature && trs.signature) {
-			var signatureBuffer = Buffer.from(trs.signature, 'hex');
+		if (!skipSignature && transaction.signature) {
+			var signatureBuffer = Buffer.from(transaction.signature, 'hex');
 			for (i = 0; i < signatureBuffer.length; i++) {
 				bb.writeByte(signatureBuffer[i]);
 			}
 		}
 
-		if (!skipSecondSignature && trs.signSignature) {
-			var signSignatureBuffer = Buffer.from(trs.signSignature, 'hex');
+		if (!skipSecondSignature && transaction.signSignature) {
+			var signSignatureBuffer = Buffer.from(transaction.signSignature, 'hex');
 			for (i = 0; i < signSignatureBuffer.length; i++) {
 				bb.writeByte(signSignatureBuffer[i]);
 			}
@@ -218,32 +218,32 @@ Transaction.prototype.getBytes = function (trs, skipSignature, skipSecondSignatu
 };
 
 /**
- * Calls `ready` based on trs type (see privateTypes)
+ * Calls `ready` based on transaction type (see privateTypes)
  * @see privateTypes
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @return {function|boolean} calls `ready` | false
  */
-Transaction.prototype.ready = function (trs, sender) {
-	if (!__private.types[trs.type]) {
-		throw 'Unknown transaction type ' + trs.type;
+Transaction.prototype.ready = function (transaction, sender) {
+	if (!__private.types[transaction.type]) {
+		throw 'Unknown transaction type ' + transaction.type;
 	}
 
 	if (!sender) {
 		return false;
 	}
 
-	return __private.types[trs.type].ready.call(this, trs, sender);
+	return __private.types[transaction.type].ready.call(this, transaction, sender);
 };
 
 /**
  * Counts transactions from `trs` table by id
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {function} cb
  * @return {setImmediateCallback} error | row.count
  */
-Transaction.prototype.countById = function (trs, cb) {
-	self.scope.db.one(sql.countById, {id: trs.id}).then(function (row) {
+Transaction.prototype.countById = function (transaction, cb) {
+	self.scope.db.one(sql.countById, {id: transaction.id}).then(function (row) {
 		return setImmediate(cb, null, row.count);
 	}).catch(function (err) {
 		self.scope.logger.error(err.stack);
@@ -253,16 +253,16 @@ Transaction.prototype.countById = function (trs, cb) {
 
 /**
  * @implements {countById}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {function} cb
  * @return {setImmediateCallback} error | cb
  */
-Transaction.prototype.checkConfirmed = function (trs, cb) {
-	this.countById(trs, function (err, count) {
+Transaction.prototype.checkConfirmed = function (transaction, cb) {
+	this.countById(transaction, function (err, count) {
 		if (err) {
 			return setImmediate(cb, err);
 		} else if (count > 0) {
-			return setImmediate(cb, 'Transaction is already confirmed: ' + trs.id);
+			return setImmediate(cb, 'Transaction is already confirmed: ' + transaction.id);
 		} else {
 			return setImmediate(cb);
 		}
@@ -274,13 +274,13 @@ Transaction.prototype.checkConfirmed = function (trs, cb) {
  * @implements {bignum}
  * @param {number} amount
  * @param {number} balance
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @returns {Object} With exceeded boolean and error: address, balance
  */
-Transaction.prototype.checkBalance = function (amount, balance, trs, sender) {
+Transaction.prototype.checkBalance = function (amount, balance, transaction, sender) {
 	var exceededBalance = new bignum(sender[balance].toString()).lessThan(amount);
-	var exceeded = (trs.blockId !== this.scope.genesisblock.block.id && exceededBalance);
+	var exceeded = (transaction.blockId !== this.scope.genesisblock.block.id && exceededBalance);
 
 	return {
 		exceeded: exceeded,
@@ -293,23 +293,23 @@ Transaction.prototype.checkBalance = function (amount, balance, trs, sender) {
 
 /**
  * Validates parameters.
- * Calls `process` based on trs type (see privateTypes)
+ * Calls `process` based on transaction type (see privateTypes)
  * @see privateTypes
  * @implements {getId}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {account} requester
  * @param {function} cb
- * @return {setImmediateCallback} validation errors | trs
+ * @return {setImmediateCallback} validation errors | transaction
  */
-Transaction.prototype.process = function (trs, sender, requester, cb) {
+Transaction.prototype.process = function (transaction, sender, requester, cb) {
 	if (typeof requester === 'function') {
 		cb = requester;
 	}
 
 	// Check transaction type
-	if (!__private.types[trs.type]) {
-		return setImmediate(cb, 'Unknown transaction type ' + trs.type);
+	if (!__private.types[transaction.type]) {
+		return setImmediate(cb, 'Unknown transaction type ' + transaction.type);
 	}
 
 	// if (!this.ready(trs, sender)) {
@@ -325,44 +325,44 @@ Transaction.prototype.process = function (trs, sender, requester, cb) {
 	var txId;
 
 	try {
-		txId = this.getId(trs);
+		txId = this.getId(transaction);
 	} catch (e) {
 		this.scope.logger.error(e.stack);
 		return setImmediate(cb, 'Failed to get transaction id');
 	}
 
 	// Check transaction id
-	if (trs.id && trs.id !== txId) {
+	if (transaction.id && transaction.id !== txId) {
 		return setImmediate(cb, 'Invalid transaction id');
 	} else {
-		trs.id = txId;
+		transaction.id = txId;
 	}
 
 	// Equalize sender address
-	trs.senderId = sender.address;
+	transaction.senderId = sender.address;
 
 	// Call process on transaction type
-	__private.types[trs.type].process.call(this, trs, sender, function (err, trs) {
+	__private.types[transaction.type].process.call(this, transaction, sender, function (err, transaction) {
 		if (err) {
 			return setImmediate(cb, err);
 		} else {
-			return setImmediate(cb, null, trs);
+			return setImmediate(cb, null, transaction);
 		}
 	}.bind(this));
 };
 
 /**
  * Validates parameters.
- * Calls `process` based on trs type (see privateTypes)
+ * Calls `process` based on transaction type (see privateTypes)
  * @see privateTypes
  * @implements {getId}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {account} requester
  * @param {function} cb
- * @return {setImmediateCallback} validation errors | trs
+ * @return {setImmediateCallback} validation errors | transaction
  */
-Transaction.prototype.verify = function (trs, sender, requester, cb) {
+Transaction.prototype.verify = function (transaction, sender, requester, cb) {
 	var valid = false;
 	var err = null;
 
@@ -376,59 +376,59 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	}
 
 	// Check transaction type
-	if (!__private.types[trs.type]) {
-		return setImmediate(cb, 'Unknown transaction type ' + trs.type);
+	if (!__private.types[transaction.type]) {
+		return setImmediate(cb, 'Unknown transaction type ' + transaction.type);
 	}
 
 	// Check for missing sender second signature
-	if (!trs.requesterPublicKey && sender.secondSignature && !trs.signSignature && trs.blockId !== this.scope.genesisblock.block.id) {
+	if (!transaction.requesterPublicKey && sender.secondSignature && !transaction.signSignature && transaction.blockId !== this.scope.genesisblock.block.id) {
 		return setImmediate(cb, 'Missing sender second signature');
 	}
 
 	// If second signature provided, check if sender has one enabled
-	if (!trs.requesterPublicKey && !sender.secondSignature && (trs.signSignature && trs.signSignature.length > 0)) {
+	if (!transaction.requesterPublicKey && !sender.secondSignature && (transaction.signSignature && transaction.signSignature.length > 0)) {
 		return setImmediate(cb, 'Sender does not have a second signature');
 	}
 
 	// Check for missing requester second signature
-	if (trs.requesterPublicKey && requester.secondSignature && !trs.signSignature) {
+	if (transaction.requesterPublicKey && requester.secondSignature && !transaction.signSignature) {
 		return setImmediate(cb, 'Missing requester second signature');
 	}
 
 	// If second signature provided, check if requester has one enabled
-	if (trs.requesterPublicKey && !requester.secondSignature && (trs.signSignature && trs.signSignature.length > 0)) {
+	if (transaction.requesterPublicKey && !requester.secondSignature && (transaction.signSignature && transaction.signSignature.length > 0)) {
 		return setImmediate(cb, 'Requester does not have a second signature');
 	}
 
 	// Check sender public key
-	if (sender.publicKey && sender.publicKey !== trs.senderPublicKey) {
-		err = ['Invalid sender public key:', trs.senderPublicKey, 'expected:', sender.publicKey].join(' ');
+	if (sender.publicKey && sender.publicKey !== transaction.senderPublicKey) {
+		err = ['Invalid sender public key:', transaction.senderPublicKey, 'expected:', sender.publicKey].join(' ');
 
-		if (exceptions.senderPublicKey.indexOf(trs.id) > -1) {
+		if (exceptions.senderPublicKey.indexOf(transaction.id) > -1) {
 			this.scope.logger.debug(err);
-			this.scope.logger.debug(JSON.stringify(trs));
+			this.scope.logger.debug(JSON.stringify(transaction));
 		} else {
 			return setImmediate(cb, err);
 		}
 	}
 
 	// Check sender is not genesis account unless block id equals genesis
-	if ([exceptions.genesisPublicKey.mainnet, exceptions.genesisPublicKey.testnet].indexOf(sender.publicKey) !== -1 && trs.blockId !== this.scope.genesisblock.block.id) {
+	if ([exceptions.genesisPublicKey.mainnet, exceptions.genesisPublicKey.testnet].indexOf(sender.publicKey) !== -1 && transaction.blockId !== this.scope.genesisblock.block.id) {
 		return setImmediate(cb, 'Invalid sender. Can not send from genesis account');
 	}
 
 	// Check sender address
-	if (String(trs.senderId).toUpperCase() !== String(sender.address).toUpperCase()) {
+	if (String(transaction.senderId).toUpperCase() !== String(sender.address).toUpperCase()) {
 		return setImmediate(cb, 'Invalid sender address');
 	}
 
 	// Determine multisignatures from sender or transaction asset
 	var multisignatures = sender.multisignatures || sender.u_multisignatures || [];
 	if (multisignatures.length === 0) {
-		if (trs.asset && trs.asset.multisignature && trs.asset.multisignature.keysgroup) {
+		if (transaction.asset && transaction.asset.multisignature && transaction.asset.multisignature.keysgroup) {
 
-			for (var i = 0; i < trs.asset.multisignature.keysgroup.length; i++) {
-				var key = trs.asset.multisignature.keysgroup[i];
+			for (var i = 0; i < transaction.asset.multisignature.keysgroup.length; i++) {
+				var key = transaction.asset.multisignature.keysgroup[i];
 
 				if (!key || typeof key !== 'string') {
 					return setImmediate(cb, 'Invalid member in keysgroup');
@@ -440,10 +440,10 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	}
 
 	// Check requester public key
-	if (trs.requesterPublicKey) {
-		multisignatures.push(trs.senderPublicKey);
+	if (transaction.requesterPublicKey) {
+		multisignatures.push(transaction.senderPublicKey);
 
-		if (!Array.isArray(sender.multisignatures) || sender.multisignatures.indexOf(trs.requesterPublicKey) < 0) {
+		if (!Array.isArray(sender.multisignatures) || sender.multisignatures.indexOf(transaction.requesterPublicKey) < 0) {
 			return setImmediate(cb, 'Account does not belong to multisignature group');
 		}
 	}
@@ -451,7 +451,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	// Verify signature
 	try {
 		valid = false;
-		valid = this.verifySignature(trs, (trs.requesterPublicKey || trs.senderPublicKey), trs.signature);
+		valid = this.verifySignature(transaction, (transaction.requesterPublicKey || transaction.senderPublicKey), transaction.signature);
 	} catch (e) {
 		this.scope.logger.error(e.stack);
 		return setImmediate(cb, e.toString());
@@ -460,9 +460,9 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	if (!valid) {
 		err = 'Failed to verify signature';
 
-		if (exceptions.signatures.indexOf(trs.id) > -1) {
+		if (exceptions.signatures.indexOf(transaction.id) > -1) {
 			this.scope.logger.debug(err);
-			this.scope.logger.debug(JSON.stringify(trs));
+			this.scope.logger.debug(JSON.stringify(transaction));
 			valid = true;
 			err = null;
 		} else {
@@ -474,7 +474,7 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	if (requester.secondSignature || sender.secondSignature) {
 		try {
 			valid = false;
-			valid = this.verifySecondSignature(trs, (requester.secondPublicKey || sender.secondPublicKey), trs.signSignature);
+			valid = this.verifySecondSignature(transaction, (requester.secondPublicKey || sender.secondPublicKey), transaction.signSignature);
 		} catch (e) {
 			return setImmediate(cb, e.toString());
 		}
@@ -485,28 +485,28 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	}
 
 	// Check that signatures are unique
-	if (trs.signatures && trs.signatures.length) {
-		var signatures = trs.signatures.reduce(function (p, c) {
+	if (transaction.signatures && transaction.signatures.length) {
+		var signatures = transaction.signatures.reduce(function (p, c) {
 			if (p.indexOf(c) < 0) { p.push(c); }
 			return p;
 		}, []);
 
-		if (signatures.length !== trs.signatures.length) {
+		if (signatures.length !== transaction.signatures.length) {
 			return setImmediate(cb, 'Encountered duplicate signature in transaction');
 		}
 	}
 
 	// Verify multisignatures
-	if (trs.signatures) {
-		for (var d = 0; d < trs.signatures.length; d++) {
+	if (transaction.signatures) {
+		for (var d = 0; d < transaction.signatures.length; d++) {
 			valid = false;
 
 			for (var s = 0; s < multisignatures.length; s++) {
-				if (trs.requesterPublicKey && multisignatures[s] === trs.requesterPublicKey) {
+				if (transaction.requesterPublicKey && multisignatures[s] === transaction.requesterPublicKey) {
 					continue;
 				}
 
-				if (this.verifySignature(trs, multisignatures[s], trs.signatures[d])) {
+				if (this.verifySignature(transaction, multisignatures[s], transaction.signatures[d])) {
 					valid = true;
 				}
 			}
@@ -518,36 +518,36 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
 	}
 
 	// Calculate fee
-	var fee = __private.types[trs.type].calculateFee.call(this, trs, sender) || false;
-	if (!fee || trs.fee !== fee) {
+	var fee = __private.types[transaction.type].calculateFee.call(this, transaction, sender) || false;
+	if (!fee || transaction.fee !== fee) {
 		return setImmediate(cb, 'Invalid transaction fee');
 	}
 
 	// Check amount
-	if (trs.amount < 0 || trs.amount > constants.totalAmount || String(trs.amount).indexOf('.') >= 0 || trs.amount.toString().indexOf('e') >= 0) {
+	if (transaction.amount < 0 || transaction.amount > constants.totalAmount || String(transaction.amount).indexOf('.') >= 0 || transaction.amount.toString().indexOf('e') >= 0) {
 		return setImmediate(cb, 'Invalid transaction amount');
 	}
 
 	// Check confirmed sender balance
-	var amount = new bignum(trs.amount.toString()).plus(trs.fee.toString());
-	var senderBalance = this.checkBalance(amount, 'balance', trs, sender);
+	var amount = new bignum(transaction.amount.toString()).plus(transaction.fee.toString());
+	var senderBalance = this.checkBalance(amount, 'balance', transaction, sender);
 
 	if (senderBalance.exceeded) {
 		return setImmediate(cb, senderBalance.error);
 	}
 
 	// Check timestamp
-	if (slots.getSlotNumber(trs.timestamp) > slots.getSlotNumber()) {
+	if (slots.getSlotNumber(transaction.timestamp) > slots.getSlotNumber()) {
 		return setImmediate(cb, 'Invalid transaction timestamp. Timestamp is in the future');
 	}
 
 	// Call verify on transaction type
-	__private.types[trs.type].verify.call(this, trs, sender, function (err) {
+	__private.types[transaction.type].verify.call(this, transaction, sender, function (err) {
 		if (err) {
 			return setImmediate(cb, err);
 		} else {
 			// Check for already confirmed transaction
-			return self.checkConfirmed(trs, cb);
+			return self.checkConfirmed(transaction, cb);
 		}
 	});
 };
@@ -556,15 +556,15 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
  * Verifies signature for valid transaction type
  * @implements {getBytes}
  * @implements {verifyBytes}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {publicKey} publicKey
  * @param {signature} signature
  * @return {boolean}
  * @throws {error}
  */
-Transaction.prototype.verifySignature = function (trs, publicKey, signature) {
-	if (!__private.types[trs.type]) {
-		throw 'Unknown transaction type ' + trs.type;
+Transaction.prototype.verifySignature = function (transaction, publicKey, signature) {
+	if (!__private.types[transaction.type]) {
+		throw 'Unknown transaction type ' + transaction.type;
 	}
 
 	if (!signature) { return false; }
@@ -572,7 +572,7 @@ Transaction.prototype.verifySignature = function (trs, publicKey, signature) {
 	var res;
 
 	try {
-		var bytes = this.getBytes(trs, true, true);
+		var bytes = this.getBytes(transaction, true, true);
 		res = this.verifyBytes(bytes, publicKey, signature);
 	} catch (e) {
 		throw e;
@@ -585,15 +585,15 @@ Transaction.prototype.verifySignature = function (trs, publicKey, signature) {
  * Verifies second signature for valid transaction type
  * @implements {getBytes}
  * @implements {verifyBytes}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {publicKey} publicKey
  * @param {signature} signature
  * @return {boolean}
  * @throws {error}
  */
-Transaction.prototype.verifySecondSignature = function (trs, publicKey, signature) {
-	if (!__private.types[trs.type]) {
-		throw 'Unknown transaction type ' + trs.type;
+Transaction.prototype.verifySecondSignature = function (transaction, publicKey, signature) {
+	if (!__private.types[transaction.type]) {
+		throw 'Unknown transaction type ' + transaction.type;
 	}
 
 	if (!signature) { return false; }
@@ -601,7 +601,7 @@ Transaction.prototype.verifySecondSignature = function (trs, publicKey, signatur
 	var res;
 
 	try {
-		var bytes = this.getBytes(trs, false, true);
+		var bytes = this.getBytes(transaction, false, true);
 		res = this.verifyBytes(bytes, publicKey, signature);
 	} catch (e) {
 		throw e;
@@ -643,25 +643,25 @@ Transaction.prototype.verifyBytes = function (bytes, publicKey, signature) {
 };
 
 /**
- * Merges account into sender address, Calls `apply` based on trs type (privateTypes).
+ * Merges account into sender address, Calls `apply` based on transaction type (privateTypes).
  * @see privateTypes
  * @implements {checkBalance}
  * @implements {account.merge}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} for errors | cb
  */
-Transaction.prototype.apply = function (trs, block, sender, cb) {
-	if (!this.ready(trs, sender)) {
+Transaction.prototype.apply = function (transaction, block, sender, cb) {
+	if (!this.ready(transaction, sender)) {
 		return setImmediate(cb, 'Transaction is not ready');
 	}
 
 	// Check confirmed sender balance
-	var amount = new bignum(trs.amount.toString()).plus(trs.fee.toString());
-	var senderBalance = this.checkBalance(amount, 'balance', trs, sender);
+	var amount = new bignum(transaction.amount.toString()).plus(transaction.fee.toString());
+	var senderBalance = this.checkBalance(amount, 'balance', transaction, sender);
 
 	if (senderBalance.exceeded) {
 		return setImmediate(cb, senderBalance.error);
@@ -682,7 +682,7 @@ Transaction.prototype.apply = function (trs, block, sender, cb) {
 		 * calls apply for Transfer, Signature, Delegate, Vote, Multisignature,
 		 * DApp, InTransfer or OutTransfer.
 		 */
-		__private.types[trs.type].apply.call(this, trs, block, sender, function (err) {
+		__private.types[transaction.type].apply.call(this, transaction, block, sender, function (err) {
 			if (err) {
 				this.scope.account.merge(sender.address, {
 					balance: amount,
@@ -699,20 +699,20 @@ Transaction.prototype.apply = function (trs, block, sender, cb) {
 };
 
 /**
- * Merges account into sender address, Calls `undo` based on trs type (privateTypes).
+ * Merges account into sender address, Calls `undo` based on transaction type (privateTypes).
  * @see privateTypes
  * @implements {bignum}
  * @implements {account.merge}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} for errors | cb
  */
-Transaction.prototype.undo = function (trs, block, sender, cb) {
-	var amount = new bignum(trs.amount.toString());
-	    amount = amount.plus(trs.fee.toString()).toNumber();
+Transaction.prototype.undo = function (transaction, block, sender, cb) {
+	var amount = new bignum(transaction.amount.toString());
+	    amount = amount.plus(transaction.fee.toString()).toNumber();
 
 	this.scope.logger.trace('Logic/Transaction->undo', {sender: sender.address, balance: amount, blockId: block.id, round: slots.calcRound(block.height)});
 	this.scope.account.merge(sender.address, {
@@ -724,7 +724,7 @@ Transaction.prototype.undo = function (trs, block, sender, cb) {
 			return setImmediate(cb, err);
 		}
 
-		__private.types[trs.type].undo.call(this, trs, block, sender, function (err) {
+		__private.types[transaction.type].undo.call(this, transaction, block, sender, function (err) {
 			if (err) {
 				this.scope.account.merge(sender.address, {
 					balance: -amount,
@@ -743,26 +743,26 @@ Transaction.prototype.undo = function (trs, block, sender, cb) {
 /**
  * Checks unconfirmed sender balance. Merges account into sender address with
  * unconfirmed balance negative amount.
- * Calls `applyUnconfirmed` based on trs type (privateTypes). If error merge
+ * Calls `applyUnconfirmed` based on transaction type (privateTypes). If error merge
  * account with amount.
  * @see privateTypes
  * @implements {bignum}
  * @implements {checkBalance}
  * @implements {account.merge}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {account} requester
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} for errors | cb
  */
-Transaction.prototype.applyUnconfirmed = function (trs, sender, requester, cb) {
+Transaction.prototype.applyUnconfirmed = function (transaction, sender, requester, cb) {
 	if (typeof requester === 'function') {
 		cb = requester;
 	}
 
 	// Check unconfirmed sender balance
-	var amount = new bignum(trs.amount.toString()).plus(trs.fee.toString());
-	var senderBalance = this.checkBalance(amount, 'u_balance', trs, sender);
+	var amount = new bignum(transaction.amount.toString()).plus(transaction.fee.toString());
+	var senderBalance = this.checkBalance(amount, 'u_balance', transaction, sender);
 
 	if (senderBalance.exceeded) {
 		return setImmediate(cb, senderBalance.error);
@@ -775,7 +775,7 @@ Transaction.prototype.applyUnconfirmed = function (trs, sender, requester, cb) {
 			return setImmediate(cb, err);
 		}
 
-		__private.types[trs.type].applyUnconfirmed.call(this, trs, sender, function (err) {
+		__private.types[transaction.type].applyUnconfirmed.call(this, transaction, sender, function (err) {
 			if (err) {
 				this.scope.account.merge(sender.address, {u_balance: amount}, function (err2) {
 					return setImmediate(cb, err2 || err);
@@ -788,27 +788,27 @@ Transaction.prototype.applyUnconfirmed = function (trs, sender, requester, cb) {
 };
 
 /**
- * Merges account into sender address with unconfirmed balance trs amount.
- * Calls `undoUnconfirmed` based on trs type (privateTypes). If error merge
+ * Merges account into sender address with unconfirmed balance transaction amount.
+ * Calls `undoUnconfirmed` based on transaction type (privateTypes). If error merge
  * account with megative amount.
  * @see privateTypes
  * @implements {bignum}
  * @implements {account.merge}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} for errors | cb
  */
-Transaction.prototype.undoUnconfirmed = function (trs, sender, cb) {
-	var amount = new bignum(trs.amount.toString());
-	    amount = amount.plus(trs.fee.toString()).toNumber();
+Transaction.prototype.undoUnconfirmed = function (transaction, sender, cb) {
+	var amount = new bignum(transaction.amount.toString());
+	    amount = amount.plus(transaction.fee.toString()).toNumber();
 
 	this.scope.account.merge(sender.address, {u_balance: amount}, function (err, sender) {
 		if (err) {
 			return setImmediate(cb, err);
 		}
 
-		__private.types[trs.type].undoUnconfirmed.call(this, trs, sender, function (err) {
+		__private.types[transaction.type].undoUnconfirmed.call(this, transaction, sender, function (err) {
 			if (err) {
 				this.scope.account.merge(sender.address, {u_balance: -amount}, function (err2) {
 					return setImmediate(cb, err2 || err);
@@ -839,24 +839,24 @@ Transaction.prototype.dbFields = [
 ];
 
 /**
- * Creates db trs object transaction. Calls `dbSave` based on trs type (privateTypes).
+ * Creates db trs object transaction. Calls `dbSave` based on transaction type (privateTypes).
  * @see privateTypes
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {Object[]} dbSave result + created object
  * @throws {String|error} error string | catch error
  */
-Transaction.prototype.dbSave = function (trs) {
-	if (!__private.types[trs.type]) {
-		throw 'Unknown transaction type ' + trs.type;
+Transaction.prototype.dbSave = function (transaction) {
+	if (!__private.types[transaction.type]) {
+		throw 'Unknown transaction type ' + transaction.type;
 	}
 
 	var senderPublicKey, signature, signSignature, requesterPublicKey;
 
 	try {
-		senderPublicKey = Buffer.from(trs.senderPublicKey, 'hex');
-		signature = Buffer.from(trs.signature, 'hex');
-		signSignature = trs.signSignature ? Buffer.from(trs.signSignature, 'hex') : null;
-		requesterPublicKey = trs.requesterPublicKey ? Buffer.from(trs.requesterPublicKey, 'hex') : null;
+		senderPublicKey = Buffer.from(transaction.senderPublicKey, 'hex');
+		signature = Buffer.from(transaction.signature, 'hex');
+		signSignature = transaction.signSignature ? Buffer.from(transaction.signSignature, 'hex') : null;
+		requesterPublicKey = transaction.requesterPublicKey ? Buffer.from(transaction.requesterPublicKey, 'hex') : null;
 	} catch (e) {
 		throw e;
 	}
@@ -866,24 +866,24 @@ Transaction.prototype.dbSave = function (trs) {
 			table: this.dbTable,
 			fields: this.dbFields,
 			values: {
-				id: trs.id,
-				blockId: trs.blockId,
-				type: trs.type,
-				timestamp: trs.timestamp,
+				id: transaction.id,
+				blockId: transaction.blockId,
+				type: transaction.type,
+				timestamp: transaction.timestamp,
 				senderPublicKey: senderPublicKey,
 				requesterPublicKey: requesterPublicKey,
-				senderId: trs.senderId,
-				recipientId: trs.recipientId || null,
-				amount: trs.amount,
-				fee: trs.fee,
+				senderId: transaction.senderId,
+				recipientId: transaction.recipientId || null,
+				amount: transaction.amount,
+				fee: transaction.fee,
 				signature: signature,
 				signSignature: signSignature,
-				signatures: trs.signatures ? trs.signatures.join(',') : null,
+				signatures: transaction.signatures ? transaction.signatures.join(',') : null,
 			}
 		}
 	];
 
-	var promise = __private.types[trs.type].dbSave(trs);
+	var promise = __private.types[transaction.type].dbSave(transaction);
 
 	if (promise) {
 		promises.push(promise);
@@ -893,20 +893,20 @@ Transaction.prototype.dbSave = function (trs) {
 };
 
 /**
- * Calls `afterSave` based on trs type (privateTypes).
+ * Calls `afterSave` based on transaction type (privateTypes).
  * @see privateTypes
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {function} cb
  * @return {setImmediateCallback} error string | cb
  */
-Transaction.prototype.afterSave = function (trs, cb) {
-	var tx_type = __private.types[trs.type];
+Transaction.prototype.afterSave = function (transaction, cb) {
+	var tx_type = __private.types[transaction.type];
 
 	if (!tx_type) {
-		return setImmediate(cb, 'Unknown transaction type ' + trs.type);
+		return setImmediate(cb, 'Unknown transaction type ' + transaction.type);
 	} else {
 		if (typeof tx_type.afterSave === 'function') {
-			return tx_type.afterSave.call(this, trs, cb);
+			return tx_type.afterSave.call(this, transaction, cb);
 		} else {
 			return setImmediate(cb);
 		}
@@ -1008,28 +1008,28 @@ Transaction.prototype.schema = {
 };
 
 /**
- * Calls `objectNormalize` based on trs type (privateTypes).
+ * Calls `objectNormalize` based on transaction type (privateTypes).
  * @see privateTypes
  * @implements {scope.schema.validate}
- * @param {transaction} trs
- * @return {error|transaction} error string | trs normalized
+ * @param {transaction} transaction
+ * @return {error|transaction} error string | transaction normalized
  * @throws {string} error message
  */
-Transaction.prototype.objectNormalize = function (trs) {
-	if (_.isEmpty(trs)) {
+Transaction.prototype.objectNormalize = function (transaction) {
+	if (_.isEmpty(transaction)) {
 		throw 'Empty trs passed';
 	}
-	if (!__private.types[trs.type]) {
-		throw 'Unknown transaction type ' + trs.type;
+	if (!__private.types[transaction.type]) {
+		throw 'Unknown transaction type ' + transaction.type;
 	}
 
-	for (var i in trs) {
-		if (trs[i] === null || typeof trs[i] === 'undefined') {
-			delete trs[i];
+	for (var i in transaction) {
+		if (transaction[i] === null || typeof transaction[i] === 'undefined') {
+			delete transaction[i];
 		}
 	}
 
-	var report = this.scope.schema.validate(trs, Transaction.prototype.schema);
+	var report = this.scope.schema.validate(transaction, Transaction.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate transaction schema: ' + self.scope.schema.getLastErrors().map(function (err) {
@@ -1038,16 +1038,16 @@ Transaction.prototype.objectNormalize = function (trs) {
 	}
 
 	try {
-		trs = __private.types[trs.type].objectNormalize.call(this, trs);
+		transaction = __private.types[transaction.type].objectNormalize.call(this, transaction);
 	} catch (e) {
 		throw e;
 	}
 
-	return trs;
+	return transaction;
 };
 
 /**
- * Calls `dbRead` based on trs type (privateTypes) to add tr asset.
+ * Calls `dbRead` based on transaction type (privateTypes) to add tr asset.
  * @see privateTypes
  * @param {Object} raw
  * @return {null|tx}

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1050,14 +1050,14 @@ Transaction.prototype.objectNormalize = function (transaction) {
  * Calls `dbRead` based on transaction type (privateTypes) to add tr asset.
  * @see privateTypes
  * @param {Object} raw
- * @return {null|tx}
+ * @return {null|transaction}
  * @throws {string} Unknown transaction type
  */
 Transaction.prototype.dbRead = function (raw) {
 	if (!raw.t_id) {
 		return null;
 	} else {
-		var tx = {
+		var transaction = {
 			id: raw.t_id,
 			height: raw.b_height,
 			blockId: raw.b_id || raw.t_blockId,
@@ -1077,17 +1077,17 @@ Transaction.prototype.dbRead = function (raw) {
 			asset: {}
 		};
 
-		if (!__private.types[tx.type]) {
-			throw 'Unknown transaction type ' + tx.type;
+		if (!__private.types[transaction.type]) {
+			throw 'Unknown transaction type ' + transaction.type;
 		}
 
-		var asset = __private.types[tx.type].dbRead.call(this, raw);
+		var asset = __private.types[transaction.type].dbRead.call(this, raw);
 
 		if (asset) {
-			tx.asset = extend(tx.asset, asset);
+			transaction.asset = extend(transaction.asset, asset);
 		}
 
-		return tx;
+		return transaction;
 	}
 };
 

--- a/logic/transfer.js
+++ b/logic/transfer.js
@@ -34,13 +34,13 @@ Transfer.prototype.bind = function (accounts) {
 
 /**
  * Returns send fees from constants.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @return {number} fee
  */
-Transfer.prototype.calculateFee = function (trs, sender) {
+Transfer.prototype.calculateFee = function (transaction, sender) {
 	var fee = new bignum(constants.fees.send);
-	if (trs.asset && trs.asset.data) {
+	if (transaction.asset && transaction.asset.data) {
 		fee = fee.plus(constants.fees.data);
 	}
 
@@ -49,44 +49,44 @@ Transfer.prototype.calculateFee = function (trs, sender) {
 
 /**
  * Verifies recipientId and amount greather than 0.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
- * @return {setImmediateCallback} errors | trs
+ * @return {setImmediateCallback} errors | transaction
  */
-Transfer.prototype.verify = function (trs, sender, cb) {
-	if (!trs.recipientId) {
+Transfer.prototype.verify = function (transaction, sender, cb) {
+	if (!transaction.recipientId) {
 		return setImmediate(cb, 'Missing recipient');
 	}
 
-	if (trs.amount <= 0) {
+	if (transaction.amount <= 0) {
 		return setImmediate(cb, 'Invalid transaction amount');
 	}
 
-	return setImmediate(cb, null, trs);
+	return setImmediate(cb, null, transaction);
 };
 
 /**
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
- * @return {setImmediateCallback} cb, null, trs
+ * @return {setImmediateCallback} cb, null, transaction
  */
-Transfer.prototype.process = function (trs, sender, cb) {
-	return setImmediate(cb, null, trs);
+Transfer.prototype.process = function (transaction, sender, cb) {
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Creates a buffer with asset.transfer.data.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {buffer} buf
  * @throws {error} error
  */
-Transfer.prototype.getBytes = function (trs) {
+Transfer.prototype.getBytes = function (transaction) {
 	var buf;
 
 	try {
-		buf = (trs.asset && trs.asset.data) ? Buffer.from(trs.asset.data, 'utf8') : null;
+		buf = (transaction.asset && transaction.asset.data) ? Buffer.from(transaction.asset.data, 'utf8') : null;
 	} catch (ex) {
 		throw ex;
 	}
@@ -96,26 +96,26 @@ Transfer.prototype.getBytes = function (trs) {
 
 /**
  * Calls setAccountAndGet based on transaction recipientId and
- * mergeAccountAndGet with unconfirmed trs amount.
+ * mergeAccountAndGet with unconfirmed transaction amount.
  * @implements {modules.accounts.setAccountAndGet}
  * @implements {modules.accounts.mergeAccountAndGet}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} error, cb
  */
-Transfer.prototype.apply = function (trs, block, sender, cb) {
-	modules.accounts.setAccountAndGet({address: trs.recipientId}, function (err, recipient) {
+Transfer.prototype.apply = function (transaction, block, sender, cb) {
+	modules.accounts.setAccountAndGet({address: transaction.recipientId}, function (err, recipient) {
 		if (err) {
 			return setImmediate(cb, err);
 		}
 
 		modules.accounts.mergeAccountAndGet({
-			address: trs.recipientId,
-			balance: trs.amount,
-			u_balance: trs.amount,
+			address: transaction.recipientId,
+			balance: transaction.amount,
+			u_balance: transaction.amount,
 			blockId: block.id,
 			round: slots.calcRound(block.height)
 		}, function (err) {
@@ -126,26 +126,26 @@ Transfer.prototype.apply = function (trs, block, sender, cb) {
 
 /**
  * Calls setAccountAndGet based on transaction recipientId and
- * mergeAccountAndGet with unconfirmed trs amount and balance negative.
+ * mergeAccountAndGet with unconfirmed transaction amount and balance negative.
  * @implements {modules.accounts.setAccountAndGet}
  * @implements {modules.accounts.mergeAccountAndGet}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} error, cb
  */
-Transfer.prototype.undo = function (trs, block, sender, cb) {
-	modules.accounts.setAccountAndGet({address: trs.recipientId}, function (err, recipient) {
+Transfer.prototype.undo = function (transaction, block, sender, cb) {
+	modules.accounts.setAccountAndGet({address: transaction.recipientId}, function (err, recipient) {
 		if (err) {
 			return setImmediate(cb, err);
 		}
 
 		modules.accounts.mergeAccountAndGet({
-			address: trs.recipientId,
-			balance: -trs.amount,
-			u_balance: -trs.amount,
+			address: transaction.recipientId,
+			balance: -transaction.amount,
+			u_balance: -transaction.amount,
 			blockId: block.id,
 			round: slots.calcRound(block.height)
 		}, function (err) {
@@ -155,22 +155,22 @@ Transfer.prototype.undo = function (trs, block, sender, cb) {
 };
 
 /**
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
  * @return {setImmediateCallback} cb
  */
-Transfer.prototype.applyUnconfirmed = function (trs, sender, cb) {
+Transfer.prototype.applyUnconfirmed = function (transaction, sender, cb) {
 	return setImmediate(cb);
 };
 
 /**
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
  * @return {setImmediateCallback} cb
  */
-Transfer.prototype.undoUnconfirmed = function (trs, sender, cb) {
+Transfer.prototype.undoUnconfirmed = function (transaction, sender, cb) {
 	return setImmediate(cb);
 };
 
@@ -193,21 +193,21 @@ Transfer.prototype.schema = {
 
 /**
  * Deletes blockId from transaction, and validates schema if asset exists.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {transaction}
  */
-Transfer.prototype.objectNormalize = function (trs) {
-	delete trs.blockId;
+Transfer.prototype.objectNormalize = function (transaction) {
+	delete transaction.blockId;
 
-	if (!trs.asset) {
-		return trs;
+	if (!transaction.asset) {
+		return transaction;
 	}
 
-	if (trs.asset.data === null || typeof trs.asset.data === 'undefined') {
-		delete trs.asset.data;
+	if (transaction.asset.data === null || typeof transaction.asset.data === 'undefined') {
+		delete transaction.asset.data;
 	}
 
-	var report = library.schema.validate(trs.asset, Transfer.prototype.schema);
+	var report = library.schema.validate(transaction.asset, Transfer.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate transfer schema: ' + library.schema.getLastErrors().map(function (err) {
@@ -215,7 +215,7 @@ Transfer.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	return trs;
+	return transaction;
 };
 
 Transfer.prototype.dbTable = 'transfer';
@@ -252,15 +252,15 @@ Transfer.prototype.dbRead = function (raw) {
 
 /**
  * Checks if asset exists, if so, returns transfer table promise, otherwise returns null.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {trsPromise|null}
  */
-Transfer.prototype.dbSave = function (trs) {
-	if (trs.asset && trs.asset.data) {
+Transfer.prototype.dbSave = function (transaction) {
+	if (transaction.asset && transaction.asset.data) {
 		var data;
 
 		try {
-			data = Buffer.from(trs.asset.data, 'utf8');
+			data = Buffer.from(transaction.asset.data, 'utf8');
 		} catch (ex) {
 			throw ex;
 		}
@@ -270,7 +270,7 @@ Transfer.prototype.dbSave = function (trs) {
 			fields: this.dbFields,
 			values: {
 				data: data,
-				transactionId: trs.id
+				transactionId: transaction.id
 			}
 		};
 	}
@@ -280,17 +280,17 @@ Transfer.prototype.dbSave = function (trs) {
 
 /**
  * Checks sender multisignatures and transaction signatures.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @return {boolean} True if transaction signatures greather than 
  * sender multimin or there are not sender multisignatures.
  */
-Transfer.prototype.ready = function (trs, sender) {
+Transfer.prototype.ready = function (transaction, sender) {
 	if (Array.isArray(sender.multisignatures) && sender.multisignatures.length) {
-		if (!Array.isArray(trs.signatures)) {
+		if (!Array.isArray(transaction.signatures)) {
 			return false;
 		}
-		return trs.signatures.length >= sender.multimin;
+		return transaction.signatures.length >= sender.multimin;
 	} else {
 		return true;
 	}

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -46,7 +46,7 @@ Vote.prototype.bind = function (delegates) {
  * @see {@link module:helpers/constants}
  * @return {number} fee
  */
-Vote.prototype.calculateFee = function (trs, sender) {
+Vote.prototype.calculateFee = function (transaction, sender) {
 	return constants.fees.vote;
 };
 
@@ -54,37 +54,37 @@ Vote.prototype.calculateFee = function (trs, sender) {
  * Validates transaction votes fields and for each vote calls verifyVote.
  * @implements {verifyVote}
  * @implements {checkConfirmedDelegates}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback|function} returns error if invalid field | 
  * calls checkConfirmedDelegates.
  */
-Vote.prototype.verify = function (trs, sender, cb) {
-	if (trs.recipientId !== trs.senderId) {
+Vote.prototype.verify = function (transaction, sender, cb) {
+	if (transaction.recipientId !== transaction.senderId) {
 		return setImmediate(cb, 'Invalid recipient');
 	}
 
-	if (!trs.asset || !trs.asset.votes) {
+	if (!transaction.asset || !transaction.asset.votes) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
 
-	if (!Array.isArray(trs.asset.votes)) {
+	if (!Array.isArray(transaction.asset.votes)) {
 		return setImmediate(cb, 'Invalid votes. Must be an array');
 	}
 
-	if (!trs.asset.votes.length) {
+	if (!transaction.asset.votes.length) {
 		return setImmediate(cb, 'Invalid votes. Must not be empty');
 	}
 
-	if (trs.asset.votes && trs.asset.votes.length > constants.maxVotesPerTransaction) {
+	if (transaction.asset.votes && transaction.asset.votes.length > constants.maxVotesPerTransaction) {
 		return setImmediate(cb, ['Voting limit exceeded. Maximum is', constants.maxVotesPerTransaction, 'votes per transaction'].join(' '));
 	}
 
-	async.eachSeries(trs.asset.votes, function (vote, eachSeriesCb) {
+	async.eachSeries(transaction.asset.votes, function (vote, eachSeriesCb) {
 		self.verifyVote(vote, function (err) {
 			if (err) {
-				return setImmediate(eachSeriesCb, ['Invalid vote at index', trs.asset.votes.indexOf(vote), '-', err].join(' '));
+				return setImmediate(eachSeriesCb, ['Invalid vote at index', transaction.asset.votes.indexOf(vote), '-', err].join(' '));
 			} else {
 				return setImmediate(eachSeriesCb);
 			}
@@ -94,11 +94,11 @@ Vote.prototype.verify = function (trs, sender, cb) {
 			return setImmediate(cb, err);
 		} else {
 
-			if (trs.asset.votes.length > _.uniqBy(trs.asset.votes, function (v) { return v.slice(1); }).length) {
+			if (transaction.asset.votes.length > _.uniqBy(transaction.asset.votes, function (v) { return v.slice(1); }).length) {
 				return setImmediate(cb, 'Multiple votes for same delegate are not allowed');
 			}
 
-			return self.checkConfirmedDelegates(trs, cb);
+			return self.checkConfirmedDelegates(transaction, cb);
 		}
 	});
 };
@@ -128,16 +128,16 @@ Vote.prototype.verifyVote = function (vote, cb) {
 /**
  * Calls checkConfirmedDelegates() with senderPublicKeykey and asset votes.
  * @implements {modules.delegates.checkConfirmedDelegates}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} cb, err(if transaction id is not in 
  * exceptions votes list)
  */
-Vote.prototype.checkConfirmedDelegates = function (trs, cb) {
-	modules.delegates.checkConfirmedDelegates(trs.senderPublicKey, trs.asset.votes, function (err) {
-		if (err && exceptions.votes.indexOf(trs.id) > -1) {
+Vote.prototype.checkConfirmedDelegates = function (transaction, cb) {
+	modules.delegates.checkConfirmedDelegates(transaction.senderPublicKey, transaction.asset.votes, function (err) {
+		if (err && exceptions.votes.indexOf(transaction.id) > -1) {
 			library.logger.debug(err);
-			library.logger.debug(JSON.stringify(trs));
+			library.logger.debug(JSON.stringify(transaction));
 			err = null;
 		}
 
@@ -148,16 +148,16 @@ Vote.prototype.checkConfirmedDelegates = function (trs, cb) {
 /**
  * Calls checkUnconfirmedDelegates() with senderPublicKeykey and asset votes.
  * @implements {modules.delegates.checkUnconfirmedDelegates}
- * @param {Object} trs
+ * @param {Object} transaction
  * @param {function} cb
  * @return {setImmediateCallback} cb, err(if transaction id is not in 
  * exceptions votes list)
  */
-Vote.prototype.checkUnconfirmedDelegates = function (trs, cb) {
-	modules.delegates.checkUnconfirmedDelegates(trs.senderPublicKey, trs.asset.votes, function (err) {
-		if (err && exceptions.votes.indexOf(trs.id) > -1) {
+Vote.prototype.checkUnconfirmedDelegates = function (transaction, cb) {
+	modules.delegates.checkUnconfirmedDelegates(transaction.senderPublicKey, transaction.asset.votes, function (err) {
+		if (err && exceptions.votes.indexOf(transaction.id) > -1) {
 			library.logger.debug(err);
-			library.logger.debug(JSON.stringify(trs));
+			library.logger.debug(JSON.stringify(transaction));
 			err = null;
 		}
 
@@ -166,26 +166,26 @@ Vote.prototype.checkUnconfirmedDelegates = function (trs, cb) {
 };
 
 /**
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb
- * @return {setImmediateCallback} cb, null, trs
+ * @return {setImmediateCallback} cb, null, transaction
  */
-Vote.prototype.process = function (trs, sender, cb) {
-	return setImmediate(cb, null, trs);
+Vote.prototype.process = function (transaction, sender, cb) {
+	return setImmediate(cb, null, transaction);
 };
 
 /**
  * Creates a buffer with asset.votes information.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {Array} Buffer
  * @throws {e} error
  */
-Vote.prototype.getBytes = function (trs) {
+Vote.prototype.getBytes = function (transaction) {
 	var buf;
 
 	try {
-		buf = trs.asset.votes ? Buffer.from(trs.asset.votes.join(''), 'utf8') : null;
+		buf = transaction.asset.votes ? Buffer.from(transaction.asset.votes.join(''), 'utf8') : null;
 	} catch (e) {
 		throw e;
 	}
@@ -199,22 +199,22 @@ Vote.prototype.getBytes = function (trs) {
  * @implements {checkConfirmedDelegates}
  * @implements {scope.account.merge}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @todo delete unnecessary var parent = this
  */
-Vote.prototype.apply = function (trs, block, sender, cb) {
+Vote.prototype.apply = function (transaction, block, sender, cb) {
 	var parent = this;
 
 	async.series([
 		function (seriesCb) {
-			self.checkConfirmedDelegates(trs, seriesCb);
+			self.checkConfirmedDelegates(transaction, seriesCb);
 		},
 		function (seriesCb) {
 			parent.scope.account.merge(sender.address, {
-				delegates: trs.asset.votes,
+				delegates: transaction.asset.votes,
 				blockId: block.id,
 				round: slots.calcRound(block.height)
 			}, function (err) {
@@ -230,16 +230,16 @@ Vote.prototype.apply = function (trs, block, sender, cb) {
  * @implements {Diff}
  * @implements {scope.account.merge}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {block} block
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} cb, err
  */
-Vote.prototype.undo = function (trs, block, sender, cb) {
-	if (trs.asset.votes === null) { return setImmediate(cb); }
+Vote.prototype.undo = function (transaction, block, sender, cb) {
+	if (transaction.asset.votes === null) { return setImmediate(cb); }
 
-	var votesInvert = Diff.reverse(trs.asset.votes);
+	var votesInvert = Diff.reverse(transaction.asset.votes);
 
 	this.scope.account.merge(sender.address, {
 		delegates: votesInvert,
@@ -255,21 +255,21 @@ Vote.prototype.undo = function (trs, block, sender, cb) {
  * merges account to sender address with votes as unconfirmed delegates.
  * @implements {checkUnconfirmedDelegates}
  * @implements {scope.account.merge}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function
  * @todo delete unnecessary var parent = this
  */
-Vote.prototype.applyUnconfirmed = function (trs, sender, cb) {
+Vote.prototype.applyUnconfirmed = function (transaction, sender, cb) {
 	var parent = this;
 
 	async.series([
 		function (seriesCb) {
-			self.checkUnconfirmedDelegates(trs, seriesCb);
+			self.checkUnconfirmedDelegates(transaction, seriesCb);
 		},
 		function (seriesCb) {
 			parent.scope.account.merge(sender.address, {
-				u_delegates: trs.asset.votes
+				u_delegates: transaction.asset.votes
 			}, function (err) {
 				return setImmediate(seriesCb, err);
 			});
@@ -283,15 +283,15 @@ Vote.prototype.applyUnconfirmed = function (trs, sender, cb) {
  * @implements {Diff}
  * @implements {scope.account.merge}
  * @implements {slots.calcRound}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @param {function} cb - Callback function
  * @return {setImmediateCallback} cb, err
  */
-Vote.prototype.undoUnconfirmed = function (trs, sender, cb) {
-	if (trs.asset.votes === null) { return setImmediate(cb); }
+Vote.prototype.undoUnconfirmed = function (transaction, sender, cb) {
+	if (transaction.asset.votes === null) { return setImmediate(cb); }
 
-	var votesInvert = Diff.reverse(trs.asset.votes);
+	var votesInvert = Diff.reverse(transaction.asset.votes);
 
 	this.scope.account.merge(sender.address, {u_delegates: votesInvert}, function (err) {
 		return setImmediate(cb, err);
@@ -320,13 +320,13 @@ Vote.prototype.schema = {
 /**
  * Validates asset schema.
  * @implements {library.schema.validate}
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {transaction}
  * @throws {string} Failed to validate vote schema.
- * @todo should pass trs.asset.vote to validate?
+ * @todo should pass transaction.asset.vote to validate?
  */
-Vote.prototype.objectNormalize = function (trs) {
-	var report = library.schema.validate(trs.asset, Vote.prototype.schema);
+Vote.prototype.objectNormalize = function (transaction) {
+	var report = library.schema.validate(transaction.asset, Vote.prototype.schema);
 
 	if (!report) {
 		throw 'Failed to validate vote schema: ' + library.schema.getLastErrors().map(function (err) {
@@ -334,7 +334,7 @@ Vote.prototype.objectNormalize = function (trs) {
 		}).join(', ');
 	}
 
-	return trs;
+	return transaction;
 };
 
 /**
@@ -361,33 +361,33 @@ Vote.prototype.dbFields = [
 
 /**
  * Creates db operation object to 'votes' table based on votes data.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @return {Object[]} table, fields, values.
  */
-Vote.prototype.dbSave = function (trs) {
+Vote.prototype.dbSave = function (transaction) {
 	return {
 		table: this.dbTable,
 		fields: this.dbFields,
 		values: {
-			votes: Array.isArray(trs.asset.votes) ? trs.asset.votes.join(',') : null,
-			transactionId: trs.id
+			votes: Array.isArray(transaction.asset.votes) ? transaction.asset.votes.join(',') : null,
+			transactionId: transaction.id
 		}
 	};
 };
 
 /**
  * Checks sender multisignatures and transaction signatures.
- * @param {transaction} trs
+ * @param {transaction} transaction
  * @param {account} sender
  * @return {boolean} True if transaction signatures greather than 
  * sender multimin or there are not sender multisignatures.
  */
-Vote.prototype.ready = function (trs, sender) {
+Vote.prototype.ready = function (transaction, sender) {
 	if (Array.isArray(sender.multisignatures) && sender.multisignatures.length) {
-		if (!Array.isArray(trs.signatures)) {
+		if (!Array.isArray(transaction.signatures)) {
 			return false;
 		}
-		return trs.signatures.length >= sender.multimin;
+		return transaction.signatures.length >= sender.multimin;
 	} else {
 		return true;
 	}

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -530,12 +530,12 @@ __private.popLastBlock = function (oldLastBlock, cb) {
 							if (err) {
 								return setImmediate(cb, err);
 							}
-							// Undoing confirmed tx - refresh confirmed balance (see: logic.transaction.undo, logic.transfer.undo)
+							// Undoing confirmed transaction - refresh confirmed balance (see: logic.transaction.undo, logic.transfer.undo)
 							// WARNING: DB_WRITE
 							modules.transactions.undo(transaction, oldLastBlock, sender, cb);
 						});
 					}, function (cb) {
-						// Undoing unconfirmed tx - refresh unconfirmed balance (see: logic.transaction.undoUnconfirmed)
+						// Undoing unconfirmed transaction - refresh unconfirmed balance (see: logic.transaction.undoUnconfirmed)
 						// WARNING: DB_WRITE
 						modules.transactions.undoUnconfirmed(transaction, cb);
 					}, function (cb) {

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -469,7 +469,7 @@ Process.prototype.loadBlocksFromPeer = function (peer, cb) {
  */
 Process.prototype.generateBlock = function (keypair, timestamp, cb) {
 	// Get transactions that will be included in block
-	var transactions = modules.transactions.getUnconfirmedTransactionList(false, constants.maxTxsPerBlock);
+	var transactions = modules.transactions.getUnconfirmedTransactionList(false, constants.maxTransactionsPerBlock);
 	var ready = [];
 
 	async.eachSeries(transactions, function (transaction, cb) {

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -238,7 +238,7 @@ __private.verifyPayload = function (block, result) {
 		result.errors.push('Included transactions do not match block transactions count');
 	}
 
-	if (block.transactions.length > constants.maxTxsPerBlock) {
+	if (block.transactions.length > constants.maxTransactionsPerBlock) {
 		result.errors.push('Number of transactions exceeds maximum per block');
 	}
 

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -248,7 +248,7 @@ __private.loadTransactions = function (cb) {
 				try {
 					transaction = library.logic.transaction.objectNormalize(transaction);
 				} catch (e) {
-					library.logger.debug('Transaction normalization failed', {id: id, err: e.toString(), module: 'loader', tx: transaction});
+					library.logger.debug('Transaction normalization failed', {id: id, err: e.toString(), module: 'loader', transaction: transaction});
 
 					library.logger.warn(['Transaction', id, 'is not valid, peer removed'].join(' '), peer.string);
 					modules.peers.remove(peer.ip, peer.port);

--- a/modules/multisignatures.js
+++ b/modules/multisignatures.js
@@ -57,20 +57,20 @@ function Multisignatures (cb, scope) {
 // Public methods
 /**
  * Gets transaction from transaction id and add it to sequence and bus.
- * @param {Object} tx - Contains transaction and signature.
+ * @param {Object} transaction - Contains transaction and signature.
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback} err messages| cb
  * @todo test function!.
  */
-Multisignatures.prototype.processSignature = function (tx, cb) {
-	if (!tx) {
+Multisignatures.prototype.processSignature = function (transaction, cb) {
+	if (!transaction) {
 		return setImmediate(cb, 'Unable to process signature. Signature is undefined.');
 	}
-	var transaction = modules.transactions.getMultisignatureTransaction(tx.transaction);
+	var transaction = modules.transactions.getMultisignatureTransaction(transaction.transaction);
 
 	function done (cb) {
 		library.balancesSequence.add(function (cb) {
-			var transaction = modules.transactions.getMultisignatureTransaction(tx.transaction);
+			var transaction = modules.transactions.getMultisignatureTransaction(transaction.transaction);
 
 			if (!transaction) {
 				return setImmediate(cb, 'Transaction not found');
@@ -85,10 +85,10 @@ Multisignatures.prototype.processSignature = function (tx, cb) {
 					return setImmediate(cb, 'Sender not found');
 				} else {
 					transaction.signatures = transaction.signatures || [];
-					transaction.signatures.push(tx.signature);
+					transaction.signatures.push(transaction.signature);
 					transaction.ready = Multisignature.prototype.ready(transaction, sender);
 
-					library.bus.message('signature', {transaction: tx.transaction, signature: tx.signature}, true);
+					library.bus.message('signature', {transaction: transaction.transaction, signature: transaction.signature}, true);
 					return setImmediate(cb);
 				}
 			});
@@ -102,7 +102,7 @@ Multisignatures.prototype.processSignature = function (tx, cb) {
 	if (transaction.type === transactionTypes.MULTI) {
 		transaction.signatures = transaction.signatures || [];
 
-		if (transaction.asset.multisignature.signatures || transaction.signatures.indexOf(tx.signature) !== -1) {
+		if (transaction.asset.multisignature.signatures || transaction.signatures.indexOf(transaction.signature) !== -1) {
 			return setImmediate(cb, 'Permission to sign transaction denied');
 		}
 
@@ -112,7 +112,7 @@ Multisignatures.prototype.processSignature = function (tx, cb) {
 		try {
 			for (var i = 0; i < transaction.asset.multisignature.keysgroup.length && !verify; i++) {
 				var key = transaction.asset.multisignature.keysgroup[i].substring(1);
-				verify = library.logic.transaction.verifySignature(transaction, key, tx.signature);
+				verify = library.logic.transaction.verifySignature(transaction, key, transaction.signature);
 			}
 		} catch (e) {
 			library.logger.error(e.stack);
@@ -145,13 +145,13 @@ Multisignatures.prototype.processSignature = function (tx, cb) {
 
 			transaction.signatures = transaction.signatures || [];
 
-			if (transaction.signatures.indexOf(tx.signature) >= 0) {
+			if (transaction.signatures.indexOf(transaction.signature) >= 0) {
 				return setImmediate(cb, 'Signature already exists');
 			}
 
 			try {
 				for (var i = 0; i < multisignatures.length && !verify; i++) {
-					verify = library.logic.transaction.verifySignature(transaction, multisignatures[i], tx.signature);
+					verify = library.logic.transaction.verifySignature(transaction, multisignatures[i], transaction.signature);
 				}
 			} catch (e) {
 				library.logger.error(e.stack);

--- a/modules/multisignatures.js
+++ b/modules/multisignatures.js
@@ -70,23 +70,23 @@ Multisignatures.prototype.processSignature = function (transaction, cb) {
 
 	function done (cb) {
 		library.balancesSequence.add(function (cb) {
-			var transaction = modules.transactions.getMultisignatureTransaction(transaction.transaction);
+			var multisignatureTransaction = modules.transactions.getMultisignatureTransaction(transaction.transaction);
 
-			if (!transaction) {
+			if (!multisignatureTransaction) {
 				return setImmediate(cb, 'Transaction not found');
 			}
 
 			modules.accounts.getAccount({
-				address: transaction.senderId
+				address: multisignatureTransaction.senderId
 			}, function (err, sender) {
 				if (err) {
 					return setImmediate(cb, err);
 				} else if (!sender) {
 					return setImmediate(cb, 'Sender not found');
 				} else {
-					transaction.signatures = transaction.signatures || [];
-					transaction.signatures.push(transaction.signature);
-					transaction.ready = Multisignature.prototype.ready(transaction, sender);
+					multisignatureTransaction.signatures = multisignatureTransaction.signatures || [];
+					multisignatureTransaction.signatures.push(transaction.signature);
+					multisignatureTransaction.ready = Multisignature.prototype.ready(multisignatureTransaction, sender);
 
 					library.bus.message('signature', {transaction: transaction.transaction, signature: transaction.signature}, true);
 					return setImmediate(cb);

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -242,7 +242,7 @@ __private.receiveTransaction = function (transaction, peer, extraLogMessage, cb)
 	try {
 		transaction = library.logic.transaction.objectNormalize(transaction);
 	} catch (e) {
-		library.logger.debug('Transaction normalization failed', {id: id, err: e.toString(), module: 'transport', tx: transaction});
+		library.logger.debug('Transaction normalization failed', {id: id, err: e.toString(), module: 'transport', transaction: transaction});
 
 		__private.removePeer({peer: peer, code: 'ETRANSACTION'}, extraLogMessage);
 

--- a/test/functional/http/post/0.transfer.js
+++ b/test/functional/http/post/0.transfer.js
@@ -24,7 +24,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 
 	describe('transaction processing', function () {
 
-		it('mutating data used to build the tx id should fail', function () {
+		it('mutating data used to build the transaction id should fail', function () {
 			transaction = node.randomTx();
 			transaction.timestamp += 1;
 

--- a/test/functional/shared.js
+++ b/test/functional/shared.js
@@ -34,8 +34,8 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 	describe('before new block', function () {
 
 		it('good transactions should remain unconfirmed', function () {
-			return node.Promise.map(goodTransactions, function (tx) {
-				return getTransactionPromise(tx.id).then(function (res) {
+			return node.Promise.map(goodTransactions, function (transaction) {
+				return getTransactionPromise(transaction.id).then(function (res) {
 					node.expect(res).to.have.property('success').to.be.not.ok;
 					node.expect(res).to.have.property('error').equal('Transaction not found');
 				});
@@ -44,8 +44,8 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 
 		if (pendingMultisignatures) {
 			it('pendingMultisignatures should remain in the pending queue', function () {
-				return node.Promise.map(pendingMultisignatures, function (tx) {
-					return getPendingMultisignaturePromise(tx).then(function (res) {
+				return node.Promise.map(pendingMultisignatures, function (transaction) {
+					return getPendingMultisignaturePromise(transaction).then(function (res) {
 						node.expect(res).to.have.property('success').to.be.ok;
 						node.expect(res).to.have.property('transactions').to.be.an('array').to.have.lengthOf(1);
 					});
@@ -53,8 +53,8 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 			});
 
 			it('pendingMultisignatures should not be confirmed', function () {
-				return node.Promise.map(pendingMultisignatures, function (tx) {
-					return getTransactionPromise(tx.id).then(function (res) {
+				return node.Promise.map(pendingMultisignatures, function (transaction) {
+					return getTransactionPromise(transaction.id).then(function (res) {
 						node.expect(res).to.have.property('success').to.be.not.ok;
 						node.expect(res).to.have.property('error').equal('Transaction not found');
 					});
@@ -70,8 +70,8 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 		});
 
 		it('bad transactions should not be confirmed', function () {
-			return node.Promise.map(badTransactions, function (tx) {
-				return getTransactionPromise(tx.id).then(function (res) {
+			return node.Promise.map(badTransactions, function (transaction) {
+				return getTransactionPromise(transaction.id).then(function (res) {
 					node.expect(res).to.have.property('success').to.be.not.ok;
 					node.expect(res).to.have.property('error').equal('Transaction not found');
 				});
@@ -79,8 +79,8 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 		});
 
 		it('good transactions should not be unconfirmed', function () {
-			return node.Promise.map(goodTransactions, function (tx) {
-				return getUnconfirmedTransactionPromise(tx.id).then(function (res) {
+			return node.Promise.map(goodTransactions, function (transaction) {
+				return getUnconfirmedTransactionPromise(transaction.id).then(function (res) {
 					node.expect(res).to.have.property('success').to.be.not.ok;
 					node.expect(res).to.have.property('error').equal('Transaction not found');
 				});
@@ -88,18 +88,18 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 		});
 
 		it('good transactions should be confirmed', function () {
-			return node.Promise.map(goodTransactions, function (tx) {
-				return getTransactionPromise(tx.id).then(function (res) {
+			return node.Promise.map(goodTransactions, function (transaction) {
+				return getTransactionPromise(transaction.id).then(function (res) {
 					node.expect(res).to.have.property('success').to.be.ok;
-					node.expect(res).to.have.property('transaction').to.have.property('id').equal(tx.id);
+					node.expect(res).to.have.property('transaction').to.have.property('id').equal(transaction.id);
 				});
 			});
 		});
 
 		if (pendingMultisignatures) {
 			it('pendingMultisignatures should remain in the pending queue', function () {
-				return node.Promise.map(pendingMultisignatures, function (tx) {
-					return getPendingMultisignaturePromise(tx).then(function (res) {
+				return node.Promise.map(pendingMultisignatures, function (transaction) {
+					return getPendingMultisignaturePromise(transaction).then(function (res) {
 						node.expect(res).to.have.property('success').to.be.ok;
 						node.expect(res).to.have.property('transactions').to.be.an('array').to.have.lengthOf(1);
 					});
@@ -107,8 +107,8 @@ function confirmationPhase (goodTransactions, badTransactions, pendingMultisigna
 			});
 
 			it('pendingMultisignatures should not be confirmed', function () {
-				return node.Promise.map(pendingMultisignatures, function (tx) {
-					return getTransactionPromise(tx.id).then(function (res) {
+				return node.Promise.map(pendingMultisignatures, function (transaction) {
+					return getTransactionPromise(transaction.id).then(function (res) {
 						node.expect(res).to.have.property('success').to.be.not.ok;
 						node.expect(res).to.have.property('error').equal('Transaction not found');
 					});

--- a/test/functional/ws/transport.transactions.stress.js
+++ b/test/functional/ws/transport.transactions.stress.js
@@ -52,7 +52,7 @@ describe('postTransactions @slow', function () {
 		});
 
 		it('should confirm all transactions', function (done) {
-			var blocksToWait = Math.ceil(maximum / node.constants.maxTxsPerBlock);
+			var blocksToWait = Math.ceil(maximum / node.constants.maxTransactionsPerBlock);
 			node.waitForBlocks(blocksToWait, function (err) {
 				node.async.eachSeries(transactions, function (transaction, eachSeriesCb) {
 					http.get('/api/transactions/get?id=' + transaction.id, function (err, res) {
@@ -94,7 +94,7 @@ describe('postTransactions @slow', function () {
 		});
 
 		it('should confirm all transactions', function (done) {
-			var blocksToWait = Math.ceil(maximum / node.constants.maxTxsPerBlock);
+			var blocksToWait = Math.ceil(maximum / node.constants.maxTransactionsPerBlock);
 			node.waitForBlocks(blocksToWait, function (err) {
 				node.async.eachSeries(transactions, function (transaction, eachSeriesCb) {
 					http.get('/api/transactions/get?id=' + transaction.id, function (err, res) {

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -72,20 +72,20 @@ describe('txPool', function () {
 			});
 		});
 
-		it('should return error when using invalid tx', function (done) {
+		it('should return error when using invalid transaction', function (done) {
 			txPool.receiveTransactions([{ id: '123' }], false, function (err) {
 				expect(err).to.exist;
 				done();
 			});
 		});
 
-		it('should process tx if valid and insert tx into queue', function (done) {
+		it('should process transaction if valid and insert transaction into queue', function (done) {
 			var account = node.randomAccount();
-			const tx = node.lisk.transaction.createTransaction(account.address, 100000000000, node.gAccount.password);
+			const transaction = node.lisk.transaction.createTransaction(account.address, 100000000000, node.gAccount.password);
 
-			txPool.receiveTransactions([tx], false, function (err) {
+			txPool.receiveTransactions([transaction], false, function (err) {
 				expect(err).to.not.exist;
-				expect(txPool.transactionInPool(tx.id)).to.be.true;
+				expect(txPool.transactionInPool(transaction.id)).to.be.true;
 				done();
 			});
 		});

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -72,13 +72,13 @@ describe('blocks/chain', function () {
 
 	describe('saveBlock', function () {
 
-		it('should call library.db.tx');
+		it('should call library.db.transaction');
 
 		it('should call library.logic.block.dbSave');
 
 		it('should call library.logic.block.dbSave with block');
 
-		describe('when library.db.tx callback throws', function () {
+		describe('when library.db.transaction callback throws', function () {
 
 			it('should call logger.error');
 
@@ -87,7 +87,7 @@ describe('blocks/chain', function () {
 			it('should call callback with "Blocks#saveBlock error"');
 		});
 
-		describe('when library.db.tx callback does not throw', function () {
+		describe('when library.db.transaction callback does not throw', function () {
 
 			it('should call __private.afterSave');
 

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -454,7 +454,7 @@ describe('blocks/verify', function () {
 			validBlock.numberOfTransactions = validBlock.transactions.length;
 		});
 
-		it('should fail when transactions length greater than maxTxsPerBlock constant value', function () {
+		it('should fail when transactions length greater than maxTransactionsPerBlock constant value', function () {
 			var transactions = validBlock.transactions;
 			validBlock.transactions = new Array(26);
 			validBlock.numberOfTransactions = validBlock.transactions.length;

--- a/test/unit/modules/multisignatures.js
+++ b/test/unit/modules/multisignatures.js
@@ -43,14 +43,14 @@ describe('multisignatures', function () {
 
 			it('should call modules.transactions.getMultisignatureTransaction');
 
-			it('should call modules.transactions.getMultisignatureTransaction with tx.transaction');
+			it('should call modules.transactions.getMultisignatureTransaction with transaction.transaction');
 
-			describe('when multisignature tx.transaction does not exist', function () {
+			describe('when multisignature transaction.transaction does not exist', function () {
 
 				it('should call callback with error = "Transaction not found"');
 			});
 
-			describe('when multisignature tx.transaction exists', function () {
+			describe('when multisignature transaction.transaction exists', function () {
 
 				it('should call modules.accounts.getAccount');
 
@@ -72,7 +72,7 @@ describe('multisignatures', function () {
 
 						it('should call Multisignature.prototype.ready');
 
-						it('should call Multisignature.prototype.ready with multisignature with signatures containing tx.signature');
+						it('should call Multisignature.prototype.ready with multisignature with signatures containing transaction.signature');
 
 						it('should call Multisignature.prototype.ready with sender');
 
@@ -80,7 +80,7 @@ describe('multisignatures', function () {
 
 						it('should call library.bus.message with "signature"');
 
-						it('should call library.bus.message with {transaction: tx.transaction, signature: tx.signature}');
+						it('should call library.bus.message with {transaction: transaction.transaction, signature: transaction.signature}');
 
 						it('should call library.bus.message with true');
 
@@ -101,14 +101,14 @@ describe('multisignatures', function () {
 
 			it('should call modules.transactions.getMultisignatureTransaction');
 
-			it('should call modules.transactions.getMultisignatureTransaction with tx.transaction');
+			it('should call modules.transactions.getMultisignatureTransaction with transaction.transaction');
 
-			describe('when multisignature tx.transaction does not exist', function () {
+			describe('when multisignature transaction.transaction does not exist', function () {
 
 				it('should call callback with error = "Transaction not found"');
 			});
 
-			describe('when multisignature tx.transaction exists', function () {
+			describe('when multisignature transaction.transaction exists', function () {
 
 				describe('when transaction type != transactionTypes.MULTI', function () {
 
@@ -130,7 +130,7 @@ describe('multisignatures', function () {
 
 						describe('when account exists', function () {
 
-							describe('when multisignature already contains tx.signature', function () {
+							describe('when multisignature already contains transaction.signature', function () {
 
 								it('should call callback with error = "Signature already exists"');
 							});
@@ -143,7 +143,7 @@ describe('multisignatures', function () {
 
 								it('should call library.logic.transaction.verifySignature with account.multisignatures');
 
-								it('should call library.logic.transaction.verifySignature with tx.signature');
+								it('should call library.logic.transaction.verifySignature with transaction.signature');
 
 								describe('when library.logic.transaction.verifySignature throws', function () {
 
@@ -175,7 +175,7 @@ describe('multisignatures', function () {
 						it('should call callback with error = "Permission to sign transaction denied"');
 					});
 
-					describe('when multisignature already contains tx.signature', function () {
+					describe('when multisignature already contains transaction.signature', function () {
 
 						it('should call callback with error = "Permission to sign transaction denied"');
 					});
@@ -188,7 +188,7 @@ describe('multisignatures', function () {
 
 						it('should call library.logic.transaction.verifySignature with keysgroup member');
 
-						it('should call library.logic.transaction.verifySignature with tx.signature');
+						it('should call library.logic.transaction.verifySignature with transaction.signature');
 
 						describe('when library.logic.transaction.verifySignature throws', function () {
 

--- a/test/unit/sql/rounds.js
+++ b/test/unit/sql/rounds.js
@@ -180,12 +180,12 @@ describe('Rounds-related SQL triggers', function () {
 			genesisAccount = library.genesisblock.block.transactions[0].senderId;
 
 			// Get unique accounts from genesis block
-			genesisAccounts = _.reduce(library.genesisblock.block.transactions, function (accounts, tx) {
-				if (tx.senderId && accounts.indexOf(tx.senderId) === -1) {
-					accounts.push(tx.senderId);
+			genesisAccounts = _.reduce(library.genesisblock.block.transactions, function (accounts, transaction) {
+				if (transaction.senderId && accounts.indexOf(transaction.senderId) === -1) {
+					accounts.push(transaction.senderId);
 				}
-				if (tx.recipientId && accounts.indexOf(tx.recipientId) === -1) {
-					accounts.push(tx.recipientId);
+				if (transaction.recipientId && accounts.indexOf(transaction.recipientId) === -1) {
+					accounts.push(transaction.recipientId);
 				}
 				return accounts;
 			}, []);
@@ -483,29 +483,29 @@ describe('Rounds-related SQL triggers', function () {
 		}
 
 		function expectedMemState (transactions) {
-			_.each(transactions, function (tx) {
+			_.each(transactions, function (transaction) {
 				var last_block = library.modules.blocks.lastBlock.get();
 
-				var address = tx.senderId
+				var address = transaction.senderId
 				if (mem_state[address]) {
 					// Update sender
-					mem_state[address].balance -= (tx.fee+tx.amount);
-					mem_state[address].u_balance -= (tx.fee+tx.amount);
+					mem_state[address].balance -= (transaction.fee+transaction.amount);
+					mem_state[address].u_balance -= (transaction.fee+transaction.amount);
 					mem_state[address].blockId = last_block.id;
 					mem_state[address].virgin = 0;
 				}
 
-				address = tx.recipientId;
+				address = transaction.recipientId;
 				if (mem_state[address]) {
 					// Update recipient
-					mem_state[address].balance += tx.amount;
-					mem_state[address].u_balance += tx.amount;
+					mem_state[address].balance += transaction.amount;
+					mem_state[address].u_balance += transaction.amount;
 					mem_state[address].blockId = last_block.id;
 				} else {
 					// Funds sent to new account
 					mem_state[address] = {
 						address: address,
-						balance: tx.amount,
+						balance: transaction.amount,
 						blockId: last_block.id,
 						delegates: null,
 						fees: 0,
@@ -521,7 +521,7 @@ describe('Rounds-related SQL triggers', function () {
 						rewards: '0',
 						secondPublicKey: null,
 						secondSignature: 0,
-						u_balance: tx.amount,
+						u_balance: transaction.amount,
 						u_delegates: null,
 						u_isDelegate: 0,
 						u_multilifetime: 0,
@@ -572,12 +572,12 @@ describe('Rounds-related SQL triggers', function () {
 
 		it('should forge block with 1 TRANSFER transaction to random account, update mem_accounts (native) and delegates (trigger block_insert_delete) tables', function () {
 			var transactions = [];
-			var tx = node.lisk.transaction.createTransaction(
+			var transaction = node.lisk.transaction.createTransaction(
 				node.randomAccount().address,
 				node.randomNumber(100000000, 1000000000),
 				node.gAccount.password
 			);
-			transactions.push(tx);
+			transactions.push(transaction);
 
 			return tickAndValidate(transactions);
 		});
@@ -587,12 +587,12 @@ describe('Rounds-related SQL triggers', function () {
 			var transactions = [];
 
 			for (var i = tx_cnt - 1; i >= 0; i--) {
-				var tx = node.lisk.transaction.createTransaction(
+				var transaction = node.lisk.transaction.createTransaction(
 					node.randomAccount().address,
 					node.randomNumber(100000000, 1000000000),
 					node.gAccount.password
 				);
-				transactions.push(tx);
+				transactions.push(transaction);
 			}
 
 			return tickAndValidate(transactions);
@@ -607,12 +607,12 @@ describe('Rounds-related SQL triggers', function () {
 				++blocks_processed;
 				var transactions = [];
 				for (var t = tx_cnt - 1; t >= 0; t--) {
-					var tx = node.lisk.transaction.createTransaction(
+					var transaction = node.lisk.transaction.createTransaction(
 						node.randomAccount().address,
 						node.randomNumber(100000000, 1000000000),
 						node.gAccount.password
 					);
-					transactions.push(tx);
+					transactions.push(transaction);
 				}
 				node.debug('	Processing block ' + blocks_processed + ' of ' + blocks_cnt + ' with ' + transactions.length + ' transactions');
 
@@ -719,11 +719,11 @@ describe('Rounds-related SQL triggers', function () {
 
 			it('should unvote expected forger of last block of round', function () {
 				var transactions = [];
-				var tx = node.lisk.vote.createVote(
+				var transaction = node.lisk.vote.createVote(
 					node.gAccount.password,
 					['-' + last_block_forger]
 				);
-				transactions.push(tx);
+				transactions.push(transaction);
 
 				return tickAndValidate(transactions)
 					.then(function () {
@@ -791,15 +791,15 @@ describe('Rounds-related SQL triggers', function () {
 						// Fund random account
 						var transactions = [];
 						tmp_account = node.randomAccount();
-						var tx = node.lisk.transaction.createTransaction(tmp_account.address, 5000000000, node.gAccount.password);
-						transactions.push(tx);
+						var transaction = node.lisk.transaction.createTransaction(tmp_account.address, 5000000000, node.gAccount.password);
+						transactions.push(transaction);
 						return tickAndValidate(transactions);
 					})
 					.then(function () {
 						// Register random delegate
 						var transactions = [];
-						var tx = node.lisk.delegate.createDelegate(tmp_account.password, 'my_little_delegate');
-						transactions.push(tx);
+						var transaction = node.lisk.delegate.createDelegate(tmp_account.password, 'my_little_delegate');
+						transactions.push(transaction);
 						return tickAndValidate(transactions);
 					});
 			});
@@ -811,11 +811,11 @@ describe('Rounds-related SQL triggers', function () {
 
 			it('after finishing round, should unvote expected forger of last block of round and vote new delegate', function () {
 				var transactions = [];
-				var tx = node.lisk.vote.createVote(
+				var transaction = node.lisk.vote.createVote(
 					node.gAccount.password,
 					['-' + last_block_forger, '+' + tmp_account.publicKey]
 				);
-				transactions.push(tx);
+				transactions.push(transaction);
 
 				return tickAndValidate(transactions)
 					.then(function () {


### PR DESCRIPTION
Rename usages of `txs` with `transactions` / `transaction`.
Rename usages of `tx` with `transaction`. 
Changes includes code base, comments and tests.
Closes #826.