### PR TITLE
Middleware for new REST API responses - Subtask #225 - Closes #857

### DIFF
--- a/helpers/apiCodes.js
+++ b/helpers/apiCodes.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	SUCCESS: 200,
+	EMPTY_RESOURCES_SUCCESS: 204,
+	ERROR_DEFAULT: 500
+};

--- a/helpers/apiError.js
+++ b/helpers/apiError.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Extends standard Error with a code field.
+ * Extends standard Error with a code field and toJson function.
  * @param {string} message
  * @param {number} code
  * @constructor
@@ -12,5 +12,12 @@ function ApiError (message, code) {
 }
 
 ApiError.prototype = new Error();
+
+ApiError.prototype.toJson = function () {
+	return {
+		message: this.message,
+		code: this.code
+	};
+};
 
 module.exports = ApiError;

--- a/helpers/apiError.js
+++ b/helpers/apiError.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Extends standard Error with a code field.
+ * @param {string} message
+ * @param {number} code
+ * @constructor
+ */
+function ApiError (message, code) {
+	this.message = message;
+	this.code = code;
+}
+
+ApiError.prototype = new Error();
+
+module.exports = ApiError;

--- a/helpers/httpApi.js
+++ b/helpers/httpApi.js
@@ -7,6 +7,7 @@
  * @module helpers/httpApi
  */
 
+var _ = require('lodash');
 var extend = require('extend');
 var checkIpInList = require('./checkIpInList');
 
@@ -192,6 +193,29 @@ function respond (res, err, response) {
 }
 
 /**
+ * Adds code status to responses for every failed request.
+ * Default error code is 500.
+ * Success code is 200.
+ * Success code for empty data is 204.
+ * @param {Object} res
+ * @param {ApiError} err
+ * @param {Object} response
+ */
+function respondWithCode (res, err, response) {
+	if (err) {
+		var DEFAULT_ERROR_CODE = 500;
+		res.code(err.code || DEFAULT_ERROR_CODE).json(err.toJson());
+	} else {
+		var SUCCESS_CODE = 200;
+		var EMPTY_RESOURCES_SUCCESS_CODE = 204;
+		var isResponseEmpty = function (response) {
+			var firstValue = _(response).values().first();
+			return _.isArray(firstValue) && _.isEmpty(firstValue);
+		};
+		return res.code(isResponseEmpty(response) ? EMPTY_RESOURCES_SUCCESS_CODE : SUCCESS_CODE).json(response);
+	}
+}
+/**
  * Register router in express app using default middleware.
  * @param {string} route
  * @param {Object} app
@@ -207,5 +231,6 @@ function registerEndpoint (route, app, router, isLoaded) {
 module.exports = {
 	middleware: middleware,
 	registerEndpoint: registerEndpoint,
-	respond: respond
+	respond: respond,
+	respondWithCode: respondWithCode
 };

--- a/helpers/httpApi.js
+++ b/helpers/httpApi.js
@@ -9,6 +9,7 @@
 
 var _ = require('lodash');
 var extend = require('extend');
+var apiCodes = require('./apiCodes');
 var checkIpInList = require('./checkIpInList');
 
 /**
@@ -203,16 +204,13 @@ function respond (res, err, response) {
  */
 function respondWithCode (res, err, response) {
 	if (err) {
-		var DEFAULT_ERROR_CODE = 500;
-		res.code(err.code || DEFAULT_ERROR_CODE).json(err.toJson());
+		res.code(err.code || apiCodes.ERROR_DEFAULT).json(err.toJson());
 	} else {
-		var SUCCESS_CODE = 200;
-		var EMPTY_RESOURCES_SUCCESS_CODE = 204;
 		var isResponseEmpty = function (response) {
 			var firstValue = _(response).values().first();
 			return _.isArray(firstValue) && _.isEmpty(firstValue);
 		};
-		return res.code(isResponseEmpty(response) ? EMPTY_RESOURCES_SUCCESS_CODE : SUCCESS_CODE).json(response);
+		return res.code(isResponseEmpty(response) ? apiCodes.EMPTY_RESOURCES_SUCCESS : apiCodes.SUCCESS).json(response);
 	}
 }
 /**

--- a/helpers/router.js
+++ b/helpers/router.js
@@ -17,6 +17,7 @@ var Router = function () {
 
 	router.map = function (root, config, options) {
 		var router = this;
+		options = options || {};
 
 		Object.keys(config).forEach(function (params) {
 			var route = params.split(' ');

--- a/helpers/router.js
+++ b/helpers/router.js
@@ -15,7 +15,7 @@ var Router = function () {
 
 	router.use(httpApi.middleware.cors);
 
-	router.map = function (root, config) {
+	router.map = function (root, config, options) {
 		var router = this;
 
 		Object.keys(config).forEach(function (params) {
@@ -29,7 +29,9 @@ var Router = function () {
 					method: req.method,
 					path: req.path
 				};
-				root[config[params]](extend({}, reqRelevantInfo, {'body': route[0] === 'get' ? req.query : req.body}), httpApi.respond.bind(null, res));
+				//ToDo: Remove optional error codes response handler choice as soon as all modules will be conformed to new REST API standards
+				var responseHandler = options.responseWithCode ? httpApi.respondWithCode.bind(null, res) : httpApi.respond.bind(null, res);
+				root[config[params]](extend({}, reqRelevantInfo, {'body': route[0] === 'get' ? req.query : req.body}), responseHandler);
 			});
 		});
 	};

--- a/test/unit/helpers/apiError.js
+++ b/test/unit/helpers/apiError.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var chai = require('chai');
+var expect = require('chai').expect;
+var express = require('express');
+var ApiError = require('../../../helpers/apiError.js');
+
+describe('helpers/apiError', function () {
+
+	var apiError;
+	var validErrorMessage;
+	var validErrorCode;
+
+	beforeEach(function () {
+		validErrorMessage = 'Valid error message';
+		validErrorCode = 501;
+		apiError = new ApiError(validErrorMessage, validErrorCode);
+	});
+
+	describe('constructor', function () {
+
+		it('should be an Error instance', function () {
+			expect(apiError).to.have.instanceOf(Error);
+		});
+
+		it('should assign field message = "Valid error message"', function () {
+			expect(apiError).to.have.property('message').equal(validErrorMessage);
+		});
+
+		it('should assign field code = 501', function () {
+			expect(apiError).to.have.property('code').equal(validErrorCode);
+		});
+	});
+
+	describe('toJson', function () {
+
+		it('should return Object type result', function () {
+			expect(apiError.toJson()).to.be.an('Object');
+		});
+
+		it('should return result containing message = "Valid error message"', function () {
+			expect(apiError.toJson()).to.have.property('message').equal(validErrorMessage);
+		});
+
+		it('should return result containing code = 501', function () {
+			expect(apiError.toJson()).to.have.property('code').equal(validErrorCode);
+		});
+	});
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -9,6 +9,7 @@ var paths = [
 	'./api/ws/workers/rules.js',
 	'./api/ws/workers/slaveToMasterSender.js',
 
+	'./helpers/apiError.js',
 	'./helpers/ed.js',
 	'./helpers/jobs-queue.js',
 	'./helpers/peersManager.js',


### PR DESCRIPTION
Parent issue: #225 
Child issue: #857
Lay out the foundations for REST API messages including status codes. 
In case of API failure, `ApiError` instance should be returned. HTTP middleware will handle error messages return in expected format: `{code: 500, message: 'Error message'}`.
In case of success, but empty result array code 204 is being returned.