### PR TITLE
Fix intermittent cache tests - Closes #954

### DIFF
--- a/helpers/cache.js
+++ b/helpers/cache.js
@@ -33,10 +33,11 @@ module.exports.connect = function (cacheEnabled, config, logger, cb) {
 
 	client.on('error', function (err) {
 		logger.error('Redis:', err);
-		// Only throw an error if cache was enabled in config but were unable to load it properly
+		// Returns redis client so application can continue to try to connect with the redis server, 
+		// and modules/cache can have client reference once it's connected
 		if (!isRedisLoaded) {
 			isRedisLoaded = true;
-			return cb(null, { cacheEnabled: cacheEnabled, client: null });
+			return cb(null, { cacheEnabled: cacheEnabled, client: client });
 		}
 	});
 };

--- a/modules/cache.js
+++ b/modules/cache.js
@@ -65,6 +65,10 @@ Cache.prototype.getJsonForKey = function (key, cb) {
  * @param {function} cb
  */
 Cache.prototype.setJsonForKey = function (key, value, cb) {
+	cb = cb || function () {
+		logger.debug('Cache - Value set for key');
+	};
+
 	logger.debug(['Cache - Set value for key:', key, '| Status:', self.isConnected()].join(' '));
 	if (!self.isConnected()) {
 		return cb(errorCacheDisabled);

--- a/test/functional/http/get/blocks.js
+++ b/test/functional/http/get/blocks.js
@@ -71,8 +71,13 @@ describe('GET /api/blocks', function () {
 
 			return getBlocksPromise(params).then(function (res) {
 				node.expect(res).to.have.nested.property('body.blocks').that.is.an('array');
-				return getJsonForKeyPromise(url + params.join('&')).then(function (response) {
-					node.expect(res.body).to.eql(response);
+				// Check key in cache after, 0, 10, 100 ms, and if value exists in any of this time period we respond with success
+				return node.Promise.all([0, 10, 100].map(function (delay) {
+					return node.Promise.delay(delay).then(function () {
+						return getJsonForKeyPromise(url + params.join('&'));
+					});
+				})).then(function (responses) {
+					node.expect(responses).to.deep.include(res.body);
 				});
 			});
 		});
@@ -101,10 +106,16 @@ describe('GET /api/blocks', function () {
 				.then(function (res) {
 					expectValidNonEmptyBlocks(res);
 					auxResponse = res.body;
-					return getJsonForKeyPromise(url + params.join('&'));
+					// Check key in cache after, 0, 10, 100 ms, and if value exists in any of this time period we respond with success
+					return node.Promise.all([0, 10, 100].map(function (delay) {
+						return node.Promise.delay(delay).then(function () {
+							return getJsonForKeyPromise(url + params.join('&'));
+						});
+					})).then(function (responses) {
+						node.expect(responses).to.deep.include(auxResponse);
+					});
 				})
-				.then(function (response) {
-					node.expect(auxResponse).to.eql(response);
+				.then(function () {
 					return onNewBlockPromise();
 				})
 				.then(function () {

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -58,8 +58,13 @@ describe('GET /api/delegates', function () {
 			return getDelegatesPromise(params).then(function (res) {
 				node.expect(res).to.have.property('success').to.be.ok;
 				node.expect(res).to.have.property('delegates').that.is.an('array');
-				return getJsonForKeyPromise(url + params.join('&')).then(function (response) {
-					node.expect(response).to.eql(res);
+				// Check key in cache after, 0, 10, 100 ms, and if value exists in any of this time period we respond with success
+				return node.Promise.all([0, 10, 100].map(function (delay) {
+					return node.Promise.delay(delay).then(function () {
+						return getJsonForKeyPromise(url + params.join('&'));
+					});
+				})).then(function (responses) {
+					node.expect(responses).to.deep.include(res);
 				});
 			});
 		});
@@ -74,6 +79,7 @@ describe('GET /api/delegates', function () {
 			return getDelegatesPromise(params).then(function (res) {
 				node.expect(res).to.have.property('success').to.be.not.ok;
 				node.expect(res).to.have.property('error').to.equal('Invalid sort field');
+
 				return getJsonForKeyPromise(url + params.join('&')).then(function (response) {
 					node.expect(response).to.eql(null);
 				});
@@ -88,9 +94,15 @@ describe('GET /api/delegates', function () {
 			return getDelegatesPromise(params).then(function (res) {
 				node.expect(res).to.have.property('success').to.be.ok;
 				node.expect(res).to.have.property('delegates').that.is.an('array');
-				return getJsonForKeyPromise(url).then(function (response) {
-					node.expect(response).to.eql(res);
-					return onNewRoundPromise().then(function (res) {
+
+				// Check key in cache after, 0, 10, 100 ms, and if value exists in any of this time period we respond with success
+				return node.Promise.all([0, 10, 100].map(function (delay) {
+					return node.Promise.delay(delay).then(function () {
+						return getJsonForKeyPromise(url + params.join('&'));
+					});
+				})).then(function (responses) {
+					node.expect(responses).to.deep.include(res);
+					return onNewRoundPromise().then(function () {
 						return getJsonForKeyPromise(url).then(function (result) {
 							node.expect(result).to.eql(null);
 						});

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -91,8 +91,13 @@ describe('GET /api/transactions', function () {
 			return getTransactionsPromise(params).then(function (res) {
 				node.expect(res).to.have.property('status').to.equal(200);
 				node.expect(res).to.have.nested.property('body.transactions').that.is.an('array');
-				return getJsonForKeyPromise(url + params.join('&')).then(function (response) {
-					node.expect(response).to.eql(res.body);
+				// Check key in cache after, 0, 10, 100 ms, and if value exists in any of this time period we respond with success
+				return node.Promise.all([0, 10, 100].map(function (delay) {
+					return node.Promise.delay(delay).then(function () {
+						return getJsonForKeyPromise(url + params.join('&'));
+					});
+				})).then(function (responses) {
+					node.expect(responses).to.deep.include(res.body);
 				});
 			});
 		});


### PR DESCRIPTION
There are two issues identified and solved related to cache with this PR: 

1- If the core cannot connect to the cache at bootup, but does so after some time, it does not propagate connection object everywhere it is required. 

2- Under high load, some tests try to read the value before it's set. Which caused tests to fail unexpectedly, and randomly.
 
Closes #954 