### PR TITLE
Update contact information for Isabella

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm test -- test/lib/transactions.js
 - Pavel Nekrasov <landgraf.paul@gmail.com>
 - Sebastian Stupurac <stupurac.sebastian@gmail.com>
 - Oliver Beddows <oliver@lightcurve.io>
-- Isabella Dell <isabella@lightcurve.io>
+- Isabella Dell <dell.isabella@gmail.com>
 - Marius Serek <mariusz@serek.net>
 - Maciej Baj <maciej@lightcurve.io>
 


### PR DESCRIPTION
This is needed to allow contact with one of the copyright holders in the event a change in license is needed in the future.
