### PR TITLE
Example of better database repositories

### DIFF
--- a/db/multisignatures.js
+++ b/db/multisignatures.js
@@ -1,28 +1,24 @@
 'use strict';
 
-var PQ = require('pg-promise').ParameterizedQuery;
+const PQ = require('pg-promise').ParameterizedQuery;
 
-function MultisignaturesRepo (db, pgp) {
-	this.db = db;
-	this.pgp = pgp;
-}
-
-var Queries = {
+const queries = {
 	getMultisignatureMemberPublicKeys: new PQ('SELECT ARRAY_AGG("dependentId") AS "memberAccountKeys" FROM mem_accounts2multisignatures WHERE "accountId" = $1'),
-
-	getMultisignatureGroupIds: new PQ('SELECT ARRAY_AGG("accountId") AS "groupAccountIds" FROM mem_accounts2multisignatures WHERE "dependentId" = $1'),
+	getMultisignatureGroupIds: new PQ('SELECT ARRAY_AGG("accountId") AS "groupAccountIds" FROM mem_accounts2multisignatures WHERE "dependentId" = $1')
 };
 
-MultisignaturesRepo.prototype.getMultisignatureMemberPublicKeys = function (address) {
-	return this.db.one(Queries.getMultisignatureMemberPublicKeys, [address]).then(function (result) {
-		return result.memberAccountKeys;
-	});
-};
+class MultisignaturesRepo {
+	constructor(db) {
+		this.db = db;
+	}
+	
+	getMultisignatureMemberPublicKeys(address) {
+		return this.db.one(queries.getMultisignatureMemberPublicKeys, address, a => a.memberAccountKeys);
+	}
 
-MultisignaturesRepo.prototype.getMultisignatureGroupIds = function (publicKey) {
-	return this.db.one(Queries.getMultisignatureGroupIds, [publicKey]).then(function (result) {
-		return result.groupAccountIds;
-	});
-};
+	getMultisignatureGroupIds(publicKey) {
+		return this.db.one(queries.getMultisignatureGroupIds, publicKey, a => a.groupAccountIds);
+	}
+}
 
 module.exports = MultisignaturesRepo;


### PR DESCRIPTION
Just an example of writing better database repositories, using ES6 syntax.

`pgp` isn't necessary to pass in, and in repositories that do need it, it can be accessed via `db.$config.pgp`, see property [$config](http://vitaly-t.github.io/pg-promise/Database.html#$config).
  