### PR TITLE
Reduce DB connections during test runs - Closes #1102

### DIFF
--- a/test/data/config.json
+++ b/test/data/config.json
@@ -17,8 +17,8 @@
         "database": "lisk_test",
         "user": "",
         "password": "password",
-        "min": 10,
-        "max": 95,
+        "min": 1,
+        "max": 9,
         "poolIdleTimeout": 30000,
         "reapIntervalMillis": 1000,
         "logEvents": [

--- a/test/integration/configs/config.non-forge.json
+++ b/test/integration/configs/config.non-forge.json
@@ -16,7 +16,8 @@
         "database": "lisk_local",
         "user": "",
         "password": "password",
-        "poolSize": 95,
+        "min": 1,
+        "max": 9,
         "poolIdleTimeout": 30000,
         "reapIntervalMillis": 1000,
         "logEvents": [


### PR DESCRIPTION
Closes: #1102 

As far as I can tell the issue is primarily how the connection pooling is configured (with a min size of 50 connections), so this results in either having to increase the allowed limit Postgres accepts (which involves tuning memory limits as well etc) or reduce the configured connection pool size. With this PR I've opted for the later!

I've also suggested an update to the parallel test runner because it spawns ALL tests in one go which also creates the same connection issue. This change limits it to run 20 tests in parallel at any one time.

Obviously any feedback and suggestions welcome.