### PR TITLE
Correct setListeners error handling in helpers/pg-notify.js

### DIFF
--- a/helpers/pg-notify.js
+++ b/helpers/pg-notify.js
@@ -125,7 +125,7 @@ function reconnect (delay, maxAttempts) {
 					connection = obj;
 					setListeners(obj.client, function (err) {
 						if (err) {
-							reject(err);
+							throw err;
 						} else {
 							resolve(obj);
 						}


### PR DESCRIPTION
You do not want to stop all attempts at that point, you just want to move on to the next attempt, hence the change.

Actually, not sure that'll be enough, since you are using a callback inside `setListeners`. Should probably just follow the [original pattern](https://github.com/vitaly-t/pg-promise/wiki/Robust-Listeners) :wink: Mixing promises with callbacks like that is not a good idea.
