### PR TITLE
replace usage of sinon.stub with sinon.stub()

### DIFF
--- a/test/unit/logic/inTransfer.js
+++ b/test/unit/logic/inTransfer.js
@@ -33,7 +33,7 @@ var validSender = {
 var senderHash = crypto.createHash('sha256').update(validSender.password, 'utf8').digest();
 var senderKeypair = ed.makeKeypair(senderHash);
 
-var validTransaction =  { 
+var validTransaction =  {
 	id: '2273003018673898961',
 	height: 843,
 	blockId: '11870363750006389009',
@@ -88,7 +88,7 @@ describe('inTransfer', function () {
 	var accountsStub;
 
 	var trs;
-	var rawTrs; 
+	var rawTrs;
 	var sender;
 	var dummyBlock;
 
@@ -379,7 +379,7 @@ describe('inTransfer', function () {
 		describe('when shared.getGenesis fails', function () {
 
 			beforeEach(function () {
-				sharedStub.getGenesis = sinon.stub.callsArgWith(1, 'getGenesis error');
+				sharedStub.getGenesis = sinon.stub().callsArgWith(1, 'getGenesis error');
 			});
 
 			it('should call callback with error', function () {
@@ -392,7 +392,7 @@ describe('inTransfer', function () {
 		describe('when shared.getGenesis succeeds', function () {
 
 			beforeEach(function () {
-				sharedStub.getGenesis = sinon.stub.callsArg(1);
+				sharedStub.getGenesis = sinon.stub().callsArg(1);
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {
@@ -424,7 +424,7 @@ describe('inTransfer', function () {
 				beforeEach(function () {
 					accountsStub.mergeAccountAndGet = sinon.stub().callsArgWith(1, 'mergeAccountAndGet error');
 				});
-				
+
 				it('should call callback with error', function () {
 					inTransfer.apply(trs, dummyBlock, sender, function (err) {
 						expect(err).not.to.be.empty;
@@ -466,7 +466,7 @@ describe('inTransfer', function () {
 		describe('when shared.getGenesis fails', function () {
 
 			beforeEach(function () {
-				sharedStub.getGenesis = sinon.stub.callsArgWith(1, 'getGenesis error');
+				sharedStub.getGenesis = sinon.stub().callsArgWith(1, 'getGenesis error');
 			});
 
 			it('should call callback with error', function () {
@@ -479,7 +479,7 @@ describe('inTransfer', function () {
 		describe('when shared.getGenesis succeeds', function () {
 
 			beforeEach(function () {
-				sharedStub.getGenesis = sinon.stub.callsArg(1);
+				sharedStub.getGenesis = sinon.stub().callsArg(1);
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {

--- a/test/unit/logic/outTransfer.js
+++ b/test/unit/logic/outTransfer.js
@@ -460,7 +460,7 @@ describe('outTransfer', function () {
 		describe('when modules.accounts.setAccountAndGet fails', function () {
 
 			beforeEach(function () {
-				accountsStub.setAccountAndGet = sinon.stub.callsArgWith(1, 'setAccountAndGet error');
+				accountsStub.setAccountAndGet = sinon.stub().callsArgWith(1, 'setAccountAndGet error');
 			});
 
 			it('should call callback with error', function () {
@@ -473,7 +473,7 @@ describe('outTransfer', function () {
 		describe('when modules.accounts.setAccountAndGet succeeds', function () {
 
 			beforeEach(function () {
-				accountsStub.setAccountAndGet = sinon.stub.callsArg(1);
+				accountsStub.setAccountAndGet = sinon.stub().callsArg(1);
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {
@@ -552,7 +552,7 @@ describe('outTransfer', function () {
 		describe('when modules.accounts.setAccountAndGet fails', function () {
 
 			beforeEach(function () {
-				accountsStub.setAccountAndGet = sinon.stub.callsArgWith(1, 'setAccountAndGet error');
+				accountsStub.setAccountAndGet = sinon.stub().callsArgWith(1, 'setAccountAndGet error');
 			});
 
 			it('should call callback with error', function () {
@@ -565,7 +565,7 @@ describe('outTransfer', function () {
 		describe('when modules.accounts.setAccountAndGet succeeds', function () {
 
 			beforeEach(function () {
-				accountsStub.setAccountAndGet = sinon.stub.callsArg(1);
+				accountsStub.setAccountAndGet = sinon.stub().callsArg(1);
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {

--- a/test/unit/modules/loader.js
+++ b/test/unit/modules/loader.js
@@ -33,7 +33,7 @@ describe('loader', function () {
 						transaction: sinon.mock(),
 						account: sinon.mock(),
 						peers: {
-							create: sinon.stub.returnsArg(0)
+							create: sinon.stub().returnsArg(0)
 						}
 					}
 				}),


### PR DESCRIPTION
As @nazarhussain mentioned:
Using `sinon.stub` produces tests with false positives because the stubbed functions are assigned to the stub generator, and not actually stubbed. 
`var stub = sinon.stub();` is the suggested notation from the `sinon` docs.