### PR TITLE
Redirect pg-monitor logs to seperate file - Closes #1185

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,6 +124,17 @@ var config = {
 var logger = new Logger({ echo: appConfig.consoleLogLevel, errorLevel: appConfig.fileLogLevel,
 	filename: appConfig.logFileName });
 
+var dbLogger = null;
+
+if (appConfig.db.logFileName && appConfig.db.logFileName === appConfig.logFileName) {
+	dbLogger = logger;
+} else {
+	dbLogger = new Logger({
+		echo: appConfig.db.consoleLogLevel || appConfig.consoleLogLevel,
+		errorLevel: appConfig.db.fileLogLevel || appConfig.fileLogLevel,
+		filename: appConfig.db.logFileName });
+}
+
 // Trying to get last git commit
 try {
 	lastCommit = git.getLastCommit();
@@ -420,7 +431,7 @@ d.run(function () {
 		}],
 		db: function (cb) {
 			var db = require('./helpers/database.js');
-			db.connect(config.db, logger, cb);
+			db.connect(config.db, dbLogger, cb);
 		},
 		/**
 		 * It tries to connect with redis server based on config. provided in config.json file

--- a/app.js
+++ b/app.js
@@ -132,7 +132,8 @@ if (appConfig.db.logFileName && appConfig.db.logFileName === appConfig.logFileNa
 	dbLogger = new Logger({
 		echo: appConfig.db.consoleLogLevel || appConfig.consoleLogLevel,
 		errorLevel: appConfig.db.fileLogLevel || appConfig.fileLogLevel,
-		filename: appConfig.db.logFileName });
+		filename: appConfig.db.logFileName
+	});
 }
 
 // Trying to get last git commit

--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
     "logEvents": [
       "error"
     ],
-	"logFileName": "logs/lisk_db.log"
+    "logFileName": "logs/lisk_db.log"
   },
   "redis": {
     "host": "127.0.0.1",

--- a/config.json
+++ b/config.json
@@ -23,7 +23,8 @@
     "reapIntervalMillis": 1000,
     "logEvents": [
       "error"
-    ]
+    ],
+	"logFileName": "logs/lisk_db.log"
   },
   "redis": {
     "host": "127.0.0.1",

--- a/schema/config.js
+++ b/schema/config.js
@@ -93,6 +93,15 @@ module.exports = {
 					},
 					logEvents: {
 						type: 'array'
+					},
+					logFileName: {
+						type: 'string'
+					},
+					consoleLogLevel: {
+						type: 'string'
+					},
+					fileLogLevel: {
+						type: 'string'
 					}
 				},
 				required: ['host', 'port', 'database', 'user', 'password', 'min', 'max', 'poolIdleTimeout', 'reapIntervalMillis', 'logEvents']

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -23,7 +23,8 @@
         "reapIntervalMillis": 1000,
         "logEvents": [
             "error"
-        ]
+        ],
+	  	"logFileName": "logs/lisk_db.log"
     },
     "redis": {
         "host": "127.0.0.1",

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -24,7 +24,7 @@
         "logEvents": [
             "error"
         ],
-	  	"logFileName": "logs/lisk_db.log"
+        "logFileName": "logs/lisk_db.log"
     },
     "redis": {
         "host": "127.0.0.1",


### PR DESCRIPTION
Closes: #1185 

NOTE: If new configuration added is not provided it will inherit from the existing log configurations. 