### PR TITLE
Peers discovery process fails due to unsuccessful peers list validation - Closes #1263

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -192,10 +192,13 @@ __private.updatePeerStatus = function (err, status, peer) {
 		}
 	} else {
 		peer.applyHeaders({
-			height: status.height,
 			broadhash: status.broadhash,
+			height: status.height,
+			httpPort: status.httpPort,
 			nonce: status.nonce,
-			state: Peer.STATE.CONNECTED //connected
+			os: status.os,
+			state: Peer.STATE.CONNECTED,
+			version: status.version
 		});
 	}
 

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -526,7 +526,16 @@ Transport.prototype.shared = {
 	},
 
 	status: function (req, cb) {
-		return setImmediate(cb, null, {success: true, height: modules.system.getHeight(), broadhash: modules.system.getBroadhash(), nonce: modules.system.getNonce()});
+		var headers = modules.system.headers();
+		return setImmediate(cb, null, {
+			success: true,
+			height: headers.height,
+			broadhash: headers.broadhash,
+			nonce: headers.nonce,
+			httpPort: headers.httpPort,
+			version: headers.version,
+			os: headers.os
+		});
 	},
 
 	postSignatures: function (query, cb) {

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1766,14 +1766,8 @@ definitions:
     type: object
     required:
       - ip
-      - httpPort
       - wsPort
-      - os
-      - version
       - state
-      - height
-      - broadhash
-      - nonce
     properties:
       ip:
         type: string

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1766,7 +1766,14 @@ definitions:
     type: object
     required:
       - ip
+      - httpPort
       - wsPort
+      - os
+      - version
+      - state
+      - height
+      - broadhash
+      - nonce
     properties:
       ip:
         type: string

--- a/test/functional/ws/transport.js
+++ b/test/functional/ws/transport.js
@@ -168,12 +168,15 @@ describe('RPC', function () {
 
 	describe('status', function () {
 
-		it('should return height and broadhash', function (done) {
+		it('should return height, broadhash, nonce, os, version and httpPort', function (done) {
 			clientSocket.wampSend('status')
 				.then(function (result) {
 					expect(result).to.have.property('success').to.be.ok;
 					expect(result).to.have.property('broadhash').that.is.a('string');
 					expect(result).to.have.property('nonce').that.is.a('string');
+					expect(result).to.have.property('os').that.is.a('string');
+					expect(result).to.have.property('version').that.is.a('string');
+					expect(result).to.have.property('httpPort').that.is.a('number');
 					expect(result).to.have.property('height').that.is.a('number').at.least(1);
 					done();
 				}).catch(function (err) {


### PR DESCRIPTION
### What was the problem?
Peers discovery process was failing on the `rpc.peers` results validation. Not all peers on the list are were containing all of the headers - after receiving information about peers in initial peers sync process, peer was stored with incomplete information: version, httpPort and os were missing.
### How did I fix it?
To standardize peers data received in discovery and sync process, I extended `rpc.status` response to contain the missing headers.
### How to test it?
Start peers discovery process by establishing connection with min 2 peers.
### Review checklist

* The PR solves #1263
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
