### PR TITLE
Increase database logging information for test config - Closes #1313

### DIFF
--- a/test/data/config.json
+++ b/test/data/config.json
@@ -22,6 +22,11 @@
         "poolIdleTimeout": 30000,
         "reapIntervalMillis": 1000,
         "logEvents": [
+            "connect",
+            "disconnect",
+            "query",
+            "task",
+            "transact",
             "error"
         ],
         "logFileName": "logs/lisk_db.log"


### PR DESCRIPTION
### What was the problem?

We were only logging errors to the db log file in test environments

### How did I fix it?

By adding all the events available to [pg-monitor](https://github.com/vitaly-t/pg-monitor)

### How to test it?

Run some tests and look inside logs/lisk_db.log

### Review checklist

* The PR solves #1313 