### PR TITLE
Fix transaction receiving logic for batch of transactions - Closes #1228

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -872,6 +872,8 @@ paths:
           required: true
           schema:
             type: array
+            maxItems: 1
+            minItems: 1
             items:
               $ref: '#/definitions/Transaction'
       responses:

--- a/test/common/helpers/api.js
+++ b/test/common/helpers/api.js
@@ -161,20 +161,22 @@ function normalizeTransactionObject (transaction) {
 	return transaction;
 }
 
+var postTransactionsEndpoint = new swaggerSpec('POST /transactions');
+
 function sendTransactionPromise (transaction, expectedStatusCode) {
 	expectedStatusCode = expectedStatusCode || 200;
 
 	transaction = normalizeTransactionObject(transaction);
 
-	return new swaggerSpec('POST /transactions').makeRequest({transactions: [transaction]}, expectedStatusCode);
+	return postTransactionsEndpoint.makeRequest({transactions: [transaction]}, expectedStatusCode);
 }
 
 function sendTransactionsPromise (transactions, expectedStatusCode) {
 	expectedStatusCode = expectedStatusCode || 200;
 
-	transactions = _.map(transactions, normalizeTransactionObject);
-
-	return new swaggerSpec('POST /transactions').makeRequest({transactions: transactions}, expectedStatusCode);
+	return Promise.map(transactions, function (transaction) {
+		return sendTransactionPromise(transaction, expectedStatusCode);
+	});
 }
 
 function sendSignature (signature, transaction, cb) {

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -92,18 +92,19 @@ describe('GET /delegates', function () {
 			var delegateTransaction = lisk.delegate.createDelegate(secondSecretAccount.password, secondSecretAccount.username);
 
 			before(function () {
-				return apiHelpers.sendTransactionsPromise([creditTransaction]).then(function (res) {
+				return apiHelpers.sendTransactionPromise(creditTransaction).then(function (res) {
 					res.statusCode.should.be.eql(200);
 					return waitFor.confirmations([creditTransaction.id]);
 				}).then(function () {
 					return apiHelpers.sendTransactionsPromise([signatureTransaction, delegateTransaction]);
 				}).then(function (res) {
-					res.statusCode.should.be.eql(200);
+					res[0].statusCode.should.be.eql(200);
+					res[1].statusCode.should.be.eql(200);
 					return waitFor.confirmations([signatureTransaction.id, delegateTransaction.id]);
 				});
 			});
 
-			it('using no secondPublicKey should return an empty array', function () {
+			it.only('using no secondPublicKey should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({secondPublicKey: ''}, 200).then(function (res) {
 					res.body.data.should.be.empty;
 				});

--- a/test/functional/http/get/node.transactions.unconfirmed.js
+++ b/test/functional/http/get/node.transactions.unconfirmed.js
@@ -19,7 +19,6 @@ var randomUtil = require('../../../common/utils/random');
 var swaggerEndpoint = require('../../../common/swaggerSpec');
 var expectSwaggerParamError = apiHelpers.expectSwaggerParamError;
 var sendTransactionPromise = apiHelpers.sendTransactionPromise;
-var sendTransactionsPromise = apiHelpers.sendTransactionsPromise;
 var accountFixtures = require('../../../fixtures/accounts');
 var Promise = require('bluebird');
 

--- a/test/functional/http/get/node.transactions.unprocessed.js
+++ b/test/functional/http/get/node.transactions.unprocessed.js
@@ -19,7 +19,6 @@ var randomUtil = require('../../../common/utils/random');
 var swaggerEndpoint = require('../../../common/swaggerSpec');
 var expectSwaggerParamError = apiHelpers.expectSwaggerParamError;
 var sendTransactionPromise = apiHelpers.sendTransactionPromise;
-var sendTransactionsPromise = apiHelpers.sendTransactionsPromise;
 var accountFixtures = require('../../../fixtures/accounts');
 var Promise = require('bluebird');
 

--- a/test/functional/http/get/node.transactions.unsigned.js
+++ b/test/functional/http/get/node.transactions.unsigned.js
@@ -19,7 +19,6 @@ var randomUtil = require('../../../common/utils/random');
 var swaggerEndpoint = require('../../../common/swaggerSpec');
 var expectSwaggerParamError = apiHelpers.expectSwaggerParamError;
 var sendTransactionPromise = apiHelpers.sendTransactionPromise;
-var sendTransactionsPromise = apiHelpers.sendTransactionsPromise;
 var accountFixtures = require('../../../fixtures/accounts');
 var Promise = require('bluebird');
 var normalizer = require('../../../common/utils/normalizer');

--- a/test/functional/http/post/4.multisig.js
+++ b/test/functional/http/post/4.multisig.js
@@ -73,8 +73,10 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 			}
 		});
 
-		return apiHelpers.sendTransactionsPromise(transactions).then(function (res) {
-			res.body.data.message.should.be.equal('Transaction(s) accepted');
+		return apiHelpers.sendTransactionsPromise(transactions).then(function (responses) {
+			responses.map(function (res) {
+				res.body.data.message.should.be.equal('Transaction(s) accepted');
+			});
 			transactionsToWaitFor = transactionsToWaitFor.concat(_.map(transactions, 'id'));
 
 			return waitFor.confirmations(transactionsToWaitFor);

--- a/test/functional/http/post/transactions.js
+++ b/test/functional/http/post/transactions.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+'use strict';
+var randomUtil = require('../../../common/utils/random');
+var swaggerSpec = require('../../../common/swaggerSpec');
+var expectSwaggerParamError = require('../../../common/helpers/api').expectSwaggerParamError;
+
+describe('POST /api/transactions (general)', function () {
+
+	var transactionsEndpoint = new swaggerSpec('POST /transactions');
+
+	it('should fail if empty transactions posted', function () {
+		return transactionsEndpoint.makeRequest({transactions: []}, 400).then(function (res) {
+			expectSwaggerParamError(res, 'transactions');
+			res.body.errors[0].errors[0].code.should.be.equal('ARRAY_LENGTH_SHORT');
+		});
+	});
+
+	it('should fail on more than one transactions at a time', function () {
+		return transactionsEndpoint.makeRequest({transactions: [randomUtil.transaction(), randomUtil.transaction()]}, 400).then(function (res) {
+			expectSwaggerParamError(res, 'transactions');
+			res.body.errors[0].errors[0].code.should.be.equal('ARRAY_LENGTH_LONG');
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

When multiple transactions are posted, these are not processed immediately in request cycle. So user always get 200 response, although some of those transactions can failed while during processing. 

### How did I fix it?

Based on discussion, we decided that for now we will restrict POST /api/transactions to accept ONLY ONE transaction in the body. While the body param still remain to be ARRAY So that we can improve it later without impacting end users a lot.

### How to test it?

Post transactions to `/api/transactions` endpoint. It should fail with 400 error code if its an empty request as well as request contains more than one transactions. Also covered in `test/functional/http/post/transactions.js`

### Review checklist

* The PR solves #1228 
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated