### PR TITLE
Blocks list is being verified against the wrong schema - Closes #1287

### DIFF
--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -413,7 +413,7 @@ Process.prototype.loadBlocksFromPeer = function (peer, cb) {
 	}
 
 	function validateBlocks (blocks, seriesCb) {
-		var report = library.schema.validate(blocks, definitions.BlocksList);
+		var report = library.schema.validate(blocks, definitions.WSBlocksList);
 
 		if (!report) {
 			return setImmediate(seriesCb, 'Received invalid blocks data');

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1628,12 +1628,6 @@ definitions:
         format: id
         example: "15918760246746894806"
 
-  BlocksList:
-    x-private: true
-    type: array
-    items:
-      $ref: '#/definitions/Block'
-
   ForgingStatus:
     type: object
     required:
@@ -2448,6 +2442,12 @@ definitions:
           $ref: '#/definitions/Signature'
         minItems: 1
         maxItems: 25
+
+  WSBlocksList:
+    x-private: true
+    type: array
+    items:
+      type: object
 
   WSBlocksCommonRequest:
     x-private: true


### PR DESCRIPTION
### What was the problem?
`modules/blocks/Process.prototype.loadBlocksFromPeer` was validating individual attributes of the received blocks against wrong schema. 

### How did I fix it?
Looked into previous implementation and found we were not validating the individual attributes of block instead was just checking is the response is an array. So reverted it. 

### How to test it?
Invoke loading common blocks procedure.

### Review checklist

* The PR solves #1287
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
