### PR TITLE
Use "should" instead of "expect" for assertions - Closes #1295

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,6 @@
 	"globals": {
 		"_": true,
 		"__testContext": true,
-		"expect": true,
 		"gc": true,
 		"should": true,
 		"sinonSandbox": true

--- a/test/common/application.js
+++ b/test/common/application.js
@@ -316,7 +316,7 @@ function __init (initScope, done) {
 				loadDelegates(function (err) {
 					var keypairs = scope.rewiredModules.delegates.__get__('__private.keypairs');
 					var delegates_cnt = Object.keys(keypairs).length;
-					expect(delegates_cnt).to.equal(__testContext.config.forging.secret.length);
+					delegates_cnt.should.equal(__testContext.config.forging.secret.length);
 
 					__testContext.debug('initApplication: Delegates loaded from config file - ' + delegates_cnt);
 					__testContext.debug('initApplication: Done');

--- a/test/functional/http/get/accounts.multisignatures.js
+++ b/test/functional/http/get/accounts.multisignatures.js
@@ -39,14 +39,14 @@ describe('GET /api/accounts', function () {
 		// Crediting accounts
 		return apiHelpers.sendTransactionPromise(scenario.creditTransaction)
 			.then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
+				res.should.have.property('status').to.equal(200);
 				return waitFor.confirmations([scenario.creditTransaction.id]);
 			})
 			.then(function (res) {
 				return apiHelpers.sendTransactionPromise(scenario.multiSigTransaction);
 			})
 			.then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
+				res.should.have.property('status').to.equal(200);
 
 				var signatures = [];
 				scenario.members.map(function (member) {

--- a/test/functional/http/get/cache.js
+++ b/test/functional/http/get/cache.js
@@ -33,16 +33,16 @@ describe('cached endpoints', function () {
 		modulesLoader.initCache(function (err, __cache) {
 			cache = __cache;
 			getJsonForKeyPromise = Promise.promisify(cache.getJsonForKey);
-			expect(err).to.not.exist;
-			expect(__cache).to.be.an('object');
+			should.not.exist(err);
+			__cache.should.be.an('object');
 			return done(err);
 		});
 	});
 
 	afterEach(function (done) {
 		cache.flushDb(function (err, status) {
-			expect(err).to.not.exist;
-			expect(status).to.equal('OK');
+			should.not.exist(err);
+			status.should.equal('OK');
 			done(err);
 		});
 	});
@@ -67,7 +67,7 @@ describe('cached endpoints', function () {
 						return getJsonForKeyPromise(res.req.path);
 					});
 				})).then(function (responses) {
-					expect(responses).to.deep.include(res.body);
+					responses.should.deep.include(res.body);
 				});
 			});
 		});
@@ -78,11 +78,11 @@ describe('cached endpoints', function () {
 			};
 
 			return transactionsEndpoint.makeRequest(params, 400).then(function (res) {
-				expect(res).to.have.property('status').to.equal(400);
-				expect(res).to.have.nested.property('body.message');
+				res.should.have.property('status').to.equal(400);
+				res.should.have.nested.property('body.message');
 
 				return getJsonForKeyPromise(res.req.path).then(function (response) {
-					expect(response).to.eql(null);
+					should.not.exist(response);
 				});
 			});
 		});
@@ -122,7 +122,7 @@ describe('cached endpoints', function () {
 				expectSwaggerParamError(res, 'height');
 				return getJsonForKeyPromise(res.req.path);
 			}).then(function (response) {
-				expect(response).to.eql(null);
+				should.not.exist(response);
 			});
 		});
 
@@ -147,7 +147,7 @@ describe('cached endpoints', function () {
 			}).then(function () {
 				return getJsonForKeyPromise(initialResponse.req.path);
 			}).then(function (result) {
-				expect(result).to.eql(null);
+				should.not.exist(result);
 			});
 		});
 	});
@@ -178,7 +178,7 @@ describe('cached endpoints', function () {
 
 			return delegatesEndpoint.makeRequest(params, 400).then(function (res) {
 				return getJsonForKeyPromise(res.req.path).then(function (response) {
-					expect(response).to.not.exist;
+					should.not.exist(response);
 				});
 			});
 		});
@@ -200,7 +200,7 @@ describe('cached endpoints', function () {
 					responses.should.deep.include(res.body);
 					return onNewRoundPromise().then(function () {
 						return getJsonForKeyPromise(urlPath).then(function (result) {
-							expect(result).to.not.exist;
+							should.not.exist(result);
 						});
 					});
 				});

--- a/test/functional/http/get/dapps.js
+++ b/test/functional/http/get/dapps.js
@@ -43,7 +43,7 @@ describe('GET /dapps', function () {
 		transactionsToWaitFor.push(transaction.id);
 		return apiHelpers.sendTransactionPromise(transaction)
 			.then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
+				res.should.have.property('status').to.equal(200);
 				return waitFor.confirmations(transactionsToWaitFor);
 			}).then(function () {
 				transactionsToWaitFor = [];
@@ -58,7 +58,7 @@ describe('GET /dapps', function () {
 				return Promise.all(promises);
 			}).then(function (results) {
 				results.forEach(function (res) {
-					expect(res).to.have.property('status').to.equal(200);
+					res.should.have.property('status').to.equal(200);
 				});
 				return waitFor.confirmations(transactionsToWaitFor);
 			});
@@ -232,7 +232,7 @@ describe('GET /dapps', function () {
 				return Promise.all(promises)
 					.then(function (results) {
 						results.forEach(function (res) {
-							expect(res).to.have.property('status').to.equal(200);
+							res.should.have.property('status').to.equal(200);
 						});
 						return waitFor.confirmations(transactionsToWaitFor);
 					});
@@ -256,7 +256,7 @@ describe('GET /dapps', function () {
 					var cloneObtainedArray = _.clone(obtainedArray);
 					var expectedArray = cloneObtainedArray.sort();
 
-					expect(expectedArray).eql(obtainedArray);
+					expectedArray.should.eql(obtainedArray);
 				});
 			});
 
@@ -266,7 +266,7 @@ describe('GET /dapps', function () {
 					var cloneObtainedArray = _.clone(obtainedArray);
 					var expectedArray = cloneObtainedArray.sort().reverse();
 
-					expect(expectedArray).eql(obtainedArray);
+					expectedArray.should.eql(obtainedArray);
 				});
 			});
 		});

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -535,8 +535,8 @@ describe('GET /api/transactions', function () {
 							dividedIndices.notNullIndices.sort(ascOrder);
 							dividedIndices.nullIndices.sort(ascOrder);
 
-							expect(dividedIndices.notNullIndices[dividedIndices.notNullIndices.length - 1])
-								.to.be.at.most(dividedIndices.nullIndices[0]);
+							dividedIndices.notNullIndices[dividedIndices.notNullIndices.length - 1]
+								.should.be.at.most(dividedIndices.nullIndices[0]);
 						}
 					});
 				});

--- a/test/functional/http/post/0.transfer.js
+++ b/test/functional/http/post/0.transfer.js
@@ -43,7 +43,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 		typesRepresentatives.allTypes.forEach(function (test) {
 			it('using ' + test.description + ' should fail', function () {
 				return sendTransactionPromise(test.input, 400).then(function (res) {
-					expect(res).to.have.nested.property('body.message').that.is.not.empty;
+					res.should.have.nested.property('body.message').that.is.not.empty;
 				});
 			});
 		});

--- a/test/functional/http/post/1.X.validation/common.js
+++ b/test/functional/http/post/1.X.validation/common.js
@@ -27,8 +27,8 @@ function beforeValidationPhase (account) {
 
 		return apiHelpers.sendTransactionPromise(transaction)
 			.then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
-				expect(res).to.have.nested.property('body.data.message').that.is.equal('Transaction(s) accepted');
+				res.should.have.property('status').to.equal(200);
+				res.should.have.nested.property('body.data.message').that.is.equal('Transaction(s) accepted');
 
 				return waitFor.confirmations([transaction.id]);
 			})
@@ -38,8 +38,8 @@ function beforeValidationPhase (account) {
 				return apiHelpers.sendTransactionPromise(transaction);
 			})
 			.then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
-				expect(res).to.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
+				res.should.have.property('status').to.equal(200);
+				res.should.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
 
 				return waitFor.confirmations([transaction.id]);
 			});

--- a/test/functional/http/post/4.X.validation/common.js
+++ b/test/functional/http/post/4.X.validation/common.js
@@ -36,8 +36,8 @@ function beforeValidationPhase (scenarios) {
 			transactionsToWaitFor.push(transaction.id);
 
 			return apiHelpers.sendTransactionPromise(transaction).then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
-				expect(res).to.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
+				res.should.have.property('status').to.equal(200);
+				res.should.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
 			});
 		}))
 			.then(function () {
@@ -50,8 +50,8 @@ function beforeValidationPhase (scenarios) {
 					transactionsToWaitFor.push(transaction.id);
 
 					return apiHelpers.sendTransactionPromise(transaction).then(function (res) {
-						expect(res).to.have.property('status').to.equal(200);
-						expect(res).to.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
+						res.should.have.property('status').to.equal(200);
+						res.should.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
 					});
 				}));
 			})
@@ -103,8 +103,8 @@ function sendAndSignMultisigTransaction (type, scenario) {
 
 	return apiHelpers.sendTransactionPromise(transaction)
 		.then(function (res) {
-			expect(res).to.have.property('status').to.equal(200);
-			expect(res).to.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
+			res.should.have.property('status').to.equal(200);
+			res.should.have.nested.property('body.data.message').to.equal('Transaction(s) accepted');
 		})
 		.then(function () {
 			var signatures = [];

--- a/test/functional/http/post/4.multisig.js
+++ b/test/functional/http/post/4.multisig.js
@@ -360,7 +360,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 
 					return signatureEndpoint.makeRequest({signatures: [signature]}, apiCodes.PROCESSING_ERROR);
 				}).then(function (res) {
-					expect(res).to.have.nested.property('body.message').to.equal('Error processing signature: Permission to sign transaction denied');
+					res.should.have.nested.property('body.message').to.equal('Error processing signature: Permission to sign transaction denied');
 				});
 			});
 
@@ -368,7 +368,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				var signature = apiHelpers.createSignatureObject(scenarios.unsigned.multiSigTransaction, randomUtil.account());
 
 				return signatureEndpoint.makeRequest({signatures: [signature]}, apiCodes.PROCESSING_ERROR).then(function (res) {
-					expect(res).to.have.nested.property('body.message').to.equal('Error processing signature: Failed to verify signature');
+					res.should.have.nested.property('body.message').to.equal('Error processing signature: Failed to verify signature');
 				});
 			});
 		});

--- a/test/functional/http/post/5.dapps.js
+++ b/test/functional/http/post/5.dapps.js
@@ -62,7 +62,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 		return Promise.all(promises)
 			.then(function (results) {
 				results.forEach(function (res) {
-					expect(res).to.have.property('status').to.equal(200);
+					res.should.have.property('status').to.equal(200);
 					res.body.data.message.should.be.equal('Transaction(s) accepted');
 				});
 
@@ -75,7 +75,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				return sendTransactionPromise(transaction);
 			})
 			.then(function (res) {
-				expect(res).to.have.property('status').to.equal(200);
+				res.should.have.property('status').to.equal(200);
 				res.body.data.message.should.be.equal('Transaction(s) accepted');
 
 				randomUtil.guestbookDapp.id = transaction.id;

--- a/test/functional/http/post/6.dapps.inTransfer.js
+++ b/test/functional/http/post/6.dapps.inTransfer.js
@@ -172,7 +172,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 			it('using > balance should fail', function () {
 				return apiHelpers.getAccountsPromise('address=' + account.address)
 					.then(function (res) {
-						expect(res.body).to.have.nested.property('data').to.have.lengthOf(1);
+						res.body.should.have.nested.property('data').to.have.lengthOf(1);
 
 						var balance = res.body.data[0].balance;
 						var amount = new bignum(balance).plus('1').toNumber();

--- a/test/functional/http/post/7.dapps.outTransfer.js
+++ b/test/functional/http/post/7.dapps.outTransfer.js
@@ -305,7 +305,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 
 				return apiHelpers.getAccountsPromise(params)
 					.then(function (res) {
-						expect(res.body).to.have.nested.property('data').to.have.lengthOf(1);
+						res.body.should.have.nested.property('data').to.have.lengthOf(1);
 
 						var balance = res.body.data[0].balance;
 						var amount = new bignum(balance).plus('1').toNumber();

--- a/test/functional/system/1.X/1.0.transfer.js
+++ b/test/functional/system/1.X/1.0.transfer.js
@@ -39,7 +39,7 @@ describe('POST /api/transactions (unconfirmed type 0 on top of type 1)', functio
 			transaction = lisk.transaction.createTransaction(randomUtil.account().address, 1, account.password, account.secondPassword);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/1.X/1.2.delegate.js
+++ b/test/functional/system/1.X/1.2.delegate.js
@@ -38,7 +38,7 @@ describe('POST /api/transactions (unconfirmed type 2 on top of type 1)', functio
 			transaction = lisk.delegate.createDelegate(account.password, account.username, account.secondPassword);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/1.X/1.3.votes.js
+++ b/test/functional/system/1.X/1.3.votes.js
@@ -39,7 +39,7 @@ describe('POST /api/transactions (unconfirmed type 3 on top of type 1)', functio
 			transaction = lisk.vote.createVote(account.password, ['+' + accountFixtures.existingDelegate.publicKey], account.secondPassword);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/1.X/1.4.multisig.js
+++ b/test/functional/system/1.X/1.4.multisig.js
@@ -41,7 +41,7 @@ describe('POST /api/transactions (unconfirmed type 4 on top of type 1)', functio
 			transaction = lisk.multisignature.createMultisignature(account.password, account.secondPassword, ['+' + accountFixtures.existingDelegate.publicKey], 1, 1);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/1.X/1.5.dapps.js
+++ b/test/functional/system/1.X/1.5.dapps.js
@@ -39,7 +39,7 @@ describe('POST /api/transactions (unconfirmed type 5 on top of type 1)', functio
 			transaction = lisk.dapp.createDapp(account.password, account.secondPassword, randomUtil.application());
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/1.X/1.6.dapps.inTransfer.js
+++ b/test/functional/system/1.X/1.6.dapps.inTransfer.js
@@ -40,7 +40,7 @@ describe('POST /api/transactions (unconfirmed type 6 on top of type 1)', functio
 			transaction = lisk.transfer.createInTransfer(randomUtil.guestbookDapp.transactionId, 10 * normalizer, account.password, account.secondPassword);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/1.X/1.7.dapps.outTransfer.js
+++ b/test/functional/system/1.X/1.7.dapps.outTransfer.js
@@ -40,7 +40,7 @@ describe('POST /api/transactions (unconfirmed type 7 on top of type 1)', functio
 			transaction = lisk.transfer.createOutTransfer(randomUtil.guestbookDapp.transactionId, randomUtil.transaction().id, randomUtil.account().address, 10 * normalizer, account.password, account.secondPassword);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				expect(res).to.have.nested.property('body.message').to.equal('Sender does not have a second signature');
+				res.should.have.nested.property('body.message').to.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/system/2.delegates.js
+++ b/test/functional/system/2.delegates.js
@@ -105,7 +105,7 @@ describe('POST /api/transactions (type 2) double delegate registration', functio
 				});
 
 				it('second transaction should fail', function () {
-					expect(secondResponse).to.have.nested.property('body.message').equal('Transaction is already processed: ' + firstTransaction.id);
+					secondResponse.should.have.nested.property('body.message').equal('Transaction is already processed: ' + firstTransaction.id);
 				});
 			});
 
@@ -124,9 +124,9 @@ describe('POST /api/transactions (type 2) double delegate registration', functio
 				});
 
 				it('should confirm one transaction', function () {
-					expect(strippedResults.statusFields).to.contain(200);
-					expect(strippedResults.transactionsIds).to.have.lengthOf(1);
-					expect([transactionWithDelay.id, transactionWithoutDelay.id]).and.to.contain(strippedResults.transactionsIds[0]);
+					strippedResults.statusFields.should.contain(200);
+					strippedResults.transactionsIds.should.have.lengthOf(1);
+					[transactionWithDelay.id, transactionWithoutDelay.id].should.contain(strippedResults.transactionsIds[0]);
 				});
 			});
 		});
@@ -151,9 +151,9 @@ describe('POST /api/transactions (type 2) double delegate registration', functio
 			});
 
 			it('should confirm only one transaction', function () {
-				expect(strippedResults.statusFields).to.contain(200);
-				expect(strippedResults.transactionsIds).to.have.lengthOf(1);
-				expect([transaction1.id, transaction2.id]).and.to.contain(strippedResults.transactionsIds[0]);
+				strippedResults.statusFields.should.contain(200);
+				strippedResults.transactionsIds.should.have.lengthOf(1);
+				[transaction1.id, transaction2.id].should.contain(strippedResults.transactionsIds[0]);
 			});
 		});
 	});
@@ -195,9 +195,9 @@ describe('POST /api/transactions (type 2) double delegate registration', functio
 			});
 
 			it('should confirm only one transaction', function () {
-				expect(strippedResults.statusFields).to.contain(200);
-				expect(strippedResults.transactionsIds).to.have.lengthOf(1);
-				expect([transaction1.id, transaction2.id]).and.to.contain(strippedResults.transactionsIds[0]);
+				strippedResults.statusFields.should.contain(200);
+				strippedResults.transactionsIds.should.have.lengthOf(1);
+				[transaction1.id, transaction2.id].should.contain(strippedResults.transactionsIds[0]);
 			});
 		});
 
@@ -217,8 +217,8 @@ describe('POST /api/transactions (type 2) double delegate registration', functio
 			});
 
 			it('should successfully confirm both transactions', function () {
-				expect(strippedResults.statusFields).eql([200, 200]);
-				expect(strippedResults.transactionsIds).to.have.lengthOf(2).and.to.contain(transaction1.id, transaction2.id);
+				strippedResults.statusFields.should.eql([200, 200]);
+				strippedResults.transactionsIds.should.have.lengthOf(2).and.to.contain(transaction1.id, transaction2.id);
 			});
 		});
 	});

--- a/test/functional/system/4.multisig.js
+++ b/test/functional/system/4.multisig.js
@@ -88,30 +88,30 @@ describe('multisignature', function () {
 					});
 
 					it('should have no rows in mem_accounts2multisignatures', function () {
-						expect(accountRow.mem_accounts2multisignatures).to.eql([]);
+						accountRow.mem_accounts2multisignatures.should.eql([]);
 					});
 
 					it('should have multimin field set to 0 on mem_accounts', function () {
-						expect(accountRow.mem_accounts.multimin).to.eql(0);
+						accountRow.mem_accounts.multimin.should.eql(0);
 					});
 
 					it('should have multilifetime field set to 0 on mem_accounts', function () {
-						expect(accountRow.mem_accounts.multilifetime).to.eql(0);
+						accountRow.mem_accounts.multilifetime.should.eql(0);
 					});
 
 					it('should include rows in mem_accounts2u_multisignatures', function () {
 						var signKeysInDb = _.map(accountRow.mem_accounts2u_multisignatures, function (row) {
 							return row.dependentId;
 						});
-						expect(signKeysInDb).to.include(signer1.publicKey, signer2.publicKey);
+						signKeysInDb.should.include(signer1.publicKey, signer2.publicKey);
 					});
 
 					it('should set u_multimin field set on mem_accounts', function () {
-						expect(accountRow.mem_accounts.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
+						accountRow.mem_accounts.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
 					});
 
 					it('should set u_multilifetime field set on mem_accounts', function () {
-						expect(accountRow.mem_accounts.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
+						accountRow.mem_accounts.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
 					});
 				});
 
@@ -121,22 +121,22 @@ describe('multisignature', function () {
 
 					before('get multisignature account', function (done) {
 						library.logic.account.get({address: multisigAccount.address}, function (err, res) {
-							expect(err).to.not.exist;
+							should.not.exist(err);
 							account = res;
 							done();
 						});
 					});
 
 					it('should have u_multisignatures field set on account', function () {
-						expect(account.u_multisignatures).to.include(signer1.publicKey, signer2.publicKey);
+						account.u_multisignatures.should.include(signer1.publicKey, signer2.publicKey);
 					});
 
 					it('should have multimin field set on account', function () {
-						expect(account.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
+						account.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
 					});
 
 					it('should have multilifetime field set on account', function () {
-						expect(account.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
+						account.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
 					});
 				});
 
@@ -231,30 +231,30 @@ describe('multisignature', function () {
 						var signKeysInDb = _.map(accountRow.mem_accounts2multisignatures, function (row) {
 							return row.dependentId;
 						});
-						expect(signKeysInDb).to.include(signer1.publicKey, signer2.publicKey);
+						signKeysInDb.should.include(signer1.publicKey, signer2.publicKey);
 					});
 
 					it('should set multimin field set on mem_accounts', function () {
-						expect(accountRow.mem_accounts.multimin).to.eql(multisigTransaction.asset.multisignature.min);
+						accountRow.mem_accounts.multimin.should.eql(multisigTransaction.asset.multisignature.min);
 					});
 
 					it('should set multilifetime field set on mem_accounts', function () {
-						expect(accountRow.mem_accounts.multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
+						accountRow.mem_accounts.multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
 					});
 
 					it('should include rows in mem_accounts2u_multisignatures', function () {
 						var signKeysInDb = _.map(accountRow.mem_accounts2u_multisignatures, function (row) {
 							return row.dependentId;
 						});
-						expect(signKeysInDb).to.include(signer1.publicKey, signer2.publicKey);
+						signKeysInDb.should.include(signer1.publicKey, signer2.publicKey);
 					});
 
 					it('should set u_multimin field set on mem_accounts', function () {
-						expect(accountRow.mem_accounts.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
+						accountRow.mem_accounts.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
 					});
 
 					it('should set u_multilifetime field set on mem_accounts', function () {
-						expect(accountRow.mem_accounts.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
+						accountRow.mem_accounts.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
 					});
 				});
 
@@ -264,34 +264,34 @@ describe('multisignature', function () {
 
 					before('get multisignature account', function (done) {
 						library.logic.account.get({address: multisigAccount.address}, function (err, res) {
-							expect(err).to.not.exist;
+							should.not.exist(err);
 							account = res;
 							done();
 						});
 					});
 
 					it('should have multisignatures field set on account', function () {
-						expect(account.multisignatures).to.include(signer1.publicKey, signer2.publicKey);
+						account.multisignatures.should.include(signer1.publicKey, signer2.publicKey);
 					});
 
 					it('should have multimin field set on account', function () {
-						expect(account.multimin).to.eql(multisigTransaction.asset.multisignature.min);
+						account.multimin.should.eql(multisigTransaction.asset.multisignature.min);
 					});
 
 					it('should have multilifetime field set on account', function () {
-						expect(account.multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
+						account.multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
 					});
 
 					it('should have u_multisignatures field set on account', function () {
-						expect(account.u_multisignatures).to.include(signer1.publicKey, signer2.publicKey);
+						account.u_multisignatures.should.include(signer1.publicKey, signer2.publicKey);
 					});
 
 					it('should have u_multimin field set on account', function () {
-						expect(account.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
+						account.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
 					});
 
 					it('should have u_multilifetime field set on account', function () {
-						expect(account.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
+						account.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
 					});
 				});
 
@@ -312,27 +312,27 @@ describe('multisignature', function () {
 						});
 
 						it('should have no rows in mem_accounts2multisignatures', function () {
-							expect(accountRow.mem_accounts2multisignatures).to.eql([]);
+							accountRow.mem_accounts2multisignatures.should.eql([]);
 						});
 
 						it('should have multimin field set to 0 on mem_accounts', function () {
-							expect(accountRow.mem_accounts.multimin).to.eql(0);
+							accountRow.mem_accounts.multimin.should.eql(0);
 						});
 
 						it('should have multilifetime field set to 0 on mem_accounts', function () {
-							expect(accountRow.mem_accounts.multilifetime).to.eql(0);
+							accountRow.mem_accounts.multilifetime.should.eql(0);
 						});
 
 						it('should have no rows in mem_accounts2u_multisignatures', function () {
-							expect(accountRow.mem_accounts2u_multisignatures).to.eql([]);
+							accountRow.mem_accounts2u_multisignatures.should.eql([]);
 						});
 
 						it('should have u_multimin field set to 0 on mem_accounts', function () {
-							expect(accountRow.mem_accounts.u_multimin).to.eql(0);
+							accountRow.mem_accounts.u_multimin.should.eql(0);
 						});
 
 						it('should have multilifetime field to 0 on mem_accounts', function () {
-							expect(accountRow.mem_accounts.u_multilifetime).to.eql(0);
+							accountRow.mem_accounts.u_multilifetime.should.eql(0);
 						});
 					});
 
@@ -342,34 +342,34 @@ describe('multisignature', function () {
 
 						before('get multisignature account', function (done) {
 							library.logic.account.get({address: multisigAccount.address}, function (err, res) {
-								expect(err).to.not.exist;
+								should.not.exist(err);
 								account = res;
 								done();
 							});
 						});
 
 						it('should set multisignatures field to null on account', function () {
-							expect(account.multisignatures).to.eql(null);
+							account.multisignatures.should.eql(null);
 						});
 
 						it('should set multimin field to 0 on account', function () {
-							expect(account.multimin).to.eql(0);
+							account.multimin.should.eql(0);
 						});
 
 						it('should set multilifetime field to 0 on account', function () {
-							expect(account.multilifetime).to.eql(0);
+							account.multilifetime.should.eql(0);
 						});
 
 						it('should set u_multisignatures field to null on account', function () {
-							expect(account.u_multisignatures).to.eql(null);
+							should.not.exist(account.u_multisignatures);
 						});
 
 						it('should set u_multimin field to null on account', function () {
-							expect(account.u_multimin).to.eql(0);
+							account.u_multimin.should.eql(0);
 						});
 
 						it('should set u_multilifetime field to null on account', function () {
-							expect(account.u_multilifetime).to.eql(0);
+							account.u_multilifetime.should.eql(0);
 						});
 					});
 				});

--- a/test/functional/ws/transport.blocks.js
+++ b/test/functional/ws/transport.blocks.js
@@ -46,50 +46,50 @@ describe('WS transport blocks', function () {
 		it('using valid headers should be ok', function (done) {
 			ws.call('blocks', null, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(res).to.have.property('blocks').that.is.an('array');
+				res.should.have.property('blocks').that.is.an('array');
 				res.blocks.forEach(function (block) {
-					expect(block).to.have.property('b_id').that.is.a('string');
-					expect(block).to.have.property('b_version').that.is.a('number');
-					expect(block).to.have.property('b_timestamp').that.is.a('number');
-					expect(block).to.have.property('b_height').that.is.a('number');
-					expect(block).to.have.property('b_previousBlock');
-					expect(block).to.have.property('b_numberOfTransactions').that.is.a('number');
-					expect(block).to.have.property('b_totalAmount').that.is.a('string');
-					expect(block).to.have.property('b_totalFee').that.is.a('string');
-					expect(block).to.have.property('b_reward').that.is.a('string');
-					expect(block).to.have.property('b_payloadLength').that.is.a('number');
-					expect(block).to.have.property('b_payloadHash').that.is.a('string');
-					expect(block).to.have.property('b_generatorPublicKey').that.is.a('string');
-					expect(block).to.have.property('b_blockSignature').that.is.a('string');
-					expect(block).to.have.property('t_id');
-					expect(block).to.have.property('t_rowId');
-					expect(block).to.have.property('t_type');
-					expect(block).to.have.property('t_timestamp');
-					expect(block).to.have.property('t_senderPublicKey');
-					expect(block).to.have.property('t_senderId');
-					expect(block).to.have.property('t_recipientId');
-					expect(block).to.have.property('t_amount');
-					expect(block).to.have.property('t_fee');
-					expect(block).to.have.property('t_signature');
-					expect(block).to.have.property('t_signSignature');
-					expect(block).to.have.property('s_publicKey');
-					expect(block).to.have.property('d_username');
-					expect(block).to.have.property('v_votes');
-					expect(block).to.have.property('m_min');
-					expect(block).to.have.property('m_lifetime');
-					expect(block).to.have.property('m_keysgroup');
-					expect(block).to.have.property('dapp_name');
-					expect(block).to.have.property('dapp_description');
-					expect(block).to.have.property('dapp_tags');
-					expect(block).to.have.property('dapp_type');
-					expect(block).to.have.property('dapp_link');
-					expect(block).to.have.property('dapp_category');
-					expect(block).to.have.property('dapp_icon');
-					expect(block).to.have.property('in_dappId');
-					expect(block).to.have.property('ot_dappId');
-					expect(block).to.have.property('ot_outTransactionId');
-					expect(block).to.have.property('t_requesterPublicKey');
-					expect(block).to.have.property('t_signatures');
+					block.should.have.property('b_id').that.is.a('string');
+					block.should.have.property('b_version').that.is.a('number');
+					block.should.have.property('b_timestamp').that.is.a('number');
+					block.should.have.property('b_height').that.is.a('number');
+					block.should.have.property('b_previousBlock');
+					block.should.have.property('b_numberOfTransactions').that.is.a('number');
+					block.should.have.property('b_totalAmount').that.is.a('string');
+					block.should.have.property('b_totalFee').that.is.a('string');
+					block.should.have.property('b_reward').that.is.a('string');
+					block.should.have.property('b_payloadLength').that.is.a('number');
+					block.should.have.property('b_payloadHash').that.is.a('string');
+					block.should.have.property('b_generatorPublicKey').that.is.a('string');
+					block.should.have.property('b_blockSignature').that.is.a('string');
+					block.should.have.property('t_id');
+					block.should.have.property('t_rowId');
+					block.should.have.property('t_type');
+					block.should.have.property('t_timestamp');
+					block.should.have.property('t_senderPublicKey');
+					block.should.have.property('t_senderId');
+					block.should.have.property('t_recipientId');
+					block.should.have.property('t_amount');
+					block.should.have.property('t_fee');
+					block.should.have.property('t_signature');
+					block.should.have.property('t_signSignature');
+					block.should.have.property('s_publicKey');
+					block.should.have.property('d_username');
+					block.should.have.property('v_votes');
+					block.should.have.property('m_min');
+					block.should.have.property('m_lifetime');
+					block.should.have.property('m_keysgroup');
+					block.should.have.property('dapp_name');
+					block.should.have.property('dapp_description');
+					block.should.have.property('dapp_tags');
+					block.should.have.property('dapp_type');
+					block.should.have.property('dapp_link');
+					block.should.have.property('dapp_category');
+					block.should.have.property('dapp_icon');
+					block.should.have.property('in_dappId');
+					block.should.have.property('ot_dappId');
+					block.should.have.property('ot_outTransactionId');
+					block.should.have.property('t_requesterPublicKey');
+					block.should.have.property('t_signatures');
 				});
 				done();
 			});
@@ -101,8 +101,8 @@ describe('WS transport blocks', function () {
 		it('using no params should fail', function (done) {
 			ws.call('blocksCommon', function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(res).to.be.undefined;
-				expect(err).to.equal('Missing required property: ids: ');
+				should.not.exist(res);
+				err.should.equal('Missing required property: ids: ');
 				done();
 			});
 		});
@@ -110,7 +110,7 @@ describe('WS transport blocks', function () {
 		it('using ids == "";"";"" should fail', function (done) {
 			ws.call('blocksCommon', {ids: '"";"";""'}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(err).to.equal('Invalid block id sequence');
+				err.should.equal('Invalid block id sequence');
 				done();
 			});
 		});
@@ -119,7 +119,7 @@ describe('WS transport blocks', function () {
 			ws.call('blocksCommon',  {ids: '\'\',\'\',\'\''}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
 
-				expect(err).to.equal('Invalid block id sequence');
+				err.should.equal('Invalid block id sequence');
 				done();
 			});
 		});
@@ -127,7 +127,7 @@ describe('WS transport blocks', function () {
 		it('using ids == "","","" should fail', function (done) {
 			ws.call('blocksCommon', {ids: '"","",""'}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(err).to.equal('Invalid block id sequence');
+				err.should.equal('Invalid block id sequence');
 				done();
 			});
 		});
@@ -135,7 +135,7 @@ describe('WS transport blocks', function () {
 		it('using ids == one,two,three should fail', function (done) {
 			ws.call('blocksCommon', {ids: 'one,two,three'}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(err).to.equal('Invalid block id sequence');
+				err.should.equal('Invalid block id sequence');
 				done();
 			});
 		});
@@ -144,7 +144,7 @@ describe('WS transport blocks', function () {
 			ws.call('blocksCommon', {ids: '"1","2","3"'}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
 
-				expect(res).to.have.property('common').to.be.null;
+				res.should.have.property('common').to.be.null;
 				done();
 			});
 		});
@@ -153,7 +153,7 @@ describe('WS transport blocks', function () {
 			ws.call('blocksCommon', {ids: '\'1\',\'2\',\'3\''}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
 
-				expect(res).to.have.property('common').to.be.null;
+				res.should.have.property('common').to.be.null;
 				done();
 			});
 		});
@@ -162,7 +162,7 @@ describe('WS transport blocks', function () {
 			ws.call('blocksCommon', {ids: '1,2,3'}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
 
-				expect(res).to.have.property('common').to.be.null;
+				res.should.have.property('common').to.be.null;
 				done();
 			});
 		});
@@ -171,11 +171,11 @@ describe('WS transport blocks', function () {
 			ws.call('blocksCommon', {ids: [genesisblock.id.toString(),'2','3'].join(',')}, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
 
-				expect(res).to.have.property('common').to.be.an('object');
-				expect(res.common).to.have.property('height').that.is.a('number');
-				expect(res.common).to.have.property('id').that.is.a('string');
-				expect(res.common).to.have.property('previousBlock').that.is.null;
-				expect(res.common).to.have.property('timestamp').that.is.equal(0);
+				res.should.have.property('common').to.be.an('object');
+				res.common.should.have.property('height').that.is.a('number');
+				res.common.should.have.property('id').that.is.a('string');
+				res.common.should.have.property('previousBlock').that.is.null;
+				res.common.should.have.property('timestamp').that.is.equal(0);
 				done();
 			});
 		});
@@ -186,7 +186,7 @@ describe('WS transport blocks', function () {
 		it('using no block should fail', function (done) {
 			ws.call('postBlock', function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(err).to.contain('Failed to validate block schema');
+				err.should.contain('Failed to validate block schema');
 				done();
 			});
 		});
@@ -198,7 +198,7 @@ describe('WS transport blocks', function () {
 
 			ws.call('postBlock', { block: bson.serialize(genesisblock) }, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(err).to.contain('Failed to validate block schema');
+				err.should.contain('Failed to validate block schema');
 				genesisblock.blockSignature = blockSignature;
 				done();
 			});
@@ -212,7 +212,7 @@ describe('WS transport blocks', function () {
 			});
 			ws.call('postBlock', { block: bson.serialize(testBlock) }, function (err, res) {
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(err), JSON.stringify(res));
-				expect(res).to.have.property('blockId').to.equal('2807833455815592401');
+				res.should.have.property('blockId').to.equal('2807833455815592401');
 				done();
 			});
 		});

--- a/test/functional/ws/transport.client.js
+++ b/test/functional/ws/transport.client.js
@@ -48,44 +48,44 @@ describe('ClientRPCStub', function () {
 	describe('should contain remote procedure', function () {
 
 		it('updatePeer', function () {
-			expect(validClientRPCStub).to.have.property('updatePeer');
+			validClientRPCStub.should.have.property('updatePeer');
 		});
 
 		it('blocksCommon', function () {
-			expect(validClientRPCStub).to.have.property('blocksCommon');
+			validClientRPCStub.should.have.property('blocksCommon');
 		});
 
 		it('height', function () {
-			expect(validClientRPCStub).to.have.property('height');
+			validClientRPCStub.should.have.property('height');
 		});
 
 		it('getTransactions', function () {
-			expect(validClientRPCStub).to.have.property('getTransactions');
+			validClientRPCStub.should.have.property('getTransactions');
 		});
 
 		it('getSignatures', function () {
-			expect(validClientRPCStub).to.have.property('getSignatures');
+			validClientRPCStub.should.have.property('getSignatures');
 		});
 
 		it('status', function () {
-			expect(validClientRPCStub).to.have.property('list');
+			validClientRPCStub.should.have.property('list');
 		});
 
 		it('postBlock', function () {
-			expect(validClientRPCStub).to.have.property('postBlock');
+			validClientRPCStub.should.have.property('postBlock');
 		});
 
 		it('postSignatures', function () {
-			expect(validClientRPCStub).to.have.property('postSignatures');
+			validClientRPCStub.should.have.property('postSignatures');
 		});
 
 		it('postTransactions', function () {
-			expect(validClientRPCStub).to.have.property('postTransactions');
+			validClientRPCStub.should.have.property('postTransactions');
 		});
 	});
 
 	it('should not contain randomProcedure', function () {
-		expect(validClientRPCStub).not.to.have.property('randomProcedure');
+		validClientRPCStub.should.not.to.have.property('randomProcedure');
 	});
 
 	describe('RPC call', function () {
@@ -102,14 +102,14 @@ describe('ClientRPCStub', function () {
 
 			it('should call a RPC callback with response', function (done) {
 				validClientRPCStub.status(function (err, response) {
-					expect(response).not.to.be.empty;
+					response.should.not.to.be.empty;
 					done();
 				});
 			});
 
 			it('should call a RPC callback without an error as null', function (done) {
 				validClientRPCStub.status(function (err) {
-					expect(err).to.be.null;
+					should.not.exist(err);
 					done();
 				});
 			});
@@ -126,8 +126,8 @@ describe('ClientRPCStub', function () {
 				delete validHeaders.wsPort;
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal('wsPort: Expected type integer but found type not-a-number');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal('wsPort: Expected type integer but found type not-a-number');
 					done();
 				});
 			});
@@ -136,7 +136,7 @@ describe('ClientRPCStub', function () {
 				validHeaders.wsPort = validHeaders.wsPort.toString();
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.be.null;
+					should.not.exist(err);
 					done();
 				});
 			});
@@ -145,8 +145,8 @@ describe('ClientRPCStub', function () {
 				validHeaders.nonce = 'TOO_SHORT';
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal('nonce: String is too short (9 chars), minimum 16');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal('nonce: String is too short (9 chars), minimum 16');
 					done();
 				});
 			});
@@ -155,8 +155,8 @@ describe('ClientRPCStub', function () {
 				validHeaders.nonce = 'NONCE_LONGER_THAN_16_CHARS';
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal('nonce: String is too long (26 chars), maximum 16');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal('nonce: String is too long (26 chars), maximum 16');
 					done();
 				});
 			});
@@ -165,8 +165,8 @@ describe('ClientRPCStub', function () {
 				delete validHeaders.nonce;
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal(': Missing required property: nonce');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal(': Missing required property: nonce');
 					done();
 				});
 			});
@@ -175,8 +175,8 @@ describe('ClientRPCStub', function () {
 				delete validHeaders.nethash;
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal(': Missing required property: nethash');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal(': Missing required property: nethash');
 					done();
 				});
 			});
@@ -185,8 +185,8 @@ describe('ClientRPCStub', function () {
 				delete validHeaders.height;
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal('height: Expected type integer but found type not-a-number');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal('height: Expected type integer but found type not-a-number');
 					done();
 				});
 			});
@@ -195,8 +195,8 @@ describe('ClientRPCStub', function () {
 				delete validHeaders.version;
 				System.setHeaders(validHeaders);
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.INVALID_HEADERS);
-					expect(err).to.have.property('description').equal(': Missing required property: version');
+					err.should.have.property('code').equal(failureCodes.INVALID_HEADERS);
+					err.should.have.property('description').equal(': Missing required property: version');
 					done();
 				});
 			});
@@ -215,8 +215,8 @@ describe('ClientRPCStub', function () {
 
 			it('should call RPC callback with CONNECTION_TIMEOUT error', function (done) {
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.CONNECTION_TIMEOUT);
-					expect(err).to.have.property('message').equal(failureCodes.errorMessages[failureCodes.CONNECTION_TIMEOUT]);
+					err.should.have.property('code').equal(failureCodes.CONNECTION_TIMEOUT);
+					err.should.have.property('message').equal(failureCodes.errorMessages[failureCodes.CONNECTION_TIMEOUT]);
 					done();
 				});
 			});
@@ -232,8 +232,8 @@ describe('ClientRPCStub', function () {
 
 			it('should call RPC callback with HANDSHAKE_ERROR error', function (done) {
 				validClientRPCStub.status(function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.HANDSHAKE_ERROR);
-					expect(err).to.have.property('message').equal(failureCodes.errorMessages[failureCodes.HANDSHAKE_ERROR]);
+					err.should.have.property('code').equal(failureCodes.HANDSHAKE_ERROR);
+					err.should.have.property('message').equal(failureCodes.errorMessages[failureCodes.HANDSHAKE_ERROR]);
 					done();
 				});
 			});

--- a/test/functional/ws/transport.handshake.js
+++ b/test/functional/ws/transport.handshake.js
@@ -64,8 +64,8 @@ describe('handshake', function () {
 		var disconnectHandler = function (code, description) {
 			currentConnectedSocket = null;
 			clientSocket.off('disconnect', disconnectHandler);
-			expect('socket had been disconnected with error code: ' + code + ' - ' + (description || failureCodes.errorMessages[code]))
-				.equal('socket should stay connected');
+			('socket had been disconnected with error code: ' + code + ' - ' + (description || failureCodes.errorMessages[code]))
+				.should.equal('socket should stay connected');
 			return cb(code);
 		};
 		var acceptedHandler = function () {
@@ -107,7 +107,7 @@ describe('handshake', function () {
 				delete validClientSocketOptions.query;
 				connect();
 				expectDisconnect(this, function (code) {
-					expect(code).equal(failureCodes.INVALID_HEADERS);
+					code.should.equal(failureCodes.INVALID_HEADERS);
 					done();
 				});
 			});
@@ -116,8 +116,8 @@ describe('handshake', function () {
 				validClientSocketOptions.query = {};
 				connect();
 				expectDisconnect(this, function (code, description) {
-					expect(code).equal(failureCodes.INVALID_HEADERS);
-					expect(description).contain('Missing required property');
+					code.should.equal(failureCodes.INVALID_HEADERS);
+					description.should.contain('Missing required property');
 					done();
 				});
 			});
@@ -126,8 +126,8 @@ describe('handshake', function () {
 				delete validClientSocketOptions.query.wsPort;
 				connect();
 				expectDisconnect(this, function (code, description) {
-					expect(code).equal(failureCodes.INVALID_HEADERS);
-					expect(description).contain('Expected type integer but found type not-a-number');
+					code.should.equal(failureCodes.INVALID_HEADERS);
+					description.should.contain('Expected type integer but found type not-a-number');
 					done();
 				});
 			});
@@ -136,8 +136,8 @@ describe('handshake', function () {
 				delete validClientSocketOptions.query.height;
 				connect();
 				expectDisconnect(this, function (code, description) {
-					expect(code).equal(failureCodes.INVALID_HEADERS);
-					expect(description).contain('height: Expected type integer but found type not-a-number');
+					code.should.equal(failureCodes.INVALID_HEADERS);
+					description.should.contain('height: Expected type integer but found type not-a-number');
 					done();
 				});
 			});
@@ -146,8 +146,8 @@ describe('handshake', function () {
 				delete validClientSocketOptions.query.version;
 				connect();
 				expectDisconnect(this, function (code, description) {
-					expect(code).equal(failureCodes.INVALID_HEADERS);
-					expect(description).contain('Missing required property: version');
+					code.should.equal(failureCodes.INVALID_HEADERS);
+					description.should.contain('Missing required property: version');
 					done();
 				});
 			});
@@ -156,8 +156,8 @@ describe('handshake', function () {
 				delete validClientSocketOptions.query.nethash;
 				connect();
 				expectDisconnect(this, function (code, description) {
-					expect(code).equal(failureCodes.INVALID_HEADERS);
-					expect(description).contain('Missing required property: nethash');
+					code.should.equal(failureCodes.INVALID_HEADERS);
+					description.should.contain('Missing required property: nethash');
 					done();
 				});
 			});

--- a/test/functional/ws/transport.js
+++ b/test/functional/ws/transport.js
@@ -69,7 +69,7 @@ describe('RPC', function () {
 							done('should not be here');
 						})
 						.catch(function (err) {
-							expect(err).to.equal('Expected type object but found type undefined');
+							err.should.equal('Expected type object but found type undefined');
 							done();
 						});
 				});
@@ -81,7 +81,7 @@ describe('RPC', function () {
 							done('should not be here');
 						})
 						.catch(function (err) {
-							expect(err).to.equal('Missing required property: peer');
+							err.should.equal('Missing required property: peer');
 							done();
 						});
 				});
@@ -93,7 +93,7 @@ describe('RPC', function () {
 							done('should not be here');
 						})
 						.catch(function (err) {
-							expect(err).to.equal('Missing required property: authKey');
+							err.should.equal('Missing required property: authKey');
 							done();
 						});
 				});
@@ -105,7 +105,7 @@ describe('RPC', function () {
 							done('should not be here');
 						})
 						.catch(function (err) {
-							expect(err).to.equal('Unable to access internal function - Incorrect authKey');
+							err.should.equal('Unable to access internal function - Incorrect authKey');
 							done();
 						});
 				});
@@ -117,7 +117,7 @@ describe('RPC', function () {
 							done('should not be here');
 						})
 						.catch(function (err) {
-							expect(err).to.equal('Missing required property: updateType');
+							err.should.equal('Missing required property: updateType');
 							done();
 						});
 				});
@@ -131,7 +131,7 @@ describe('RPC', function () {
 								eachCb('should not be here');
 							})
 							.catch(function (err) {
-								expect(err).to.contain('Expected type integer but found type');
+								err.should.contain('Expected type integer but found type');
 								eachCb();
 							});
 					}, done);
@@ -144,7 +144,7 @@ describe('RPC', function () {
 							done('should not be here');
 						})
 						.catch(function (err) {
-							expect(err).to.contain('Value ' + validAcceptRequest.updateType + ' is greater than maximum 1');
+							err.should.contain('Value ' + validAcceptRequest.updateType + ' is greater than maximum 1');
 							done();
 						});
 				});
@@ -157,8 +157,8 @@ describe('RPC', function () {
 		it('should return height', function (done) {
 			clientSocket.wampSend('height')
 				.then(function (result) {
-					expect(result).to.have.property('success').to.be.ok;
-					expect(result).to.have.property('height').that.is.a('number').at.least(1);
+					result.should.have.property('success').to.be.ok;
+					result.should.have.property('height').that.is.a('number').at.least(1);
 					done();
 				}).catch(function (err) {
 					done(err);
@@ -171,10 +171,10 @@ describe('RPC', function () {
 		it('should return height and broadhash', function (done) {
 			clientSocket.wampSend('status')
 				.then(function (result) {
-					expect(result).to.have.property('success').to.be.ok;
-					expect(result).to.have.property('broadhash').that.is.a('string');
-					expect(result).to.have.property('nonce').that.is.a('string');
-					expect(result).to.have.property('height').that.is.a('number').at.least(1);
+					result.should.have.property('success').to.be.ok;
+					result.should.have.property('broadhash').that.is.a('string');
+					result.should.have.property('nonce').that.is.a('string');
+					result.should.have.property('height').that.is.a('number').at.least(1);
 					done();
 				}).catch(function (err) {
 					done(err);
@@ -193,8 +193,8 @@ describe('RPC', function () {
 		it('should return list of peers', function (done) {
 			clientSocket.wampSend('list')
 				.then(function (result) {
-					expect(result).to.have.property('success').to.be.ok;
-					expect(result).to.have.property('peers').to.be.an('array');
+					result.should.have.property('success').to.be.ok;
+					result.should.have.property('peers').to.be.an('array');
 					done();
 				}).catch(function (err) {
 					done(err);
@@ -207,8 +207,8 @@ describe('RPC', function () {
 			for (var i = 0; i < 100; i += 1) {
 				clientSocket.wampSend('list')
 					.then(function (result) {
-						expect(result).to.have.property('success').to.be.ok;
-						expect(result).to.have.property('peers').to.be.an('array');
+						result.should.have.property('success').to.be.ok;
+						result.should.have.property('peers').to.be.an('array');
 						successfulAsks += 1;
 						if (successfulAsks === 100) {
 							done();
@@ -225,7 +225,7 @@ describe('RPC', function () {
 		it('should return height and broadhash', function (done) {
 			clientSocket.wampSend('blocks')
 				.then(function (result) {
-					expect(result).to.have.property('blocks').to.be.an('array');
+					result.should.have.property('blocks').to.be.an('array');
 					done();
 				}).catch(function (err) {
 					done(err);

--- a/test/functional/ws/transport.transactions.js
+++ b/test/functional/ws/transport.transactions.js
@@ -47,8 +47,8 @@ describe('Posting transaction (type 0)', function () {
 			var transaction = lisk.transaction.createTransaction('1L', 1, account.password);
 
 			postTransaction(transaction, function (err, res) {
-				expect(res).to.have.property('success').to.be.not.ok;
-				expect(res).to.have.property('message').to.equal('Account does not have enough LSK: ' + account.address + ' balance: 0');
+				res.should.have.property('success').to.be.not.ok;
+				res.should.have.property('message').to.equal('Account does not have enough LSK: ' + account.address + ' balance: 0');
 				badTransactions.push(transaction);
 				done();
 			});
@@ -56,8 +56,8 @@ describe('Posting transaction (type 0)', function () {
 
 		it('when sender has funds should be ok', function (done) {
 			postTransaction(transaction, function (err, res) {
-				expect(res).to.have.property('success').to.be.ok;
-				expect(res).to.have.property('transactionId').to.equal(transaction.id);
+				res.should.have.property('success').to.be.ok;
+				res.should.have.property('transactionId').to.equal(transaction.id);
 				goodTransactions.push(transaction);
 				done();
 			});

--- a/test/integration/peers.integration.js
+++ b/test/integration/peers.integration.js
@@ -317,15 +317,15 @@ describe('integration', function () {
 				return socket.wampSend('list', {});
 			})).then(function (results) {
 				results.forEach(function (result) {
-					expect(result).to.have.property('success').to.be.ok;
-					expect(result).to.have.property('peers').to.be.a('array');
+					result.should.have.property('success').to.be.ok;
+					result.should.have.property('peers').to.be.a('array');
 					var peerPorts = result.peers.map(function (p) {
 						return p.wsPort;
 					});
 					var allPeerPorts = testNodeConfigs.map(function (testNodeConfig) {
 						return testNodeConfig.wsPort;
 					});
-					expect(_.intersection(allPeerPorts, peerPorts)).to.be.an('array').and.not.to.be.empty;
+					_.intersection(allPeerPorts, peerPorts).should.be.an('array').and.not.to.be.empty;
 				});
 			});
 		});
@@ -340,8 +340,8 @@ describe('integration', function () {
 				var maxHeight = 1;
 				var heightSum = 0;
 				results.forEach(function (result) {
-					expect(result).to.have.property('success').to.be.ok;
-					expect(result).to.have.property('height').to.be.a('number');
+					result.should.have.property('success').to.be.ok;
+					result.should.have.property('height').to.be.a('number');
 					if (result.height > maxHeight) {
 						maxHeight = result.height;
 					}
@@ -395,26 +395,26 @@ describe('integration', function () {
 			});
 
 			it('should have no error', function () {
-				expect(getNetworkStatusError).not.to.exist;
+				should.not.exist(getNetworkStatusError);
 			});
 
 			it('should have height > 1', function () {
-				expect(networkHeight).to.be.above(1);
+				networkHeight.should.be.above(1);
 			});
 
 			it('should have average height above 1', function () {
-				expect(networkAverageHeight).to.be.above(1);
+				networkAverageHeight.should.be.above(1);
 			});
 
 			it('should have different peers heights propagated correctly on peers lists', function () {
 				return Promise.all(sockets.map(function (socket) {
 					return socket.wampSend('list');
 				})).then(function (results) {
-					expect(results.some(function (peersList) {
+					results.some(function (peersList) {
 						return peersList.peers.some(function (peer) {
 							return peer.height > 1;
 						});
-					}));
+					}).should.be.true;
 				});
 			});
 		});
@@ -443,26 +443,26 @@ describe('integration', function () {
 					nodesBlocks = results.map(function (res) {
 						return JSON.parse(res.body).data;
 					});
-					expect(nodesBlocks).to.have.lengthOf(testNodeConfigs.length);
+					nodesBlocks.should.have.lengthOf(testNodeConfigs.length);
 				});
 			});
 
 			it('should contain non empty blocks after running functional tests', function () {
 				nodesBlocks.forEach(function (blocks) {
-					expect(blocks).to.be.an('array').and.not.empty;
+					blocks.should.be.an('array').and.not.empty;
 				});
 			});
 
 			it('should have all peers at the same height', function () {
 				var uniquePeersHeights = _(nodesBlocks).map('length').uniq().value();
-				expect(uniquePeersHeights).to.have.lengthOf.at.least(1);
+				uniquePeersHeights.should.have.lengthOf.at.least(1);
 			});
 
 			it('should have all blocks the same at all peers', function () {
 				var patternBlocks = nodesBlocks[0];
 				for (var i = 0; i < patternBlocks.length; i += 1) {
 					for (var j = 1; j < nodesBlocks.length; j += 1) {
-						expect(_.isEqual(nodesBlocks[j][i], patternBlocks[i]));
+						_.isEqual(nodesBlocks[j][i], patternBlocks[i]).should.be.true;
 					}
 				}
 			});
@@ -479,26 +479,26 @@ describe('integration', function () {
 					nodesTransactions = results.map(function (res) {
 						return res.blocks;
 					});
-					expect(nodesTransactions).to.have.lengthOf(testNodeConfigs.length);
+					nodesTransactions.should.have.lengthOf(testNodeConfigs.length);
 				});
 			});
 
 			it('should contain non empty transactions after running functional tests', function () {
 				nodesTransactions.forEach(function (transactions) {
-					expect(transactions).to.be.an('array').and.not.empty;
+					transactions.should.be.an('array').and.not.empty;
 				});
 			});
 
 			it('should have all peers having same amount of confirmed transactions', function () {
 				var uniquePeersTransactionsNumber = _(nodesTransactions).map('length').uniq().value();
-				expect(uniquePeersTransactionsNumber).to.have.lengthOf.at.least(1);
+				uniquePeersTransactionsNumber.should.have.lengthOf.at.least(1);
 			});
 
 			it('should have all transactions the same at all peers', function () {
 				var patternTransactions = nodesTransactions[0];
 				for (var i = 0; i < patternTransactions.length; i += 1) {
 					for (var j = 1; j < nodesTransactions.length; j += 1) {
-						expect(_.isEqual(nodesTransactions[j][i], patternTransactions[i]));
+						_.isEqual(nodesTransactions[j][i], patternTransactions[i]).should.be.true;
 					}
 				}
 			});

--- a/test/integration/scenarios/network/peers.js
+++ b/test/integration/scenarios/network/peers.js
@@ -25,15 +25,15 @@ module.exports = function (params) {
 				return socket.wampSend('list', {});
 			})).then(function (results) {
 				results.forEach(function (result) {
-					expect(result).to.have.property('success').to.be.true;
-					expect(result).to.have.property('peers').to.be.a('array');
+					result.should.have.property('success').to.be.true;
+					result.should.have.property('peers').to.be.a('array');
 					var peerPorts = result.peers.map(function (peer) {
 						return peer.wsPort;
 					});
 					var allPorts = params.configurations.map(function (configuration) {
 						return configuration.wsPort;
 					});
-					expect(_.intersection(allPorts, peerPorts)).to.be.an('array').and.not.to.be.empty;
+					_.intersection(allPorts, peerPorts).should.be.an('array').and.not.to.be.empty;
 				});
 			});
 		});
@@ -48,8 +48,8 @@ module.exports = function (params) {
 				var maxHeight = 1;
 				var heightSum = 0;
 				results.forEach(function (result) {
-					expect(result).to.have.property('success').to.be.true;
-					expect(result).to.have.property('height').to.be.a('number');
+					result.should.have.property('success').to.be.true;
+					result.should.have.property('height').to.be.a('number');
 					if (result.height > maxHeight) {
 						maxHeight = result.height;
 					}
@@ -103,26 +103,26 @@ module.exports = function (params) {
 			});
 
 			it('should have no error', function () {
-				expect(getNetworkStatusError).not.to.exist;
+				should.not.exist(getNetworkStatusError);
 			});
 
 			it('should have height > 1', function () {
-				expect(networkHeight).to.be.above(1);
+				networkHeight.should.be.above(1);
 			});
 
 			it('should have average height above 1', function () {
-				expect(networkAverageHeight).to.be.above(1);
+				networkAverageHeight.should.be.above(1);
 			});
 
 			it('should have different peers heights propagated correctly on peers lists', function () {
 				return Promise.all(params.sockets.map(function (socket) {
 					return socket.wampSend('list', {});
 				})).then(function (results) {
-					expect(results.some(function (peersList) {
+					results.some(function (peersList) {
 						return peersList.peers.some(function (peer) {
 							return peer.height > 1;
 						});
-					}));
+					}).should.be.true;
 				});
 			});
 		});

--- a/test/integration/scenarios/propagation/blocks.js
+++ b/test/integration/scenarios/propagation/blocks.js
@@ -31,25 +31,25 @@ module.exports = function (params) {
 		});
 
 		it('should be able to get blocks list from every peer', function () {
-			expect(nodesBlocks).to.have.lengthOf(params.configurations.length);
+			nodesBlocks.should.have.lengthOf(params.configurations.length);
 		});
 
 		it('should contain non empty blocks after running functional tests', function () {
 			nodesBlocks.forEach(function (blocks) {
-				expect(blocks).to.be.an('array').and.not.to.be.empty;
+				blocks.should.be.an('array').and.not.to.be.empty;
 			});
 		});
 
 		it('should have all peers at the same height', function () {
 			var uniquePeersHeights = _(nodesBlocks).map('length').uniq().value();
-			expect(uniquePeersHeights).to.have.lengthOf.at.least(1);
+			uniquePeersHeights.should.have.lengthOf.at.least(1);
 		});
 
 		it('should have all blocks the same at all peers', function () {
 			var patternBlocks = nodesBlocks[0];
 			for (var i = 0; i < patternBlocks.length; i += 1) {
 				for (var j = 1; j < nodesBlocks.length; j += 1) {
-					expect(_.isEqual(nodesBlocks[j][i], patternBlocks[i]));
+					_.isEqual(nodesBlocks[j][i], patternBlocks[i]).should.be.true;
 				}
 			}
 		});

--- a/test/integration/scenarios/propagation/transactions.js
+++ b/test/integration/scenarios/propagation/transactions.js
@@ -28,26 +28,26 @@ module.exports = function (params) {
 				nodesTransactions = results.map(function (res) {
 					return res.blocks;
 				});
-				expect(nodesTransactions).to.have.lengthOf(params.configurations.length);
+				nodesTransactions.should.have.lengthOf(params.configurations.length);
 			});
 		});
 
 		it('should contain non empty transactions after running functional tests', function () {
 			nodesTransactions.forEach(function (transactions) {
-				expect(transactions).to.be.an('array').and.not.empty;
+				transactions.should.be.an('array').and.not.empty;
 			});
 		});
 
 		it('should have all peers having same amount of confirmed transactions', function () {
 			var uniquePeersTransactionsNumber = _(nodesTransactions).map('length').uniq().value();
-			expect(uniquePeersTransactionsNumber).to.have.lengthOf.at.least(1);
+			uniquePeersTransactionsNumber.should.have.lengthOf.at.least(1);
 		});
 
 		it('should have all transactions the same at all peers', function () {
 			var patternTransactions = nodesTransactions[0];
 			for (var i = 0; i < patternTransactions.length; i += 1) {
 				for (var j = 1; j < nodesTransactions.length; j += 1) {
-					expect(_.isEqual(nodesTransactions[j][i], patternTransactions[i]));
+					_.isEqual(nodesTransactions[j][i], patternTransactions[i]).should.be.true;
 				}
 			}
 		});

--- a/test/integration/scenarios/stress/0.transfer.js
+++ b/test/integration/scenarios/stress/0.transfer.js
@@ -39,7 +39,7 @@ module.exports = function (params) {
 				});
 			})).then(function (results) {
 				results.forEach(function (transaction) {
-					expect(transaction).to.have.property('id').that.is.an('string');
+					transaction.should.have.property('id').that.is.an('string');
 				});
 			});
 		}

--- a/test/integration/setup/index.js
+++ b/test/integration/setup/index.js
@@ -46,6 +46,10 @@ module.exports = {
 				network.waitForAllNodesToBeReady(configurations, cbSeries);
 			},
 			function (cbSeries) {
+				utils.logger.log('Waiting ' + WAIT_BEFORE_CONNECT_MS / 1000 + ' seconds for nodes to establish connections');
+				setTimeout(cbSeries, WAIT_BEFORE_CONNECT_MS);
+			},
+			function (cbSeries) {
 				utils.logger.log('Enabling forging with registered delegates');
 				network.enableForgingOnDelegates(configurations, cbSeries);
 			},

--- a/test/unit/api/ws/workers/connectionsTable.js
+++ b/test/unit/api/ws/workers/connectionsTable.js
@@ -28,156 +28,156 @@ describe('ConnectionsTable', function () {
 	describe('constructor', function () {
 
 		it('should have empty connectionIdToNonceMap map after initialization', function () {
-			expect(connectionsTable).to.have.property('connectionIdToNonceMap').to.be.empty;
+			connectionsTable.should.have.property('connectionIdToNonceMap').to.be.empty;
 		});
 
 		it('should have empty nonceToConnectionIdMap map after initialization', function () {
-			expect(connectionsTable).to.have.property('nonceToConnectionIdMap').to.be.empty;
+			connectionsTable.should.have.property('nonceToConnectionIdMap').to.be.empty;
 		});
 	});
 
 	describe('add', function () {
 
 		it('should throw an error when invoked without arguments', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add();
-			}).to.throw('Cannot add connection table entry without nonce');
+			}).should.throw('Cannot add connection table entry without nonce');
 		});
 
 		it('should throw an error when invoked with nonce equal undefined', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add(undefined, validConnectionId);
-			}).to.throw('Cannot add connection table entry without nonce');
+			}).should.throw('Cannot add connection table entry without nonce');
 		});
 
 		it('should throw an error when invoked with nonce equal null', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add(null, validConnectionId);
-			}).to.throw('Cannot add connection table entry without nonce');
+			}).should.throw('Cannot add connection table entry without nonce');
 		});
 
 		it('should throw an error when invoked with nonce equal 0', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add(0, validConnectionId);
-			}).to.throw('Cannot add connection table entry without nonce');
+			}).should.throw('Cannot add connection table entry without nonce');
 		});
 
 		it('should throw an error when invoked with connectionId equal undefined', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add(validNonce);
-			}).to.throw('Cannot add connection table entry without connectionId');
+			}).should.throw('Cannot add connection table entry without connectionId');
 		});
 
 		it('should throw an error when invoked with connectionId equal null', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add(validNonce, null);
-			}).to.throw('Cannot add connection table entry without connectionId');
+			}).should.throw('Cannot add connection table entry without connectionId');
 		});
 
 		it('should throw an error when invoked with connectionId equal 0', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.add(validNonce, 0);
-			}).to.throw('Cannot add connection table entry without connectionId');
+			}).should.throw('Cannot add connection table entry without connectionId');
 		});
 
 		it('should add entry to connectionIdToNonceMap when invoked with valid arguments', function () {
 			connectionsTable.add(validNonce, validConnectionId);
-			expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionId).equal(validNonce);
+			connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionId).equal(validNonce);
 		});
 
 		it('should add entry to nonceToConnectionIdMap when invoked with valid arguments', function () {
 			connectionsTable.add(validNonce, validConnectionId);
-			expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validNonce).equal(validConnectionId);
+			connectionsTable.nonceToConnectionIdMap.should.have.property(validNonce).equal(validConnectionId);
 		});
 
 		it('should add multiple entries in nonceToConnectionIdMap after multiple valid entries added', function () {
 			connectionsTable.add(validNonce + '0', validConnectionId + '0');
 			connectionsTable.add(validNonce + '1', validConnectionId + '1');
-			expect(Object.keys(connectionsTable.nonceToConnectionIdMap).length).to.equal(2);
-			expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validNonce + '0').equal(validConnectionId + '0');
-			expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validNonce + '1').equal(validConnectionId + '1');
+			Object.keys(connectionsTable.nonceToConnectionIdMap).length.should.equal(2);
+			connectionsTable.nonceToConnectionIdMap.should.have.property(validNonce + '0').equal(validConnectionId + '0');
+			connectionsTable.nonceToConnectionIdMap.should.have.property(validNonce + '1').equal(validConnectionId + '1');
 		});
 
 		it('should add multiple entries in connectionIdToNonceMap after multiple valid entries added', function () {
 			connectionsTable.add(validNonce + '0', validConnectionId + '0');
 			connectionsTable.add(validNonce + '1', validConnectionId + '1');
-			expect(Object.keys(connectionsTable.connectionIdToNonceMap).length).to.equal(2);
-			expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionId + '0').equal(validNonce + '0');
-			expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionId + '1').equal(validNonce + '1');
+			Object.keys(connectionsTable.connectionIdToNonceMap).length.should.equal(2);
+			connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionId + '0').equal(validNonce + '0');
+			connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionId + '1').equal(validNonce + '1');
 		});
 
 		it('should not add multiple entries in nonceToConnectionIdMap and connectionIdToNonceMap after multiple addition of the same entry', function () {
 			connectionsTable.add(validNonce, validConnectionId);
 			connectionsTable.add(validNonce, validConnectionId);
-			expect(Object.keys(connectionsTable.nonceToConnectionIdMap).length).to.equal(1);
-			expect(Object.keys(connectionsTable.connectionIdToNonceMap).length).to.equal(1);
+			Object.keys(connectionsTable.nonceToConnectionIdMap).length.should.equal(1);
+			Object.keys(connectionsTable.connectionIdToNonceMap).length.should.equal(1);
 		});
 	});
 
 	describe('remove', function () {
 
 		it('should throw an error when invoked without arguments', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.remove();
-			}).to.throw('Cannot remove connection table entry without nonce');
+			}).should.throw('Cannot remove connection table entry without nonce');
 		});
 
 		it('should throw an error when invoked with nonce equal null', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.remove(null);
-			}).to.throw('Cannot remove connection table entry without nonce');
+			}).should.throw('Cannot remove connection table entry without nonce');
 		});
 
 		it('should throw an error when invoked with nonce equal 0', function () {
-			expect(function () {
+			(function () {
 				connectionsTable.remove(0);
-			}).to.throw('Cannot remove connection table entry without nonce');
+			}).should.throw('Cannot remove connection table entry without nonce');
 		});
 
 		it('should not change a state of connections table when removing not existing entry', function () {
 			connectionsTable.remove(validNonce);
-			expect(connectionsTable).to.have.property('connectionIdToNonceMap').to.be.empty;
-			expect(connectionsTable).to.have.property('nonceToConnectionIdMap').to.be.empty;
+			connectionsTable.should.have.property('connectionIdToNonceMap').to.be.empty;
+			connectionsTable.should.have.property('nonceToConnectionIdMap').to.be.empty;
 		});
 
 		it('should remove previously added valid entry', function () {
 			connectionsTable.add(validNonce, validConnectionId);
-			expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validNonce).equal(validConnectionId);
+			connectionsTable.nonceToConnectionIdMap.should.have.property(validNonce).equal(validConnectionId);
 			connectionsTable.remove(validNonce);
-			expect(connectionsTable).to.have.property('connectionIdToNonceMap').to.be.empty;
-			expect(connectionsTable).to.have.property('nonceToConnectionIdMap').to.be.empty;
+			connectionsTable.should.have.property('connectionIdToNonceMap').to.be.empty;
+			connectionsTable.should.have.property('nonceToConnectionIdMap').to.be.empty;
 		});
 	});
 
 	describe('getNonce', function () {
 
 		it('should return undefined when invoked without arguments', function () {
-			expect(connectionsTable.getNonce()).to.be.undefined;
+			should.not.exist(connectionsTable.getNonce());
 		});
 
 		it('should return undefined when asking of not existing entry', function () {
-			expect(connectionsTable.getNonce(validConnectionId)).to.be.undefined;
+			should.not.exist(connectionsTable.getNonce(validConnectionId));
 		});
 
 		it('should return nonce assigned to connection id when entry exists', function () {
 			connectionsTable.add(validNonce, validConnectionId);
-			expect(connectionsTable.getNonce(validConnectionId)).to.equal(validNonce);
+			connectionsTable.getNonce(validConnectionId).should.equal(validNonce);
 		});
 	});
 
 	describe('getConnectionId', function () {
 
 		it('should return undefined when invoked without arguments', function () {
-			expect(connectionsTable.getConnectionId()).to.be.undefined;
+			should.not.exist(connectionsTable.getConnectionId());
 		});
 
 		it('should return undefined when asking of not existing entry', function () {
-			expect(connectionsTable.getConnectionId(validNonce)).to.be.undefined;
+			should.not.exist(connectionsTable.getConnectionId(validNonce));
 		});
 
 		it('should return connection id assigned to nonce id when entry exists', function () {
 			connectionsTable.add(validNonce, validConnectionId);
-			expect(connectionsTable.getConnectionId(validNonce)).to.equal(validConnectionId);
+			connectionsTable.getConnectionId(validNonce).should.equal(validConnectionId);
 		});
 	});
 });

--- a/test/unit/api/ws/workers/peersUpdateRules.js
+++ b/test/unit/api/ws/workers/peersUpdateRules.js
@@ -50,11 +50,11 @@ describe('PeersUpdateRules', function () {
 	describe('constructor', function () {
 
 		it('should have empty slaveToMasterSender object assigned', function () {
-			expect(peersUpdateRules).to.have.property('slaveToMasterSender').to.be.a('object');
+			peersUpdateRules.should.have.property('slaveToMasterSender').to.be.a('object');
 		});
 
 		it('should have empty rules object assigned', function () {
-			expect(peersUpdateRules).to.have.property('rules').to.be.a('object');
+			peersUpdateRules.should.have.property('rules').to.be.a('object');
 		});
 	});
 
@@ -62,53 +62,53 @@ describe('PeersUpdateRules', function () {
 
 		it('should return an error when invoked with callback only', function (done) {
 			peersUpdateRules.insert(undefined, undefined, function (err) {
-				expect(err).to.be.an('error');
+				err.should.be.an('error');
 				done();
 			});
 		});
 
 		it('should return an error when invoked with undefined peer', function (done) {
 			peersUpdateRules.insert(undefined, validConnectionId, function (err) {
-				expect(err).to.have.property('message').equal('Cannot read property \'nonce\' of undefined');
+				err.should.have.property('message').equal('Cannot read property \'nonce\' of undefined');
 				done();
 			});
 		});
 
 		it('should return an error when invoked with peer without nonce', function (done) {
 			peersUpdateRules.insert({}, validConnectionId, function (err) {
-				expect(err).to.have.property('message').equal('Cannot add connection table entry without nonce');
+				err.should.have.property('message').equal('Cannot add connection table entry without nonce');
 				done();
 			});
 		});
 
 		it('should return an error when invoked with undefined connection id', function (done) {
 			peersUpdateRules.insert(validPeer, undefined, function (err) {
-				expect(err).to.have.property('message').equal('Cannot add connection table entry without connectionId');
+				err.should.have.property('message').equal('Cannot add connection table entry without connectionId');
 				done();
 			});
 		});
 
 		it('should not return an error when invoked with valid arguments', function (done) {
 			peersUpdateRules.insert(validPeer, validConnectionId, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call sendInternally when invoked with valid arguments', function () {
 			peersUpdateRules.insert(validPeer, validConnectionId, actionCb);
-			expect(peersUpdateRules.slaveToMasterSender.send.called).to.be.true;
+			peersUpdateRules.slaveToMasterSender.send.called.should.be.true;
 		});
 
 		it('should call sendInternally with acceptPeer procedure when invoked with valid arguments', function () {
 			peersUpdateRules.insert(validPeer, validConnectionId, actionCb);
-			expect(peersUpdateRules.slaveToMasterSender.send.calledWith('updatePeer')).to.be.true;
+			peersUpdateRules.slaveToMasterSender.send.calledWith('updatePeer').should.be.true;
 		});
 
 		it('should insert entries to connectionsTable when invoked with valid arguments', function () {
 			peersUpdateRules.insert(validPeer, validConnectionId, actionCb);
-			expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validPeer.nonce).equal(validConnectionId);
-			expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionId).equal(validPeer.nonce);
+			connectionsTable.nonceToConnectionIdMap.should.have.property(validPeer.nonce).equal(validConnectionId);
+			connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionId).equal(validPeer.nonce);
 		});
 
 		it('should return an error from server when invoked with valid arguments and received error code', function (done) {
@@ -116,7 +116,7 @@ describe('PeersUpdateRules', function () {
 			peersUpdateRules.slaveToMasterSender.send =
 				sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, {code: validErrorCode});
 			peersUpdateRules.insert(validPeer, validConnectionId, function (err) {
-				expect(err).to.have.property('code').equal(validErrorCode);
+				err.should.have.property('code').equal(validErrorCode);
 				done();
 			});
 		});
@@ -125,9 +125,9 @@ describe('PeersUpdateRules', function () {
 			peersUpdateRules.slaveToMasterSender.send.restore();
 			peersUpdateRules.slaveToMasterSender.send = sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, 'On remove error');
 			peersUpdateRules.insert(validPeer, validConnectionId, function (err) {
-				expect(err).to.have.property('code').equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
-				expect(err).to.have.property('message').equal('Transport error while invoking update procedure');
-				expect(err).to.have.property('description').equal('On remove error');
+				err.should.have.property('code').equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
+				err.should.have.property('message').equal('Transport error while invoking update procedure');
+				err.should.have.property('description').equal('On remove error');
 				done();
 			});
 		});
@@ -136,8 +136,8 @@ describe('PeersUpdateRules', function () {
 			peersUpdateRules.slaveToMasterSender.send.restore();
 			peersUpdateRules.slaveToMasterSender.send = sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, 'On insert error');
 			peersUpdateRules.insert(validPeer, validConnectionId, function () {
-				expect(connectionsTable.nonceToConnectionIdMap).to.be.empty;
-				expect(connectionsTable.connectionIdToNonceMap).to.be.empty;
+				connectionsTable.nonceToConnectionIdMap.should.be.empty;
+				connectionsTable.connectionIdToNonceMap.should.be.empty;
 				done();
 			});
 		});
@@ -146,8 +146,8 @@ describe('PeersUpdateRules', function () {
 			peersUpdateRules.slaveToMasterSender.send.restore();
 			peersUpdateRules.slaveToMasterSender.send = sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, {code: validErrorCode});
 			peersUpdateRules.insert(validPeer, validConnectionId, function () {
-				expect(connectionsTable.nonceToConnectionIdMap).to.be.empty;
-				expect(connectionsTable.connectionIdToNonceMap).to.be.empty;
+				connectionsTable.nonceToConnectionIdMap.should.be.empty;
+				connectionsTable.connectionIdToNonceMap.should.be.empty;
 				done();
 			});
 		});
@@ -170,16 +170,16 @@ describe('PeersUpdateRules', function () {
 			});
 
 			it('should insert multiple entries to connectionsTable when invoked with valid arguments', function () {
-				expect(Object.keys(connectionsTable.nonceToConnectionIdMap).length).to.equal(2);
-				expect(Object.keys(connectionsTable.connectionIdToNonceMap).length).to.equal(2);
-				expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validPeerA.nonce).equal(validConnectionIdA);
-				expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validPeerB.nonce).equal(validConnectionIdB);
-				expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionIdA).equal(validPeerA.nonce);
-				expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionIdB).equal(validPeerB.nonce);
+				Object.keys(connectionsTable.nonceToConnectionIdMap).length.should.equal(2);
+				Object.keys(connectionsTable.connectionIdToNonceMap).length.should.equal(2);
+				connectionsTable.nonceToConnectionIdMap.should.have.property(validPeerA.nonce).equal(validConnectionIdA);
+				connectionsTable.nonceToConnectionIdMap.should.have.property(validPeerB.nonce).equal(validConnectionIdB);
+				connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionIdA).equal(validPeerA.nonce);
+				connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionIdB).equal(validPeerB.nonce);
 			});
 
 			it('should call sendInternally multiple times', function () {
-				expect(peersUpdateRules.slaveToMasterSender.send.calledTwice).to.be.true;
+				peersUpdateRules.slaveToMasterSender.send.calledTwice.should.be.true;
 			});
 		});
 	});
@@ -188,47 +188,47 @@ describe('PeersUpdateRules', function () {
 
 		it('should return an error when invoked with callback only', function (done) {
 			peersUpdateRules.remove(undefined, undefined, function (err) {
-				expect(err).to.be.an('error');
+				err.should.be.an('error');
 				done();
 			});
 		});
 
 		it('should return an error when invoked with undefined peer', function (done) {
 			peersUpdateRules.remove(undefined, validConnectionId, function (err) {
-				expect(err).to.have.property('message').equal('Cannot read property \'nonce\' of undefined');
+				err.should.have.property('message').equal('Cannot read property \'nonce\' of undefined');
 				done();
 			});
 		});
 
 		it('should be ok to invoke with undefined connection id', function (done) {
 			peersUpdateRules.remove(validPeer, undefined, function (err) {
-				expect(err).to.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should return an error when invoked with peer without nonce', function (done) {
 			peersUpdateRules.remove({}, validConnectionId, function (err) {
-				expect(err).to.have.property('message').equal('Cannot remove connection table entry without nonce');
+				err.should.have.property('message').equal('Cannot remove connection table entry without nonce');
 				done();
 			});
 		});
 
 		it('should be ok to remove peer which was not added previously', function (done) {
 			peersUpdateRules.remove(validPeer, validConnectionId, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call slaveToMasterSender.send when invoked with valid arguments', function () {
 			peersUpdateRules.remove(validPeer, validConnectionId, actionCb);
-			expect(peersUpdateRules.slaveToMasterSender.send.calledOnce).to.be.true;
+			peersUpdateRules.slaveToMasterSender.send.calledOnce.should.be.true;
 		});
 
 		it('should call slaveToMasterSender.send with updatePeer procedure when invoked with valid arguments', function () {
 			peersUpdateRules.remove(validPeer, validConnectionId, actionCb);
-			expect(peersUpdateRules.slaveToMasterSender.send.calledWith('updatePeer')).to.be.true;
+			peersUpdateRules.slaveToMasterSender.send.calledWith('updatePeer').should.be.true;
 		});
 
 		describe('after peer is added', function () {
@@ -241,14 +241,14 @@ describe('PeersUpdateRules', function () {
 
 			it('should leave the connections table in empty state after successful removal', function () {
 				peersUpdateRules.remove(validPeer, validConnectionId, actionCb);
-				expect(peersUpdateRules.slaveToMasterSender.send.calledOnce).to.be.true;
-				expect(connectionsTable).to.have.property('connectionIdToNonceMap').to.be.empty;
-				expect(connectionsTable).to.have.property('nonceToConnectionIdMap').to.be.empty;
+				peersUpdateRules.slaveToMasterSender.send.calledOnce.should.be.true;
+				connectionsTable.should.have.property('connectionIdToNonceMap').to.be.empty;
+				connectionsTable.should.have.property('nonceToConnectionIdMap').to.be.empty;
 			});
 
 			it('should be ok to remove peer using different connection id', function (done) {
 				peersUpdateRules.remove(validPeer, 'different connection id', function (err) {
-					expect(err).to.be.undefined;
+					should.not.exist(err);
 					done();
 				});
 			});
@@ -258,7 +258,7 @@ describe('PeersUpdateRules', function () {
 				peersUpdateRules.slaveToMasterSender.send =
 					sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, {code: validErrorCode});
 				peersUpdateRules.remove(validPeer, validConnectionId, function (err) {
-					expect(err).to.have.property('code').equal(validErrorCode);
+					err.should.have.property('code').equal(validErrorCode);
 					done();
 				});
 			});
@@ -267,9 +267,9 @@ describe('PeersUpdateRules', function () {
 				peersUpdateRules.slaveToMasterSender.send.restore();
 				peersUpdateRules.slaveToMasterSender.send = sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, 'On remove error');
 				peersUpdateRules.remove(validPeer, validConnectionId, function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
-					expect(err).to.have.property('message').equal('Transport error while invoking update procedure');
-					expect(err).to.have.property('description').equal('On remove error');
+					err.should.have.property('code').equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
+					err.should.have.property('message').equal('Transport error while invoking update procedure');
+					err.should.have.property('description').equal('On remove error');
 					done();
 				});
 			});
@@ -278,9 +278,9 @@ describe('PeersUpdateRules', function () {
 				peersUpdateRules.slaveToMasterSender.send.restore();
 				peersUpdateRules.slaveToMasterSender.send = sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, 'On remove error');
 				peersUpdateRules.remove(validPeer, validConnectionId, function (err) {
-					expect(err).to.have.property('code').equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
-					expect(connectionsTable.nonceToConnectionIdMap).to.have.property(validPeer.nonce).equal(validConnectionId);
-					expect(connectionsTable.connectionIdToNonceMap).to.have.property(validConnectionId).equal(validPeer.nonce);
+					err.should.have.property('code').equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
+					connectionsTable.nonceToConnectionIdMap.should.have.property(validPeer.nonce).equal(validConnectionId);
+					connectionsTable.connectionIdToNonceMap.should.have.property(validConnectionId).equal(validPeer.nonce);
 					done();
 				});
 			});
@@ -289,8 +289,8 @@ describe('PeersUpdateRules', function () {
 				peersUpdateRules.slaveToMasterSender.send.restore();
 				peersUpdateRules.slaveToMasterSender.send = sinonSandbox.stub(peersUpdateRules.slaveToMasterSender, 'send').callsArgWith(3, {code: validErrorCode});
 				peersUpdateRules.remove(validPeer, validConnectionId, function (err) {
-					expect(connectionsTable.nonceToConnectionIdMap).to.be.empty;
-					expect(connectionsTable.connectionIdToNonceMap).to.be.empty;
+					connectionsTable.nonceToConnectionIdMap.should.be.empty;
+					connectionsTable.connectionIdToNonceMap.should.be.empty;
 					done();
 				});
 			});
@@ -303,7 +303,7 @@ describe('PeersUpdateRules', function () {
 
 		it('should return the PeerUpdateError when called', function (done) {
 			peersUpdateRules.block(validFailureCode, validPeer, validConnectionId, function (err) {
-				expect(err).to.have.instanceOf(PeerUpdateError);
+				err.should.have.instanceOf(PeerUpdateError);
 				done();
 			});
 		});
@@ -356,28 +356,28 @@ describe('PeersUpdateRules', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(blockStub.called).to.be.true;
+					blockStub.called.should.be.true;
 				});
 
 				it('with present nonce and not present connectionId should call block', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(blockStub.called).to.be.true;
+					blockStub.called.should.be.true;
 				});
 
 				it('with not present nonce and present connectionId should call insert', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(insertStub.called).to.be.true;
+					insertStub.called.should.be.true;
 				});
 
 				it('with not present nonce and not present connectionId should call insert', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(insertStub.called).to.be.true;
+					insertStub.called.should.be.true;
 				});
 			});
 
@@ -393,28 +393,28 @@ describe('PeersUpdateRules', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(insertStub.called).to.be.true;
+					insertStub.called.should.be.true;
 				});
 
 				it('with present nonce and not present connectionId should call insert', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(insertStub.called).to.be.true;
+					insertStub.called.should.be.true;
 				});
 
 				it('with not present nonce and present connectionId should call insert', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(insertStub.called).to.be.true;
+					insertStub.called.should.be.true;
 				});
 
 				it('with not present nonce and not present connectionId should call insert', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(INSERT, validPeer, validConnectionId, actionCb);
-					expect(insertStub.called).to.be.true;
+					insertStub.called.should.be.true;
 				});
 			});
 		});
@@ -435,28 +435,28 @@ describe('PeersUpdateRules', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(removeStub.called).to.be.true;
+					removeStub.called.should.be.true;
 				});
 
 				it('with present nonce and not present connectionId should call block', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(blockStub.called).to.be.true;
+					blockStub.called.should.be.true;
 				});
 
 				it('with not present nonce and present connectionId should call remove', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(removeStub.called).to.be.true;
+					removeStub.called.should.be.true;
 				});
 
 				it('with not present nonce and not present connectionId should call remove', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(removeStub.called).to.be.true;
+					removeStub.called.should.be.true;
 				});
 			});
 
@@ -472,28 +472,28 @@ describe('PeersUpdateRules', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(removeStub.called).to.be.true;
+					removeStub.called.should.be.true;
 				});
 
 				it('with present nonce and not present connectionId should call block', function () {
 					setNoncePresence('validNonce');
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(removeStub.called).to.be.true;
+					removeStub.called.should.be.true;
 				});
 
 				it('with not present nonce and present connectionId should call remove', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence('validConnectionId');
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(removeStub.called).to.be.true;
+					removeStub.called.should.be.true;
 				});
 
 				it('with not present nonce and not present connectionId should call block', function () {
 					setNoncePresence(null);
 					setConnectionIdPresence(null);
 					peersUpdateRules.internal.update(REMOVE, validPeer, validConnectionId, actionCb);
-					expect(blockStub.called).to.be.true;
+					blockStub.called.should.be.true;
 				});
 			});
 		});
@@ -516,7 +516,7 @@ describe('PeersUpdateRules', function () {
 
 			it('should reject empty requests', function (done) {
 				peersUpdateRules.external.update(undefined, function (err, res) {
-					expect(err).to.equal('Expected type object but found type undefined');
+					err.should.equal('Expected type object but found type undefined');
 					done();
 				});
 			});
@@ -524,7 +524,7 @@ describe('PeersUpdateRules', function () {
 			it('should reject requests without data field', function (done) {
 				delete minimalValidUpdateRequest.data;
 				peersUpdateRules.external.update(minimalValidUpdateRequest, function (err) {
-					expect(err).to.equal('Missing required property: data');
+					err.should.equal('Missing required property: data');
 					done();
 				});
 			});
@@ -532,7 +532,7 @@ describe('PeersUpdateRules', function () {
 			it('should reject requests without socketId field', function (done) {
 				delete minimalValidUpdateRequest.socketId;
 				peersUpdateRules.external.update(minimalValidUpdateRequest, function (err) {
-					expect(err).to.equal('Missing required property: socketId');
+					err.should.equal('Missing required property: socketId');
 					done();
 				});
 			});
@@ -540,7 +540,7 @@ describe('PeersUpdateRules', function () {
 			it('should reject requests without nonce', function (done) {
 				delete minimalValidUpdateRequest.data.nonce;
 				peersUpdateRules.external.update(minimalValidUpdateRequest, function (err) {
-					expect(err).to.equal('Missing required property: nonce');
+					err.should.equal('Missing required property: nonce');
 					done();
 				});
 			});
@@ -548,7 +548,7 @@ describe('PeersUpdateRules', function () {
 			it('should reject requests with nonce being number', function (done) {
 				minimalValidUpdateRequest.data.nonce = 1234567890123456;
 				peersUpdateRules.external.update(minimalValidUpdateRequest, function (err) {
-					expect(err).to.equal('Expected type string but found type integer');
+					err.should.equal('Expected type string but found type integer');
 					done();
 				});
 			});
@@ -556,7 +556,7 @@ describe('PeersUpdateRules', function () {
 			it('should reject requests with nonce being object', function (done) {
 				minimalValidUpdateRequest.data.nonce = {};
 				peersUpdateRules.external.update(minimalValidUpdateRequest, function (err) {
-					expect(err).to.equal('Expected type string but found type object');
+					err.should.equal('Expected type string but found type object');
 					done();
 				});
 			});
@@ -564,7 +564,7 @@ describe('PeersUpdateRules', function () {
 
 		it('should return an error when attempting to update peer which has no connection established', function (done) {
 			peersUpdateRules.external.update(minimalValidUpdateRequest, function (err) {
-				expect(err).to.have.property('message').equal('Connection id does not match with corresponding peer');
+				err.should.have.property('message').equal('Connection id does not match with corresponding peer');
 				done();
 			});
 		});

--- a/test/unit/api/ws/workers/rules.js
+++ b/test/unit/api/ws/workers/rules.js
@@ -33,30 +33,30 @@ describe('Rules', function () {
 	describe('constructor', function () {
 
 		it('should construct set of rules', function () {
-			expect(rules).to.have.property('rules').not.to.be.empty;
+			rules.should.have.property('rules').not.to.be.empty;
 		});
 	});
 
 	describe('rules', function () {
 
 		it('should have entries for every configuration', function () {
-			expect(rules.rules).to.have.nested.property('0.true.true.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.true.true.false').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.true.false.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.true.false.false').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.false.true.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.false.true.false').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.false.false.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('0.false.false.false').to.be.a('function');
+			rules.rules.should.have.nested.property('0.true.true.true').to.be.a('function');
+			rules.rules.should.have.nested.property('0.true.true.false').to.be.a('function');
+			rules.rules.should.have.nested.property('0.true.false.true').to.be.a('function');
+			rules.rules.should.have.nested.property('0.true.false.false').to.be.a('function');
+			rules.rules.should.have.nested.property('0.false.true.true').to.be.a('function');
+			rules.rules.should.have.nested.property('0.false.true.false').to.be.a('function');
+			rules.rules.should.have.nested.property('0.false.false.true').to.be.a('function');
+			rules.rules.should.have.nested.property('0.false.false.false').to.be.a('function');
 
-			expect(rules.rules).to.have.nested.property('1.true.true.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.true.true.false').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.true.false.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.true.false.false').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.false.true.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.false.true.false').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.false.false.true').to.be.a('function');
-			expect(rules.rules).to.have.nested.property('1.false.false.false').to.be.a('function');
+			rules.rules.should.have.nested.property('1.true.true.true').to.be.a('function');
+			rules.rules.should.have.nested.property('1.true.true.false').to.be.a('function');
+			rules.rules.should.have.nested.property('1.true.false.true').to.be.a('function');
+			rules.rules.should.have.nested.property('1.true.false.false').to.be.a('function');
+			rules.rules.should.have.nested.property('1.false.true.true').to.be.a('function');
+			rules.rules.should.have.nested.property('1.false.true.false').to.be.a('function');
+			rules.rules.should.have.nested.property('1.false.false.true').to.be.a('function');
+			rules.rules.should.have.nested.property('1.false.false.false').to.be.a('function');
 		});
 
 		describe('error codes', function () {
@@ -71,12 +71,12 @@ describe('Rules', function () {
 
 				it('should return ALREADY_ADDED code when present on master, nonce is present, and present connection id', function () {
 					rules.rules[updateType][true][true][true]();
-					expect(blockMock.calledWithExactly(failureCodes.ALREADY_ADDED)).to.be.true;
+					blockMock.calledWithExactly(failureCodes.ALREADY_ADDED).should.be.true;
 				});
 
 				it('should return DIFFERENT_CONN_ID code when present on master, nonce is not present, and present connection id', function () {
 					rules.rules[updateType][true][false][true]();
-					expect(blockMock.calledWithExactly(failureCodes.DIFFERENT_CONN_ID)).to.be.true;
+					blockMock.calledWithExactly(failureCodes.DIFFERENT_CONN_ID).should.be.true;
 				});
 			});
 
@@ -88,12 +88,12 @@ describe('Rules', function () {
 
 				it('should return ALREADY_ADDED code when not present on master, nonce is not present, and not present connection id', function () {
 					rules.rules[updateType][false][false][false]();
-					expect(blockMock.calledWithExactly(failureCodes.ALREADY_REMOVED)).to.be.true;
+					blockMock.calledWithExactly(failureCodes.ALREADY_REMOVED).should.be.true;
 				});
 
 				it('should return DIFFERENT_CONN_ID code when present on master, nonce is not present, and present connection id', function () {
 					rules.rules[updateType][true][false][true]();
-					expect(blockMock.calledWithExactly(failureCodes.DIFFERENT_CONN_ID)).to.be.true;
+					blockMock.calledWithExactly(failureCodes.DIFFERENT_CONN_ID).should.be.true;
 				});
 			});
 		});

--- a/test/unit/api/ws/workers/slaveToMasterSender.js
+++ b/test/unit/api/ws/workers/slaveToMasterSender.js
@@ -42,7 +42,7 @@ describe('SlaveToMasterSender', function () {
 
 	describe('constructor', function () {
 		it('should have slaveWAMPServer assigned', function () {
-			expect(slaveToMasterSender).to.have.property('slaveWAMPServer').to.equal(slaveWAMPServerMock);
+			slaveToMasterSender.should.have.property('slaveWAMPServer').to.equal(slaveWAMPServerMock);
 		});
 	});
 
@@ -73,15 +73,15 @@ describe('SlaveToMasterSender', function () {
 			});
 
 			it('passed procedure as a first argument', function () {
-				expect(slaveWAMPServerMock.sendToMaster.firstCall.args[0]).equal(validProcedureName);
+				slaveWAMPServerMock.sendToMaster.firstCall.args[0].should.equal(validProcedureName);
 			});
 
 			it('expected payload as a second argument', function () {
-				expect(slaveWAMPServerMock.sendToMaster.firstCall.args[1]).eql(expectedPayload);
+				slaveWAMPServerMock.sendToMaster.firstCall.args[1].should.eql(expectedPayload);
 			});
 
 			it('nonce as a third argument', function () {
-				expect(slaveWAMPServerMock.sendToMaster.firstCall.args[2]).equal(validNonce);
+				slaveWAMPServerMock.sendToMaster.firstCall.args[2].should.equal(validNonce);
 			});
 		});
 	});
@@ -102,7 +102,7 @@ describe('SlaveToMasterSender', function () {
 			slaveWAMPServerMock.sendToMaster.restore();
 			slaveWAMPServerMock.sendToMaster = sinonSandbox.stub(slaveWAMPServerMock, 'sendToMaster').callsArgWith(3, 'On master error');
 			slaveToMasterSender.getPeer(validNonce, function (err) {
-				expect(err).to.equal('On master error');
+				err.should.equal('On master error');
 				done();
 			});
 		});
@@ -111,7 +111,7 @@ describe('SlaveToMasterSender', function () {
 			slaveWAMPServerMock.sendToMaster.restore();
 			slaveWAMPServerMock.sendToMaster = sinonSandbox.stub(slaveWAMPServerMock, 'sendToMaster').callsArgWith(3, null, {peers: []});
 			slaveToMasterSender.getPeer(validNonce, function (err, res) {
-				expect(res).to.be.false;
+				res.should.be.false;
 				done();
 			});
 		});
@@ -120,7 +120,7 @@ describe('SlaveToMasterSender', function () {
 			slaveWAMPServerMock.sendToMaster.restore();
 			slaveWAMPServerMock.sendToMaster = sinonSandbox.stub(slaveWAMPServerMock, 'sendToMaster').callsArgWith(3, null, {peers: [1]});
 			slaveToMasterSender.getPeer(validNonce, function (err, res) {
-				expect(res).to.be.true;
+				res.should.be.true;
 				done();
 			});
 		});
@@ -132,15 +132,15 @@ describe('SlaveToMasterSender', function () {
 			});
 
 			it('list a first argument', function () {
-				expect(slaveWAMPServerMock.sendToMaster.firstCall.args[0]).equal('list');
+				slaveWAMPServerMock.sendToMaster.firstCall.args[0].should.equal('list');
 			});
 
 			it('expected payload as a second argument', function () {
-				expect(slaveWAMPServerMock.sendToMaster.firstCall.args[1]).eql(expectedPayload);
+				slaveWAMPServerMock.sendToMaster.firstCall.args[1].should.eql(expectedPayload);
 			});
 
 			it('nonce as a third argument', function () {
-				expect(slaveWAMPServerMock.sendToMaster.firstCall.args[2]).equal(validNonce);
+				slaveWAMPServerMock.sendToMaster.firstCall.args[2].should.equal(validNonce);
 			});
 		});
 	});

--- a/test/unit/common/schemaDynamicTest.js
+++ b/test/unit/common/schemaDynamicTest.js
@@ -114,7 +114,7 @@ SchemaDynamicTest.prototype.carpetTesting = function (test, inputs, description)
 };
 
 SchemaDynamicTest.prototype.standardInvalidArgumentAssertion = function (input, expectedType, err) {
-	expect(err).to.be.an('array').and.to.have.nested.property('0.message')
+	err.should.be.an('array').and.to.have.nested.property('0.message')
 		.equal('Expected type ' + expectedType + ' but found type ' + input.expectation);
 };
 
@@ -149,7 +149,7 @@ SchemaDynamicTest.prototype.testProperty = function (expectedType, invalidInputs
 };
 
 SchemaDynamicTest.prototype.standardMissingRequiredPropertiesAssertion = function (property, err) {
-	expect(err).to.be.an('array').and.to.have.nested.property('0.message')
+	err.should.be.an('array').and.to.have.nested.property('0.message')
 		.equal('Missing required property: ' + property);
 };
 

--- a/test/unit/helpers/RPC.js
+++ b/test/unit/helpers/RPC.js
@@ -35,17 +35,17 @@ describe('wsRPC', function () {
 	});
 
 	it('should have empty clientsConnectionsMap field', function () {
-		expect(wsRPC).to.have.property('clientsConnectionsMap').to.be.a('object').and.to.be.empty;
+		wsRPC.should.have.property('clientsConnectionsMap').to.be.a('object').and.to.be.empty;
 	});
 
 	it('should have wampClient field of instance WAMPClient', function () {
-		expect(wsRPC).to.have.property('wampClient').and.to.be.a('object');
-		expect(wsRPC.wampClient.constructor.name).equal('WAMPClient');
+		wsRPC.should.have.property('wampClient').and.to.be.a('object');
+		wsRPC.wampClient.constructor.name.should.equal('WAMPClient');
 	});
 
 	it('should have scClient field without connections', function () {
-		expect(wsRPC).to.have.property('scClient').and.to.be.a('object');
-		expect(wsRPC.scClient).to.have.property('connections').to.be.a('object').and.to.be.empty;
+		wsRPC.should.have.property('scClient').and.to.be.a('object');
+		wsRPC.scClient.should.have.property('connections').to.be.a('object').and.to.be.empty;
 	});
 
 	describe('setServer', function () {
@@ -61,24 +61,24 @@ describe('wsRPC', function () {
 		it('should return server instance after setting it', function () {
 			wsRPC.setServer({name: 'my ws server'});
 			var wsRPCServer = wsRPC.getServer();
-			expect(wsRPCServer).to.be.an('object').eql({name: 'my ws server'});
+			wsRPCServer.should.be.an('object').eql({name: 'my ws server'});
 		});
 
 		describe('getter', function () {
 
 			it('should throw an error when setting server to null', function () {
 				wsRPC.setServer(null);
-				expect(wsRPC.getServer).to.throw('WS server has not been initialized!');
+				wsRPC.getServer.should.throw('WS server has not been initialized!');
 			});
 
 			it('should throw an error when setting server to 0', function () {
 				wsRPC.setServer(0);
-				expect(wsRPC.getServer).to.throw('WS server has not been initialized!');
+				wsRPC.getServer.should.throw('WS server has not been initialized!');
 			});
 
 			it('should throw an error when setting server to undefined', function () {
 				wsRPC.setServer(undefined);
-				expect(wsRPC.getServer).to.throw('WS server has not been initialized!');
+				wsRPC.getServer.should.throw('WS server has not been initialized!');
 			});
 		});
 	});
@@ -94,13 +94,13 @@ describe('wsRPC', function () {
 		});
 
 		it('should throw an error when WS server has not been initialized', function () {
-			expect(wsRPC.getServer).to.throw('WS server has not been initialized!');
+			wsRPC.getServer.should.throw('WS server has not been initialized!');
 		});
 
 		it('should return WS server if set before', function () {
 			wsRPC.setServer({name: 'my ws server'});
-			expect(wsRPC.getServer).not.to.throw;
-			expect(wsRPC.getServer()).to.a('object').eql({name: 'my ws server'});
+			wsRPC.getServer.should.not.to.throw;
+			wsRPC.getServer().should.a('object').eql({name: 'my ws server'});
 		});
 	});
 
@@ -119,14 +119,14 @@ describe('wsRPC', function () {
 		});
 
 		it('should throw error when no arguments specified', function () {
-			expect(wsRPC.getClientRPCStub).to.throw('RPC client needs ip and port to establish WS connection with: undefined:undefined');
+			wsRPC.getClientRPCStub.should.throw('RPC client needs ip and port to establish WS connection with: undefined:undefined');
 		});
 
 		it('should throw error when no port specified', function (done) {
 			try {
 				wsRPC.getClientRPCStub(validIp, undefined);
 			} catch (er) {
-				expect(er.message).equal('RPC client needs ip and port to establish WS connection with: 127.0.0.1:undefined');
+				er.message.should.equal('RPC client needs ip and port to establish WS connection with: 127.0.0.1:undefined');
 				return done();
 			}
 			done('Should not be here');
@@ -136,7 +136,7 @@ describe('wsRPC', function () {
 			try {
 				wsRPC.getClientRPCStub(undefined, validPort);
 			} catch (er) {
-				expect(er.message).equal('RPC client needs ip and port to establish WS connection with: undefined:4000');
+				er.message.should.equal('RPC client needs ip and port to establish WS connection with: undefined:4000');
 				return done();
 			}
 			done('Should not be here');
@@ -144,17 +144,17 @@ describe('wsRPC', function () {
 
 		it('should not initialize new connection just after getting RPC stub', function () {
 			wsRPC.getClientRPCStub(validIp, validPort);
-			expect(initializeNewConnectionStub.called).to.be.false;
+			initializeNewConnectionStub.called.should.be.false;
 		});
 
 		it('should add new entry in clientsConnectionsMap after getting stub', function () {
 			wsRPC.getClientRPCStub(validIp, validPort);
-			expect(wsRPC.clientsConnectionsMap).to.have.property(validIp + ':' + validPort).to.be.an.instanceof(ConnectionState);
+			wsRPC.clientsConnectionsMap.should.have.property(validIp + ':' + validPort).to.be.an.instanceof(ConnectionState);
 		});
 
 		it('should return empty client stub when no endpoints registered', function () {
 			var rpcStub = wsRPC.getClientRPCStub(validIp, validPort);
-			expect(rpcStub).to.be.a('object').and.to.be.empty;
+			rpcStub.should.be.a('object').and.to.be.empty;
 		});
 
 		describe('stub', function () {
@@ -186,7 +186,7 @@ describe('wsRPC', function () {
 				var wsServer = wsRPC.getServer();
 				wsServer.reassignRPCEndpoints(validRPCEndpoint);
 				var rpcStub = wsRPC.getClientRPCStub(validIp, validPort);
-				expect(rpcStub).to.have.property('rpcProcedure').and.to.be.a('function');
+				rpcStub.should.have.property('rpcProcedure').and.to.be.a('function');
 			});
 
 			it('should return client stub with event and rpc methods registered on MasterWAMPServer', function () {
@@ -194,8 +194,8 @@ describe('wsRPC', function () {
 				wsServer.reassignRPCEndpoints(validRPCEndpoint);
 				wsServer.reassignEventEndpoints(validEventEndpoint);
 				var rpcStub = wsRPC.getClientRPCStub(validIp, validPort);
-				expect(rpcStub).to.have.property('eventProcedure').and.to.be.a('function');
-				expect(rpcStub).to.have.property('rpcProcedure').and.to.be.a('function');
+				rpcStub.should.have.property('eventProcedure').and.to.be.a('function');
+				rpcStub.should.have.property('rpcProcedure').and.to.be.a('function');
 			});
 		});
 	});

--- a/test/unit/helpers/RoundChanges.js
+++ b/test/unit/helpers/RoundChanges.js
@@ -34,8 +34,8 @@ describe('RoundChanges', function () {
 		it('should accept valid scope', function () {
 			var roundChanges = new RoundChanges(validScope);
 
-			expect(roundChanges.roundFees).equal(validScope.roundFees);
-			expect(_.isEqual(roundChanges.roundRewards, validScope.roundRewards)).to.be.ok;
+			roundChanges.roundFees.should.equal(validScope.roundFees);
+			_.isEqual(roundChanges.roundRewards, validScope.roundRewards).should.be.ok;
 		});
 
 		it('should floor fees value', function () {
@@ -43,7 +43,7 @@ describe('RoundChanges', function () {
 
 			var roundChanges = new RoundChanges(validScope);
 
-			expect(roundChanges.roundFees).equal(50);
+			roundChanges.roundFees.should.equal(50);
 		});
 
 		it('should round up fees after exceeding precision', function () {
@@ -51,7 +51,7 @@ describe('RoundChanges', function () {
 
 			var roundChanges = new RoundChanges(validScope);
 
-			expect(roundChanges.roundFees).equal(51);
+			roundChanges.roundFees.should.equal(51);
 		});
 
 		it('should accept Infinite fees as expected', function () {
@@ -59,7 +59,7 @@ describe('RoundChanges', function () {
 
 			var roundChanges = new RoundChanges(validScope);
 
-			expect(roundChanges.roundFees).equal(Infinity);
+			roundChanges.roundFees.should.equal(Infinity);
 		});
 	});
 
@@ -70,10 +70,10 @@ describe('RoundChanges', function () {
 			var rewardsAt = 2;
 			var res = roundChanges.at(rewardsAt);
 
-			expect(res.fees).equal(4);
-			expect(res.feesRemaining).equal(96);
-			expect(res.rewards).equal(validScope.roundRewards[rewardsAt]); // 100
-			expect(res.balance).equal(104);
+			res.fees.should.equal(4);
+			res.feesRemaining.should.equal(96);
+			res.rewards.should.equal(validScope.roundRewards[rewardsAt]); // 100
+			res.balance.should.equal(104);
 		});
 
 		it('should calculate round changes from Infinite fees', function () {
@@ -83,10 +83,10 @@ describe('RoundChanges', function () {
 			var rewardsAt = 2;
 			var res = roundChanges.at(rewardsAt);
 
-			expect(res.fees).equal(Infinity);
-			expect(res.feesRemaining).to.be.NaN;
-			expect(res.rewards).equal(validScope.roundRewards[rewardsAt]); // 100
-			expect(res.balance).equal(Infinity);
+			res.fees.should.equal(Infinity);
+			res.feesRemaining.should.be.NaN;
+			res.rewards.should.equal(validScope.roundRewards[rewardsAt]); // 100
+			res.balance.should.equal(Infinity);
 		});
 
 		it('should calculate round changes from Number.MAX_VALUE fees', function () {
@@ -97,12 +97,12 @@ describe('RoundChanges', function () {
 			var res = roundChanges.at(rewardsAt);
 			var expectedFees = 1779894192932990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099; // 1.7976931348623157e+308 / 101 (delegates num)
 
-			expect(res.fees).equal(expectedFees);
-			expect(res.rewards).equal(validScope.roundRewards[rewardsAt]); // 100
-			expect(res.feesRemaining).equal(1);
+			res.fees.should.equal(expectedFees);
+			res.rewards.should.equal(validScope.roundRewards[rewardsAt]); // 100
+			res.feesRemaining.should.equal(1);
 
 			var expectedBalance = 1779894192932990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990199; // 1.7976931348623157e+308 / 101 (delegates num) + 100
-			expect(res.balance).equal(expectedBalance);
+			res.balance.should.equal(expectedBalance);
 		});
 	});
 });

--- a/test/unit/helpers/apiError.js
+++ b/test/unit/helpers/apiError.js
@@ -31,26 +31,26 @@ describe('helpers/apiError', function () {
 	describe('constructor', function () {
 
 		it('should be an Error instance', function () {
-			expect(apiError).to.have.instanceOf(Error);
+			apiError.should.have.instanceOf(Error);
 		});
 
 		it('should assign field message = "Valid error message"', function () {
-			expect(apiError).to.have.property('message').equal(validErrorMessage);
+			apiError.should.have.property('message').equal(validErrorMessage);
 		});
 
 		it('should assign field code = 501', function () {
-			expect(apiError).to.have.property('code').equal(validErrorCode);
+			apiError.should.have.property('code').equal(validErrorCode);
 		});
 	});
 
 	describe('toJson', function () {
 
 		it('should return Object type result', function () {
-			expect(apiError.toJson()).to.be.an('Object');
+			apiError.toJson().should.be.an('Object');
 		});
 
 		it('should return result containing message = "Valid error message"', function () {
-			expect(apiError.toJson()).to.have.property('message').equal(validErrorMessage);
+			apiError.toJson().should.have.property('message').equal(validErrorMessage);
 		});
 	});
 });

--- a/test/unit/helpers/bignum.js
+++ b/test/unit/helpers/bignum.js
@@ -46,9 +46,9 @@ describe('BigNumber', function () {
 				});
 
 				it('should throw RangeError', function () {
-					expect(function () {
+					(function () {
 						bignum.fromBuffer(validBuf, validOpts);
-					}).throws('Buffer length (14) must be a multiple of size (3)');
+					}).should.throw('Buffer length (14) must be a multiple of size (3)');
 				});
 			});
 		});
@@ -67,7 +67,7 @@ describe('BigNumber', function () {
 			describe('when opts does not have a size attribute', function () {
 
 				it('should set opts to an empty object', function () {
-					expect(bignumResult).to.eql(new bignum(validSeed));
+					bignumResult.should.eql(new bignum(validSeed));
 				});
 			});
 
@@ -84,7 +84,7 @@ describe('BigNumber', function () {
 					});
 
 					it('should equal BUFFER_SEED', function () {
-						expect(bignumResult).to.eql(new bignum(validSeed));
+						bignumResult.should.eql(new bignum(validSeed));
 					});
 				});
 
@@ -99,7 +99,7 @@ describe('BigNumber', function () {
 					});
 
 					it('should equal BUFFER_SEED', function () {
-						expect(bignumResult).to.eql(new bignum(validSeed));
+						bignumResult.should.eql(new bignum(validSeed));
 					});
 				});
 
@@ -113,7 +113,7 @@ describe('BigNumber', function () {
 					});
 
 					it('should equal BUFFER_SEED', function () {
-						expect(bignumResult).to.eql(new bignum(validSeed));
+						bignumResult.should.eql(new bignum(validSeed));
 					});
 				});
 			});
@@ -142,8 +142,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should throw RangeError', function () {
-					expect(bignumResult.toBuffer(validOpts)
-					).to.eq('Unsupported Buffer representation');
+					bignumResult.toBuffer(validOpts).should.eq('Unsupported Buffer representation');
 				});
 			});
 
@@ -159,7 +158,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should throw Error: "Converting negative numbers to Buffers not supported yet', function () {
-					expect(function () {bignumResult.toBuffer(validOpts);}).throws('Converting negative numbers to Buffers not supported yet');
+					(function () {bignumResult.toBuffer(validOpts);}).should.throw('Converting negative numbers to Buffers not supported yet');
 				});
 			});
 		});
@@ -184,7 +183,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeed', function () {
-					expect(toBufferResult).to.eql(validBufferSeed);
+					toBufferResult.should.eql(validBufferSeed);
 				});
 			});
 
@@ -195,7 +194,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeed', function () {
-					expect(toBufferResult).to.eql(validBufferSeed);
+					toBufferResult.should.eql(validBufferSeed);
 				});
 			});
 
@@ -206,7 +205,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeedSize2', function () {
-					expect(toBufferResult).to.eql(validBufferSeedSize2);
+					toBufferResult.should.eql(validBufferSeedSize2);
 				});
 			});
 
@@ -217,7 +216,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeed', function () {
-					expect(toBufferResult).to.eql(validBufferSeed);
+					toBufferResult.should.eql(validBufferSeed);
 				});
 			});
 
@@ -228,7 +227,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeed', function () {
-					expect(toBufferResult).to.eql(validBufferSeed);
+					toBufferResult.should.eql(validBufferSeed);
 				});
 			});
 
@@ -239,7 +238,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeed', function () {
-					expect(toBufferResult).to.eql(validBufferSeed);
+					toBufferResult.should.eql(validBufferSeed);
 				});
 			});
 
@@ -250,7 +249,7 @@ describe('BigNumber', function () {
 				});
 
 				it('should return validBufferSeedMpint', function () {
-					expect(toBufferResult).to.eql(validBufferSeedMpint);
+					toBufferResult.should.eql(validBufferSeedMpint);
 				});
 			});
 		});

--- a/test/unit/helpers/cache.js
+++ b/test/unit/helpers/cache.js
@@ -37,11 +37,11 @@ describe('cache', function () {
 		before(function () {
 			validLogger = {
 				info: function (info) {
-					expect(info).to.eq('App connected with redis server');
+					info.should.eq('App connected with redis server');
 				},
 				error: function (message, errorObject) {
-					expect(message).to.eq('Redis:');
-					expect(errorObject).to.be.an('error');
+					message.should.eq('Redis:');
+					errorObject.should.be.an('error');
 				}
 			};
 			validConfig = {};
@@ -70,15 +70,15 @@ describe('cache', function () {
 			});
 
 			it('should call callback with error = null', function () {
-				expect(err).to.be.null;
+				should.not.exist(err);
 			});
 
 			it('should call callback with result containing cacheEnabled = false', function () {
-				expect(result).to.have.property('cacheEnabled').equal(false);
+				result.should.have.property('cacheEnabled').equal(false);
 			});
 
 			it('should call callback with result containing client = null', function () {
-				expect(result).to.have.property('client').to.be.null;
+				result.should.have.property('client').to.be.null;
 			});
 		});
 
@@ -95,7 +95,7 @@ describe('cache', function () {
 				});
 
 				it('should delete the password attribute from config', function () {
-					expect(validConfig).to.not.have.property('password');
+					validConfig.should.not.have.property('password');
 				});
 			});
 
@@ -106,11 +106,11 @@ describe('cache', function () {
 				});
 
 				it('should call callback with result containing cacheEnabled = true', function () {
-					expect(result.cacheEnabled).to.eq(true);
+					result.cacheEnabled.should.eq(true);
 				});
 
 				it('should call callback with result containing client object', function () {
-					expect(result.client).to.equal(redisCreateClientResult);
+					result.client.should.equal(redisCreateClientResult);
 				});
 			});
 
@@ -121,11 +121,11 @@ describe('cache', function () {
 				});
 
 				it('should call callback with result containing with cacheEnabled = true', function () {
-					expect(result.cacheEnabled).to.eq( true );
+					result.cacheEnabled.should.eq( true );
 				});
 
 				it('should call callback with result containing an instance of redis client', function () {
-					expect(result.client).to.eql(redisCreateClientResult);
+					result.client.should.eql(redisCreateClientResult);
 				});
 			});
 		});

--- a/test/unit/helpers/checkIpInList.js
+++ b/test/unit/helpers/checkIpInList.js
@@ -51,7 +51,7 @@ describe('checkIpInList', function () {
 			});
 
 			it('should set returnListIsEmpty to true', function () {
-				expect(checkIpInListResult).to.eq(true);
+				checkIpInListResult.should.eq(true);
 			});
 		});
 
@@ -63,7 +63,7 @@ describe('checkIpInList', function () {
 			});
 
 			it('should return validReturnListIsEmpty', function () {
-				expect(checkIpInListResult).to.eq(validReturnListIsEmpty);
+				checkIpInListResult.should.eq(validReturnListIsEmpty);
 			});
 		});
 
@@ -74,7 +74,7 @@ describe('checkIpInList', function () {
 			});
 
 			it('should return validReturnListIsEmpty', function () {
-				expect(checkIpInListResult).to.eq(validReturnListIsEmpty);
+				checkIpInListResult.should.eq(validReturnListIsEmpty);
 			});
 		});
 
@@ -85,7 +85,7 @@ describe('checkIpInList', function () {
 			});
 
 			it('should return validReturnListIsEmpty', function () {
-				expect(checkIpInListResult).to.eq(validReturnListIsEmpty);
+				checkIpInListResult.should.eq(validReturnListIsEmpty);
 			});
 
 			it('should call console.error with "CheckIpInList:" + error', function () {
@@ -112,7 +112,7 @@ describe('checkIpInList', function () {
 			});
 
 			it('should return validReturnListIsEmpty', function () {
-				expect(checkIpInListResult).to.eq(false);
+				checkIpInListResult.should.eq(false);
 			});
 		});
 
@@ -123,7 +123,7 @@ describe('checkIpInList', function () {
 			});
 
 			it('should return validReturnListIsEmpty', function () {
-				expect(checkIpInListResult).to.eq(true);
+				checkIpInListResult.should.eq(true);
 			});
 		});
 	});

--- a/test/unit/helpers/ed.js
+++ b/test/unit/helpers/ed.js
@@ -31,16 +31,16 @@ describe('ed', function () {
 		});
 
 		it('should create keypair from a random string', function () {
-			expect(keys).to.have.a.property('privateKey');
-			expect(keys).to.have.a.property('publicKey');
+			keys.should.have.a.property('privateKey');
+			keys.should.have.a.property('publicKey');
 		});
 
 		it('should create a publicKey as a Buffer type', function () {
-			expect(Buffer.isBuffer(keys.publicKey)).to.be.ok;
+			Buffer.isBuffer(keys.publicKey).should.be.ok;
 		});
 
 		it('should create a privateKey should have be a Buffer type', function () {
-			expect(Buffer.isBuffer(keys.privateKey)).to.be.ok;
+			Buffer.isBuffer(keys.privateKey).should.be.ok;
 		});
 	});
 
@@ -59,20 +59,20 @@ describe('ed', function () {
 
 		it('should create signature as Buffer from data as Buffer and privateKey', function () {
 			var signature = ed.sign(Buffer.from(JSON.stringify(messageToSign)), keys.privateKey);
-			expect(Buffer.isBuffer(signature)).to.be.ok;
+			Buffer.isBuffer(signature).should.be.ok;
 		});
 
 		it('should create signature as Buffer from data as Buffer and a privateKey after Buffer.from function applied on it', function () {
 			var signature = ed.sign(Buffer.from(JSON.stringify(messageToSign)),  Buffer.from(keys.privateKey, 'hex'));
-			expect(Buffer.isBuffer(signature)).to.be.ok;
+			Buffer.isBuffer(signature).should.be.ok;
 		});
 
 		it('should throw error when passing string as message to sign', function () {
-			expect(ed.sign.bind(null, JSON.stringify(messageToSign), keys.privateKey)).to.throw('argument message must be a buffer');
+			ed.sign.bind(null, JSON.stringify(messageToSign), keys.privateKey).should.throw('argument message must be a buffer');
 		});
 
 		it('should throw error when passing JSON as message to sign', function () {
-			expect(ed.sign.bind(null, messageToSign, keys.privateKey)).to.throw('argument message must be a buffer');
+			ed.sign.bind(null, messageToSign, keys.privateKey).should.throw('argument message must be a buffer');
 		});
 	});
 
@@ -91,26 +91,26 @@ describe('ed', function () {
 
 		it('should return true when valid Buffer signature is checked with matching Buffer public key and valid Buffer message', function () {
 			var verified = ed.verify(Buffer.from(JSON.stringify(messageToSign)), signature, keys.publicKey);
-			expect(verified).to.be.ok;
+			verified.should.be.ok;
 		});
 
 		it('should return false when malformed signature is checked with Buffer public key', function () {
 			var wrongSignature = ed.sign(Buffer.from(JSON.stringify('wrong message')), keys.privateKey);
 			var verified = ed.verify(Buffer.from(JSON.stringify(messageToSign)), wrongSignature, keys.publicKey);
-			expect(verified).not.to.be.ok;
+			verified.should.not.to.be.ok;
 		});
 
 		it('should return false proper signature and proper publicKey is check against malformed data', function () {
 			var verified = ed.verify(Buffer.from('malformed data'), signature, keys.publicKey);
-			expect(verified).not.to.be.ok;
+			verified.should.not.to.be.ok;
 		});
 
 		it('should throw an error when proper non hex string signature is checked with matching string hex public key', function () {
-			expect(ed.verify.bind(null, Buffer.from(JSON.stringify(messageToSign)), signature.toString(), keys.publicKey.toString('hex'))).to.throw();
+			ed.verify.bind(null, Buffer.from(JSON.stringify(messageToSign)), signature.toString(), keys.publicKey.toString('hex')).should.throw();
 		});
 
 		it('should throw an error when proper non hex string signature is checked with matching string non hex public key', function () {
-			expect(ed.verify.bind(null, Buffer.from(JSON.stringify(messageToSign)), signature.toString('hex'), keys.publicKey.toString())).to.throw();
+			ed.verify.bind(null, Buffer.from(JSON.stringify(messageToSign)), signature.toString('hex'), keys.publicKey.toString()).should.throw();
 		});
 	});
 });

--- a/test/unit/helpers/git.js
+++ b/test/unit/helpers/git.js
@@ -34,7 +34,7 @@ describe('git', function () {
 			});
 
 			it('should throw an error', function () {
-				expect(git.getLastCommit).throws(Error, validErrorMessage);
+				git.getLastCommit.should.throws(Error, validErrorMessage);
 			});
 		});
 
@@ -52,7 +52,7 @@ describe('git', function () {
 			});
 
 			it('should return a commit hash', function () {
-				expect(git.getLastCommit()).equal(validCommitHash);
+				git.getLastCommit().should.equal(validCommitHash);
 			});
 		});
 	});

--- a/test/unit/helpers/httpApi.js
+++ b/test/unit/helpers/httpApi.js
@@ -93,15 +93,15 @@ describe('httpApi', function () {
 			});
 
 			it('should call res.header with "Access-Control-Allow-Origin" and "*"', function () {
-				expect(resMock.header.calledWith('Access-Control-Allow-Origin', '*')).to.eql(true);
+				resMock.header.calledWith('Access-Control-Allow-Origin', '*').should.eql(true);
 			});
 
 			it('should call res.header "Access-Control-Allow-Headers" and "Origin, X-Objected-With, Content-Type, Accept"', function () {
-				expect(resMock.header.calledWith('Access-Control-Allow-Headers', 'Origin, X-Objected-With, Content-Type, Accept')).to.eql(true);
+				resMock.header.calledWith('Access-Control-Allow-Headers', 'Origin, X-Objected-With, Content-Type, Accept').should.eql(true);
 			});
 
 			it('should call next()', function () {
-				expect(validNextSpy.calledOnce).to.be.true;
+				validNextSpy.calledOnce.should.be.true;
 			});
 		});
 
@@ -118,11 +118,11 @@ describe('httpApi', function () {
 				});
 
 				it('should never call logger.error', function () {
-					expect(loggerMock.error.notCalled).to.be.true;
+					loggerMock.error.notCalled.should.be.true;
 				});
 
 				it('should call next()', function () {
-					expect(validNextSpy.calledOnce).to.be.true;
+					validNextSpy.calledOnce.should.be.true;
 				});
 			});
 
@@ -133,16 +133,16 @@ describe('httpApi', function () {
 				});
 
 				it('should call logger.error with "API error: validError"', function () {
-					expect(loggerMock.error.calledWith('API error ' + validReq.url, validError.message)).to.be.true;
+					loggerMock.error.calledWith('API error ' + validReq.url, validError.message).should.be.true;
 				});
 
 				it('should call console.trace with error', function () {
-					expect(spyConsoleTrace.calledOnce).to.be.true;
+					spyConsoleTrace.calledOnce.should.be.true;
 				});
 
 				it('should send status 500 and error-object', function () {
-					expect(resMock.status.calledWith(500)).to.be.true;
-					expect(resMock.status().send.calledWith(validSendObject)).to.be.true;
+					resMock.status.calledWith(500).should.be.true;
+					resMock.status().send.calledWith(validSendObject).should.be.true;
 				});
 			});
 		});
@@ -154,15 +154,16 @@ describe('httpApi', function () {
 			});
 
 			beforeEach(function () {
+				debugger;
 				httpApi.middleware.logClientConnections(loggerMock, validReq, validRes, validNextSpy);
 			});
 
-			it('should call logger.log with string "GET req/url from 127.0.0.1"', function () {
-				expect(loggerMock.log.calledWith('GET req/url from 127.0.0.1'));
+			it('should call logger.log with string "GET api/url from 127.0.0.1"', function () {
+				loggerMock.log.calledWith('GET api/url from 127.0.0.1').should.be.true;
 			});
 
 			it('should call next function', function () {
-				expect(validNextSpy.calledOnce).to.be.true;
+				validNextSpy.calledOnce.should.be.true;
 			});
 		});
 
@@ -186,7 +187,7 @@ describe('httpApi', function () {
 				});
 
 				it('should call next function', function () {
-					expect(validNextSpy.calledOnce).to.be.true;
+					validNextSpy.calledOnce.should.be.true;
 				});
 			});
 
@@ -197,8 +198,8 @@ describe('httpApi', function () {
 				});
 
 				it('should send status 500 and error-object', function () {
-					expect(resMock.status.calledWith(500)).to.be.true;
-					expect(resMock.status().send.calledWith(validSendObject)).to.be.true;
+					resMock.status.calledWith(500).should.be.true;
+					resMock.status().send.calledWith(validSendObject).should.be.true;
 				});
 			});
 		});
@@ -214,8 +215,8 @@ describe('httpApi', function () {
 			});
 
 			it('should send status 500 and error-object', function () {
-				expect(resMock.status.calledWith(500)).to.be.true;
-				expect(resMock.status().send.calledWith(validSendObject)).to.be.true;
+				resMock.status.calledWith(500).should.be.true;
+				resMock.status().send.calledWith(validSendObject).should.be.true;
 			});
 		});
 
@@ -237,7 +238,7 @@ describe('httpApi', function () {
 			});
 
 			it('should return a function', function () {
-				expect(sanitizeResultFunction).to.be.a('function');
+				sanitizeResultFunction.should.be.a('function');
 			});
 
 			describe('when sanitize result is called', function () {
@@ -268,7 +269,7 @@ describe('httpApi', function () {
 				});
 
 				it('should call req.sanitize with req[property], schema and cb as arguments', function () {
-					expect(validReqMock.sanitize.calledWith(validReqMock[validProperty],validSchema)).to.be.true;
+					validReqMock.sanitize.calledWith(validReqMock[validProperty],validSchema).should.be.true;
 				});
 
 				describe('when report.isValid = false', function () {
@@ -278,7 +279,7 @@ describe('httpApi', function () {
 					});
 
 					it('should call res.json', function () {
-						expect(validCbSpy.called).to.be.true;
+						validCbSpy.called.should.be.true;
 					});
 				});
 
@@ -289,7 +290,7 @@ describe('httpApi', function () {
 					});
 
 					it('should call callback', function () {
-						expect(validCbSpy.called).to.be.true;
+						validCbSpy.called.should.be.true;
 					});
 				});
 			});
@@ -311,11 +312,11 @@ describe('httpApi', function () {
 			});
 
 			it('should attach provided key and value to a response-header', function () {
-				expect(resMock.setHeader.calledWith(validHeaderKey,validHeaderValue)).to.be.true;
+				resMock.setHeader.calledWith(validHeaderKey,validHeaderValue).should.be.true;
 			});
 
 			it('should call next function', function () {
-				expect(validNextSpy.calledOnce).to.be.true;
+				validNextSpy.calledOnce.should.be.true;
 			});
 		});
 
@@ -345,7 +346,7 @@ describe('httpApi', function () {
 
 				it('should call checkIpInList with parameters: config.peers.access.blackList, req.ip, false', function () {
 					sinonSandbox.assert.called(checkIpInListStub);
-					expect(checkIpInListStub.calledWith(validConfig.peers.access.blacklist,validReq.ip, false)).to.be.true;
+					checkIpInListStub.calledWith(validConfig.peers.access.blacklist,validReq.ip, false).should.be.true;
 				});
 
 				describe('when config.peers.enabled = true and checkIpInList() = false', function () {
@@ -424,7 +425,7 @@ describe('httpApi', function () {
 				});
 
 				it('should call next function', function () {
-					expect(validNextSpy.calledOnce).to.be.true;
+					validNextSpy.calledOnce.should.be.true;
 				});
 			});
 
@@ -436,7 +437,7 @@ describe('httpApi', function () {
 				});
 
 				it('should call cache.getJsonForKey with key = req.originalUrl', function () {
-					expect(validCache.getJsonForKey.calledWith(validReq.originalUrl)).to.be.true;
+					validCache.getJsonForKey.calledWith(validReq.originalUrl).should.be.true;
 				});
 
 				describe('when err = true', function () {
@@ -446,7 +447,7 @@ describe('httpApi', function () {
 					});
 
 					it('should add json function to response', function () {
-						expect(validRes.json).to.be.a('function');
+						validRes.json.should.be.a('function');
 					});
 
 					// Not tested, because defined function is not executed at this point
@@ -457,17 +458,17 @@ describe('httpApi', function () {
 						});
 
 						it('should call logger.debug with "cached response for key: api/url"', function () {
-							expect(loggerMock.debug.calledWith('cached response for key: api/url')).to.be.true;
+							loggerMock.debug.calledWith('cached response for key: api/url').should.be.true;
 						});
 
 						it('should call cache.setJsonForKey with key, response as arguments', function () {
-							// expect(validCache.setJsonForKey.calledWith(validReq.url, validCachedValue));
-							expect(validCache.setJsonForKey.calledWith(validReq.url, validCachedValue)).to.be.true;
+							// validCache.setJsonForKey.calledWith(validReq.url, validCachedValue).should.be.true;
+							validCache.setJsonForKey.calledWith(validReq.url, validCachedValue).should.be.true;
 						});
 					});
 
 					it('should call next function', function () {
-						expect(validNextSpy.calledOnce).to.be.true;
+						validNextSpy.calledOnce.should.be.true;
 					});
 				});
 
@@ -478,11 +479,11 @@ describe('httpApi', function () {
 					});
 
 					it('should add json function to response', function () {
-						expect(validRes.json).to.be.a('function');
+						validRes.json.should.be.a('function');
 					});
 
 					it('should call next function', function () {
-						expect(validNextSpy.calledOnce).to.be.true;
+						validNextSpy.calledOnce.should.be.true;
 					});
 				});
 
@@ -499,11 +500,11 @@ describe('httpApi', function () {
 					});
 
 					it('should call logger.debug', function () {
-						expect(loggerMock.debug.called).to.be.true;
+						loggerMock.debug.called.should.be.true;
 					});
 
 					it('should call res.json with cachedValue', function () {
-						expect(validRes.json.calledWith(validCachedValue)).to.be.true;
+						validRes.json.calledWith(validCachedValue).should.be.true;
 					});
 				});
 			});
@@ -531,7 +532,7 @@ describe('httpApi', function () {
 		describe('when error is defined', function () {
 
 			it('should call res.json with {"success": false, "error": err}', function () {
-				expect(validRes.json.calledWith({'success': false, 'error': validError})).to.be.true;
+				validRes.json.calledWith({'success': false, 'error': validError}).should.be.true;
 			});
 		});
 
@@ -543,7 +544,7 @@ describe('httpApi', function () {
 
 			it('should call res.json with extend({}, {"success": true}, response)', function () {
 				validResponse.success = true;
-				expect(validRes.json.calledWith(validResponse)).to.be.true;
+				validRes.json.calledWith(validResponse).should.be.true;
 			});
 		});
 	});
@@ -588,8 +589,8 @@ describe('httpApi', function () {
 			it('should call res.status(500).json() with error in json format', function () {
 				var tmp_error = validError.code ? validError.code : apiCodes.INTERNAL_SERVER_ERROR;
 
-				expect(validRes.status.calledWith(tmp_error)).to.be.true;
-				expect(validRes.json.calledOnce).to.be.true;
+				validRes.status.calledWith(tmp_error).should.be.true;
+				validRes.json.calledOnce.should.be.true;
 			});
 		});
 
@@ -602,8 +603,8 @@ describe('httpApi', function () {
 			describe('when response is empty', function () {
 
 				it('should call res.status with code = 204 and res.json', function () {
-					expect(validRes.status.calledWith(apiCodes.EMPTY_RESOURCES_OK)).to.be.true;
-					expect(validRes.json.calledOnce).to.be.true;
+					validRes.status.calledWith(apiCodes.EMPTY_RESOURCES_OK).should.be.true;
+					validRes.json.calledOnce.should.be.true;
 				});
 			});
 
@@ -616,8 +617,8 @@ describe('httpApi', function () {
 				});
 
 				it('should call res.status with code = 200 and res.json', function () {
-					expect(validRes.status.calledWith(apiCodes.OK)).to.be.true;
-					expect(validRes.json.calledOnce).to.be.true;
+					validRes.status.calledWith(apiCodes.OK).should.be.true;
+					validRes.json.calledOnce.should.be.true;
 				});
 			});
 		});
@@ -643,15 +644,15 @@ describe('httpApi', function () {
 		});
 
 		it('should call router.use with middleware.notFound', function () {
-			expect(validRouter.use.calledWith(httpApi.middleware.notFound)).to.be.true;
+			validRouter.use.calledWith(httpApi.middleware.notFound).should.be.true;
 		});
 
 		it('should call router.use with middleware.blockchainReady.bind(null, validIsLoaded)', function () {
-			 expect(validRouter.use.args[1][0].toString()).to.equal(httpApi.middleware.blockchainReady.bind(null, validIsLoaded).toString());
+			 validRouter.use.args[1][0].toString().should.equal(httpApi.middleware.blockchainReady.bind(null, validIsLoaded).toString());
 		});
 
 		it('should call app.use with route and router as arguments', function () {
-			expect(validApp.use.calledWith(validRoute, validRouter));
+			validApp.use.calledWith(validRoute, validRouter).should.be.true;
 		});
 	});
 });

--- a/test/unit/helpers/jobs-queue.js
+++ b/test/unit/helpers/jobs-queue.js
@@ -37,25 +37,25 @@ describe('helpers/jobsQueue', function () {
 			});
 
 			afterEach(function () {
-				expect(validFunction.notCalled).to.be.true;
+				validFunction.notCalled.should.be.true;
 			});
 
 			it('should throw an error when trying to pass job that is not a function', function () {
-				expect(function () {
+				(function () {
 					jobsQueue.register('test_job', 'test', recallInterval);
-				}).to.throw('Syntax error - invalid parameters supplied');
+				}).should.throw('Syntax error - invalid parameters supplied');
 			});
 
 			it('should throw an error when trying to pass name that is not a string', function () {
-				expect(function () {
+				(function () {
 					jobsQueue.register(123, validFunction, recallInterval);
-				}).to.throw('Syntax error - invalid parameters supplied');
+				}).should.throw('Syntax error - invalid parameters supplied');
 			});
 
 			it('should throw an error when trying to pass time that is not integer', function () {
-				expect(function () {
+				(function () {
 					jobsQueue.register('test_job', validFunction, 0.22);
-				}).to.throw('Syntax error - invalid parameters supplied');
+				}).should.throw('Syntax error - invalid parameters supplied');
 			});
 		});
 
@@ -71,46 +71,46 @@ describe('helpers/jobsQueue', function () {
 				var interval = execTimeInterval + recallInterval;
 
 				setTimeout(function () {
-					expect(jobsQueue.jobs).to.be.an('object');
+					jobsQueue.jobs.should.be.an('object');
 
 				}, expectingTimesToCall * interval);
 
-				expect(jobsQueue.jobs).to.be.an('object');
+				jobsQueue.jobs.should.be.an('object');
 				// Job returned from 'register' should be equal to one in 'jobsQueue'
-				expect(job).to.equal(jobsQueue.jobs[name]);
+				should.equal(job, jobsQueue.jobs[name]);
 
 				// First execution should happen immediatelly
-				expect(spy.callCount).to.equal(1);
+				spy.callCount.should.equal(1);
 
 				// Every next execution should happen after execTimeInterval+recallInterval and not before
 				clock.tick(interval-10);
-				expect(spy.callCount).to.equal(1);
+				spy.callCount.should.equal(1);
 
 				clock.tick(11);
-				expect(spy.callCount).to.equal(2);
+				spy.callCount.should.equal(2);
 
 				// Job returned from 'register' should no longer be equal to one in 'jobsQueue'
-				expect(job).to.not.equal(jobsQueue.jobs[name]);
+				should.not.equal(job, jobsQueue.jobs[name]);
 
 				// Next execution should happen after recallInterval+execTimeInterval
 				clock.tick(interval-10);
-				expect(spy.callCount).to.equal(2);
+				spy.callCount.should.equal(2);
 
 				clock.tick(11);
-				expect(spy.callCount).to.equal(3);
+				spy.callCount.should.equal(3);
 
 				// Job returned from 'register' should no longer be equal to one in 'jobsQueue'
-				expect(job).to.not.equal(jobsQueue.jobs[name]);
+				should.not.equal(job, jobsQueue.jobs[name]);
 
 				// Next execution should happen after recallInterval+execTimeInterval
 				clock.tick(interval-10);
-				expect(spy.callCount).to.equal(3);
+				spy.callCount.should.equal(3);
 
 				clock.tick(11);
-				expect(spy.callCount).to.equal(4);
+				spy.callCount.should.equal(4);
 
 				// Job returned from 'register' should no longer be equal to one in 'jobsQueue'
-				expect(job).to.not.equal(jobsQueue.jobs[name]);
+				should.not.equal(job, jobsQueue.jobs[name]);
 			}
 
 			var clock;
@@ -128,7 +128,7 @@ describe('helpers/jobsQueue', function () {
 				var name = 'job1';
 				var spy = sinonSandbox.spy(dummyFunction);
 				var job = jobsQueue.register(name, spy, recallInterval);
-				expect(Object.keys(jobsQueue.jobs)).to.be.an('array').and.lengthOf(1);
+				Object.keys(jobsQueue.jobs).should.be.an('array').and.lengthOf(1);
 				testExecution(job, name, spy);
 			});
 
@@ -138,7 +138,7 @@ describe('helpers/jobsQueue', function () {
 				var name = 'job2';
 				var spy = sinonSandbox.spy(dummyFunction);
 				var job = jobsQueue.register(name, spy, recallInterval);
-				expect(Object.keys(jobsQueue.jobs)).to.be.an('array').and.lengthOf(2);
+				Object.keys(jobsQueue.jobs).should.be.an('array').and.lengthOf(2);
 				testExecution(job, name, spy);
 			});
 
@@ -149,7 +149,7 @@ describe('helpers/jobsQueue', function () {
 				var name = 'job3';
 				var spy = sinonSandbox.spy(dummyFunction);
 				var job = jobsQueue.register(name, spy, recallInterval);
-				expect(Object.keys(jobsQueue.jobs)).to.be.an('array').and.lengthOf(3);
+				Object.keys(jobsQueue.jobs).should.be.an('array').and.lengthOf(3);
 				testExecution(job, name, spy);
 			});
 
@@ -157,27 +157,27 @@ describe('helpers/jobsQueue', function () {
 				var name = 'job4';
 				var spy = sinonSandbox.spy(dummyFunction);
 				var job = jobsQueue.register(name, spy, recallInterval);
-				expect(Object.keys(jobsQueue.jobs)).to.be.an('array').and.lengthOf(4);
+				Object.keys(jobsQueue.jobs).should.be.an('array').and.lengthOf(4);
 				testExecution(job, name, spy);
 
-				expect(function () {
+				(function () {
 					jobsQueue.register('job4', dummyFunction, recallInterval);
-				}).to.throw('Synchronous job job4 already registered');
+				}).should.throw('Synchronous job job4 already registered');
 			});
 
 			it('should use same instance when required in different module (because of modules cache)', function () {
 				var jobsQueuePeers = peers.__get__('jobsQueue');
 				// Instances should be the same
-				expect(jobsQueuePeers).to.equal(jobsQueue);
+				jobsQueuePeers.should.equal(jobsQueue);
 
 				// Register new job in peers module
 				var name = 'job5';
 				var spy = sinonSandbox.spy(dummyFunction);
 				var job = jobsQueuePeers.register(name, spy, recallInterval);
-				expect(Object.keys(jobsQueuePeers.jobs)).to.be.an('array').and.lengthOf(5);
+				Object.keys(jobsQueuePeers.jobs).should.be.an('array').and.lengthOf(5);
 				testExecution(job, name, spy);
 				// Instances still should be the same
-				expect(jobsQueuePeers).to.equal(jobsQueue);
+				jobsQueuePeers.should.equal(jobsQueue);
 			});
 		});
 	});

--- a/test/unit/helpers/peersManager.js
+++ b/test/unit/helpers/peersManager.js
@@ -22,15 +22,15 @@ describe('PeersManager', function () {
 	describe('constructor', function () {
 
 		it('should have empty peers map after initialization', function () {
-			expect(peersManager).to.have.property('peers').to.be.empty;
+			peersManager.should.have.property('peers').to.be.empty;
 		});
 
 		it('should have empty addressToNonceMap map after initialization', function () {
-			expect(peersManager).to.have.property('addressToNonceMap').to.be.empty;
+			peersManager.should.have.property('addressToNonceMap').to.be.empty;
 		});
 
 		it('should have empty nonceToConnectionIdMap map after initialization', function () {
-			expect(peersManager).to.have.property('nonceToAddressMap').to.be.empty;
+			peersManager.should.have.property('nonceToAddressMap').to.be.empty;
 		});
 	});
 
@@ -48,55 +48,55 @@ describe('PeersManager', function () {
 		describe('add', function () {
 
 			it('should return false when invoked without arguments', function () {
-				expect(peersManager.add()).not.to.be.ok;
+				peersManager.add().should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer equal null', function () {
-				expect(peersManager.add(null)).not.to.be.ok;
+				peersManager.add(null).should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer equal 0', function () {
-				expect(peersManager.add(0)).not.to.be.ok;
+				peersManager.add(0).should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer has no string field', function () {
-				expect(peersManager.add({})).not.to.be.ok;
+				peersManager.add({}).should.not.to.be.ok;
 			});
 
 			it('should add entry to peers when invoked with valid arguments', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.peers).to.have.property(validPeer.string).eql(validPeer);
+				peersManager.peers.should.have.property(validPeer.string).eql(validPeer);
 			});
 
 			it('should add entry to addressToNonceMap when invoked with valid arguments', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.addressToNonceMap).to.have.property(validPeer.string).eql(validPeer.nonce);
+				peersManager.addressToNonceMap.should.have.property(validPeer.string).eql(validPeer.nonce);
 			});
 
 			it('should add entry to nonceToAddressMap when invoked with valid arguments', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.nonceToAddressMap).to.have.property(validPeer.nonce).eql(validPeer.string);
+				peersManager.nonceToAddressMap.should.have.property(validPeer.nonce).eql(validPeer.string);
 			});
 
 			it('should prevent from adding peer with the same nonce but different address', function () {
-				expect(peersManager.add(validPeer)).to.be.ok;
+				peersManager.add(validPeer).should.be.ok;
 				validPeer.string = 'DIFFERENT';
-				expect(peersManager.add(validPeer)).not.to.be.ok;
+				peersManager.add(validPeer).should.not.to.be.ok;
 			});
 
 			it('should update data on peers list', function () {
-				expect(peersManager.add(validPeer)).to.be.ok;
+				peersManager.add(validPeer).should.be.ok;
 				validPeer.height = 'DIFFERENT';
-				expect(peersManager.add(validPeer)).to.be.ok;
-				expect(peersManager.peers[validPeer.string]).eql(validPeer);
+				peersManager.add(validPeer).should.be.ok;
+				peersManager.peers[validPeer.string].should.eql(validPeer);
 			});
 
 			it('should remove old entry when nonce is different', function () {
-				expect(peersManager.add(validPeer)).to.be.ok;
+				peersManager.add(validPeer).should.be.ok;
 				validPeer.nonce = 'DIFFERENT';
-				expect(peersManager.add(validPeer)).to.be.ok;
-				expect(Object.keys(peersManager.peers).length).to.equal(1);
-				expect(peersManager.peers[validPeer.string]).eql(validPeer);
+				peersManager.add(validPeer).should.be.ok;
+				Object.keys(peersManager.peers).length.should.equal(1);
+				peersManager.peers[validPeer.string].should.eql(validPeer);
 			});
 
 			describe('multiple valid entries', function () {
@@ -112,26 +112,26 @@ describe('PeersManager', function () {
 					validPeerB.string += 'B';
 					validPeerB.nonce += 'B';
 
-					expect(peersManager.add(validPeerA)).to.be.ok;
-					expect(peersManager.add(validPeerB)).to.be.ok;
+					peersManager.add(validPeerA).should.be.ok;
+					peersManager.add(validPeerB).should.be.ok;
 				});
 
 				it('should contain multiple entries in peers after multiple valid entries added', function () {
-					expect(Object.keys(peersManager.peers).length).to.equal(2);
-					expect(peersManager.peers).to.have.property(validPeerA.string).eql(validPeerA);
-					expect(peersManager.peers).to.have.property(validPeerB.string).eql(validPeerB);
+					Object.keys(peersManager.peers).length.should.equal(2);
+					peersManager.peers.should.have.property(validPeerA.string).eql(validPeerA);
+					peersManager.peers.should.have.property(validPeerB.string).eql(validPeerB);
 				});
 
 				it('should contain multiple entries in addressToNonceMap after multiple valid entries added', function () {
-					expect(Object.keys(peersManager.addressToNonceMap).length).to.equal(2);
-					expect(peersManager.addressToNonceMap).to.have.property(validPeerA.string).equal(validPeerA.nonce);
-					expect(peersManager.addressToNonceMap).to.have.property(validPeerB.string).equal(validPeerB.nonce);
+					Object.keys(peersManager.addressToNonceMap).length.should.equal(2);
+					peersManager.addressToNonceMap.should.have.property(validPeerA.string).equal(validPeerA.nonce);
+					peersManager.addressToNonceMap.should.have.property(validPeerB.string).equal(validPeerB.nonce);
 				});
 
 				it('should contain multiple entries in nonceToAddressMap after multiple valid entries added', function () {
-					expect(Object.keys(peersManager.addressToNonceMap).length).to.equal(2);
-					expect(peersManager.nonceToAddressMap).to.have.property(validPeerA.nonce).equal(validPeerA.string);
-					expect(peersManager.nonceToAddressMap).to.have.property(validPeerB.nonce).equal(validPeerB.string);
+					Object.keys(peersManager.addressToNonceMap).length.should.equal(2);
+					peersManager.nonceToAddressMap.should.have.property(validPeerA.nonce).equal(validPeerA.string);
+					peersManager.nonceToAddressMap.should.have.property(validPeerB.nonce).equal(validPeerB.string);
 				});
 			});
 		});
@@ -139,117 +139,117 @@ describe('PeersManager', function () {
 		describe('remove', function () {
 
 			it('should return false when invoked without arguments', function () {
-				expect(peersManager.remove()).not.to.be.ok;
+				peersManager.remove().should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with null', function () {
-				expect(peersManager.remove(null)).not.to.be.ok;
+				peersManager.remove(null).should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with 0', function () {
-				expect(peersManager.remove(0)).not.to.be.ok;
+				peersManager.remove(0).should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer without string property', function () {
-				expect(peersManager.remove({})).not.to.be.ok;
+				peersManager.remove({}).should.not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer while attempt to remove not existing peer', function () {
-				expect(peersManager.remove(validPeer)).not.to.be.ok;
+				peersManager.remove(validPeer).should.not.to.be.ok;
 			});
 
 			it('should not change a state of connections table when removing not existing entry', function () {
 				peersManager.remove(validPeer);
-				expect(peersManager).to.have.property('peers').to.be.empty;
-				expect(peersManager).to.have.property('addressToNonceMap').to.be.empty;
-				expect(peersManager).to.have.property('nonceToAddressMap').to.be.empty;
+				peersManager.should.have.property('peers').to.be.empty;
+				peersManager.should.have.property('addressToNonceMap').to.be.empty;
+				peersManager.should.have.property('nonceToAddressMap').to.be.empty;
 			});
 
 			it('should remove previously added valid entry', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.peers).to.have.property(validPeer.string).eql(validPeer);
+				peersManager.peers.should.have.property(validPeer.string).eql(validPeer);
 				peersManager.remove(validPeer);
-				expect(peersManager).to.have.property('peers').to.be.empty;
-				expect(peersManager).to.have.property('addressToNonceMap').to.be.empty;
-				expect(peersManager).to.have.property('nonceToAddressMap').to.be.empty;
+				peersManager.should.have.property('peers').to.be.empty;
+				peersManager.should.have.property('addressToNonceMap').to.be.empty;
+				peersManager.should.have.property('nonceToAddressMap').to.be.empty;
 			});
 		});
 
 		describe('getNonce', function () {
 
 			it('should return undefined when invoked without arguments', function () {
-				expect(peersManager.getNonce()).to.be.undefined;
+				should.not.exist(peersManager.getNonce());
 			});
 
 			it('should return undefined when asking of not existing entry', function () {
-				expect(peersManager.getNonce(validPeer.string)).to.be.undefined;
+				should.not.exist(peersManager.getNonce(validPeer.string));
 			});
 
 			it('should return nonce assigned to connection id when entry exists', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.getNonce(validPeer.string)).to.equal(validPeer.nonce);
+				peersManager.getNonce(validPeer.string).should.equal(validPeer.nonce);
 			});
 		});
 
 		describe('getAddress', function () {
 
 			it('should return undefined when invoked without arguments', function () {
-				expect(peersManager.getAddress()).to.be.undefined;
+				should.not.exist(peersManager.getAddress());
 			});
 
 			it('should return undefined when asking of not existing entry', function () {
-				expect(peersManager.getAddress(validPeer.nonce)).to.be.undefined;
+				should.not.exist(peersManager.getAddress(validPeer.nonce));
 			});
 
 			it('should return nonce assigned to connection id when entry exists', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.getAddress(validPeer.nonce)).to.equal(validPeer.string);
+				peersManager.getAddress(validPeer.nonce).should.equal(validPeer.string);
 			});
 		});
 
 		describe('getAll', function () {
 
 			it('should return empty object if no peers were added before', function () {
-				expect(peersManager.getAll()).to.be.empty;
+				peersManager.getAll().should.be.empty;
 			});
 
 			it('should return map of added peers', function () {
 				peersManager.add(validPeer);
 				var validResult = {};
 				validResult[validPeer.string] = validPeer;
-				expect(peersManager.getAll(validPeer.nonce)).eql(validResult);
+				peersManager.getAll(validPeer.nonce).should.eql(validResult);
 			});
 		});
 
 		describe('getByNonce', function () {
 
 			it('should return undefined when invoked without arguments', function () {
-				expect(peersManager.getByNonce()).to.be.undefined;
+				should.not.exist(peersManager.getByNonce());
 			});
 
 			it('should return undefined when asking of not existing entry', function () {
-				expect(peersManager.getByNonce(validPeer.nonce)).to.be.undefined;
+				should.not.exist(peersManager.getByNonce(validPeer.nonce));
 			});
 
 			it('should return previously added peer when asking with valid nonce', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.getByNonce(validPeer.nonce)).eql(validPeer);
+				peersManager.getByNonce(validPeer.nonce).should.eql(validPeer);
 			});
 		});
 
 		describe('getByAddress', function () {
 
 			it('should return undefined when invoked without arguments', function () {
-				expect(peersManager.getByAddress()).to.be.undefined;
+				should.not.exist(peersManager.getByAddress());
 			});
 
 			it('should return undefined when asking of not existing entry', function () {
-				expect(peersManager.getByAddress(validPeer.string)).to.be.undefined;
+				should.not.exist(peersManager.getByAddress(validPeer.string));
 			});
 
 			it('should return previously added peer when asking with valid nonce', function () {
 				peersManager.add(validPeer);
-				expect(peersManager.getByAddress(validPeer.string)).eql(validPeer);
+				peersManager.getByAddress(validPeer.string).should.eql(validPeer);
 			});
 		});
 	});

--- a/test/unit/helpers/promiseDefer.js
+++ b/test/unit/helpers/promiseDefer.js
@@ -24,10 +24,10 @@ describe('PromiseDefer', function () {
 	beforeEach(function () {
 		promiseDefer = PromiseDefer();
 		promiseDefer.promise.then(function (input) {
-			expect(input.message).to.equal(RESOLVED);
+			input.message.should.equal(RESOLVED);
 			input.done();
 		}).catch(function (input) {
-			expect(input.message).to.equal(REJECTED);
+			input.message.should.equal(REJECTED);
 			input.done();
 		});
 	});
@@ -35,18 +35,18 @@ describe('PromiseDefer', function () {
 	describe('when it fails', function () {
 
 		it('should reject', function (done) {
-			expect(promiseDefer.promise.isRejected()).to.be.false;
+			promiseDefer.promise.isRejected().should.be.false;
 			promiseDefer.reject({message: REJECTED, done: done});
-			expect(promiseDefer.promise.isRejected()).to.be.true;
+			promiseDefer.promise.isRejected().should.be.true;
 		});
 	});
 
 	describe('when it succeeds', function () {
 
 		it('should resolve', function (done) {
-			expect(promiseDefer.promise.isFulfilled()).to.be.false;
+			promiseDefer.promise.isFulfilled().should.be.false;
 			promiseDefer.resolve({message: RESOLVED, done: done});
-			expect(promiseDefer.promise.isFulfilled()).to.be.true;
+			promiseDefer.promise.isFulfilled().should.be.true;
 		});
 	});
 });

--- a/test/unit/helpers/slots.js
+++ b/test/unit/helpers/slots.js
@@ -22,16 +22,16 @@ describe('helpers/slots', function () {
 	describe('calc', function () {
 
 		it('should calculate round number from given block height', function () {
-			expect(slots.calcRound(100)).equal(1);
-			expect(slots.calcRound(200)).equal(2);
-			expect(slots.calcRound(303)).equal(3);
-			expect(slots.calcRound(304)).equal(4);
+			slots.calcRound(100).should.equal(1);
+			slots.calcRound(200).should.equal(2);
+			slots.calcRound(303).should.equal(3);
+			slots.calcRound(304).should.equal(4);
 		});
 
 		it('should calculate round number from Number.MAX_VALUE', function () {
 			var res = slots.calcRound(Number.MAX_VALUE);
-			expect(_.isNumber(res)).to.be.ok;
-			expect(res).to.be.below(Number.MAX_VALUE);
+			_.isNumber(res).should.be.ok;
+			res.should.be.below(Number.MAX_VALUE);
 		});
 	});
 });

--- a/test/unit/helpers/sort_by.js
+++ b/test/unit/helpers/sort_by.js
@@ -24,34 +24,34 @@ describe('SortBy', function () {
 		describe('when sortQuery is not a string', function () {
 
 			it('should return an empty object', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat(1, validSortFieldsArray)).to.be.an('object').and.to.be.empty;
+				SortBy.sortQueryToJsonSqlFormat(1, validSortFieldsArray).should.be.an('object').and.to.be.empty;
 			});
 		});
 
 		describe('when sortQuery is a string', function () {
 
 			it('should return an empty object when sortQuery is an empty string', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat('', validSortFieldsArray)).to.be.an('object').and.to.be.empty;
+				SortBy.sortQueryToJsonSqlFormat('', validSortFieldsArray).should.be.an('object').and.to.be.empty;
 			});
 
 			it('should return {address: 1} (default sort type) when sortQuery contains member of validSortFieldsArray', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat('address', validSortFieldsArray)).to.be.an('object').eql({address: 1});
+				SortBy.sortQueryToJsonSqlFormat('address', validSortFieldsArray).should.be.an('object').eql({address: 1});
 			});
 
 			it('should return an empty object when sortQuery is not a member of validSortFieldsArray', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat('unknown', validSortFieldsArray)).to.be.an('object').and.to.be.empty;
+				SortBy.sortQueryToJsonSqlFormat('unknown', validSortFieldsArray).should.be.an('object').and.to.be.empty;
 			});
 
 			it('should return {address: 1} given "address:asc" ', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat('address:asc', validSortFieldsArray)).eql({address: 1});
+				SortBy.sortQueryToJsonSqlFormat('address:asc', validSortFieldsArray).should.eql({address: 1});
 			});
 
 			it('should return {address: -1} given "address:desc" ', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat('address:desc', validSortFieldsArray)).eql({address: -1});
+				SortBy.sortQueryToJsonSqlFormat('address:desc', validSortFieldsArray).should.eql({address: -1});
 			});
 
 			it('should return an empty object given "address:desc&username:asc" ', function () {
-				expect(SortBy.sortQueryToJsonSqlFormat('address:desc&username:asc', validSortFieldsArray)).to.be.an('object').and.to.be.empty;
+				SortBy.sortQueryToJsonSqlFormat('address:desc&username:asc', validSortFieldsArray).should.be.an('object').and.to.be.empty;
 			});
 		});
 	});

--- a/test/unit/helpers/wsApi.js
+++ b/test/unit/helpers/wsApi.js
@@ -59,8 +59,8 @@ describe('handshake', function () {
 		it('should return an error when nonce is identical to server', function (done) {
 			validHeaders.nonce = validConfig.config.nonce;
 			handshake(validHeaders, function (err) {
-				expect(err).to.have.property('code').equal(failureCodes.INCOMPATIBLE_NONCE);
-				expect(err).to.have.property('description').equal('Expected nonce to be not equal to: ' + validConfig.config.nonce);
+				err.should.have.property('code').equal(failureCodes.INCOMPATIBLE_NONCE);
+				err.should.have.property('description').equal('Expected nonce to be not equal to: ' + validConfig.config.nonce);
 				done();
 			});
 		});
@@ -68,8 +68,8 @@ describe('handshake', function () {
 		it('should return an error when nethash does not match', function (done) {
 			validHeaders.nethash = 'DIFFERENT_NETWORK_NETHASH';
 			handshake(validHeaders, function (err) {
-				expect(err).to.have.property('code').equal(failureCodes.INCOMPATIBLE_NETWORK);
-				expect(err).to.have.property('description').contain('Expected nethash: ' + config.nethash + ' but received: ' + validHeaders.nethash);
+				err.should.have.property('code').equal(failureCodes.INCOMPATIBLE_NETWORK);
+				err.should.have.property('description').contain('Expected nethash: ' + config.nethash + ' but received: ' + validHeaders.nethash);
 				done();
 			});
 		});
@@ -77,8 +77,8 @@ describe('handshake', function () {
 		it('should return an error when version is incompatible', function (done) {
 			validHeaders.version = '0.0.0';
 			handshake(validHeaders, function (err) {
-				expect(err).to.have.property('code').equal(failureCodes.INCOMPATIBLE_VERSION);
-				expect(err).to.have.property('description').equal('Expected version: ' + minVersion + ' but received: ' + validHeaders.version);
+				err.should.have.property('code').equal(failureCodes.INCOMPATIBLE_VERSION);
+				err.should.have.property('description').equal('Expected version: ' + minVersion + ' but received: ' + validHeaders.version);
 				done();
 			});
 		});
@@ -104,14 +104,14 @@ describe('handshake', function () {
 				invalidTypes.forEach(function (type) {
 					it('should call callback with error.description when input is: ' + type.description, function (done) {
 						handshake(type.input, function (err) {
-							expect(err.description).to.equal(': Expected type object but found type ' + type.expectation);
+							err.description.should.equal(': Expected type object but found type ' + type.expectation);
 							done();
 						});
 					});
 
 					it('should call callback with error.code when input is: ' + type.description, function (done) {
 						handshake(type.input, function (err) {
-							expect(err.code).to.equal(failureCodes.INVALID_HEADERS);
+							err.code.should.equal(failureCodes.INVALID_HEADERS);
 							done();
 						});
 					});
@@ -131,7 +131,7 @@ describe('handshake', function () {
 						it('should call callback with error.description when input is: ' + type.description, function (done) {
 							headers.nonce = type.input;
 							handshake(headers, function (err) {
-								expect(err.description).to.equal('nonce: Expected type string but found type ' + type.expectation);
+								err.description.should.equal('nonce: Expected type string but found type ' + type.expectation);
 								done();
 							});
 						});
@@ -139,7 +139,7 @@ describe('handshake', function () {
 						it('should call callback with error.code when input is: ' + type.description, function (done) {
 							headers.nonce = type.input;
 							handshake(headers, function (err) {
-								expect(err.code).to.equal(failureCodes.INVALID_HEADERS);
+								err.code.should.equal(failureCodes.INVALID_HEADERS);
 								done();
 							});
 						});
@@ -148,7 +148,7 @@ describe('handshake', function () {
 					validValues.forEach(function (input) {
 						it('should call callback with error = null when input is:' + input, function (done) {
 							handshake(headers, function (err) {
-								expect(err).to.not.exist;
+								should.not.exist(err);
 								done();
 							});
 						});
@@ -176,7 +176,7 @@ describe('handshake', function () {
 						it('should call callback with error.description when input is: ' + type.description, function (done) {
 							headers.height = type.input;
 							handshake(headers, function (err) {
-								expect(err.description).to.equal('height: Expected type integer but found type ' + type.expectation);
+								err.description.should.equal('height: Expected type integer but found type ' + type.expectation);
 								done();
 							});
 						});
@@ -184,7 +184,7 @@ describe('handshake', function () {
 						it('should call callback with error.code when input is: ' + type.description, function (done) {
 							headers.height = type.input;
 							handshake(headers, function (err) {
-								expect(err.code).to.equal(failureCodes.INVALID_HEADERS);
+								err.code.should.equal(failureCodes.INVALID_HEADERS);
 								done();
 							});
 						});
@@ -194,7 +194,7 @@ describe('handshake', function () {
 						it('should call callback with error = null when input is: ' + input, function (done) {
 							headers.height = input;
 							handshake(headers, function (err) {
-								expect(err).to.not.exist;
+								should.not.exist(err);
 								done();
 							});
 						});
@@ -215,7 +215,7 @@ describe('handshake', function () {
 						it('should call callback with error.description when input is: ' + type.description, function (done) {
 							headers.nethash = type.input;
 							handshake(headers, function (err) {
-								expect(err.description).to.equal('nethash: Expected type string but found type ' + type.expectation);
+								err.description.should.equal('nethash: Expected type string but found type ' + type.expectation);
 								done();
 							});
 						});
@@ -223,7 +223,7 @@ describe('handshake', function () {
 						it('should call callback with error.code when input is: ' + type.description, function (done) {
 							headers.nethash = type.input;
 							handshake(headers, function (err) {
-								expect(err.code).to.equal(failureCodes.INVALID_HEADERS);
+								err.code.should.equal(failureCodes.INVALID_HEADERS);
 								done();
 							});
 						});
@@ -240,7 +240,7 @@ describe('handshake', function () {
 						it('should call callback with error.description when input is: ' + type.description, function (done) {
 							headers.version = type.input;
 							handshake(headers, function (err) {
-								expect(err.description).to.equal('version: Expected type string but found type ' + type.expectation);
+								err.description.should.equal('version: Expected type string but found type ' + type.expectation);
 								done();
 							});
 						});
@@ -248,7 +248,7 @@ describe('handshake', function () {
 						it('should call callback with error.code when input is: ' + type.description, function (done) {
 							headers.version = type.input;
 							handshake(headers, function (err) {
-								expect(err.code).to.equal(failureCodes.INVALID_HEADERS);
+								err.code.should.equal(failureCodes.INVALID_HEADERS);
 								done();
 							});
 						});
@@ -260,7 +260,7 @@ describe('handshake', function () {
 					it('should call callback with error for required property: ' + property, function (done) {
 						headers[property] = undefined;
 						handshake(headers, function (err) {
-							expect(err.description).to.equal(': Missing required property: ' + property);
+							err.description.should.equal(': Missing required property: ' + property);
 							done();
 						});
 					});

--- a/test/unit/helpers/z_schema-express.js
+++ b/test/unit/helpers/z_schema-express.js
@@ -54,11 +54,11 @@ describe('z_schema.express', function () {
 	});
 
 	it('should add a sanitize function to the request-object', function () {
-		expect(validReq.sanitize).to.be.a('function');
+		validReq.sanitize.should.be.a('function');
 	});
 
 	it('should call callback', function () {
-		expect(validNextCb.calledOnce).to.be.true;
+		validNextCb.calledOnce.should.be.true;
 	});
 
 	describe('sanitize', function () {
@@ -76,7 +76,7 @@ describe('z_schema.express', function () {
 			});
 
 			it('should return invalid object', function () {
-				expect(reqSanitizeFunctionResult).to.eq(validObject);
+				reqSanitizeFunctionResult.should.eq(validObject);
 			});
 		});
 
@@ -93,7 +93,7 @@ describe('z_schema.express', function () {
 			});
 
 			it('should return valid object', function () {
-				expect(reqSanitizeFunctionResult).to.eq(validObject);
+				reqSanitizeFunctionResult.should.eq(validObject);
 			});
 		});
 	});

--- a/test/unit/helpers/z_schema.js
+++ b/test/unit/helpers/z_schema.js
@@ -33,7 +33,7 @@ describe('schema - custom formats', function () {
 			invalidData.push(randomstring.generate(constants.additionalData.maxLength + 1));
 
 			invalidData.forEach(function (item) {
-				expect(validator.validate(item, schema)).to.equal(false);
+				validator.validate(item, schema).should.equal(false);
 			});
 		});
 
@@ -43,7 +43,7 @@ describe('schema - custom formats', function () {
 			validData.push(randomstring.generate(constants.additionalData.maxLength));
 
 			validData.forEach(function (item) {
-				expect(validator.validate(item, schema)).to.equal(true);
+				validator.validate(item, schema).should.equal(true);
 			});
 		});
 	});
@@ -55,17 +55,17 @@ describe('schema - custom formats', function () {
 
 		it('should return false for invalid hex value', function () {
 			var invalidHex = 'ec0c50z';
-			expect(validator.validate(invalidHex, schema)).to.equal(false);
+			validator.validate(invalidHex, schema).should.equal(false);
 		});
 
 		it('should return true for empty string', function () {
 			var emptyString = '';
-			expect(validator.validate(emptyString, schema)).to.equal(true);
+			validator.validate(emptyString, schema).should.equal(true);
 		});
 
 		it('should return true for valid hex value', function () {
 			var validHex = 'ec0c50e';
-			expect(validator.validate(validHex, schema)).to.equal(true);
+			validator.validate(validHex, schema).should.equal(true);
 		});
 	});
 
@@ -76,27 +76,27 @@ describe('schema - custom formats', function () {
 
 		it('should return false if value is not in hex format', function () {
 			var invalidPublicKey = 'zxcdec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8';
-			expect(validator.validate(invalidPublicKey, schema)).to.equal(false);
+			validator.validate(invalidPublicKey, schema).should.equal(false);
 		});
 
 		it('should return false for value < 64', function () {
 			var invalidLengthPublicKey = 'c3595ff6041c3bd28b76b8cf75dce8225173d1241624ee89b50f2a8';
-			expect(validator.validate(invalidLengthPublicKey, schema)).to.equal(false);
+			validator.validate(invalidLengthPublicKey, schema).should.equal(false);
 		});
 
 		it('should return false for value > 64', function () {
 			var invalidLengthPublicKey = 'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8123';
-			expect(validator.validate(invalidLengthPublicKey, schema)).to.equal(false);
+			validator.validate(invalidLengthPublicKey, schema).should.equal(false);
 		});
 
 		it('should return true for empty string', function () {
 			var emptyString = '';
-			expect(validator.validate(emptyString, schema)).to.equal(true);
+			validator.validate(emptyString, schema).should.equal(true);
 		});
 
 		it('should return true for valid publicKey', function () {
 			var validPublicKey = 'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8';
-			expect(validator.validate(validPublicKey, schema)).to.equal(true);
+			validator.validate(validPublicKey, schema).should.equal(true);
 		});
 	});
 
@@ -107,27 +107,27 @@ describe('schema - custom formats', function () {
 
 		it('should return false if value is not in hex format', function () {
 			var invalidPublicKey = 'zxcdec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8';
-			expect(validator.validate(invalidPublicKey, schema)).to.equal(false);
+			validator.validate(invalidPublicKey, schema).should.equal(false);
 		});
 
 		it('should return false if value < 128', function () {
 			var invalidLengthSignature = '3d0ea2004c3dea8076a6a22c6db8bae95bc0db819240c77fc5335f32920e91b9f41f58b01fc86dfda11019c9fd1c6c3dcbab0a4e478e3c9186ff6090dc05';
-			expect(validator.validate(invalidLengthSignature, schema)).to.equal(false);
+			validator.validate(invalidLengthSignature, schema).should.equal(false);
 		});
 
 		it('should return false if value > 128', function () {
 			var invalidLengthSignature = '1231d8103d0ea2004c3dea8076a6a22c6db8bae95bc0db819240c77fc5335f32920e91b9f41f58b01fc86dfda11019c9fd1c6c3dcbab0a4e478e3c9186ff6090dc05';
-			expect(validator.validate(invalidLengthSignature, schema)).to.equal(false);
+			validator.validate(invalidLengthSignature, schema).should.equal(false);
 		});
 
 		it('should return true for empty string', function () {
 			var emptyString = '';
-			expect(validator.validate(emptyString, schema)).to.equal(true);
+			validator.validate(emptyString, schema).should.equal(true);
 		});
 
 		it('should return true for valid publicKey', function () {
 			var validSignature = 'd8103d0ea2004c3dea8076a6a22c6db8bae95bc0db819240c77fc5335f32920e91b9f41f58b01fc86dfda11019c9fd1c6c3dcbab0a4e478e3c9186ff6090dc05';
-			expect(validator.validate(validSignature, schema)).to.equal(true);
+			validator.validate(validSignature, schema).should.equal(true);
 		});
 	});
 
@@ -140,7 +140,7 @@ describe('schema - custom formats', function () {
 			var invalidData = ['192.168', 'alpha-', 'apha_server', 'alpha.server.'];
 
 			invalidData.forEach(function (item) {
-				expect(validator.validate(item, schema)).to.equal(false);
+				validator.validate(item, schema).should.equal(false);
 			});
 		});
 
@@ -148,7 +148,7 @@ describe('schema - custom formats', function () {
 			var validData = ['192.168.0.1', '127.0.0.1', 'localhost', 'app.server', 'alpha.server.com', '8.8.8.8'];
 
 			validData.forEach(function (item) {
-				expect(validator.validate(item, schema)).to.equal(true);
+				validator.validate(item, schema).should.equal(true);
 			});
 		});
 	});

--- a/test/unit/logic/account.js
+++ b/test/unit/logic/account.js
@@ -95,15 +95,15 @@ describe('account', function () {
 		});
 
 		it('should attach schema to scope variable', function () {
-			expect(accountLogic.scope.schema).to.eql(modulesLoader.scope.schema);
+			accountLogic.scope.schema.should.eql(modulesLoader.scope.schema);
 		});
 
 		it('should attach db to scope variable', function () {
-			expect(accountLogic.scope.db).to.eql(dbStub);
+			accountLogic.scope.db.should.eql(dbStub);
 		});
 
 		it('should attach logger to library variable', function () {
-			expect(library.logger).to.eql(modulesLoader.scope.logger);
+			library.logger.should.eql(modulesLoader.scope.logger);
 		});
 	});
 
@@ -111,8 +111,8 @@ describe('account', function () {
 
 		it('should create the tables', function (done) {
 			accountLogic.createTables(function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.undefined;
+				should.not.exist(err);
+				should.not.exist(res);
 				done();
 			});
 		});
@@ -122,8 +122,8 @@ describe('account', function () {
 
 		it('should remove the tables', function (done) {
 			accountLogic.removeTables(function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.undefined;
+				should.not.exist(err);
+				should.not.exist(res);
 				done();
 			});
 		});
@@ -131,38 +131,38 @@ describe('account', function () {
 
 	describe('objectNormalize', function () {
 		it('should be okay for a valid account object', function () {
-			expect(account.objectNormalize(validAccount)).to.be.an('object');
+			account.objectNormalize(validAccount).should.be.an('object');
 		});
 	});
 
 	describe('verifyPublicKey', function () {
 
 		it('should be okay for empty params', function () {
-			expect(account.verifyPublicKey()).to.be.undefined;
+			should.not.exist(account.verifyPublicKey());
 		});
 
 		it('should throw error if parameter is not a string', function () {
-			expect(function () {
+			(function () {
 				account.verifyPublicKey(1);
-			}).to.throw('Invalid public key, must be a string');
+			}).should.throw('Invalid public key, must be a string');
 		});
 
 		it('should throw error if parameter is of invalid length', function () {
-			expect(function () {
+			(function () {
 				account.verifyPublicKey('231312312321');
-			}).to.throw('Invalid public key, must be 64 characters long');
+			}).should.throw('Invalid public key, must be 64 characters long');
 		});
 
 		it('should throw error if parameter is not a hex string', function () {
-			expect(function () {
+			(function () {
 				account.verifyPublicKey('c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2az');
-			}).to.throw('Invalid public key, must be a hex string');
+			}).should.throw('Invalid public key, must be a hex string');
 		});
 
 		it('should be okay if parameter is in correct format', function () {
-			expect(function () {
+			(function () {
 				account.verifyPublicKey('c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a2');
-			}).to.not.throw();
+			}).should.not.throw();
 		});
 	});
 
@@ -177,9 +177,9 @@ describe('account', function () {
 			var toDBRes = _.cloneDeep(raw);
 
 			account.toDB(toDBRes);
-			expect(toDBRes.address).to.equal(raw.address.toUpperCase());
-			expect(toDBRes.publicKey).to.deep.equal(Buffer.from(raw.publicKey, 'hex'));
-			expect(toDBRes.secondPublicKey).to.deep.equal(Buffer.from(raw.secondPublicKey, 'hex'));
+			toDBRes.address.should.equal(raw.address.toUpperCase());
+			toDBRes.publicKey.should.deep.equal(Buffer.from(raw.publicKey, 'hex'));
+			toDBRes.secondPublicKey.should.deep.equal(Buffer.from(raw.secondPublicKey, 'hex'));
 			done();
 		});
 	});
@@ -190,38 +190,38 @@ describe('account', function () {
 			var requestedFields = ['username', 'isDelegate', 'address', 'publicKey'];
 
 			account.get({address: validAccount.address}, requestedFields, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.an('object');
-				expect(Object.keys(res)).to.eql(requestedFields);
+				should.not.exist(err);
+				res.should.be.an('object');
+				Object.keys(res).should.eql(requestedFields);
 				done();
 			});
 		});
 
 		it('should get all fields if fields parameters is not set', function (done) {
 			account.get({address: validAccount.address}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(Object.keys(res)).to.eql(Object.keys(validAccount));
+				should.not.exist(err);
+				Object.keys(res).should.eql(Object.keys(validAccount));
 				done();
 			});
 		});
 
 		it('should return null for non-existent account', function (done) {
 			account.get({address: 'invalid address'}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.equal(null);
+				should.not.exist(err);
+				should.not.exist(res);
 				done();
 			});
 		});
 
 		it('should get the correct account against address', function (done) {
 			account.get({address: validAccount.address}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.an('object');
-				expect(res.username).to.equal(validAccount.username);
-				expect(res.isDelegate).to.equal(validAccount.isDelegate);
-				expect(res.address).to.equal(validAccount.address);
-				expect(res.publicKey).to.equal(validAccount.publicKey);
-				expect(res.delegates).to.equal(validAccount.delegates);
+				should.not.exist(err);
+				res.should.be.an('object');
+				res.username.should.equal(validAccount.username);
+				res.isDelegate.should.equal(validAccount.isDelegate);
+				res.address.should.equal(validAccount.address);
+				res.publicKey.should.equal(validAccount.publicKey);
+				should.equal(res.delegates, validAccount.delegates);
 				done();
 			});
 		});
@@ -230,49 +230,49 @@ describe('account', function () {
 	describe('calculateApproval', function () {
 
 		it('when voterBalance = 0 and totalSupply = 0, it should return 0', function () {
-			expect(account.calculateApproval(0, 0)).to.equal(0);
+			account.calculateApproval(0, 0).should.equal(0);
 		});
 
 		it('when voterBalance = totalSupply, it should return 100', function () {
 			var totalSupply = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 			var votersBalance = totalSupply;
-			expect(account.calculateApproval(votersBalance, totalSupply)).to.equal(100);
+			account.calculateApproval(votersBalance, totalSupply).should.equal(100);
 		});
 
 		it('when voterBalance = 50 and total supply = 100, it should return 50', function () {
-			expect(account.calculateApproval(50, 100)).to.equal(50);
+			account.calculateApproval(50, 100).should.equal(50);
 		});
 
 		it('with random values, it should return approval between 0 and 100', function () {
 			// So total supply is never 0
 			var totalSupply = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 			var votersBalance = Math.floor(Math.random() * totalSupply);
-			expect(account.calculateApproval(votersBalance, totalSupply)).to.be.least(0).and.be.at.most(100);
+			account.calculateApproval(votersBalance, totalSupply).should.be.least(0).and.be.at.most(100);
 		});
 	});
 
 	describe('calculateProductivity', function () {
 
 		it('when missedBlocks = 0 and producedBlocks = 0, it should return 0', function () {
-			expect(account.calculateProductivity(0, 0)).to.equal(0);
+			account.calculateProductivity(0, 0).should.equal(0);
 		});
 
 		it('when missedBlocks = producedBlocks, it should return 50', function () {
 			var producedBlocks = Math.floor(Math.random() * 1000000000);
 			var missedBlocks = producedBlocks;
-			expect(account.calculateProductivity(producedBlocks, missedBlocks)).to.equal(50);
+			account.calculateProductivity(producedBlocks, missedBlocks).should.equal(50);
 		});
 
 		it('when missedBlocks = 5 and producedBlocks = 15, it should return 75', function () {
 			var missedBlocks = 5;
 			var producedBlocks = 15;
-			expect(account.calculateProductivity(producedBlocks, missedBlocks)).to.equal(75);
+			account.calculateProductivity(producedBlocks, missedBlocks).should.equal(75);
 		});
 
 		it('with random values, it should return approval between 0 and 100', function () {
 			var missedBlocks = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 			var producedBlocks = Math.floor(Math.random() * missedBlocks);
-			expect(account.calculateProductivity(producedBlocks, missedBlocks)).to.be.least(0).and.be.at.most(100);
+			account.calculateProductivity(producedBlocks, missedBlocks).should.be.least(0).and.be.at.most(100);
 		});
 	});
 
@@ -295,11 +295,11 @@ describe('account', function () {
 			];
 
 			account.getAll({address: validAccount.address}, fields, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.length).to.equal(1);
-				expect(res[0].username).to.equal(validAccount.username);
-				expect(res[0].address).to.equal(validAccount.address);
-				expect(Object.keys(res[0])).to.include('address', 'username');
+				should.not.exist(err);
+				res.length.should.equal(1);
+				res[0].username.should.equal(validAccount.username);
+				res[0].address.should.equal(validAccount.address);
+				Object.keys(res[0]).should.include('address', 'username');
 				done();
 			});
 		});
@@ -308,19 +308,19 @@ describe('account', function () {
 			var requestedFields = ['username', 'isDelegate', 'address', 'publicKey'];
 
 			account.get({address: validAccount.address}, requestedFields, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.an('object');
-				expect(Object.keys(res)).to.eql(requestedFields);
+				should.not.exist(err);
+				res.should.be.an('object');
+				Object.keys(res).should.eql(requestedFields);
 				done();
 			});
 		});
 
 		it('should get rows with only productivity field', function (done) {
 			account.getAll({}, ['productivity'], function (err, res) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				res.forEach(function (row) {
-					expect(row).to.have.property('productivity').that.is.a('Number').to.be.at.least(0).and.at.most(100);
-					expect(Object.keys(row)).to.have.length(1);
+					row.should.have.property('productivity').that.is.a('Number').to.be.at.least(0).and.at.most(100);
+					Object.keys(row).should.have.length(1);
 				});
 				done();
 			});
@@ -328,10 +328,10 @@ describe('account', function () {
 
 		it('should get rows with only approval field', function (done) {
 			account.getAll({}, ['approval'], function (err, res) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				res.forEach(function (row) {
-					expect(row).to.have.property('approval').that.is.a('Number').to.be.at.least(0).and.at.most(100);
-					expect(Object.keys(row)).to.have.length(1);
+					row.should.have.property('approval').that.is.a('Number').to.be.at.least(0).and.at.most(100);
+					Object.keys(row).should.have.length(1);
 				});
 				done();
 			});
@@ -339,11 +339,11 @@ describe('account', function () {
 
 		it('should not remove dependent fields if they were requested', function (done) {
 			account.getAll({}, ['approval', 'vote'], function (err, res) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				res.forEach(function (row) {
-					expect(row).to.have.property('approval').that.is.a('Number').to.be.at.least(0).and.at.most(100);
-					expect(row).to.have.property('vote').that.is.a('String');
-					expect(Object.keys(row)).to.have.length(2);
+					row.should.have.property('approval').that.is.a('Number').to.be.at.least(0).and.at.most(100);
+					row.should.have.property('vote').that.is.a('String');
+					Object.keys(row).should.have.length(2);
 				});
 				done();
 			});
@@ -358,8 +358,8 @@ describe('account', function () {
 				limit: 0,
 				sort: 'username:asc'
 			}, ['username'], function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.eql(sortedUsernames);
+				should.not.exist(err);
+				res.should.eql(sortedUsernames);
 				done();
 			});
 		});
@@ -373,64 +373,64 @@ describe('account', function () {
 				offset: 0,
 				sort: 'username:asc'
 			}, ['username'], function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.eql(sortedUsernames);
+				should.not.exist(err);
+				res.should.eql(sortedUsernames);
 				done();
 			});
 		});
 
 		it('should fetch correct result using address as filter', function (done) {
 			account.getAll({address: validAccount.address }, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.length).to.equal(1);
-				expect(res[0].username).to.equal(validAccount.username);
-				expect(res[0].isDelegate).to.equal(validAccount.isDelegate);
-				expect(res[0].address).to.equal(validAccount.address);
-				expect(res[0].publicKey).to.equal(validAccount.publicKey);
-				expect(res[0].delegates).to.equal(validAccount.delegates);
+				should.not.exist(err);
+				res.length.should.equal(1);
+				res[0].username.should.equal(validAccount.username);
+				res[0].isDelegate.should.equal(validAccount.isDelegate);
+				res[0].address.should.equal(validAccount.address);
+				res[0].publicKey.should.equal(validAccount.publicKey);
+			  should.equal(res[0].delegates, validAccount.delegates);
 				done();
 			});
 		});
 
 		it('should fetch correct result using address as filter when its in lower case', function (done) {
 			account.getAll({address: validAccount.address.toLowerCase() }, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.length).to.equal(1);
-				expect(res[0].username).to.equal(validAccount.username);
-				expect(res[0].isDelegate).to.equal(validAccount.isDelegate);
-				expect(res[0].address).to.equal(validAccount.address);
-				expect(res[0].publicKey).to.equal(validAccount.publicKey);
-				expect(res[0].delegates).to.equal(validAccount.delegates);
+				should.not.exist(err);
+				res.length.should.equal(1);
+				res[0].username.should.equal(validAccount.username);
+				res[0].isDelegate.should.equal(validAccount.isDelegate);
+				res[0].address.should.equal(validAccount.address);
+				res[0].publicKey.should.equal(validAccount.publicKey);
+				should.equal(res[0].delegates, validAccount.delegates);
 				done();
 			});
 		});
 
 		it('should fetch correct result using username as filter', function (done) {
 			account.getAll({username: validAccount.username}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.length).to.equal(1);
-				expect(res[0].username).to.equal(validAccount.username);
-				expect(res[0].isDelegate).to.equal(validAccount.isDelegate);
-				expect(res[0].address).to.equal(validAccount.address);
-				expect(res[0].publicKey).to.equal(validAccount.publicKey);
-				expect(res[0].delegates).to.equal(validAccount.delegates);
+				should.not.exist(err);
+				res.length.should.equal(1);
+				res[0].username.should.equal(validAccount.username);
+				res[0].isDelegate.should.equal(validAccount.isDelegate);
+				res[0].address.should.equal(validAccount.address);
+				res[0].publicKey.should.equal(validAccount.publicKey);
+			  should.equal(res[0].delegates, validAccount.delegates);
 				done();
 			});
 		});
 
 		it('should fetch all delegates using isDelegate filter', function (done) {
 			account.getAll({isDelegate: 1}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.filter(function (a) {
+				should.not.exist(err);
+				res.filter(function (a) {
 					return a.isDelegate === 1;
-				}).length).to.equal(res.length);
+				}).length.should.equal(res.length);
 				done();
 			});
 		});
 
 		it('should throw error if unrelated filters are provided', function (done) {
 			account.getAll({publicKey: validAccount.publicKey, unrelatedfield: 'random value'}, function (err, res) {
-				expect(err).to.equal('Account#getAll error');
+				err.should.equal('Account#getAll error');
 				done();
 			});
 		});
@@ -445,9 +445,9 @@ describe('account', function () {
 				offset: 0,
 				sort: 'username:asc'
 			}, ['username'], function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.have.length(50);
-				expect(res).to.eql(_.sortBy(res, 'username'));
+				should.not.exist(err);
+				res.should.have.length(50);
+				res.should.eql(_.sortBy(res, 'username'));
 				done();
 			});
 		});
@@ -457,8 +457,8 @@ describe('account', function () {
 				limit: -50,
 				sort: 'username:asc'
 			}, ['username'], function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.eql(_.sortBy(res, 'username'));
+				should.not.exist(err);
+				res.should.eql(_.sortBy(res, 'username'));
 				done();
 			});
 		});
@@ -467,8 +467,8 @@ describe('account', function () {
 
 			it('should sort the result according to field type in ascending order', function (done) {
 				account.getAll({sort: 'username:asc'}, ['username'], function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.eql(_.sortBy(res, 'username'));
+					should.not.exist(err);
+					res.should.eql(_.sortBy(res, 'username'));
 					done();
 				});
 			});
@@ -476,8 +476,8 @@ describe('account', function () {
 
 			it('should sort the result according to field type in descending order', function (done) {
 				account.getAll({sort: 'username:desc'}, ['username'], function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.eql(_.sortBy(res, 'username').reverse());
+					should.not.exist(err);
+					res.should.eql(_.sortBy(res, 'username').reverse());
 					done();
 				});
 			});
@@ -487,16 +487,16 @@ describe('account', function () {
 
 			it('should sort the result according to field type in ascending order', function (done) {
 				account.getAll({sort: {'username': 1}}, ['username'], function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.eql(_.sortBy(res, 'username'));
+					should.not.exist(err);
+					res.should.eql(_.sortBy(res, 'username'));
 					done();
 				});
 			});
 
 			it('should sort the result according to field type in descending order', function (done) {
 				account.getAll({sort: {'username': -1}}, ['username'], function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.eql(_.sortBy(res, 'username').reverse());
+					should.not.exist(err);
+					res.should.eql(_.sortBy(res, 'username').reverse());
 					done();
 				});
 			});
@@ -507,23 +507,23 @@ describe('account', function () {
 
 		it('should insert an account', function (done) {
 			account.set('123L', {u_username: 'test_set_insert'}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.undefined;
+				should.not.exist(err);
+				should.not.exist(res);
 				done();
 			});
 		});
 
 		it('should set provided fields when valid', function (done) {
 			account.set(validAccount.address, {u_username: 'test_set', vote: 1}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.undefined;
+				should.not.exist(err);
+				should.not.exist(res);
 				done();
 			});
 		});
 
 		it('should throw error when unrelated fields are provided', function (done) {
 			account.set(validAccount.address, {unrelatedfield: 'random value'}, function (err, res) {
-				expect(err).to.equal('Account#set error');
+				err.should.equal('Account#set error');
 				done();
 			});
 		});
@@ -533,9 +533,9 @@ describe('account', function () {
 
 		it('should merge diff when values are correct', function (done) {
 			account.merge(validAccount.address, {multisignatures: ['MS1'], delegates: ['DLG1']}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.delegates).to.deep.equal(['DLG1']);
-				expect(res.multisignatures).to.deep.equal(['MS1']);
+				should.not.exist(err);
+				res.delegates.should.deep.equal(['DLG1']);
+				res.multisignatures.should.deep.equal(['MS1']);
 				done();
 			});
 		});
@@ -543,21 +543,21 @@ describe('account', function () {
 		describe('verify public key', function () {
 
 			it('should throw error if parameter is not a string', function () {
-				expect(function () {
+				(function () {
 					account.merge(validAccount.address, {publicKey: 1});
-				}).to.throw('Invalid public key, must be a string');
+				}).should.throw('Invalid public key, must be a string');
 			});
 
 			it('should throw error if parameter is of invalid length', function () {
-				expect(function () {
+				(function () {
 					account.merge(validAccount.address, {publicKey: '231312312321'});
-				}).to.throw('Invalid public key, must be 64 characters long');
+				}).should.throw('Invalid public key, must be 64 characters long');
 			});
 
 			it('should throw error if parameter is not a hex string', function () {
-				expect(function () {
+				(function () {
 					account.merge(validAccount.address, {publicKey: 'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2az'});
-				}).to.throw('Invalid public key, must be a hex string');
+				}).should.throw('Invalid public key, must be a hex string');
 			});
 		});
 
@@ -565,28 +565,28 @@ describe('account', function () {
 
 			it('should throw error when address does not exist for u_delegates', function (done) {
 				account.merge('1L', {u_delegates: [validAccount.publicKey]}, function (err, res) {
-					expect(err).to.equal('Account#merge error');
+					err.should.equal('Account#merge error');
 					done();
 				});
 			});
 
 			it('should throw error when address does not exist for delegates', function (done) {
 				account.merge('1L', {delegates: [validAccount.publicKey]}, function (err, res) {
-					expect(err).to.equal('Account#merge error');
+					err.should.equal('Account#merge error');
 					done();
 				});
 			});
 
 			it('should throw error when address does not exist for u_multisignatures', function (done) {
 				account.merge('1L', {u_multisignatures: [validAccount.publicKey]}, function (err, res) {
-					expect(err).to.equal('Account#merge error');
+					err.should.equal('Account#merge error');
 					done();
 				});
 			});
 
 			it('should throw error when address does not exist for multisignatures', function (done) {
 				account.merge('1L', {multisignatures: [validAccount.publicKey]}, function (err, res) {
-					expect(err).to.equal('Account#merge error');
+					err.should.equal('Account#merge error');
 					done();
 				});
 			});
@@ -594,8 +594,11 @@ describe('account', function () {
 
 		it('should throw error when a numeric field receives non numeric value', function (done) {
 			account.merge(validAccount.address, {balance: 'Not a Number'}, function (err, res) {
-				expect(err).to.equal('Encountered unsane number: Not a Number');
-				done();
+				// callback gets called multiple times
+				if (err) {
+					err.should.equal('Encountered unsane number: Not a Number');
+					done();
+				}
 			});
 		});
 	});
@@ -604,8 +607,8 @@ describe('account', function () {
 
 		it('should remove an account', function (done) {
 			account.remove('123L', function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.equal('123L');
+				should.not.exist(err);
+				res.should.equal('123L');
 				done();
 			});
 		});

--- a/test/unit/logic/block.js
+++ b/test/unit/logic/block.js
@@ -316,8 +316,8 @@ describe('block', function () {
 				});
 
 				it('should sort transactions in the correct order', function () {
-					expect(generatedBlock.transactions.length).to.equal(data.transactions.length);
-					expect(transactionsOrder).to.eql(correctOrder);
+					generatedBlock.transactions.length.should.equal(data.transactions.length);
+					transactionsOrder.should.eql(correctOrder);
 				});
 			});
 
@@ -341,9 +341,9 @@ describe('block', function () {
 					});
 
 					it('should sort transactions in the correct order', function () {
-						expect(generatedBlock.transactions.length).to.equal(data.transactions.length);
-						expect(expectedOrderOfTransactions(generatedBlock.transactions)).to.equal(true);
-						expect(transactionsOrder).to.eql(correctOrderOfTransactions);
+						generatedBlock.transactions.length.should.equal(data.transactions.length);
+						expectedOrderOfTransactions(generatedBlock.transactions).should.equal(true);
+						transactionsOrder.should.eql(correctOrderOfTransactions);
 					});
 				});
 
@@ -365,9 +365,9 @@ describe('block', function () {
 					});
 
 					it('should sort transactions in the correct order', function () {
-						expect(generatedBlock.transactions.length).to.equal(data.transactions.length);
-						expect(expectedOrderOfTransactions(generatedBlock.transactions)).to.equal(true);
-						expect(transactionsOrder).to.eql(correctOrderOfTransactions);
+						generatedBlock.transactions.length.should.equal(data.transactions.length);
+						expectedOrderOfTransactions(generatedBlock.transactions).should.equal(true);
+						transactionsOrder.should.eql(correctOrderOfTransactions);
 					});
 				});
 
@@ -387,9 +387,9 @@ describe('block', function () {
 					});
 
 					it('should sort transactions in the correct order', function () {
-						expect(generatedBlock.transactions.length).to.equal(data.transactions.length);
-						expect(expectedOrderOfTransactions(generatedBlock.transactions)).to.equal(true);
-						expect(transactionsOrder).to.eql(correctOrderOfTransactions);
+						generatedBlock.transactions.length.should.equal(data.transactions.length);
+						expectedOrderOfTransactions(generatedBlock.transactions).should.equal(true);
+						transactionsOrder.should.eql(correctOrderOfTransactions);
 					});
 				});
 
@@ -409,9 +409,9 @@ describe('block', function () {
 					});
 
 					it('should sort transactions in the correct order', function () {
-						expect(generatedBlock.transactions.length).to.equal(data.transactions.length);
-						expect(expectedOrderOfTransactions(generatedBlock.transactions)).to.equal(true);
-						expect(transactionsOrder).to.eql(correctOrderOfTransactions);
+						generatedBlock.transactions.length.should.equal(data.transactions.length);
+						expectedOrderOfTransactions(generatedBlock.transactions).should.equal(true);
+						transactionsOrder.should.eql(correctOrderOfTransactions);
 					});
 				});
 			});

--- a/test/unit/logic/blockReward.js
+++ b/test/unit/logic/blockReward.js
@@ -26,345 +26,345 @@ describe('BlockReward @slow', function () {
 	describe('returning calcMilestone', function () {
 
 		it('when height is undefined should throw an error', function () {
-			expect(blockReward.calcMilestone).to.throw(/Invalid block height/);
+			blockReward.calcMilestone.should.throw(/Invalid block height/);
 		});
 
 		it('when height == 0 should return 0', function () {
-			expect(blockReward.calcMilestone(0)).to.equal(0);
+			blockReward.calcMilestone(0).should.equal(0);
 		});
 
 		it('when height == 1 should return 0', function () {
-			expect(blockReward.calcMilestone(1)).to.equal(0);
+			blockReward.calcMilestone(1).should.equal(0);
 		});
 
 		it('when height == (offset - 1) should return 0', function () {
-			expect(blockReward.calcMilestone(1451519)).to.equal(0);
+			blockReward.calcMilestone(1451519).should.equal(0);
 		});
 
 		it('when height == (offset) should return 0', function () {
-			expect(blockReward.calcMilestone(1451520)).to.equal(0);
+			blockReward.calcMilestone(1451520).should.equal(0);
 		});
 
 		it('when height == (offset + 1) should return 0', function () {
-			expect(blockReward.calcMilestone(1451521)).to.equal(0);
+			blockReward.calcMilestone(1451521).should.equal(0);
 		});
 
 		it('when height == (offset + 2) should return 0', function () {
-			expect(blockReward.calcMilestone(1451522)).to.equal(0);
+			blockReward.calcMilestone(1451522).should.equal(0);
 		});
 
 		it('when height == (distance) should return 0', function () {
-			expect(blockReward.calcMilestone(3000000)).to.equal(0);
+			blockReward.calcMilestone(3000000).should.equal(0);
 		});
 
 		it('when height == (distance + 1) should return 0', function () {
-			expect(blockReward.calcMilestone(3000001)).to.equal(0);
+			blockReward.calcMilestone(3000001).should.equal(0);
 		});
 
 		it('when height == (distance + 2) should return 0', function () {
-			expect(blockReward.calcMilestone(3000002)).to.equal(0);
+			blockReward.calcMilestone(3000002).should.equal(0);
 		});
 
 		it('when height == (milestoneOne - 1) should return 0', function () {
-			expect(blockReward.calcMilestone(4451519)).to.equal(0);
+			blockReward.calcMilestone(4451519).should.equal(0);
 		});
 
 		it('when height == (milestoneOne) should return 1', function () {
-			expect(blockReward.calcMilestone(4451520)).to.equal(1);
+			blockReward.calcMilestone(4451520).should.equal(1);
 		});
 
 		it('when height == (milestoneOne + 1) should return 1', function () {
-			expect(blockReward.calcMilestone(4451521)).to.equal(1);
+			blockReward.calcMilestone(4451521).should.equal(1);
 		});
 
 		it('when height == (milestoneTwo - 1) should return 1', function () {
-			expect(blockReward.calcMilestone(7451519)).to.equal(1);
+			blockReward.calcMilestone(7451519).should.equal(1);
 		});
 
 		it('when height == (milestoneTwo) should return 2', function () {
-			expect(blockReward.calcMilestone(7451520)).to.equal(2);
+			blockReward.calcMilestone(7451520).should.equal(2);
 		});
 
 		it('when height == (milestoneTwo + 1) should return 2', function () {
-			expect(blockReward.calcMilestone(7451521)).to.equal(2);
+			blockReward.calcMilestone(7451521).should.equal(2);
 		});
 
 		it('when height == (milestoneThree - 1) should return 2', function () {
-			expect(blockReward.calcMilestone(10451519)).to.equal(2);
+			blockReward.calcMilestone(10451519).should.equal(2);
 		});
 
 		it('when height == (milestoneThree) should return 3', function () {
-			expect(blockReward.calcMilestone(10451520)).to.equal(3);
+			blockReward.calcMilestone(10451520).should.equal(3);
 		});
 
 		it('when height == (milestoneThree + 1) should return 3', function () {
-			expect(blockReward.calcMilestone(10451521)).to.equal(3);
+			blockReward.calcMilestone(10451521).should.equal(3);
 		});
 
 		it('when height == (milestoneFour - 1) should return 3', function () {
-			expect(blockReward.calcMilestone(13451519)).to.equal(3);
+			blockReward.calcMilestone(13451519).should.equal(3);
 		});
 
 		it('when height == (milestoneFour) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520)).to.equal(4);
+			blockReward.calcMilestone(13451520).should.equal(4);
 		});
 
 		it('when height == (milestoneFour + 1) should return 4', function () {
-			expect(blockReward.calcMilestone(13451521)).to.equal(4);
+			blockReward.calcMilestone(13451521).should.equal(4);
 		});
 
 		it('when height == (milestoneFour * 2) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520 * 2)).to.equal(4);
+			blockReward.calcMilestone(13451520 * 2).should.equal(4);
 		});
 
 		it('when height == (milestoneFour * 10) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520 * 10)).to.equal(4);
+			blockReward.calcMilestone(13451520 * 10).should.equal(4);
 		});
 
 		it('when height == (milestoneFour * 100) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520 * 100)).to.equal(4);
+			blockReward.calcMilestone(13451520 * 100).should.equal(4);
 		});
 
 		it('when height == (milestoneFour * 1000) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520 * 1000)).to.equal(4);
+			blockReward.calcMilestone(13451520 * 1000).should.equal(4);
 		});
 
 		it('when height == (milestoneFour * 10000) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520 * 10000)).to.equal(4);
+			blockReward.calcMilestone(13451520 * 10000).should.equal(4);
 		});
 
 		it('when height == (milestoneFour * 100000) should return 4', function () {
-			expect(blockReward.calcMilestone(13451520 * 100000)).to.equal(4);
+			blockReward.calcMilestone(13451520 * 100000).should.equal(4);
 		});
 	});
 
 	describe('returning calcReward', function () {
 
 		it('when height is undefined should throw an error', function () {
-			expect(blockReward.calcReward).to.throw(/Invalid block height/);
+			blockReward.calcReward.should.throw(/Invalid block height/);
 		});
 
 		it('when height == 0 should return 0', function () {
-			expect(blockReward.calcReward(0)).to.equal(0);
+			blockReward.calcReward(0).should.equal(0);
 		});
 
 		it('when height == 1 should return 0', function () {
-			expect(blockReward.calcReward(1)).to.equal(0);
+			blockReward.calcReward(1).should.equal(0);
 		});
 
 		it('when height == (offset - 1) should return 0', function () {
-			expect(blockReward.calcReward(1451519)).to.equal(0);
+			blockReward.calcReward(1451519).should.equal(0);
 		});
 
 		it('when height == (offset) should return 500000000', function () {
-			expect(blockReward.calcReward(1451520)).to.equal(500000000);
+			blockReward.calcReward(1451520).should.equal(500000000);
 		});
 
 		it('when height == (offset + 1) should return 500000000', function () {
-			expect(blockReward.calcReward(1451521)).to.equal(500000000);
+			blockReward.calcReward(1451521).should.equal(500000000);
 		});
 
 		it('when height == (offset + 2) should return 500000000', function () {
-			expect(blockReward.calcReward(1451522)).to.equal(500000000);
+			blockReward.calcReward(1451522).should.equal(500000000);
 		});
 
 		it('when height == (distance) should return 500000000', function () {
-			expect(blockReward.calcReward(3000000)).to.equal(500000000);
+			blockReward.calcReward(3000000).should.equal(500000000);
 		});
 
 		it('when height == (distance + 1) should return 500000000', function () {
-			expect(blockReward.calcReward(3000001)).to.equal(500000000);
+			blockReward.calcReward(3000001).should.equal(500000000);
 		});
 
 		it('when height == (distance + 2) should return 500000000', function () {
-			expect(blockReward.calcReward(3000002)).to.equal(500000000);
+			blockReward.calcReward(3000002).should.equal(500000000);
 		});
 
 		it('when height == (milestoneOne - 1) should return 500000000', function () {
-			expect(blockReward.calcReward(4451519)).to.equal(500000000);
+			blockReward.calcReward(4451519).should.equal(500000000);
 		});
 
 		it('when height == (milestoneOne) should return 400000000', function () {
-			expect(blockReward.calcReward(4451520)).to.equal(400000000);
+			blockReward.calcReward(4451520).should.equal(400000000);
 		});
 
 		it('when height == (milestoneOne + 1) should return 400000000', function () {
-			expect(blockReward.calcReward(4451521)).to.equal(400000000);
+			blockReward.calcReward(4451521).should.equal(400000000);
 		});
 
 		it('when height == (milestoneTwo - 1) should return 400000000', function () {
-			expect(blockReward.calcReward(7451519)).to.equal(400000000);
+			blockReward.calcReward(7451519).should.equal(400000000);
 		});
 
 		it('when height == (milestoneTwo) should return 300000000', function () {
-			expect(blockReward.calcReward(7451521)).to.equal(300000000);
+			blockReward.calcReward(7451521).should.equal(300000000);
 		});
 
 		it('when height == (milestoneTwo + 1) should return 300000000', function () {
-			expect(blockReward.calcReward(7451522)).to.equal(300000000);
+			blockReward.calcReward(7451522).should.equal(300000000);
 		});
 
 		it('when height == (milestoneThree - 1) should return 300000000', function () {
-			expect(blockReward.calcReward(10451519)).to.equal(300000000);
+			blockReward.calcReward(10451519).should.equal(300000000);
 		});
 
 		it('when height == (milestoneThree) should return 200000000', function () {
-			expect(blockReward.calcReward(10451520)).to.equal(200000000);
+			blockReward.calcReward(10451520).should.equal(200000000);
 		});
 
 		it('when height == (milestoneThree + 1) should return 200000000', function () {
-			expect(blockReward.calcReward(10451521)).to.equal(200000000);
+			blockReward.calcReward(10451521).should.equal(200000000);
 		});
 
 		it('when height == (milestoneFour - 1) should return 200000000', function () {
-			expect(blockReward.calcReward(13451519)).to.equal(200000000);
+			blockReward.calcReward(13451519).should.equal(200000000);
 		});
 
 		it('when height == (milestoneFour) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520)).to.equal(100000000);
+			blockReward.calcReward(13451520).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour + 1) should return 100000000', function () {
-			expect(blockReward.calcReward(13451521)).to.equal(100000000);
+			blockReward.calcReward(13451521).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour * 2) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520 * 2)).to.equal(100000000);
+			blockReward.calcReward(13451520 * 2).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour * 10) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520 * 10)).to.equal(100000000);
+			blockReward.calcReward(13451520 * 10).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour * 100) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520 * 100)).to.equal(100000000);
+			blockReward.calcReward(13451520 * 100).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour * 1000) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520 * 1000)).to.equal(100000000);
+			blockReward.calcReward(13451520 * 1000).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour * 10000) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520 * 10000)).to.equal(100000000);
+			blockReward.calcReward(13451520 * 10000).should.equal(100000000);
 		});
 
 		it('when height == (milestoneFour * 100000) should return 100000000', function () {
-			expect(blockReward.calcReward(13451520 * 100000)).to.equal(100000000);
+			blockReward.calcReward(13451520 * 100000).should.equal(100000000);
 		});
 	});
 
 	describe('returning calcSupply', function () {
 
 		it('when height is undefined should throw an error', function () {
-			expect(blockReward.calcSupply).to.throw(/Invalid block height/);
+			blockReward.calcSupply.should.throw(/Invalid block height/);
 		});
 
 		it('when height == 0 should return 10000000000000000', function () {
-			expect(blockReward.calcSupply(0)).to.equal(10000000000000000);
+			blockReward.calcSupply(0).should.equal(10000000000000000);
 		});
 
 		it('when height == 1 should return 10000000000000000', function () {
-			expect(blockReward.calcSupply(1)).to.equal(10000000000000000);
+			blockReward.calcSupply(1).should.equal(10000000000000000);
 		});
 
 		it('when height == (offset - 1) should return 10000000000000000', function () {
-			expect(blockReward.calcSupply(1451519)).to.equal(10000000000000000);
+			blockReward.calcSupply(1451519).should.equal(10000000000000000);
 		});
 
 		it('when height == (offset) should return 10000000500000000', function () {
-			expect(blockReward.calcSupply(1451520)).to.equal(10000000500000000);
+			blockReward.calcSupply(1451520).should.equal(10000000500000000);
 		});
 
 		it('when height == (offset + 1) should return 10000001000000000', function () {
-			expect(blockReward.calcSupply(1451521)).to.equal(10000001000000000);
+			blockReward.calcSupply(1451521).should.equal(10000001000000000);
 		});
 
 		it('when height == (offset + 2) should return 10000001500000000', function () {
-			expect(blockReward.calcSupply(1451522)).to.equal(10000001500000000);
+			blockReward.calcSupply(1451522).should.equal(10000001500000000);
 		});
 
 		it('when height == (distance) should return 10774240500000000', function () {
-			expect(blockReward.calcSupply(3000000)).to.equal(10774240500000000);
+			blockReward.calcSupply(3000000).should.equal(10774240500000000);
 		});
 
 		it('when height == (distance + 1) should return 10774241000000000', function () {
-			expect(blockReward.calcSupply(3000001)).to.equal(10774241000000000);
+			blockReward.calcSupply(3000001).should.equal(10774241000000000);
 		});
 
 		it('when height == (distance + 2) should return 10774241500000000', function () {
-			expect(blockReward.calcSupply(3000002)).to.equal(10774241500000000);
+			blockReward.calcSupply(3000002).should.equal(10774241500000000);
 		});
 
 		it('when height == (milestoneOne - 1) should return 11500000000000000', function () {
-			expect(blockReward.calcSupply(4451519)).to.equal(11500000000000000);
+			blockReward.calcSupply(4451519).should.equal(11500000000000000);
 		});
 
 		it('when height == (milestoneOne) should return 11500000400000000', function () {
-			expect(blockReward.calcSupply(4451520)).to.equal(11500000400000000);
+			blockReward.calcSupply(4451520).should.equal(11500000400000000);
 		});
 
 		it('when height == (milestoneOne + 1) should return 11500000800000000', function () {
-			expect(blockReward.calcSupply(4451521)).to.equal(11500000800000000);
+			blockReward.calcSupply(4451521).should.equal(11500000800000000);
 		});
 
 		it('when height == (milestoneTwo - 1) should return 12700000000000000', function () {
-			expect(blockReward.calcSupply(7451519)).to.equal(12700000000000000);
+			blockReward.calcSupply(7451519).should.equal(12700000000000000);
 		});
 
 		it('when height == (milestoneTwo) should return 12700000300000000', function () {
-			expect(blockReward.calcSupply(7451520)).to.equal(12700000300000000);
+			blockReward.calcSupply(7451520).should.equal(12700000300000000);
 		});
 
 		it('when height == (milestoneTwo + 1) should return 12700000600000000', function () {
-			expect(blockReward.calcSupply(7451521)).to.equal(12700000600000000);
+			blockReward.calcSupply(7451521).should.equal(12700000600000000);
 		});
 
 		it('when height == (milestoneThree - 1) should return 13600000000000000', function () {
-			expect(blockReward.calcSupply(10451519)).to.equal(13600000000000000);
+			blockReward.calcSupply(10451519).should.equal(13600000000000000);
 		});
 
 		it('when height == (milestoneThree) should return 13600000200000000', function () {
-			expect(blockReward.calcSupply(10451520)).to.equal(13600000200000000);
+			blockReward.calcSupply(10451520).should.equal(13600000200000000);
 		});
 
 		it('when height == (milestoneThree + 1) should return 13600000400000000', function () {
-			expect(blockReward.calcSupply(10451521)).to.equal(13600000400000000);
+			blockReward.calcSupply(10451521).should.equal(13600000400000000);
 		});
 
 		it('when height == (milestoneFour - 1) should return 14200000000000000', function () {
-			expect(blockReward.calcSupply(13451519)).to.equal(14200000000000000);
+			blockReward.calcSupply(13451519).should.equal(14200000000000000);
 		});
 
 		it('when height == (milestoneFour) should return 14200000100000000', function () {
-			expect(blockReward.calcSupply(13451520)).to.equal(14200000100000000);
+			blockReward.calcSupply(13451520).should.equal(14200000100000000);
 		});
 
 		it('when height == (milestoneFour + 1) should return 14200000200000000', function () {
-			expect(blockReward.calcSupply(13451521)).to.equal(14200000200000000);
+			blockReward.calcSupply(13451521).should.equal(14200000200000000);
 		});
 
 		it('when height == (milestoneFour * 2) should return 15545152100000000', function () {
-			expect(blockReward.calcSupply(13451520 * 2)).to.equal(15545152100000000);
+			blockReward.calcSupply(13451520 * 2).should.equal(15545152100000000);
 		});
 
 		it('when height == (milestoneFour * 10) should return 26306368100000000', function () {
-			expect(blockReward.calcSupply(13451520 * 10)).to.equal(26306368100000000);
+			blockReward.calcSupply(13451520 * 10).should.equal(26306368100000000);
 		});
 
 		it('when height == (milestoneFour * 100) should return 147370048100000000', function () {
-			expect(blockReward.calcSupply(13451520 * 100)).to.equal(147370048100000000);
+			blockReward.calcSupply(13451520 * 100).should.equal(147370048100000000);
 		});
 
 		it('when height == (milestoneFour * 1000) should return 1358006848100000000', function () {
-			expect(blockReward.calcSupply(13451520 * 1000)).to.equal(1358006848100000000);
+			blockReward.calcSupply(13451520 * 1000).should.equal(1358006848100000000);
 		});
 
 		it('when height == (milestoneFour * 10000) should return 13464374848100000000', function () {
-			expect(blockReward.calcSupply(13451520 * 10000)).to.equal(13464374848100000000);
+			blockReward.calcSupply(13451520 * 10000).should.equal(13464374848100000000);
 		});
 
 		it('when height == (milestoneFour * 100000) should return 134528054848100000000', function () {
-			expect(blockReward.calcSupply(13451520 * 100000)).to.equal(134528054848100000000);
+			blockReward.calcSupply(13451520 * 100000).should.equal(134528054848100000000);
 		});
 
 		describe('completely', function () {
@@ -377,7 +377,7 @@ describe('BlockReward @slow', function () {
 
 					for (var i = 1; i < 1451520; i++) {
 						supply = blockReward.calcSupply(i);
-						expect(supply).to.equal(constants.totalAmount);
+						supply.should.equal(constants.totalAmount);
 						prev = supply;
 					}
 				});
@@ -391,7 +391,7 @@ describe('BlockReward @slow', function () {
 
 					for (var i = 1451520; i < 4451520; i++) {
 						supply = blockReward.calcSupply(i);
-						expect(supply).to.equal(prev + constants.rewards.milestones[0]);
+						supply.should.equal(prev + constants.rewards.milestones[0]);
 						prev = supply;
 					}
 				});
@@ -405,7 +405,7 @@ describe('BlockReward @slow', function () {
 
 					for (var i = 4451520; i < 7451520; i++) {
 						supply = blockReward.calcSupply(i);
-						expect(supply).to.equal(prev + constants.rewards.milestones[1]);
+						supply.should.equal(prev + constants.rewards.milestones[1]);
 						prev = supply;
 					}
 				});
@@ -419,7 +419,7 @@ describe('BlockReward @slow', function () {
 
 					for (var i = 7451520; i < 10451520; i++) {
 						supply = blockReward.calcSupply(i);
-						expect(supply).to.equal(prev + constants.rewards.milestones[2]);
+						supply.should.equal(prev + constants.rewards.milestones[2]);
 						prev = supply;
 					}
 				});
@@ -433,7 +433,7 @@ describe('BlockReward @slow', function () {
 
 					for (var i = 10451520; i < 13451520; i++) {
 						supply = blockReward.calcSupply(i);
-						expect(supply).to.equal(prev + constants.rewards.milestones[3]);
+						supply.should.equal(prev + constants.rewards.milestones[3]);
 						prev = supply;
 					}
 				});
@@ -447,7 +447,7 @@ describe('BlockReward @slow', function () {
 
 					for (var i = 13451520; i < (13451520 + 100); i++) {
 						supply = blockReward.calcSupply(i);
-						expect(supply).to.equal(prev + constants.rewards.milestones[4]);
+						supply.should.equal(prev + constants.rewards.milestones[4]);
 						prev = supply;
 					}
 				});

--- a/test/unit/logic/dapp.js
+++ b/test/unit/logic/dapp.js
@@ -87,19 +87,19 @@ describe('dapp', function () {
 				});
 
 				it('should attach dbStub', function () {
-					expect(library.db).to.eql(dbStub);
+					library.db.should.eql(dbStub);
 				});
 
 				it('should attach dbStub', function () {
-					expect(library.schema).to.eql(modulesLoader.scope.schema);
+					library.schema.should.eql(modulesLoader.scope.schema);
 				});
 
 				it('should attach logger', function () {
-					expect(library.logger).to.eql(modulesLoader.scope.logger);
+					library.logger.should.eql(modulesLoader.scope.logger);
 				});
 
 				it('should attach logger', function () {
-					expect(library.network).to.eql(modulesLoader.scope.network);
+					library.network.should.eql(modulesLoader.scope.network);
 				});
 			});
 		});
@@ -114,7 +114,7 @@ describe('dapp', function () {
 		describe('calculateFee', function () {
 
 			it('should return constants.fees.dappRegistration', function () {
-				expect(dapp.calculateFee(transaction)).to.equal(constants.fees.dappRegistration);
+				dapp.calculateFee(transaction).should.equal(constants.fees.dappRegistration);
 			});
 		});
 
@@ -128,7 +128,7 @@ describe('dapp', function () {
 						transaction.recipientId = '4835566122337813671L';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid recipient');
+							err.should.equal('Invalid recipient');
 							done();
 						});
 					});
@@ -140,7 +140,7 @@ describe('dapp', function () {
 						transaction.amount = 1;
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid transaction amount');
+							err.should.equal('Invalid transaction amount');
 							done();
 						});
 					});
@@ -152,7 +152,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.category = undefined;
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid application category');
+							err.should.equal('Invalid application category');
 							done();
 						});
 					});
@@ -164,7 +164,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.category = 9;
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application category not found');
+							err.should.equal('Application category not found');
 							done();
 						});
 					});
@@ -176,7 +176,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.icon = 'random string';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid application icon link');
+							err.should.equal('Invalid application icon link');
 							done();
 						});
 					});
@@ -188,7 +188,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.icon = 'https://www.youtube.com/watch?v=de1-igivvda';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid application icon file type');
+							err.should.equal('Invalid application icon file type');
 							done();
 						});
 					});
@@ -200,7 +200,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.type = -1;
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid application type');
+							err.should.equal('Invalid application type');
 							done();
 						});
 					});
@@ -212,7 +212,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.link = 'random string';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid application link');
+							err.should.equal('Invalid application link');
 							done();
 						});
 					});
@@ -224,7 +224,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.link = 'https://www.youtube.com/watch?v=de1-igivvda';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid application file type');
+							err.should.equal('Invalid application file type');
 							done();
 						});
 					});
@@ -235,7 +235,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.name = '  ';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application name must not be blank');
+							err.should.equal('Application name must not be blank');
 							done();
 						});
 					});
@@ -247,7 +247,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.name = ' randomname ';
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application name must not be blank');
+							err.should.equal('Application name must not be blank');
 							done();
 						});
 					});
@@ -259,7 +259,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.name = Array.apply(null, Array(33)).map(function () { return 'a';}).join('');
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application name is too long. Maximum is 32 characters');
+							err.should.equal('Application name is too long. Maximum is 32 characters');
 							done();
 						});
 					});
@@ -271,7 +271,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.description = Array.apply(null, Array(161)).map(function () { return 'a';}).join('');
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application description is too long. Maximum is 160 characters');
+							err.should.equal('Application description is too long. Maximum is 160 characters');
 							done();
 						});
 					});
@@ -283,7 +283,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.tags = Array.apply(null, Array(161)).map(function () { return 'a';}).join('');
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application tags is too long. Maximum is 160 characters');
+							err.should.equal('Application tags is too long. Maximum is 160 characters');
 							done();
 						});
 					});
@@ -295,7 +295,7 @@ describe('dapp', function () {
 						transaction.asset.dapp.tags = Array.apply(null, Array(3)).map(function () { return 'a';}).join(',');
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Encountered duplicate tag: a in application');
+							err.should.equal('Encountered duplicate tag: a in application');
 							done();
 						});
 					});
@@ -313,7 +313,7 @@ describe('dapp', function () {
 						}).rejects(dbError);
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('DApp#verify error');
+							err.should.equal('DApp#verify error');
 							done();
 						});
 					});
@@ -338,7 +338,7 @@ describe('dapp', function () {
 						}]);
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application name already exists: ' + transaction.asset.dapp.name);
+							err.should.equal('Application name already exists: ' + transaction.asset.dapp.name);
 							done();
 						});
 					});
@@ -350,7 +350,7 @@ describe('dapp', function () {
 						}]);
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application link already exists: ' + transaction.asset.dapp.link);
+							err.should.equal('Application link already exists: ' + transaction.asset.dapp.link);
 							done();
 						});
 					});
@@ -363,7 +363,7 @@ describe('dapp', function () {
 						}).resolves([{tags: 'a,b,c'}]);
 
 						dapp.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Application already exists');
+							err.should.equal('Application already exists');
 							done();
 						});
 					});
@@ -384,27 +384,27 @@ describe('dapp', function () {
 					transaction.asset.dapp.type = 2;
 
 					dapp.verify(transaction, sender, function (err) {
-						expect(err).to.equal('Invalid application type');
+						err.should.equal('Invalid application type');
 						done();
 					});
 				});
 
 				it('should call dbStub.query with correct params', function (done) {
 					dapp.verify(transaction, sender, function (err, res) {
-						expect(dbStub.dapps.getExisting.calledOnce).to.equal(true);
-						expect(dbStub.dapps.getExisting.calledWithExactly({
+						dbStub.dapps.getExisting.calledOnce.should.equal(true);
+						dbStub.dapps.getExisting.calledWithExactly({
 							name: transaction.asset.dapp.name,
 							link: transaction.asset.dapp.link || null,
 							transactionId: transaction.id
-						})).to.equal(true);
+						}).should.be.true;
 						done();
 					});
 				});
 
 				it('should call callback with error = null and transaction', function (done) {
 					dapp.verify(transaction, sender, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(transaction);
+						should.not.exist(err);
+						res.should.eql(transaction);
 						done();
 					});
 				});
@@ -430,7 +430,7 @@ describe('dapp', function () {
 				});
 
 				it('should throw', function () {
-					expect(dapp.getBytes.bind(null, transaction)).to.throw();
+					dapp.getBytes.bind(null, transaction).should.throw();
 				});
 			});
 
@@ -441,7 +441,7 @@ describe('dapp', function () {
 				});
 
 				it('should throw', function () {
-					expect(dapp.getBytes.bind(null, transaction)).to.throw();
+					dapp.getBytes.bind(null, transaction).should.throw();
 				});
 			});
 
@@ -452,22 +452,22 @@ describe('dapp', function () {
 				});
 
 				it('should throw', function () {
-					expect(dapp.getBytes.bind(null, transaction)).to.throw();
+					dapp.getBytes.bind(null, transaction).should.throw();
 				});
 			});
 
 			describe('when transaction.asset.dapp is a valid asset', function () {
 
 				it('should not throw', function () {
-					expect(dapp.getBytes.bind(null, transaction)).not.to.throw();
+					dapp.getBytes.bind(null, transaction).should.not.to.throw();
 				});
 
 				it('should get bytes of valid transaction', function () {
-					expect(dapp.getBytes(transaction).toString('hex')).to.equal('414f37657a42313143674364555a69356f38597a784341746f524c41364669687474703a2f2f7777772e6c69736b2e696f2f414f37657a42313143674364555a69356f38597a784341746f524c413646692e7a69700100000002000000');
+					dapp.getBytes(transaction).toString('hex').should.equal('414f37657a42313143674364555a69356f38597a784341746f524c41364669687474703a2f2f7777772e6c69736b2e696f2f414f37657a42313143674364555a69356f38597a784341746f524c413646692e7a69700100000002000000');
 				});
 
 				it('should return result as a Buffer type', function () {
-					expect(dapp.getBytes(transaction)).to.be.instanceOf(Buffer);
+					dapp.getBytes(transaction).should.be.instanceOf(Buffer);
 				});
 			});
 		});
@@ -489,14 +489,14 @@ describe('dapp', function () {
 
 			it('should update private unconfirmed name variable', function (done) {
 				dapp.apply(transaction, dummyBlock, sender, function (err, cb) {
-					expect(unconfirmedNames[transaction.asset.dapp.name]).to.not.exist;
+					should.not.exist(unconfirmedNames[transaction.asset.dapp.name]);
 					done();
 				});
 			});
 
 			it('should update private unconfirmed links variable', function (done) {
 				dapp.apply(transaction, dummyBlock, sender, function (err, cb) {
-					expect(unconfirmedLinks[transaction.asset.dapp.link]).to.not.exist;
+					should.not.exist(unconfirmedLinks[transaction.asset.dapp.link]);
 					done();
 				});
 			});
@@ -529,7 +529,7 @@ describe('dapp', function () {
 
 				it('should call callback with error', function (done) {
 					dapp.applyUnconfirmed(transaction, sender, function (err)  {
-						expect(err).to.equal('Application name already exists');
+						err.should.equal('Application name already exists');
 						done();
 					});
 				});
@@ -546,7 +546,7 @@ describe('dapp', function () {
 
 				it('should call callback with error', function (done) {
 					dapp.applyUnconfirmed(transaction, sender, function (err)  {
-						expect(err).to.equal('Application link already exists');
+						err.should.equal('Application link already exists');
 						done();
 					});
 				});
@@ -568,14 +568,14 @@ describe('dapp', function () {
 
 				it('should update unconfirmed name private variable', function (done) {
 					dapp.applyUnconfirmed(transaction, sender, function () {
-						expect(unconfirmedNames[transaction.asset.dapp.name]).to.equal(true);
+						unconfirmedNames[transaction.asset.dapp.name].should.equal(true);
 						done();
 					});
 				});
 
 				it('should update unconfirmed link private variable', function (done) {
 					dapp.applyUnconfirmed(transaction, sender, function () {
-						expect(unconfirmedLinks[transaction.asset.dapp.link]).to.equal(true);
+						unconfirmedLinks[transaction.asset.dapp.link].should.equal(true);
 						done();
 					});
 				});
@@ -604,14 +604,14 @@ describe('dapp', function () {
 
 			it('should delete unconfirmed name private variable', function (done) {
 				dapp.undoUnconfirmed(transaction, sender, function () {
-					expect(unconfirmedNames[transaction.asset.dapp.name]).not.exist;
+					should.not.exist(unconfirmedNames[transaction.asset.dapp.name]);
 					done();
 				});
 			});
 
 			it('should delete unconfirmed link private variable', function (done) {
 				dapp.undoUnconfirmed(transaction, sender, function () {
-					expect(unconfirmedLinks[transaction.asset.dapp.link]).not.exist;
+					should.not.exist(unconfirmedLinks[transaction.asset.dapp.link]);
 					done();
 				});
 			});
@@ -638,12 +638,12 @@ describe('dapp', function () {
 
 				it('should remove undefined properties', function () {
 					transaction = dapp.objectNormalize(transaction);
-					expect(transaction).to.not.have.property('dummyUndefinedProperty');
+					transaction.should.not.have.property('dummyUndefinedProperty');
 				});
 
 				it('should remove null properties', function () {
 					transaction = dapp.objectNormalize(transaction);
-					expect(transaction).to.not.have.property('dummpyNullProperty');
+					transaction.should.not.have.property('dummpyNullProperty');
 				});
 			});
 
@@ -663,8 +663,8 @@ describe('dapp', function () {
 
 				it('should use the correct format to validate against', function () {
 					dapp.objectNormalize(transaction);
-					expect(schemaSpy.calledOnce).to.equal(true);
-					expect(schemaSpy.calledWithExactly(transaction.asset.dapp, Dapp.prototype.schema)).to.equal(true);
+					schemaSpy.calledOnce.should.equal(true);
+					schemaSpy.calledWithExactly(transaction.asset.dapp, Dapp.prototype.schema).should.equal(true);
 				});
 			});
 
@@ -687,14 +687,14 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.category = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type integer but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type integer but found type ' + type.expectation);
 						});
 					});
 
 					otherTypes.forEach(function (type) {
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.category = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -702,7 +702,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.category = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -733,14 +733,14 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.name = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
 						});
 					});
 
 					otherTypes.forEach(function (type) {
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.name = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -748,7 +748,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.name = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -756,7 +756,7 @@ describe('dapp', function () {
 
 						it('should not throw error for value: ' + input, function () {
 							transaction.asset.dapp.name = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).not.throw();
+							dapp.objectNormalize.bind(null, transaction).should.not.throw();
 						});
 					});
 				});
@@ -777,7 +777,7 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.description = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
 						});
 					});
 
@@ -785,7 +785,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.description = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -793,7 +793,7 @@ describe('dapp', function () {
 
 						it('should not throw error for value: ' + input, function () {
 							transaction.asset.dapp.description = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.not.throw();
+							dapp.objectNormalize.bind(null, transaction).should.not.throw();
 						});
 					});
 				});
@@ -813,7 +813,7 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.tags = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
 						});
 					});
 
@@ -821,7 +821,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.tags = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -829,7 +829,7 @@ describe('dapp', function () {
 
 						it('should not throw error for value: ' + input, function () {
 							transaction.asset.dapp.tags = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.not.throw();
+							dapp.objectNormalize.bind(null, transaction).should.not.throw();
 						});
 					});
 				});
@@ -854,14 +854,14 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.type = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type integer but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type integer but found type ' + type.expectation);
 						});
 					});
 
 					otherTypes.forEach(function (type) {
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.type = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -869,7 +869,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.type = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -877,7 +877,7 @@ describe('dapp', function () {
 
 						it('should not throw error for value: ' + input, function () {
 							transaction.asset.dapp.type = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.not.throw();
+							dapp.objectNormalize.bind(null, transaction).should.not.throw();
 						});
 					});
 				});
@@ -900,7 +900,7 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.link = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
 						});
 					});
 
@@ -908,7 +908,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.link = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -916,7 +916,7 @@ describe('dapp', function () {
 
 						it('should not throw error for value: ' + input, function () {
 							transaction.asset.dapp.link = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.not.throw();
+							dapp.objectNormalize.bind(null, transaction).should.not.throw();
 						});
 					});
 				});
@@ -939,7 +939,7 @@ describe('dapp', function () {
 
 						it('should throw error for: ' + type.description, function () {
 							transaction.asset.dapp.icon = type.input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
+							dapp.objectNormalize.bind(null, transaction).should.throw('Failed to validate dapp schema: Expected type string but found type ' + type.expectation);
 						});
 					});
 
@@ -947,7 +947,7 @@ describe('dapp', function () {
 
 						it('should throw error for value: ' + input, function () {
 							transaction.asset.dapp.icon = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.throw();
+							dapp.objectNormalize.bind(null, transaction).should.throw();
 						});
 					});
 
@@ -955,14 +955,14 @@ describe('dapp', function () {
 
 						it('should not throw error for value: ' + input, function () {
 							transaction.asset.dapp.icon = input;
-							expect(dapp.objectNormalize.bind(null, transaction)).to.not.throw();
+							dapp.objectNormalize.bind(null, transaction).should.not.throw();
 						});
 					});
 				});
 			});
 
 			it('should return transaction when asset is valid', function () {
-				expect(dapp.objectNormalize(transaction)).to.eql(transaction);
+				dapp.objectNormalize(transaction).should.eql(transaction);
 			});
 		});
 
@@ -975,42 +975,42 @@ describe('dapp', function () {
 				});
 
 				it('should return null', function () {
-					expect(dapp.dbRead(rawTransaction)).to.eql(null);
+					should.not.exist(dapp.dbRead(rawTransaction));
 				});
 			});
 
 			describe('when rawTransaction.dapp_name exists', function () {
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.property('dapp');
+					dapp.dbRead(rawTransaction).should.have.property('dapp');
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.category').to.equal(rawTransaction.dapp_category);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.category').to.equal(rawTransaction.dapp_category);
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.description').to.eql(rawTransaction.dapp_description);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.description').to.eql(rawTransaction.dapp_description);
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.icon').to.eql(rawTransaction.dapp_icon);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.icon').to.eql(rawTransaction.dapp_icon);
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.link').to.eql(rawTransaction.dapp_link);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.link').to.eql(rawTransaction.dapp_link);
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.name').to.eql(rawTransaction.dapp_name);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.name').to.eql(rawTransaction.dapp_name);
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.tags').to.eql(rawTransaction.dapp_tags);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.tags').to.eql(rawTransaction.dapp_tags);
 				});
 
 				it('should return result containing dapp property', function () {
-					expect(dapp.dbRead(rawTransaction)).to.have.nested.property('dapp.type').to.eql(rawTransaction.dapp_type);
+					dapp.dbRead(rawTransaction).should.have.nested.property('dapp.type').to.eql(rawTransaction.dapp_type);
 				});
 			});
 		});
@@ -1018,13 +1018,13 @@ describe('dapp', function () {
 		describe('ready', function () {
 
 			it('should return true for single signature transaction', function () {
-				expect(dapp.ready(transaction, sender)).to.equal(true);
+				dapp.ready(transaction, sender).should.equal(true);
 			});
 
 			it('should return false for multi signature transaction with less signatures', function () {
 				sender.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-				expect(dapp.ready(transaction, sender)).to.equal(false);
+				dapp.ready(transaction, sender).should.equal(false);
 			});
 
 			it('should return true for multi signature transaction with alteast min signatures', function () {
@@ -1036,7 +1036,7 @@ describe('dapp', function () {
 				transaction.signature = crypto.randomBytes(64).toString('hex');;
 				transaction.signatures = [crypto.randomBytes(64).toString('hex')];
 
-				expect(dapp.ready(transaction, sender)).to.equal(true);
+				dapp.ready(transaction, sender).should.equal(true);
 			});
 		});
 	});

--- a/test/unit/logic/delegate.js
+++ b/test/unit/logic/delegate.js
@@ -117,12 +117,12 @@ describe('delegate', function () {
 
 		it('should attach schema to library variable', function () {
 			var library = Delegate.__get__('library');
-			expect(library).to.have.property('schema').equal(modulesLoader.scope.schema);
+			library.should.have.property('schema').equal(modulesLoader.scope.schema);
 		});
 
 		it('should attach schema to library variable', function () {
 			var library = Delegate.__get__('library');
-			expect(library).to.have.property('logger').equal(loggerMock);
+			library.should.have.property('logger').equal(loggerMock);
 		});
 	});
 
@@ -132,7 +132,7 @@ describe('delegate', function () {
 			delegate.bind({});
 			var modules = Delegate.__get__('modules');
 
-			expect(modules).to.eql({
+			modules.should.eql({
 				accounts: {}
 			});
 		});
@@ -141,7 +141,7 @@ describe('delegate', function () {
 			delegate.bind(accountsMock);
 			var modules = Delegate.__get__('modules');
 
-			expect(modules).to.eql({
+			modules.should.eql({
 				accounts: accountsMock
 			});
 		});
@@ -150,7 +150,7 @@ describe('delegate', function () {
 	describe('calculateFee', function () {
 
 		it('should return the correct fee for delegate transaction', function () {
-			expect(delegate.calculateFee(transaction)).to.equal(constants.fees.delegate);
+			delegate.calculateFee(transaction).should.equal(constants.fees.delegate);
 		});
 	});
 
@@ -162,7 +162,7 @@ describe('delegate', function () {
 				transaction.recipientId = '123456';
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid recipient');
+					err.should.equal('Invalid recipient');
 					done();
 				});
 			});
@@ -171,7 +171,7 @@ describe('delegate', function () {
 				transaction.amount = 1;
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction amount');
+					err.should.equal('Invalid transaction amount');
 					done();
 				});
 			});
@@ -180,7 +180,7 @@ describe('delegate', function () {
 				sender.isDelegate = 1;
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Account is already a delegate');
+					err.should.equal('Account is already a delegate');
 					done();
 				});
 			});
@@ -189,7 +189,7 @@ describe('delegate', function () {
 				transaction.asset = undefined;
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -198,7 +198,7 @@ describe('delegate', function () {
 				transaction.asset = {};
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -207,7 +207,7 @@ describe('delegate', function () {
 				transaction.asset.delegate.username = undefined;
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Username is undefined');
+					err.should.equal('Username is undefined');
 					done();
 				});
 			});
@@ -216,7 +216,7 @@ describe('delegate', function () {
 				transaction.asset.delegate.username = 'UiOjKl';
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Username must be lowercase');
+					err.should.equal('Username must be lowercase');
 					done();
 				});
 			});
@@ -227,7 +227,7 @@ describe('delegate', function () {
 				}).join('');
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Username is too long. Maximum is 20 characters');
+					err.should.equal('Username is too long. Maximum is 20 characters');
 					done();
 				});
 			});
@@ -237,7 +237,7 @@ describe('delegate', function () {
 
 				delegate.verify(transaction, sender, function (err) {
 					// Cannot check specific error because '' coerces to false and we get error: Username is undefined
-					expect(err).to.exist;
+					err.should.exist;
 					done();
 				});
 			});
@@ -246,7 +246,7 @@ describe('delegate', function () {
 				transaction.asset.delegate.username = '163137396616706346l';
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Username can not be a potential address');
+					err.should.equal('Username can not be a potential address');
 					done();
 				});
 			});
@@ -255,7 +255,7 @@ describe('delegate', function () {
 				transaction.asset.delegate.username = '^%)';
 
 				delegate.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Username can only contain alphanumeric characters with the exception of !@$&_.');
+					err.should.equal('Username can only contain alphanumeric characters with the exception of !@$&_.');
 					done();
 				});
 			});
@@ -275,7 +275,7 @@ describe('delegate', function () {
 
 			it('should call checkConfirmed with correct transaction', function (done) {
 				delegate.verify(transaction, sender, function () {
-					expect(checkConfirmedStub.calledWith(transaction)).to.be.true;
+					checkConfirmedStub.calledWith(transaction).should.be.true;
 					done();
 				});
 			});
@@ -285,14 +285,14 @@ describe('delegate', function () {
 				it('should call callback with valid transaction when username contains symbols which are valid', function (done) {
 					transaction.asset.delegate.username = random.username() + '!@.';
 					delegate.verify(transaction, sender, function () {
-						expect(checkConfirmedStub.calledWith(transaction)).to.be.true;
+						checkConfirmedStub.calledWith(transaction).should.be.true;
 						done();
 					});
 				});
 
 				it('should call callback with error = null', function (done) {
 					delegate.verify(transaction, sender, function (err) {
-						expect(err).to.be.null;
+						should.not.exist(err);
 						done();
 					});
 				});
@@ -310,7 +310,7 @@ describe('delegate', function () {
 
 				it('should not return an error', function (done) {
 					delegate.verify(validTransaction, validSender, function (err) {
-						expect(err).to.be.undefined;
+						should.not.exist(err);
 						done();
 					});
 				});
@@ -328,7 +328,7 @@ describe('delegate', function () {
 
 				it('should return an error for valid params', function (done) {
 					delegate.verify(validTransaction, validSender, function (err) {
-						expect(err).to.equal('Username ' + accounts.existingDelegate.delegateName + ' already exists');
+						err.should.equal('Username ' + accounts.existingDelegate.delegateName + ' already exists');
 						done();
 					});
 				});
@@ -346,7 +346,7 @@ describe('delegate', function () {
 
 				it('should return not return an error', function (done) {
 					delegate.verify(validTransaction, validSender, function (err) {
-						expect(err).to.be.undefined;
+						should.not.exist(err);
 						done();
 					});
 				});
@@ -364,7 +364,7 @@ describe('delegate', function () {
 
 				it('should return an error = "Account is already a delegate"', function (done) {
 					delegate.verify(validTransaction, validSender, function (err) {
-						expect(err).equal('Account is already a delegate');
+						err.should.equal('Account is already a delegate');
 						done();
 					});
 				});
@@ -384,12 +384,12 @@ describe('delegate', function () {
 		it('should return null when username is empty', function () {
 			delete transaction.asset.delegate.username;
 
-			expect(delegate.getBytes(transaction)).to.eql(null);
+			should.not.exist(delegate.getBytes(transaction));
 		});
 
 		it('should return bytes for signature asset', function () {
 			var delegateBytes = delegate.getBytes(transaction);
-			expect(delegateBytes.toString()).to.equal(transaction.asset.delegate.username);
+			delegateBytes.toString().should.equal(transaction.asset.delegate.username);
 		});
 	});
 
@@ -412,18 +412,18 @@ describe('delegate', function () {
 		});
 
 		it('should call modules.accounts.getAccount twice', function () {
-			expect(accountsMock.getAccount.calledTwice).to.be.true;
+			accountsMock.getAccount.calledTwice.should.be.true;
 		});
 
 		it('should call modules.accounts.getAccount with checking delegate registration params', function () {
-			expect(accountsMock.getAccount.calledWith({
+			(accountsMock.getAccount.calledWith({
 				publicKey: accounts.existingDelegate.publicKey,
 				u_isDelegate: 1
-			})).to.be.true;
+			})).should.be.true;
 		});
 
 		it('should call modules.accounts.getAccount with checking username params', function () {
-			expect(accountsMock.getAccount.calledWith({u_username: accounts.existingDelegate.delegateName})).to.be.true;
+			accountsMock.getAccount.calledWith({u_username: accounts.existingDelegate.delegateName}).should.be.true;
 		});
 
 		describe('when username exists', function () {
@@ -438,7 +438,7 @@ describe('delegate', function () {
 			});
 
 			it('should call callback with the error', function () {
-				expect(error).to.equal('Username ' + accounts.existingDelegate.delegateName + ' already exists');
+				error.should.equal('Username ' + accounts.existingDelegate.delegateName + ' already exists');
 			});
 		});
 
@@ -454,18 +454,18 @@ describe('delegate', function () {
 			});
 
 			it('should return an error = "Account is already a delegate"', function () {
-				expect(error).to.equal('Account is already a delegate');
+				error.should.equal('Account is already a delegate');
 			});
 		});
 
 		describe('when publicKey and username does not match any account', function () {
 
 			it('should not return the error', function () {
-				expect(error).to.be.undefined;
+				should.not.exist(error);
 			});
 
 			it('should not return the result', function () {
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 			});
 		});
 	});
@@ -489,21 +489,21 @@ describe('delegate', function () {
 
 		it('should call checkDuplicates with valid transaction', function (done) {
 			delegate.checkConfirmed(validTransaction, function () {
-				expect(checkDuplicatesStub.calledWith(validTransaction)).to.be.true;
+				checkDuplicatesStub.calledWith(validTransaction).should.be.true;
 				done();
 			});
 		});
 
 		it('should call checkDuplicates with "username"', function (done) {
 			delegate.checkConfirmed(validTransaction, function () {
-				expect(checkDuplicatesStub.args[0][1] === 'username').to.be.true;
+				(checkDuplicatesStub.args[0][1] === 'username').should.be.true;
 				done();
 			});
 		});
 
 		it('should call checkDuplicates with "isDelegate"', function (done) {
 			delegate.checkConfirmed(validTransaction, function () {
-				expect(checkDuplicatesStub.args[0][2] === 'isDelegate').to.be.true;
+				(checkDuplicatesStub.args[0][2] === 'isDelegate').should.be.true;
 				done();
 			});
 		});
@@ -531,14 +531,14 @@ describe('delegate', function () {
 
 			it('should call callback with an error', function (done) {
 				delegate.checkConfirmed(validTransaction, function (err) {
-					expect(err).equal(validDelegateRegistrationError);
+					err.should.equal(validDelegateRegistrationError);
 					done();
 				});
 			});
 
 			it('should check if transaction exception occurred', function (done) {
 				delegate.checkConfirmed(validTransaction, function () {
-					expect(transactionsExceptionsIndexOfStub.called).to.be.true;
+					transactionsExceptionsIndexOfStub.called.should.be.true;
 					done();
 				});
 			});
@@ -558,21 +558,21 @@ describe('delegate', function () {
 
 				it('should call callback with an error = null', function (done) {
 					delegate.checkConfirmed(validTransaction, function (err) {
-						expect(err).to.be.null;
+						should.not.exist(err);
 						done();
 					});
 				});
 
 				it('should call library.logger.debug with an error message', function (done) {
 					delegate.checkConfirmed(validTransaction, function () {
-						expect(loggerMock.debug.calledWith(validDelegateRegistrationError)).to.be.true;
+						loggerMock.debug.calledWith(validDelegateRegistrationError).should.be.true;
 						done();
 					});
 				});
 
 				it('should call library.logger.debug with stringified transaction', function (done) {
 					delegate.checkConfirmed(validTransaction, function () {
-						expect(loggerMock.debug.calledWith(JSON.stringify(validTransaction))).to.be.true;
+						loggerMock.debug.calledWith(JSON.stringify(validTransaction)).should.be.true;
 						done();
 					});
 				});
@@ -596,21 +596,21 @@ describe('delegate', function () {
 
 		it('should call checkDuplicates with valid transaction', function (done) {
 			delegate.checkUnconfirmed(validTransaction, function () {
-				expect(checkDuplicatesStub.calledWith(validTransaction)).to.be.true;
+				checkDuplicatesStub.calledWith(validTransaction).should.be.true;
 				done();
 			});
 		});
 
 		it('should call checkDuplicates with "u_username"', function (done) {
 			delegate.checkUnconfirmed(validTransaction, function () {
-				expect(checkDuplicatesStub.args[0][1] === 'u_username').to.be.true;
+				(checkDuplicatesStub.args[0][1] === 'u_username').should.be.true;
 				done();
 			});
 		});
 
 		it('should call checkDuplicates with "u_isDelegate"', function (done) {
 			delegate.checkUnconfirmed(validTransaction, function () {
-				expect(checkDuplicatesStub.args[0][2] === 'u_isDelegate').to.be.true;
+				(checkDuplicatesStub.args[0][2] === 'u_isDelegate').should.be.true;
 				done();
 			});
 		});
@@ -638,7 +638,7 @@ describe('delegate', function () {
 
 			it('should call callback with an error', function (done) {
 				delegate.checkUnconfirmed(validTransaction, function (err) {
-					expect(err).equal(validDelegateRegistrationError);
+					err.should.equal(validDelegateRegistrationError);
 					done();
 				});
 			});
@@ -673,7 +673,7 @@ describe('delegate', function () {
 
 			it('should call accounts.setAccountAndGet module with correct parameter', function (done) {
 				delegate.apply(validTransaction, dummyBlock, validSender, function () {
-					expect(accountsMock.setAccountAndGet.calledWith(validConfirmedAccount)).to.be.true;
+					accountsMock.setAccountAndGet.calledWith(validConfirmedAccount).should.be.true;
 					done();
 				});
 			});
@@ -691,14 +691,14 @@ describe('delegate', function () {
 
 			it('should not call accounts.setAccountAndGet', function (done) {
 				delegate.apply(validTransaction, dummyBlock, validSender, function () {
-					expect(accountsMock.setAccountAndGet.notCalled).to.be.true;
+					accountsMock.setAccountAndGet.notCalled.should.be.true;
 					done();
 				});
 			});
 
 			it('should return an error', function (done) {
 				delegate.apply(validTransaction, dummyBlock, validSender, function (err) {
-					expect(err).to.be.equal('Username already exists');
+					err.should.be.equal('Username already exists');
 					done();
 				});
 			});
@@ -732,7 +732,7 @@ describe('delegate', function () {
 
 			it('should call accounts.setAccountAndGet module with correct parameter', function (done) {
 				delegate.applyUnconfirmed(validTransaction, validSender, function () {
-					expect(accountsMock.setAccountAndGet.calledWith(validUnconfirmedAccount)).to.be.true;
+					accountsMock.setAccountAndGet.calledWith(validUnconfirmedAccount).should.be.true;
 					done();
 				});
 			});
@@ -750,14 +750,14 @@ describe('delegate', function () {
 
 			it('should not call accounts.setAccountAndGet', function (done) {
 				delegate.applyUnconfirmed(validTransaction, validSender, function () {
-					expect(accountsMock.setAccountAndGet.notCalled).to.be.true;
+					accountsMock.setAccountAndGet.notCalled.should.be.true;
 					done();
 				});
 			});
 
 			it('should return an error', function (done) {
 				delegate.applyUnconfirmed(validTransaction, validSender, function (err) {
-					expect(err).to.be.equal('Username already exists');
+					err.should.be.equal('Username already exists');
 					done();
 				});
 			});
@@ -768,14 +768,14 @@ describe('delegate', function () {
 
 		it('should call accounts.setAccountAndGet module with correct parameters', function (done) {
 			delegate.undo(transaction, dummyBlock, sender, function () {
-				expect(accountsMock.setAccountAndGet.calledWith({
+				accountsMock.setAccountAndGet.calledWith({
 					address: sender.address,
 					u_isDelegate: 1,
 					isDelegate: 0,
 					vote: 0,
 					username: null,
 					u_username: transaction.asset.delegate.username
-				}));
+				}).should.be.true;
 				done();
 			});
 		});
@@ -785,14 +785,14 @@ describe('delegate', function () {
 			sender.nameexist = 0;
 
 			delegate.undo(transaction, dummyBlock, sender, function () {
-				expect(accountsMock.setAccountAndGet.calledWith({
+				accountsMock.setAccountAndGet.calledWith({
 					address: sender.address,
 					u_isDelegate: 1,
 					isDelegate: 0,
 					vote: 0,
 					username: null,
 					u_username: transaction.asset.delegate.username
-				}));
+				}).should.be.true;
 				done();
 			});
 		});
@@ -802,13 +802,13 @@ describe('delegate', function () {
 
 		it('should call accounts.setAccountAndGet module with correct parameters', function (done) {
 			delegate.undoUnconfirmed(transaction, sender, function () {
-				expect(accountsMock.setAccountAndGet.calledWith({
+				accountsMock.setAccountAndGet.calledWith({
 					address: sender.address,
 					u_isDelegate: 0,
 					isDelegate: 0,
 					username: null,
 					u_username: null
-				}));
+				}).should.be.true;
 				done();
 			});
 		});
@@ -820,8 +820,8 @@ describe('delegate', function () {
 			var library = Delegate.__get__('library');
 			var schemaSpy = sinonSandbox.spy(library.schema, 'validate');
 			delegate.objectNormalize(transaction);
-			expect(schemaSpy.calledOnce).to.equal(true);
-			expect(schemaSpy.calledWithExactly(transaction.asset.delegate, Delegate.prototype.schema)).to.equal(true);
+			schemaSpy.calledOnce.should.equal(true);
+			schemaSpy.calledWithExactly(transaction.asset.delegate, Delegate.prototype.schema).should.equal(true);
 			schemaSpy.restore();
 		});
 
@@ -830,7 +830,7 @@ describe('delegate', function () {
 			var schemaDynamicTest = new SchemaDynamicTest({
 				testStyle: SchemaDynamicTest.TEST_STYLE.THROWABLE,
 				customPropertyAssertion: function (input, expectedType, property, err) {
-					expect(err).to.equal('Failed to validate delegate schema: Expected type ' + expectedType + ' but found type ' + input.expectation);
+					err.should.equal('Failed to validate delegate schema: Expected type ' + expectedType + ' but found type ' + input.expectation);
 				}
 			});
 
@@ -849,16 +849,16 @@ describe('delegate', function () {
 			it('should throw error', function () {
 				transaction.asset.delegate.username = '*';
 
-				expect(function () {
+				(function () {
 					delegate.objectNormalize(transaction);
-				}).to.throw('Failed to validate delegate schema: Object didn\'t pass validation for format username: ');
+				}).should.throw('Failed to validate delegate schema: Object didn\'t pass validation for format username: ');
 			});
 		});
 
 		describe('when library.schema.validate succeeds', function () {
 
 			it('should return transaction', function () {
-				expect(delegate.objectNormalize(transaction)).to.eql(transaction);
+				delegate.objectNormalize(transaction).should.eql(transaction);
 			});
 		});
 	});
@@ -868,7 +868,7 @@ describe('delegate', function () {
 		it('should return null when d_username is not set', function () {
 			delete rawTransaction.d_username;
 
-			expect(delegate.dbRead(rawTransaction)).to.eql(null);
+			should.not.exist(delegate.dbRead(rawTransaction));
 		});
 
 		it('should return delegate asset for raw transaction passed', function () {
@@ -878,20 +878,20 @@ describe('delegate', function () {
 				username: rawValidTransaction.d_username
 			};
 
-			expect(delegate.dbRead(rawTransaction).delegate).to.eql(expectedAsset);
+			delegate.dbRead(rawTransaction).delegate.should.eql(expectedAsset);
 		});
 	});
 
 	describe('ready', function () {
 
 		it('should return true for single signature transasction', function () {
-			expect(delegate.ready(transaction, sender)).to.equal(true);
+			delegate.ready(transaction, sender).should.equal(true);
 		});
 
 		it('should return false for multi signature transaction with less signatures', function () {
 			sender.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-			expect(delegate.ready(transaction, sender)).to.equal(false);
+			delegate.ready(transaction, sender).should.equal(false);
 		});
 
 		it('should return true for multi signature transaction with at least min signatures', function () {
@@ -903,7 +903,7 @@ describe('delegate', function () {
 			transaction.signature = crypto.randomBytes(64).toString('hex');;
 			transaction.signatures = [crypto.randomBytes(64).toString('hex')];
 
-			expect(delegate.ready(transaction, sender)).to.equal(true);
+			delegate.ready(transaction, sender).should.equal(true);
 		});
 	});
 });

--- a/test/unit/logic/inTransfer.js
+++ b/test/unit/logic/inTransfer.js
@@ -143,11 +143,11 @@ describe('inTransfer', function () {
 			});
 
 			it('should assign db', function () {
-				expect(library).to.have.property('db').eql(dbStub);
+				library.should.have.property('db').eql(dbStub);
 			});
 
 			it('should assign schema', function () {
-				expect(library).to.have.property('schema').eql(modulesLoader.scope.schema);
+				library.should.have.property('schema').eql(modulesLoader.scope.schema);
 			});
 		});
 	});
@@ -166,19 +166,19 @@ describe('inTransfer', function () {
 		describe('modules', function () {
 
 			it('should assign accounts', function () {
-				expect(modules).to.have.property('accounts').eql(accountsStub);
+				modules.should.have.property('accounts').eql(accountsStub);
 			});
 		});
 
 		it('should assign shared', function () {
-			expect(shared).to.eql(sharedStub);
+			shared.should.eql(sharedStub);
 		});
 	});
 
 	describe('calculateFee', function () {
 
 		it('should return constants.fees.send', function () {
-			expect(inTransfer.calculateFee(trs)).to.equal(constants.fees.send);
+			inTransfer.calculateFee(trs).should.equal(constants.fees.send);
 		});
 	});
 
@@ -189,7 +189,7 @@ describe('inTransfer', function () {
 			it('should call callback with error = "Invalid recipient"', function (done) {
 				trs.recipientId = '4835566122337813671L';
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).to.equal('Invalid recipient');
+					err.should.equal('Invalid recipient');
 					done();
 				});
 			});
@@ -200,7 +200,7 @@ describe('inTransfer', function () {
 			it('should call callback with error = "Invalid transaction amount"', function (done) {
 				trs.amount = undefined;
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).to.equal('Invalid transaction amount');
+					err.should.equal('Invalid transaction amount');
 					done();
 				});
 			});
@@ -211,7 +211,7 @@ describe('inTransfer', function () {
 			it('should call callback with error = "Invalid transaction amount"', function (done) {
 				trs.amount = 0;
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).to.equal('Invalid transaction amount');
+					err.should.equal('Invalid transaction amount');
 					done();
 				});
 			});
@@ -222,7 +222,7 @@ describe('inTransfer', function () {
 			it('should call callback with error = "Invalid transaction asset"', function (done) {
 				trs.asset = undefined;
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -233,7 +233,7 @@ describe('inTransfer', function () {
 			it('should call callback with error = "Invalid transaction asset"', function (done) {
 				trs.asset.inTransfer = undefined;
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -244,7 +244,7 @@ describe('inTransfer', function () {
 			it('should call callback with error = "Invalid transaction asset"', function (done) {
 				trs.asset.inTransfer = 0;
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -252,21 +252,21 @@ describe('inTransfer', function () {
 
 		it('should call library.db.dapps.countByTransactionId', function (done) {
 			inTransfer.verify(trs, sender, function () {
-				expect(dbStub.dapps.countByTransactionId.calledOnce).to.be.true;
+				dbStub.dapps.countByTransactionId.calledOnce.should.be.true;
 				done();
 			});
 		});
 
 		it('should call library.db.dapps.countByTransactionId with trs.asset.inTransfer.dappId', function (done) {
 			inTransfer.verify(trs, sender, function () {
-				expect(dbStub.dapps.countByTransactionId.calledWith(trs.asset.inTransfer.dappId)).to.be.true;
+				dbStub.dapps.countByTransactionId.calledWith(trs.asset.inTransfer.dappId).should.be.true;
 				done();
 			});
 		});
 
 		it('should call library.db.dapps.countByTransactionId with trs.asset.inTransfer.dappId', function (done) {
 			inTransfer.verify(trs, sender, function () {
-				expect(dbStub.dapps.countByTransactionId.calledWith(trs.asset.inTransfer.dappId)).to.be.true;
+				dbStub.dapps.countByTransactionId.calledWith(trs.asset.inTransfer.dappId).should.be.true;
 				done();
 			});
 		});
@@ -279,7 +279,7 @@ describe('inTransfer', function () {
 
 			it('should call callback with error', function (done) {
 				inTransfer.verify(trs, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 					done();
 				});
 			});
@@ -295,7 +295,7 @@ describe('inTransfer', function () {
 
 				it('should call callback with error', function (done) {
 					inTransfer.verify(trs, sender, function (err) {
-						expect(err).to.equal('Application not found: ' + trs.asset.inTransfer.dappId);
+						err.should.equal('Application not found: ' + trs.asset.inTransfer.dappId);
 						done();
 					});
 				});
@@ -309,14 +309,14 @@ describe('inTransfer', function () {
 
 				it('should call callback with error = undefined', function (done) {
 					inTransfer.verify(trs, sender, function (err) {
-						expect(err).to.be.undefined;
+						should.not.exist(err);
 						done();
 					});
 				});
 
 				it('should call callback with result = undefined', function (done) {
 					inTransfer.verify(trs, sender, function (err, res) {
-						expect(res).to.be.undefined;
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -328,14 +328,14 @@ describe('inTransfer', function () {
 
 		it('should call callback with error = null', function (done) {
 			inTransfer.process(trs, sender, function (err) {
-				expect(err).to.be.null;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call callback with result = transaction', function (done) {
 			inTransfer.process(trs, sender, function (err, result) {
-				expect(result).to.eql(trs);
+				result.should.eql(trs);
 				done();
 			});
 		});
@@ -350,22 +350,22 @@ describe('inTransfer', function () {
 			});
 
 			it('should throw', function () {
-				expect(inTransfer.getBytes.bind(null, trs)).to.throw;
+				inTransfer.getBytes.bind(null, trs).should.throw;
 			});
 		});
 
 		describe('when trs.asset.inTransfer.dappId is a valid dapp id', function () {
 
 			it('should not throw', function () {
-				expect(inTransfer.getBytes.bind(null, trs)).not.to.throw;
+				inTransfer.getBytes.bind(null, trs).should.not.to.throw;
 			});
 
 			it('should get bytes of valid transaction', function () {
-				expect(inTransfer.getBytes(trs).toString('utf8')).to.equal(validTransaction.asset.inTransfer.dappId);
+				inTransfer.getBytes(trs).toString('utf8').should.equal(validTransaction.asset.inTransfer.dappId);
 			});
 
 			it('should return result as a Buffer type', function () {
-				expect(inTransfer.getBytes(trs)).to.be.instanceOf(Buffer);
+				inTransfer.getBytes(trs).should.be.instanceOf(Buffer);
 			});
 		});
 	});
@@ -377,11 +377,11 @@ describe('inTransfer', function () {
 		});
 
 		it('should call shared.getGenesis', function () {
-			expect(sharedStub.getGenesis.calledOnce).to.be.true;
+			sharedStub.getGenesis.calledOnce.should.be.true;
 		});
 
 		it('should call shared.getGenesis with {dappid: trs.asset.inTransfer.dappId}', function () {
-			expect(sharedStub.getGenesis.calledWith({dappid: trs.asset.inTransfer.dappId})).to.be.true;
+			sharedStub.getGenesis.calledWith({dappid: trs.asset.inTransfer.dappId}).should.be.true;
 		});
 
 		describe('when shared.getGenesis fails', function () {
@@ -392,7 +392,7 @@ describe('inTransfer', function () {
 
 			it('should call callback with error', function () {
 				inTransfer.apply(trs, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -404,27 +404,27 @@ describe('inTransfer', function () {
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {
-				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true;
+				accountsStub.mergeAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with address = dapp.authorId', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: validGetGensisResult.authorId}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: validGetGensisResult.authorId})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with balance = trs.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: trs.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: trs.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with u_balance = trs.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: trs.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: trs.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with blockId = block.id', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with round = slots.calcRound result', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)})).should.be.true;
 			});
 		});
 
@@ -436,7 +436,7 @@ describe('inTransfer', function () {
 
 			it('should call callback with error', function () {
 				inTransfer.apply(trs, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -445,13 +445,13 @@ describe('inTransfer', function () {
 
 			it('should call callback with error = undefined', function () {
 				inTransfer.apply(trs, dummyBlock, sender, function (err) {
-					expect(err).to.be.undefined;
+					should.not.exist(err);
 				});
 			});
 
 			it('should call callback with result = undefined', function () {
 				inTransfer.apply(trs, dummyBlock, sender, function (err, res) {
-					expect(res).to.be.undefined;
+					should.not.exist(res);
 				});
 			});
 		});
@@ -464,11 +464,11 @@ describe('inTransfer', function () {
 		});
 
 		it('should call shared.getGenesis', function () {
-			expect(sharedStub.getGenesis.calledOnce).to.be.true;
+			sharedStub.getGenesis.calledOnce.should.be.true;
 		});
 
 		it('should call shared.getGenesis with {dappid: trs.asset.inTransfer.dappId}', function () {
-			expect(sharedStub.getGenesis.calledWith({dappid: trs.asset.inTransfer.dappId})).to.be.true;
+			sharedStub.getGenesis.calledWith({dappid: trs.asset.inTransfer.dappId}).should.be.true;
 		});
 
 		describe('when shared.getGenesis fails', function () {
@@ -479,7 +479,7 @@ describe('inTransfer', function () {
 
 			it('should call callback with error', function () {
 				inTransfer.undo(trs, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -491,27 +491,27 @@ describe('inTransfer', function () {
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {
-				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true;
+				accountsStub.mergeAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with address = dapp.authorId', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: validGetGensisResult.authorId}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: validGetGensisResult.authorId})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with balance = -trs.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: -trs.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: -trs.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with u_balance = -trs.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: -trs.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: -trs.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with blockId = block.id', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with round = slots.calcRound result', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)})).should.be.true;
 			});
 		});
 		
@@ -523,7 +523,7 @@ describe('inTransfer', function () {
 
 			it('should call callback with error', function () {
 				inTransfer.undo(trs, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -532,13 +532,13 @@ describe('inTransfer', function () {
 
 			it('should call callback with error = undefined', function () {
 				inTransfer.undo(trs, dummyBlock, sender, function (err) {
-					expect(err).to.be.undefined;
+					should.not.exist(err);
 				});
 			});
 
 			it('should call callback with result = undefined', function () {
 				inTransfer.undo(trs, dummyBlock, sender, function (err, res) {
-					expect(res).to.be.undefined;
+					should.not.exist(res);
 				});
 			});
 		});
@@ -548,14 +548,14 @@ describe('inTransfer', function () {
 
 		it('should call callback with error = undefined', function (done) {
 			inTransfer.applyUnconfirmed(trs, sender, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call callback with result = undefined', function (done) {
 			inTransfer.applyUnconfirmed(trs, sender, function (err, result) {
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				done();
 			});
 		});
@@ -565,14 +565,14 @@ describe('inTransfer', function () {
 
 		it('should call callback with error = undefined', function (done) {
 			inTransfer.undoUnconfirmed(trs, sender, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call callback with result = undefined', function (done) {
 			inTransfer.undoUnconfirmed(trs, sender, function (err, result) {
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				done();
 			});
 		});
@@ -594,24 +594,24 @@ describe('inTransfer', function () {
 
 		it('should call library.schema.validate', function () {
 			inTransfer.objectNormalize(trs);
-			expect(schemaSpy.calledOnce).to.be.true;
+			schemaSpy.calledOnce.should.be.true;
 		});
 
 		it('should call library.schema.validate with trs.asset.inTransfer', function () {
 			inTransfer.objectNormalize(trs);
-			expect(schemaSpy.calledWith(trs.asset.inTransfer)).to.be.true;
+			schemaSpy.calledWith(trs.asset.inTransfer).should.be.true;
 		});
 
 		it('should call library.schema.validate InTransfer.prototype.schema', function () {
 			inTransfer.objectNormalize(trs);
-			expect(schemaSpy.args[0][1]).to.eql(InTransfer.prototype.schema);
+			schemaSpy.args[0][1].should.eql(InTransfer.prototype.schema);
 		});
 
 		describe('when transaction.asset.inTransfer is invalid object argument', function () {
 
 			typesRepresentatives.nonObjects.forEach(function (nonObject) {
 				it('should throw for transaction.asset.inTransfer = ' + nonObject.description, function () {
-					expect(inTransfer.objectNormalize.bind(null, nonObject.input)).to.throw();
+					inTransfer.objectNormalize.bind(null, nonObject.input).should.throw();
 				});
 			});
 		});
@@ -621,7 +621,7 @@ describe('inTransfer', function () {
 			typesRepresentatives.nonStrings.forEach(function (nonString) {
 				it('should throw for transaction.asset.inTransfer.dappId = ' + nonString.description, function () {
 					trs.asset.inTransfer.dappId = nonString.input;
-					expect(inTransfer.objectNormalize.bind(null, trs)).to.throw();
+					inTransfer.objectNormalize.bind(null, trs).should.throw();
 				});
 			});
 		});
@@ -629,7 +629,7 @@ describe('inTransfer', function () {
 		describe('when when transaction.asset.inTransfer is valid', function () {
 
 			it('should return transaction', function () {
-				expect(inTransfer.objectNormalize(trs)).to.eql(trs);
+				inTransfer.objectNormalize(trs).should.eql(trs);
 			});
 		});
 	});
@@ -643,18 +643,18 @@ describe('inTransfer', function () {
 			});
 
 			it('should return null', function () {
-				expect(inTransfer.dbRead(rawTrs)).to.eql(null);
+				should.not.exist(inTransfer.dbRead(rawTrs));
 			});
 		});
 
 		describe('when raw.in_dappId exists', function () {
 
 			it('should return result containing inTransfer', function () {
-				expect(inTransfer.dbRead(rawTrs)).to.have.property('inTransfer');
+				inTransfer.dbRead(rawTrs).should.have.property('inTransfer');
 			});
 
 			it('should return result containing inTransfer.dappId = raw.dapp_id', function () {
-				expect(inTransfer.dbRead(rawTrs)).to.have.nested.property('inTransfer.dappId').equal(rawTrs.in_dappId);
+				inTransfer.dbRead(rawTrs).should.have.nested.property('inTransfer.dappId').equal(rawTrs.in_dappId);
 			});
 		});
 	});
@@ -663,13 +663,13 @@ describe('inTransfer', function () {
 
 		it('should call callback with error = undefined', function () {
 			inTransfer.afterSave(trs, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 			});
 		});
 
 		it('should call callback with result = undefined', function () {
 			inTransfer.afterSave(trs, function (err, res) {
-				expect(res).to.be.undefined;
+				should.not.exist(res);
 			});
 		});
 	});
@@ -677,13 +677,13 @@ describe('inTransfer', function () {
 	describe('ready', function () {
 
 		it('should return true for single signature trs', function () {
-			expect(inTransfer.ready(trs, sender)).to.equal(true);
+			inTransfer.ready(trs, sender).should.equal(true);
 		});
 
 		it('should return false for multi signature transaction with less signatures', function () {
 			sender.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-			expect(inTransfer.ready(trs, sender)).to.equal(false);
+			inTransfer.ready(trs, sender).should.equal(false);
 		});
 
 		it('should return true for multi signature transaction with alteast min signatures', function () {
@@ -695,7 +695,7 @@ describe('inTransfer', function () {
 			trs.signature = crypto.randomBytes(64).toString('hex');
 			trs.signatures = [crypto.randomBytes(64).toString('hex')];
 
-			expect(inTransfer.ready(trs, sender)).to.equal(true);
+			inTransfer.ready(trs, sender).should.equal(true);
 		});
 	});
 });

--- a/test/unit/logic/multisignature.js
+++ b/test/unit/logic/multisignature.js
@@ -96,23 +96,23 @@ describe('multisignature', function () {
 		});
 
 		it('should attach schema to library variable', function () {
-			expect(library.schema).to.eql(modulesLoader.scope.schema);
+			library.schema.should.eql(modulesLoader.scope.schema);
 		});
 
 		it('should attach network to library variable', function () {
-			expect(library.network).to.eql(modulesLoader.scope.network);
+			library.network.should.eql(modulesLoader.scope.network);
 		});
 
 		it('should attach logger to library variable', function () {
-			expect(library.logger).to.eql(modulesLoader.logger);
+			library.logger.should.eql(modulesLoader.logger);
 		});
 
 		it('should attach logic.transaction to library variable', function () {
-			expect(library.logic.transaction).to.eql(transactionMock);
+			library.logic.transaction.should.eql(transactionMock);
 		});
 
 		it('should attach schema to library variable', function () {
-			expect(library.logic.account).to.eql(accountMock);
+			library.logic.account.should.eql(accountMock);
 		});
 	});
 
@@ -124,7 +124,7 @@ describe('multisignature', function () {
 				multisignature.bind(accountsMock);
 				var modules = Multisignature.__get__('modules');
 
-				expect(modules).to.eql({
+				modules.should.eql({
 					accounts: accountsMock
 				});
 			});
@@ -137,26 +137,26 @@ describe('multisignature', function () {
 			transaction.asset.multisignature.keysgroup = [
 				'+' + lisk.crypto.getKeys(randomUtil.password()).publicKey
 			];
-			expect(multisignature.calculateFee(transaction).toString()).to.equal('1000000000');
+			multisignature.calculateFee(transaction).toString().should.equal('1000000000');
 		});
 
 
 		it('should return correct fee based on formula for 4 keysgroup', function () {
 			transaction.asset.multisignature.keysgroup = new Array(4).fill('+' + lisk.crypto.getKeys(randomUtil.password()).publicKey);
 
-			expect(multisignature.calculateFee(transaction).toString()).to.equal('2500000000');
+			multisignature.calculateFee(transaction).toString().should.equal('2500000000');
 		});
 
 		it('should return correct fee based on formula for 8 keysgroup', function () {
 			transaction.asset.multisignature.keysgroup = new Array(8).fill('+' + lisk.crypto.getKeys(randomUtil.password()).publicKey);
 
-			expect(multisignature.calculateFee(transaction).toString()).to.equal('4500000000');
+			multisignature.calculateFee(transaction).toString().should.equal('4500000000');
 		});
 
 		it('should return correct fee based on formula for 16 keysgroup', function () {
 			transaction.asset.multisignature.keysgroup = new Array(16).fill('+' + lisk.crypto.getKeys(randomUtil.password()).publicKey);
 
-			expect(multisignature.calculateFee(transaction).toString()).to.equal('8500000000');
+			multisignature.calculateFee(transaction).toString().should.equal('8500000000');
 		});
 	});
 
@@ -170,7 +170,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.min = min;
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Invalid multisignature min. Must be between 1 and 15');
+					err.should.equal('Invalid multisignature min. Must be between 1 and 15');
 					done();
 				});
 			});
@@ -181,7 +181,7 @@ describe('multisignature', function () {
 			var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '+' + multiSigAccount2.publicKey], 1, min);
 
 			multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-				expect(err).to.equal('Invalid multisignature min. Must be between 1 and 15');
+				err.should.equal('Invalid multisignature min. Must be between 1 and 15');
 				done();
 			});
 		});
@@ -192,7 +192,7 @@ describe('multisignature', function () {
 				delete transaction.asset;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -204,7 +204,7 @@ describe('multisignature', function () {
 				delete transaction.asset.multisignature;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -216,7 +216,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup = [];
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid multisignature keysgroup. Must not be empty');
+					err.should.equal('Invalid multisignature keysgroup. Must not be empty');
 					done();
 				});
 			});
@@ -228,7 +228,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.min = 0;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid multisignature min. Must be between 1 and 15');
+					err.should.equal('Invalid multisignature min. Must be between 1 and 15');
 					done();
 				});
 			});
@@ -240,7 +240,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.min = 16;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid multisignature min. Must be between 1 and 15');
+					err.should.equal('Invalid multisignature min. Must be between 1 and 15');
 					done();
 				});
 			});
@@ -252,7 +252,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.min = 2;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					done();
 				});
 			});
@@ -269,7 +269,7 @@ describe('multisignature', function () {
 
 			it('should call callback with error = null', function (done) {
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					done();
 				});
 			});
@@ -281,7 +281,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.lifetime = 0;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid multisignature lifetime. Must be between 1 and 72');
+					err.should.equal('Invalid multisignature lifetime. Must be between 1 and 72');
 					done();
 				});
 			});
@@ -293,7 +293,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.lifetime = 73;
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid multisignature lifetime. Must be between 1 and 72');
+					err.should.equal('Invalid multisignature lifetime. Must be between 1 and 72');
 					done();
 				});
 			});
@@ -305,7 +305,7 @@ describe('multisignature', function () {
 				sender.multisignatures = [lisk.crypto.getKeys(randomUtil.password()).publicKey];
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Account already has multisignatures enabled');
+					err.should.equal('Account already has multisignatures enabled');
 					done();
 				});
 			});
@@ -318,7 +318,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push('+' + sender.publicKey);
 
 				multisignature.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid multisignature keysgroup. Can not contain sender');
+					err.should.equal('Invalid multisignature keysgroup. Can not contain sender');
 					done();
 				});
 			});
@@ -330,7 +330,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push('-' + lisk.crypto.getKeys(randomUtil.password()).publicKey);
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Invalid math operator in multisignature keysgroup');
+					err.should.equal('Invalid math operator in multisignature keysgroup');
 					done();
 				});
 			});
@@ -342,7 +342,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push(null);
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Invalid member in keysgroup');
+					err.should.equal('Invalid member in keysgroup');
 					done();
 				});
 			});
@@ -354,7 +354,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push(undefined);
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Invalid member in keysgroup');
+					err.should.equal('Invalid member in keysgroup');
 					done();
 				});
 			});
@@ -366,7 +366,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push(1);
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Invalid member in keysgroup');
+					err.should.equal('Invalid member in keysgroup');
 					done();
 				});
 			});
@@ -378,7 +378,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push(1);
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Invalid member in keysgroup');
+					err.should.equal('Invalid member in keysgroup');
 					done();
 				});
 			});
@@ -390,7 +390,7 @@ describe('multisignature', function () {
 				transaction.asset.multisignature.keysgroup.push(transaction.asset.multisignature.keysgroup[0]);
 
 				multisignature.verify(transaction, accountFixtures.genesis, function (err) {
-					expect(err).to.equal('Encountered duplicate public key in multisignature keysgroup');
+					err.should.equal('Encountered duplicate public key in multisignature keysgroup');
 					done();
 				});
 			});
@@ -398,8 +398,8 @@ describe('multisignature', function () {
 
 		it('should be okay for valid transaction', function (done) {
 			multisignature.verify(transaction, sender, function (err, result) {
-				expect(err).to.not.exist;
-				expect(transaction).to.eql(result);
+				should.not.exist(err);
+				transaction.should.eql(result);
 				done();
 			});
 		});
@@ -409,14 +409,14 @@ describe('multisignature', function () {
 
 		it('should call callback with error = null', function (done) {
 			multisignature.process(transaction, sender, function (err) {
-				expect(err).to.be.null;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call callback with result = transaction', function (done) {
 			multisignature.process(transaction, sender, function (err, result) {
-				expect(result).to.eql(transaction);
+				result.should.eql(transaction);
 				done();
 			});
 		});
@@ -431,24 +431,24 @@ describe('multisignature', function () {
 			});
 
 			it('should throw', function () {
-				expect(multisignature.getBytes.bind(null, transaction)).to.throw();
+				multisignature.getBytes.bind(null, transaction).should.throw();
 			});
 		});
 
 		describe('when transaction.asset.multisignature.keysgroup is a valid keysgroup', function () {
 
 			it('should not throw', function () {
-				expect(multisignature.getBytes.bind(null, transaction)).not.to.throw();
+				multisignature.getBytes.bind(null, transaction).should.not.to.throw();
 			});
 
 			it('should get bytes of valid transaction', function () {
 				var bytes = multisignature.getBytes(transaction);
-				expect(bytes.toString('utf8')).to.equal('\u0002\u0002+bd6d0388dcc0b07ab2035689c60a78d3ebb27901c5a5ed9a07262eab1a2e9bd2+addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9');
-				expect(bytes.length).to.equal(132);
+				bytes.toString('utf8').should.equal('\u0002\u0002+bd6d0388dcc0b07ab2035689c60a78d3ebb27901c5a5ed9a07262eab1a2e9bd2+addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9');
+				bytes.length.should.equal(132);
 			});
 
 			it('should return result as a Buffer type', function () {
-				expect(multisignature.getBytes(transaction)).to.be.instanceOf(Buffer);
+				multisignature.getBytes(transaction).should.be.instanceOf(Buffer);
 			});
 		});
 	});
@@ -462,15 +462,15 @@ describe('multisignature', function () {
 
 		it('should set __private.unconfirmedSignatures[sender.address] = false', function () {
 			var unconfirmedSignatures = Multisignature.__get__('__private.unconfirmedSignatures');
-			expect(unconfirmedSignatures).to.contain.property(sender.address).equal(false);
+			unconfirmedSignatures.should.contain.property(sender.address).equal(false);
 		});
 
 		it('should call library.logic.account.merge', function () {
-			expect(accountMock.merge.calledOnce).to.be.true;
+			accountMock.merge.calledOnce.should.be.true;
 		});
 
 		it('should call library.logic.account.merge with sender.address', function () {
-			expect(accountMock.merge.calledWith(sender.address)).to.be.true;
+			accountMock.merge.calledWith(sender.address).should.be.true;
 		});
 
 		it('should call library.logic.account.merge with expected params', function () {
@@ -481,7 +481,7 @@ describe('multisignature', function () {
 				blockId: dummyBlock.id,
 				round: slots.calcRound(dummyBlock.height)
 			};
-			expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
+			accountMock.merge.args[0][1].should.eql(expectedParams);
 		});
 
 		describe('when library.logic.account.merge fails', function () {
@@ -492,7 +492,7 @@ describe('multisignature', function () {
 
 			it('should call callback with error', function () {
 				multisignature.apply(transaction, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -504,11 +504,11 @@ describe('multisignature', function () {
 				validTransaction.asset.multisignature.keysgroup.forEach(function (member) {
 
 					it('should call modules.accounts.generateAddressByPublicKey', function () {
-						expect(accountsMock.generateAddressByPublicKey.callCount).to.equal(validTransaction.asset.multisignature.keysgroup.length);
+						accountsMock.generateAddressByPublicKey.callCount.should.equal(validTransaction.asset.multisignature.keysgroup.length);
 					});
 
 					it('should call modules.accounts.generateAddressByPublicKey with member.substring(1)', function () {
-						expect(accountsMock.generateAddressByPublicKey.calledWith(member.substring(1))).to.be.true;
+						accountsMock.generateAddressByPublicKey.calledWith(member.substring(1)).should.be.true;
 					});
 
 					describe('when key and the address', function () {
@@ -522,15 +522,15 @@ describe('multisignature', function () {
 						});
 
 						it('should call library.logic.account.setAccountAndGet', function () {
-							expect(accountsMock.setAccountAndGet.callCount).to.equal(validTransaction.asset.multisignature.keysgroup.length);
+							accountsMock.setAccountAndGet.callCount.should.equal(validTransaction.asset.multisignature.keysgroup.length);
 						});
 
 						it('should call library.logic.account.setAccountAndGet with {address: address}', function () {
-							expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: address}))).to.be.true;
+							accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: address})).should.be.true;
 						});
 
 						it('should call library.logic.account.setAccountAndGet with sender.address', function () {
-							expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({publicKey: key}))).to.be.true;
+							accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({publicKey: key})).should.be.true;
 						});
 
 						describe('when modules.accounts.setAccountAndGet fails', function () {
@@ -541,7 +541,7 @@ describe('multisignature', function () {
 
 							it('should call callback with error', function () {
 								multisignature.apply(transaction, dummyBlock, sender, function (err) {
-									expect(err).not.to.be.empty;
+									err.should.not.to.be.empty;
 								});
 							});
 						});
@@ -550,13 +550,13 @@ describe('multisignature', function () {
 
 							it('should call callback with error = null', function () {
 								multisignature.apply(transaction, dummyBlock, sender, function (err) {
-									expect(err).to.be.null;
+									should.not.exist(err);
 								});
 							});
 
 							it('should call callback with result = undefined', function () {
 								multisignature.apply(transaction, dummyBlock, sender, function (err, res) {
-									expect(res).to.be.undefined;
+									should.not.exist(res);
 								});
 							});
 						});
@@ -576,15 +576,15 @@ describe('multisignature', function () {
 
 		it('should set __private.unconfirmedSignatures[sender.address] = true', function () {
 			var unconfirmedSignatures = Multisignature.__get__('__private.unconfirmedSignatures');
-			expect(unconfirmedSignatures).to.contain.property(sender.address).equal(true);
+			unconfirmedSignatures.should.contain.property(sender.address).equal(true);
 		});
 
 		it('should call library.logic.account.merge', function () {
-			expect(accountMock.merge.calledOnce).to.be.true;
+			accountMock.merge.calledOnce.should.be.true;
 		});
 
 		it('should call library.logic.account.merge with sender.address', function () {
-			expect(accountMock.merge.calledWith(sender.address)).to.be.true;
+			accountMock.merge.calledWith(sender.address).should.be.true;
 		});
 
 		it('should call library.logic.account.merge with expected params', function () {
@@ -595,7 +595,7 @@ describe('multisignature', function () {
 				blockId: dummyBlock.id,
 				round: slots.calcRound(dummyBlock.height)
 			};
-			expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
+			accountMock.merge.args[0][1].should.eql(expectedParams);
 		});
 
 		describe('when library.logic.account.merge fails', function () {
@@ -606,7 +606,7 @@ describe('multisignature', function () {
 
 			it('should call callback with error', function () {
 				multisignature.undo(transaction, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -615,13 +615,13 @@ describe('multisignature', function () {
 
 			it('should call callback with error = null', function () {
 				multisignature.apply(transaction, dummyBlock, sender, function (err) {
-					expect(err).to.be.null;
+					should.not.exist(err);
 				});
 			});
 
 			it('should call callback with result = undefined', function () {
 				multisignature.apply(transaction, dummyBlock, sender, function (err, res) {
-					expect(res).to.be.undefined;
+					should.not.exist(res);
 				});
 			});
 		});
@@ -639,7 +639,7 @@ describe('multisignature', function () {
 			it('should call callback with error = "Signature on this account is pending confirmation"', function (done) {
 
 				multisignature.applyUnconfirmed(transaction, sender, function (err) {
-					expect(err).to.equal('Signature on this account is pending confirmation');
+					err.should.equal('Signature on this account is pending confirmation');
 					done();
 				});
 			});
@@ -655,21 +655,21 @@ describe('multisignature', function () {
 			it('should set __private.unconfirmedSignatures[sender.address] = true', function (done) {
 				var unconfirmedSignatures = Multisignature.__get__('__private.unconfirmedSignatures');
 				multisignature.applyUnconfirmed(transaction, sender, function (err) {
-					expect(unconfirmedSignatures).to.contain.property(sender.address).equal(true);
+					unconfirmedSignatures.should.contain.property(sender.address).equal(true);
 					done();
 				});
 			});
 
 			it('should call library.logic.account.merge', function (done) {
 				multisignature.applyUnconfirmed(transaction, sender, function (err) {
-					expect(accountMock.merge.calledOnce).to.be.true;
+					accountMock.merge.calledOnce.should.be.true;
 					done();
 				});
 			});
 
 			it('should call library.logic.account.merge with sender.address', function (done) {
 				multisignature.applyUnconfirmed(transaction, sender, function (err) {
-					expect(accountMock.merge.calledWith(sender.address)).to.be.true;
+					accountMock.merge.calledWith(sender.address).should.be.true;
 					done();
 				});
 			});
@@ -681,7 +681,7 @@ describe('multisignature', function () {
 					u_multilifetime: transaction.asset.multisignature.lifetime
 				};
 				multisignature.applyUnconfirmed(transaction, sender, function (err) {
-					expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
+					accountMock.merge.args[0][1].should.eql(expectedParams);
 					done();
 				});
 			});
@@ -698,8 +698,8 @@ describe('multisignature', function () {
 
 				it('should call callback with error = merge error', function (done) {
 					multisignature.applyUnconfirmed(transaction, sender, function (err) {
-						expect(err).not.to.be.empty;
-						expect(err).to.equal('merge error');
+						err.should.not.to.be.empty;
+						err.should.equal('merge error');
 						done();
 					});
 				});
@@ -709,14 +709,14 @@ describe('multisignature', function () {
 
 				it('should call callback with error = null', function (done) {
 					multisignature.applyUnconfirmed(transaction, sender, function (err) {
-						expect(err).to.be.not.exist;
+						should.not.exist(err);
 						done();
 					});
 				});
 
 				it('should call callback with result = undefined', function (done) {
 					multisignature.applyUnconfirmed(transaction, sender, function (err, res) {
-						expect(res).to.be.undefined;
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -733,15 +733,15 @@ describe('multisignature', function () {
 
 		it('should set __private.unconfirmedSignatures[sender.address] = false', function () {
 			var unconfirmedSignatures = Multisignature.__get__('__private.unconfirmedSignatures');
-			expect(unconfirmedSignatures).to.contain.property(sender.address).equal(false);
+			unconfirmedSignatures.should.contain.property(sender.address).equal(false);
 		});
 
 		it('should call library.logic.account.merge', function () {
-			expect(accountMock.merge.calledOnce).to.be.true;
+			accountMock.merge.calledOnce.should.be.true;
 		});
 
 		it('should call library.logic.account.merge with sender.address', function () {
-			expect(accountMock.merge.calledWith(sender.address)).to.be.true;
+			accountMock.merge.calledWith(sender.address).should.be.true;
 		});
 
 		it('should call library.logic.account.merge with expected params', function () {
@@ -750,7 +750,7 @@ describe('multisignature', function () {
 				u_multimin: -transaction.asset.multisignature.min,
 				u_multilifetime: -transaction.asset.multisignature.lifetime,
 			};
-			expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
+			accountMock.merge.args[0][1].should.eql(expectedParams);
 		});
 
 		describe('when library.logic.account.merge fails', function () {
@@ -761,7 +761,7 @@ describe('multisignature', function () {
 
 			it('should call callback with error', function () {
 				multisignature.undo(transaction, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -770,13 +770,13 @@ describe('multisignature', function () {
 
 			it('should call callback with error = null', function () {
 				multisignature.apply(transaction, dummyBlock, sender, function (err) {
-					expect(err).to.be.null;
+					should.not.exist(err);
 				});
 			});
 
 			it('should call callback with result = undefined', function () {
 				multisignature.apply(transaction, dummyBlock, sender, function (err, res) {
-					expect(res).to.be.undefined;
+					should.not.exist(res);
 				});
 			});
 		});
@@ -791,9 +791,9 @@ describe('multisignature', function () {
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '+' + multiSigAccount2.publicKey], 1, 2);
 				transaction.asset.multisignature.min = min;
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Expected type integer but found type string');
+				}).should.throw('Failed to validate multisignature schema: Expected type integer but found type string');
 			});
 
 			it('should return error when value is a negative integer', function () {
@@ -801,27 +801,27 @@ describe('multisignature', function () {
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '+' + multiSigAccount2.publicKey], 1, 2);
 				transaction.asset.multisignature.min = min;
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value -1 is less than minimum 1');
+				}).should.throw('Failed to validate multisignature schema: Value -1 is less than minimum 1');
 			});
 
 			it('should return error when value is smaller than minimum acceptable value', function () {
 				var min = constants.multisigConstraints.min.minimum - 1;
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '+' + multiSigAccount2.publicKey], 1, min);
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value 0 is less than minimum 1');
+				}).should.throw('Failed to validate multisignature schema: Value 0 is less than minimum 1');
 			});
 
 			it('should return error when value is greater than maximum acceptable value', function () {
 				var min = constants.multisigConstraints.min.maximum + 1;
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '-' + multiSigAccount2.publicKey], 1, min);
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value 16 is greater than maximum 15');
+				}).should.throw('Failed to validate multisignature schema: Value 16 is greater than maximum 15');
 			});
 
 			it('should return error when value is an overflow number', function () {
@@ -829,9 +829,9 @@ describe('multisignature', function () {
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '-' + multiSigAccount2.publicKey], 1, 2);
 				transaction.asset.multisignature.min = min;
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value 1.7976931348623157e+308 is greater than maximum 15');
+				}).should.throw('Failed to validate multisignature schema: Value 1.7976931348623157e+308 is greater than maximum 15');
 			});
 		});
 
@@ -842,27 +842,27 @@ describe('multisignature', function () {
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '-' + multiSigAccount2.publicKey], 1, 2);
 				transaction.asset.multisignature.lifetime = lifetime;
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Expected type integer but found type string');
+				}).should.throw('Failed to validate multisignature schema: Expected type integer but found type string');
 			});
 
 			it('should return error when value is smaller than minimum acceptable value', function () {
 				var lifetime = constants.multisigConstraints.lifetime.minimum - 1;
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '-' + multiSigAccount2.publicKey], lifetime, 2);
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value 0 is less than minimum 1');
+				}).should.throw('Failed to validate multisignature schema: Value 0 is less than minimum 1');
 			});
 
 			it('should return error when value is greater than maximum acceptable value', function () {
 				var lifetime = constants.multisigConstraints.lifetime.maximum + 1;
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '-' + multiSigAccount2.publicKey], lifetime, 2);
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value 73 is greater than maximum 72');
+				}).should.throw('Failed to validate multisignature schema: Value 73 is greater than maximum 72');
 			});
 
 			it('should return error when value is an overflow number', function () {
@@ -870,9 +870,9 @@ describe('multisignature', function () {
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, ['+' + multiSigAccount1.publicKey, '-' + multiSigAccount2.publicKey], 1, 2);
 				transaction.asset.multisignature.lifetime = lifetime;
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Value 1.7976931348623157e+308 is greater than maximum 72');
+				}).should.throw('Failed to validate multisignature schema: Value 1.7976931348623157e+308 is greater than maximum 72');
 			});
 		});
 
@@ -882,18 +882,18 @@ describe('multisignature', function () {
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, [''], 1, 2);
 				transaction.asset.multisignature.keysgroup = '';
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Expected type array but found type string');
+				}).should.throw('Failed to validate multisignature schema: Expected type array but found type string');
 			});
 
 			it('should return error when array length is smaller than minimum acceptable value', function () {
 				var keysgroup = [];
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, keysgroup, 1, 2);
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Array is too short (0), minimum 1');
+				}).should.throw('Failed to validate multisignature schema: Array is too short (0), minimum 1');
 			});
 
 			it('should return error when array length is greater than maximum acceptable value', function () {
@@ -902,9 +902,9 @@ describe('multisignature', function () {
 				});
 				var transaction	= lisk.multisignature.createMultisignature(accountFixtures.genesis.password, null, keysgroup, 1, 2);
 
-				expect(function () {
+				(function () {
 					multisignature.objectNormalize(transaction);
-				}).to.throw('Failed to validate multisignature schema: Array is too long (16), maximum 15');
+				}).should.throw('Failed to validate multisignature schema: Array is too long (16), maximum 15');
 			});
 		});
 
@@ -913,28 +913,28 @@ describe('multisignature', function () {
 				return '+' + lisk.crypto.getKeys(randomUtil.password()).publicKey;
 			}), 1, 2);
 
-			expect(multisignature.objectNormalize(transaction)).to.eql(transaction);
+			multisignature.objectNormalize(transaction).should.eql(transaction);
 		});
 
 		it('should use the correct format to validate against', function () {
 			var library = Multisignature.__get__('library');
 			var schemaSpy = sinonSandbox.spy(library.schema, 'validate');
 			multisignature.objectNormalize(transaction);
-			expect(schemaSpy.calledOnce).to.equal(true);
-			expect(schemaSpy.calledWithExactly(transaction.asset.multisignature, Multisignature.prototype.schema)).to.equal(true);
+			schemaSpy.calledOnce.should.equal(true);
+			schemaSpy.calledWithExactly(transaction.asset.multisignature, Multisignature.prototype.schema).should.equal(true);
 			schemaSpy.restore();
 		});
 
 		it('should return error asset schema is invalid', function () {
 			transaction.asset.multisignature.min = -1;
 
-			expect(function () {
+			(function () {
 				multisignature.objectNormalize(transaction);
-			}).to.throw('Failed to validate multisignature schema: Value -1 is less than minimum 1');
+			}).should.throw('Failed to validate multisignature schema: Value -1 is less than minimum 1');
 		});
 
 		it('should return transaction when asset is valid', function () {
-			expect(multisignature.objectNormalize(transaction)).to.eql(transaction);
+			multisignature.objectNormalize(transaction).should.eql(transaction);
 		});
 	});
 
@@ -947,22 +947,22 @@ describe('multisignature', function () {
 			});
 
 			it('should return null', function () {
-				expect(multisignature.dbRead(rawTransaction)).to.eql(null);
+				should.not.exist(multisignature.dbRead(rawTransaction));
 			});
 		});
 
 		describe('when raw.m_keysgroup exists', function () {
 
 			it('should return result containing multisignature', function () {
-				expect(multisignature.dbRead(rawTransaction)).to.have.property('multisignature');
+				multisignature.dbRead(rawTransaction).should.have.property('multisignature');
 			});
 
 			it('should return result containing multisignature.min = raw.m_min', function () {
-				expect(multisignature.dbRead(rawTransaction)).to.have.nested.property('multisignature.min').equal(rawTransaction.m_min);
+				multisignature.dbRead(rawTransaction).should.have.nested.property('multisignature.min').equal(rawTransaction.m_min);
 			});
 
 			it('should return result containing multisignature.lifetime = raw.lifetime', function () {
-				expect(multisignature.dbRead(rawTransaction)).to.have.nested.property('multisignature.lifetime').equal(rawTransaction.m_lifetime);
+				multisignature.dbRead(rawTransaction).should.have.nested.property('multisignature.lifetime').equal(rawTransaction.m_lifetime);
 			});
 
 			describe('when raw.m_keysgroup is not a string', function () {
@@ -972,7 +972,7 @@ describe('multisignature', function () {
 				});
 
 				it('should return result containing multisignature.keysgroup = []', function () {
-					expect(multisignature.dbRead(rawTransaction)).to.have.nested.property('multisignature.keysgroup').eql([]);
+					multisignature.dbRead(rawTransaction).should.have.nested.property('multisignature.keysgroup').eql([]);
 				});
 			});
 
@@ -983,7 +983,7 @@ describe('multisignature', function () {
 				});
 
 				it('should return result containing multisignature.keysgroup = ["a", "b", "c"]', function () {
-					expect(multisignature.dbRead(rawTransaction)).to.have.nested.property('multisignature.keysgroup').eql(['a', 'b', 'c']);
+					multisignature.dbRead(rawTransaction).should.have.nested.property('multisignature.keysgroup').eql(['a', 'b', 'c']);
 				});
 			});
 		});
@@ -992,13 +992,13 @@ describe('multisignature', function () {
 	describe('ready', function () {
 
 		it('should return true for single signature transaction', function () {
-			expect(multisignature.ready(transaction, sender)).to.equal(true);
+			multisignature.ready(transaction, sender).should.equal(true);
 		});
 
 		it('should return false for multi signature transaction with less signatures', function () {
 			sender.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-			expect(multisignature.ready(transaction, sender)).to.equal(false);
+			multisignature.ready(transaction, sender).should.equal(false);
 		});
 
 		it('should return true for multi signature transaction with alteast min signatures', function () {
@@ -1010,7 +1010,7 @@ describe('multisignature', function () {
 			transaction.signature = crypto.randomBytes(64).toString('hex');;
 			transaction.signatures = [crypto.randomBytes(64).toString('hex')];
 
-			expect(multisignature.ready(transaction, sender)).to.equal(true);
+			multisignature.ready(transaction, sender).should.equal(true);
 		});
 	});
 });

--- a/test/unit/logic/outTransfer.js
+++ b/test/unit/logic/outTransfer.js
@@ -91,15 +91,15 @@ describe('outTransfer', function () {
 			});
 
 			it('should assign db', function () {
-				expect(library).to.have.property('db').eql(dbStub);
+				library.should.have.property('db').eql(dbStub);
 			});
 
 			it('should assign schema', function () {
-				expect(library).to.have.property('schema').eql(modulesLoader.scope.schema);
+				library.should.have.property('schema').eql(modulesLoader.scope.schema);
 			});
 
 			it('should assign logger', function () {
-				expect(library).to.have.property('logger').eql(modulesLoader.logger);
+				library.should.have.property('logger').eql(modulesLoader.logger);
 			});
 		});
 	});
@@ -116,7 +116,7 @@ describe('outTransfer', function () {
 		describe('modules', function () {
 
 			it('should assign accounts', function () {
-				expect(modules).to.have.property('accounts').eql(accountsStub);
+				modules.should.have.property('accounts').eql(accountsStub);
 			});
 		});
 	});
@@ -124,7 +124,7 @@ describe('outTransfer', function () {
 	describe('calculateFee', function () {
 
 		it('should return constants.fees.send', function () {
-			expect(outTransfer.calculateFee(transaction)).to.equal(constants.fees.send);
+			outTransfer.calculateFee(transaction).should.equal(constants.fees.send);
 		});
 	});
 
@@ -135,7 +135,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid recipient"', function (done) {
 				delete transaction.recipientId;
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid recipient');
+					err.should.equal('Invalid recipient');
 					done();
 				});
 			});
@@ -146,7 +146,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid transaction amount"', function (done) {
 				delete transaction.amount;
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction amount');
+					err.should.equal('Invalid transaction amount');
 					done();
 				});
 			});
@@ -157,7 +157,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid transaction amount"', function (done) {
 				transaction.amount = 0;
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction amount');
+					err.should.equal('Invalid transaction amount');
 					done();
 				});
 			});
@@ -168,7 +168,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid transaction asset"', function (done) {
 				delete transaction.asset;
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -179,7 +179,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid transaction asset"', function (done) {
 				delete transaction.asset.outTransfer;
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -190,7 +190,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid transaction asset"', function (done) {
 				transaction.asset.outTransfer = 0;
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid transaction asset');
+					err.should.equal('Invalid transaction asset');
 					done();
 				});
 			});
@@ -201,7 +201,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid outTransfer dappId"', function (done) {
 				transaction.asset.outTransfer.dappId = 'ab1231';
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid outTransfer dappId');
+					err.should.equal('Invalid outTransfer dappId');
 					done();
 				});
 			});
@@ -212,7 +212,7 @@ describe('outTransfer', function () {
 			it('should call callback with error = "Invalid outTransfer transactionId"', function (done) {
 				transaction.asset.outTransfer.transactionId = 'ab1231';
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.equal('Invalid outTransfer transactionId');
+					err.should.equal('Invalid outTransfer transactionId');
 					done();
 				});
 			});
@@ -222,14 +222,14 @@ describe('outTransfer', function () {
 
 			it('should call callback with error = null', function (done) {
 				outTransfer.verify(transaction, sender, function (err) {
-					expect(err).to.be.null;
+					should.not.exist(err);
 					done();
 				});
 			});
 
 			it('should call callback with result = transaction', function (done) {
 				outTransfer.verify(transaction, sender, function (err, res) {
-					expect(res).to.eql(transaction);
+					res.should.eql(transaction);
 					done();
 				});
 			});
@@ -244,21 +244,21 @@ describe('outTransfer', function () {
 
 		it('should call library.db.dapps.countByTransactionId', function (done) {
 			outTransfer.process(transaction, sender, function () {
-				expect(dbStub.dapps.countByTransactionId.calledOnce).to.be.true;
+				dbStub.dapps.countByTransactionId.calledOnce.should.be.true;
 				done();
 			});
 		});
 
 		it('should call library.db.dapps.countByTransactionId', function (done) {
 			outTransfer.process(transaction, sender, function () {
-				expect(dbStub.dapps.countByTransactionId.calledWith(transaction.asset.outTransfer.dappId)).to.be.true;
+				dbStub.dapps.countByTransactionId.calledWith(transaction.asset.outTransfer.dappId).should.be.true;
 				done();
 			});
 		});
 
 		it('should call library.db.dapps.countByTransactionId with transaction.asset.outTransfer.dappId}', function (done) {
 			outTransfer.process(transaction, sender, function () {
-				expect(dbStub.dapps.countByTransactionId.calledWith(transaction.asset.outTransfer.dappId)).to.be.true;
+				dbStub.dapps.countByTransactionId.calledWith(transaction.asset.outTransfer.dappId).should.be.true;
 				done();
 			});
 		});
@@ -271,7 +271,7 @@ describe('outTransfer', function () {
 
 			it('should call callback with error', function (done) {
 				outTransfer.process(transaction, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 					done();
 				});
 			});
@@ -288,7 +288,7 @@ describe('outTransfer', function () {
 
 				it('should call callback with error', function (done) {
 					outTransfer.process(transaction, sender, function (err) {
-						expect(err).to.equal('Application not found: ' + transaction.asset.outTransfer.dappId);
+						err.should.equal('Application not found: ' + transaction.asset.outTransfer.dappId);
 						done();
 					});
 				});
@@ -311,7 +311,7 @@ describe('outTransfer', function () {
 
 					it('should call callback with error', function (done) {
 						outTransfer.process(transaction, sender, function (err) {
-							expect(err).to.equal('Transaction is already processed: ' + transaction.asset.outTransfer.transactionId);
+							err.should.equal('Transaction is already processed: ' + transaction.asset.outTransfer.transactionId);
 							done();
 						});
 					});
@@ -325,22 +325,22 @@ describe('outTransfer', function () {
 
 					it('should call library.db.dapps.countByTransactionId second time', function (done) {
 						outTransfer.process(transaction, sender, function () {
-							expect(dbStub.dapps.countByTransactionId.calledOnce).to.be.true;
-							expect(dbStub.dapps.countByOutTransactionId.calledOnce).to.be.true;
+							dbStub.dapps.countByTransactionId.calledOnce.should.be.true;
+							dbStub.dapps.countByOutTransactionId.calledOnce.should.be.true;
 							done();
 						});
 					});
 
 					it('should call library.db.dapps.countByOutTransactionId', function (done) {
 						outTransfer.process(transaction, sender, function () {
-							expect(dbStub.dapps.countByOutTransactionId.calledWith(transaction.asset.outTransfer.transactionId)).to.be.true;
+							dbStub.dapps.countByOutTransactionId.calledWith(transaction.asset.outTransfer.transactionId).should.be.true;
 							done();
 						});
 					});
 
 					it('should call library.db.dapps.countByOutTransactionId transaction.asset.outTransfer.transactionId', function (done) {
 						outTransfer.process(transaction, sender, function () {
-							expect(dbStub.dapps.countByOutTransactionId.calledWith(transaction.asset.outTransfer.transactionId)).to.be.true;
+							dbStub.dapps.countByOutTransactionId.calledWith(transaction.asset.outTransfer.transactionId).should.be.true;
 							done();
 						});
 					});
@@ -353,7 +353,7 @@ describe('outTransfer', function () {
 
 						it('should call callback with error', function (done) {
 							outTransfer.process(transaction, sender, function (err) {
-								expect(err).not.to.be.empty;
+								err.should.not.to.be.empty;
 								done();
 							});
 						});
@@ -369,7 +369,7 @@ describe('outTransfer', function () {
 
 							it('should call callback with error', function (done) {
 								outTransfer.process(transaction, sender, function (err) {
-									expect(err).to.equal('Transaction is already confirmed: ' + transaction.asset.outTransfer.transactionId);
+									err.should.equal('Transaction is already confirmed: ' + transaction.asset.outTransfer.transactionId);
 									done();
 								});
 							});
@@ -384,14 +384,14 @@ describe('outTransfer', function () {
 
 							it('should call callback with error = null', function (done) {
 								outTransfer.process(transaction, sender, function (err) {
-									expect(err).to.be.null;
+									should.not.exist(err);
 									done();
 								});
 							});
 
 							it('should call callback with result = transaction', function (done) {
 								outTransfer.process(transaction, sender, function (err, res) {
-									expect(res).to.eql(transaction);
+									res.should.eql(transaction);
 									done();
 								});
 							});
@@ -411,7 +411,7 @@ describe('outTransfer', function () {
 			});
 
 			it('should throw', function () {
-				expect(outTransfer.getBytes.bind(null, transaction)).to.throw;
+				outTransfer.getBytes.bind(null, transaction).should.throw;
 			});
 		});
 
@@ -424,22 +424,22 @@ describe('outTransfer', function () {
 				});
 
 				it('should throw', function () {
-					expect(outTransfer.getBytes.bind(null, transaction)).to.throw;
+					outTransfer.getBytes.bind(null, transaction).should.throw;
 				});
 			});
 
 			describe('when transaction.asset.outTransfer.transactionId is valid transaction id', function () {
 
 				it('should not throw', function () {
-					expect(outTransfer.getBytes.bind(null, transaction)).not.to.throw;
+					outTransfer.getBytes.bind(null, transaction).should.not.to.throw;
 				});
 
 				it('should get bytes of valid transaction', function () {
-					expect(outTransfer.getBytes(transaction).toString('hex')).to.equal('343136333731333037383236363532343230393134313434333533313632323737313338383231');
+					outTransfer.getBytes(transaction).toString('hex').should.equal('343136333731333037383236363532343230393134313434333533313632323737313338383231');
 				});
 
 				it('should return result as a Buffer type', function () {
-					expect(outTransfer.getBytes(transaction)).to.be.instanceOf(Buffer);
+					outTransfer.getBytes(transaction).should.be.instanceOf(Buffer);
 				});
 			});
 		});
@@ -453,15 +453,15 @@ describe('outTransfer', function () {
 
 		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false', function () {
 			var unconfirmedOutTransfers = OutTransfer.__get__('__private.unconfirmedOutTansfers');
-			expect(unconfirmedOutTransfers).to.contain.property(transaction.asset.outTransfer.transactionId).equal(false);
+			unconfirmedOutTransfers.should.contain.property(transaction.asset.outTransfer.transactionId).equal(false);
 		});
 
 		it('should call modules.accounts.setAccountAndGet', function () {
-			expect(accountsStub.setAccountAndGet.calledOnce).to.be.true;
+			accountsStub.setAccountAndGet.calledOnce.should.be.true;
 		});
 
 		it('should call modules.accounts.setAccountAndGet with {address: transaction.recipientId}', function () {
-			expect(accountsStub.setAccountAndGet.calledWith({address: transaction.recipientId})).to.be.true;
+			accountsStub.setAccountAndGet.calledWith({address: transaction.recipientId}).should.be.true;
 		});
 
 		describe('when modules.accounts.setAccountAndGet fails', function () {
@@ -472,7 +472,7 @@ describe('outTransfer', function () {
 
 			it('should call callback with error', function () {
 				outTransfer.apply(transaction, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -484,27 +484,27 @@ describe('outTransfer', function () {
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {
-				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true;
+				accountsStub.mergeAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with address = transaction.recipientId', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: transaction.recipientId}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: transaction.recipientId})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with balance = transaction.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: transaction.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: transaction.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with u_balance = transaction.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: transaction.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: transaction.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with blockId = block.id', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with round = slots.calcRound result', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)})).should.be.true;
 			});
 
 			describe('when modules.accounts.mergeAccountAndGet fails', function () {
@@ -515,7 +515,7 @@ describe('outTransfer', function () {
 
 				it('should call callback with error', function () {
 					outTransfer.apply(transaction, dummyBlock, sender, function (err) {
-						expect(err).not.to.be.empty;
+						err.should.not.to.be.empty;
 					});
 				});
 			});
@@ -524,13 +524,13 @@ describe('outTransfer', function () {
 
 				it('should call callback with error = undefined', function () {
 					outTransfer.apply(transaction, dummyBlock, sender, function (err) {
-						expect(err).to.be.undefined;
+						should.not.exist(err);
 					});
 				});
 
 				it('should call callback with result = undefined', function () {
 					outTransfer.apply(transaction, dummyBlock, sender, function (err, res) {
-						expect(res).to.be.undefined;
+						should.not.exist(res);
 					});
 				});
 			});
@@ -545,15 +545,15 @@ describe('outTransfer', function () {
 
 		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true', function () {
 			var unconfirmedOutTransfers = OutTransfer.__get__('__private.unconfirmedOutTansfers');
-			expect(unconfirmedOutTransfers).to.contain.property(transaction.asset.outTransfer.transactionId).equal(true);
+			unconfirmedOutTransfers.should.contain.property(transaction.asset.outTransfer.transactionId).equal(true);
 		});
 
 		it('should call modules.accounts.setAccountAndGet', function () {
-			expect(accountsStub.setAccountAndGet.calledOnce).to.be.true;
+			accountsStub.setAccountAndGet.calledOnce.should.be.true;
 		});
 
 		it('should call modules.accounts.setAccountAndGet with {address: transaction.recipientId}', function () {
-			expect(accountsStub.setAccountAndGet.calledWith({address: transaction.recipientId})).to.be.true;
+			accountsStub.setAccountAndGet.calledWith({address: transaction.recipientId}).should.be.true;
 		});
 
 		describe('when modules.accounts.setAccountAndGet fails', function () {
@@ -564,7 +564,7 @@ describe('outTransfer', function () {
 
 			it('should call callback with error', function () {
 				outTransfer.undo(transaction, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -576,27 +576,27 @@ describe('outTransfer', function () {
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet', function () {
-				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true;
+				accountsStub.mergeAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with address = transaction.recipientId', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: transaction.recipientId}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({address: transaction.recipientId})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with balance = -transaction.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: -transaction.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({balance: -transaction.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with u_balance = -transaction.amount', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: -transaction.amount}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({u_balance: -transaction.amount})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with blockId = block.id', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({blockId: dummyBlock.id})).should.be.true;
 			});
 
 			it('should call modules.accounts.mergeAccountAndGet with round = slots.calcRound result', function () {
-				expect(accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)}))).to.be.true;
+				accountsStub.mergeAccountAndGet.calledWith(sinonSandbox.match({round: slots.calcRound(dummyBlock.height)})).should.be.true;
 			});
 		});
 
@@ -608,7 +608,7 @@ describe('outTransfer', function () {
 
 			it('should call callback with error', function () {
 				outTransfer.undo(transaction, dummyBlock, sender, function (err) {
-					expect(err).not.to.be.empty;
+					err.should.not.to.be.empty;
 				});
 			});
 		});
@@ -617,13 +617,13 @@ describe('outTransfer', function () {
 
 			it('should call callback with error = undefined', function () {
 				outTransfer.undo(transaction, dummyBlock, sender, function (err) {
-					expect(err).to.be.undefined;
+					should.not.exist(err);
 				});
 			});
 
 			it('should call callback with result = undefined', function () {
 				outTransfer.undo(transaction, dummyBlock, sender, function (err, res) {
-					expect(res).to.be.undefined;
+					should.not.exist(res);
 				});
 			});
 		});
@@ -634,21 +634,21 @@ describe('outTransfer', function () {
 		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true', function (done) {
 			var unconfirmedOutTransfers = OutTransfer.__get__('__private.unconfirmedOutTansfers');
 			outTransfer.applyUnconfirmed(transaction, sender, function () {
-				expect(unconfirmedOutTransfers).to.contain.property(transaction.asset.outTransfer.transactionId).equal(true);
+				unconfirmedOutTransfers.should.contain.property(transaction.asset.outTransfer.transactionId).equal(true);
 				done();
 			});
 		});
 
 		it('should call callback with error = undefined', function (done) {
 			outTransfer.applyUnconfirmed(transaction, sender, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call callback with result = undefined', function (done) {
 			outTransfer.applyUnconfirmed(transaction, sender, function (err, result) {
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				done();
 			});
 		});
@@ -659,21 +659,21 @@ describe('outTransfer', function () {
 		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false', function (done) {
 			var unconfirmedOutTransfers = OutTransfer.__get__('__private.unconfirmedOutTansfers');
 			outTransfer.undoUnconfirmed(transaction, sender, function () {
-				expect(unconfirmedOutTransfers).to.contain.property(transaction.asset.outTransfer.transactionId).equal(false);
+				unconfirmedOutTransfers.should.contain.property(transaction.asset.outTransfer.transactionId).equal(false);
 				done();
 			});
 		});
 
 		it('should call callback with error = undefined', function (done) {
 			outTransfer.undoUnconfirmed(transaction, sender, function (err) {
-				expect(err).to.be.undefined;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should call callback with result = undefined', function (done) {
 			outTransfer.undoUnconfirmed(transaction, sender, function (err, result) {
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				done();
 			});
 		});
@@ -695,24 +695,24 @@ describe('outTransfer', function () {
 
 		it('should call library.schema.validate', function () {
 			outTransfer.objectNormalize(transaction);
-			expect(schemaSpy.calledOnce).to.be.true;
+			schemaSpy.calledOnce.should.be.true;
 		});
 
 		it('should call library.schema.validate with transaction.asset.outTransfer', function () {
 			outTransfer.objectNormalize(transaction);
-			expect(schemaSpy.calledWith(transaction.asset.outTransfer)).to.be.true;
+			schemaSpy.calledWith(transaction.asset.outTransfer).should.be.true;
 		});
 
 		it('should call library.schema.validate outTransfer.prototype.schema', function () {
 			outTransfer.objectNormalize(transaction);
-			expect(schemaSpy.args[0][1]).to.eql(OutTransfer.prototype.schema);
+			schemaSpy.args[0][1].should.eql(OutTransfer.prototype.schema);
 		});
 
 		describe('when transaction.asset.outTransfer is invalid object argument', function () {
 
 			typesRepresentatives.nonObjects.forEach(function (nonObject) {
 				it('should throw for transaction.asset.outTransfer = ' + nonObject.description, function () {
-					expect(outTransfer.objectNormalize.bind(null, nonObject.input)).to.throw();
+					outTransfer.objectNormalize.bind(null, nonObject.input).should.throw();
 				});
 			});
 		});
@@ -722,7 +722,7 @@ describe('outTransfer', function () {
 			typesRepresentatives.nonStrings.forEach(function (nonString) {
 				it('should throw for transaction.asset.outTransfer.dappId = ' + nonString.description, function () {
 					transaction.asset.outTransfer.dappId = nonString.input;
-					expect(outTransfer.objectNormalize.bind(null, transaction)).to.throw();
+					outTransfer.objectNormalize.bind(null, transaction).should.throw();
 				});
 			});
 		});
@@ -732,7 +732,7 @@ describe('outTransfer', function () {
 			typesRepresentatives.nonStrings.forEach(function (nonString) {
 				it('should throw for transaction.asset.outTransfer.transactionId = ' + nonString.description, function () {
 					transaction.asset.outTransfer.transactionId = nonString.input;
-					expect(outTransfer.objectNormalize.bind(null, nonString.input)).to.throw();
+					outTransfer.objectNormalize.bind(null, nonString.input).should.throw();
 				});
 			});
 		});
@@ -740,7 +740,7 @@ describe('outTransfer', function () {
 		describe('when when transaction.asset.outTransfer is valid', function () {
 
 			it('should return transaction', function () {
-				expect(outTransfer.objectNormalize(transaction)).to.eql(transaction);
+				outTransfer.objectNormalize(transaction).should.eql(transaction);
 			});
 		});
 	});
@@ -754,22 +754,22 @@ describe('outTransfer', function () {
 			});
 
 			it('should return null', function () {
-				expect(outTransfer.dbRead(rawTransaction)).to.eql(null);
+				should.not.exist(outTransfer.dbRead(rawTransaction));
 			});
 		});
 
 		describe('when raw.in_dappId exists', function () {
 
 			it('should return result containing outTransfer', function () {
-				expect(outTransfer.dbRead(rawTransaction)).to.have.property('outTransfer');
+				outTransfer.dbRead(rawTransaction).should.have.property('outTransfer');
 			});
 
 			it('should return result containing outTransfer.dappId = raw.ot_dappId', function () {
-				expect(outTransfer.dbRead(rawTransaction)).to.have.nested.property('outTransfer.dappId').equal(rawTransaction.ot_dappId);
+				outTransfer.dbRead(rawTransaction).should.have.nested.property('outTransfer.dappId').equal(rawTransaction.ot_dappId);
 			});
 
 			it('should return result containing outTransfer.dappId = raw.ot_dappId', function () {
-				expect(outTransfer.dbRead(rawTransaction)).to.have.nested.property('outTransfer.transactionId').equal(rawTransaction.ot_outTransactionId);
+				outTransfer.dbRead(rawTransaction).should.have.nested.property('outTransfer.transactionId').equal(rawTransaction.ot_outTransactionId);
 			});
 		});
 	});
@@ -777,13 +777,13 @@ describe('outTransfer', function () {
 	describe('ready', function () {
 
 		it('should return true for single signature transaction', function () {
-			expect(outTransfer.ready(transaction, sender)).to.equal(true);
+			outTransfer.ready(transaction, sender).should.equal(true);
 		});
 
 		it('should return false for multi signature transaction with less signatures', function () {
 			sender.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-			expect(outTransfer.ready(transaction, sender)).to.equal(false);
+			outTransfer.ready(transaction, sender).should.equal(false);
 		});
 
 		it('should return true for multi signature transaction with at least min signatures', function () {
@@ -795,7 +795,7 @@ describe('outTransfer', function () {
 			transaction.signature = crypto.randomBytes(64).toString('hex');;
 			transaction.signatures = [crypto.randomBytes(64).toString('hex')];
 
-			expect(outTransfer.ready(transaction, sender)).to.equal(true);
+			outTransfer.ready(transaction, sender).should.equal(true);
 		});
 	});
 });

--- a/test/unit/logic/peer.js
+++ b/test/unit/logic/peer.js
@@ -31,10 +31,10 @@ describe('peer', function () {
 
 		it('should create Peer with all properties implemented', function () {
 			var __peer = new Peer({ip: '127.0.0.1', wsPort: 4000});
-			expect(__peer).to.have.property('ip').equal('127.0.0.1');
-			expect(__peer).to.have.property('wsPort').equal(4000);
-			expect(__peer).to.have.property('state').equal(1);
-			expect(__peer).to.have.property('string').equal('127.0.0.1:4000');
+			__peer.should.have.property('ip').equal('127.0.0.1');
+			__peer.should.have.property('wsPort').equal(4000);
+			__peer.should.have.property('state').equal(1);
+			__peer.should.have.property('string').equal('127.0.0.1:4000');
 		});
 	});
 
@@ -44,37 +44,37 @@ describe('peer', function () {
 			var peer = new Peer({});
 			var __peer = peer.accept(prefixedPeer);
 			['height', 'ip', 'wsPort', 'state'].forEach(function (property) {
-				expect(__peer[property]).equals(prefixedPeer[property]);
+				__peer[property].should.equals(prefixedPeer[property]);
 			});
-			expect(__peer.string).equals(prefixedPeer.ip + ':' + prefixedPeer.wsPort);
+			__peer.string.should.equals(prefixedPeer.ip + ':' + prefixedPeer.wsPort);
 		});
 
 		it('should accept empty peer and set default values', function () {
 			var __peer = peer.accept({});
-			expect(__peer.wsPort).to.equal(0);
-			expect(__peer.ip).to.be.undefined;
-			expect(__peer.state).to.equal(1);
-			expect(__peer.height).to.be.undefined;
-			expect(__peer.string).to.be.undefined;
+			__peer.wsPort.should.equal(0);
+			should.not.exist(__peer.ip);
+			__peer.state.should.equal(1);
+			should.not.exist(__peer.height);
+			should.not.exist(__peer.string);
 		});
 
 		it('should accept peer with ip as long', function () {
 			var __peer = peer.accept({ip: ip.toLong(prefixedPeer.ip)});
-			expect(__peer.ip).to.equal(prefixedPeer.ip);
+			__peer.ip.should.equal(prefixedPeer.ip);
 		});
 	});
 
 	describe('parseInt', function () {
 
 		it('should always return a number', function () {
-			expect(peer.parseInt('1')).to.equal(1);
-			expect(peer.parseInt(1)).to.equal(1);
+			peer.parseInt('1').should.equal(1);
+			peer.parseInt(1).should.equal(1);
 		});
 
 		it('should return default value when NaN passed', function () {
-			expect(peer.parseInt('not a number', 1)).to.equal(1);
-			expect(peer.parseInt(undefined, 1)).to.equal(1);
-			expect(peer.parseInt(null, 1)).to.equal(1);
+			peer.parseInt('not a number', 1).should.equal(1);
+			peer.parseInt(undefined, 1).should.equal(1);
+			peer.parseInt(null, 1).should.equal(1);
 		});
 	});
 
@@ -82,7 +82,7 @@ describe('peer', function () {
 
 		it('should not apply random values to the peer scope', function () {
 			peer.applyHeaders({headerA: 'HeaderA'});
-			expect(peer.headerA).to.not.exist;
+			should.not.exist(peer.headerA);
 		});
 
 		it('should apply defined values as headers', function () {
@@ -92,7 +92,7 @@ describe('peer', function () {
 					var headers = {};
 					headers[header] = prefixedPeer[header];
 					peer.applyHeaders(headers);
-					expect(peer[header]).to.equal(prefixedPeer[header]);
+					peer[header].should.equal(prefixedPeer[header]);
 				}
 			});
 		});
@@ -104,7 +104,7 @@ describe('peer', function () {
 					var headers = {};
 					headers[header] = prefixedPeer[header];
 					peer.applyHeaders(headers);
-					expect(peer[header]).to.not.exist;
+					should.not.exist(peer[header]);
 				}
 			});
 		});
@@ -112,8 +112,8 @@ describe('peer', function () {
 		it('should parse height and port', function () {
 			var appliedHeaders = peer.applyHeaders({wsPort: '4000', height: '1'});
 
-			expect(appliedHeaders.wsPort).to.equal(4000);
-			expect(appliedHeaders.height).to.equal(1);
+			appliedHeaders.wsPort.should.equal(4000);
+			appliedHeaders.height.should.equal(1);
 		});
 	});
 
@@ -121,17 +121,17 @@ describe('peer', function () {
 
 		it('should not apply random values to the peer scope', function () {
 			peer.update({someProp: 'someValue'});
-			expect(peer.someProp).to.not.exist;
+			should.not.exist(peer.someProp);
 		});
 
 		it('should not apply undefined to the peer scope', function () {
 			peer.update({someProp: undefined});
-			expect(peer.someProp).to.not.exist;
+			should.not.exist(peer.someProp);
 		});
 
 		it('should not apply null to the peer scope', function () {
 			peer.update({someProp: null});
-			expect(peer.someProp).to.not.exist;
+			should.not.exist(peer.someProp);
 		});
 
 		it('should change state of banned peer', function () {
@@ -140,7 +140,7 @@ describe('peer', function () {
 			peer.state = 0;
 			// Try to unban peer
 			peer.update({state: 2});
-			expect(peer.state).to.equal(2);
+			peer.state.should.equal(2);
 			peer.state = initialState;
 		});
 
@@ -150,7 +150,7 @@ describe('peer', function () {
 			peer.state = 0;
 			// Try to unban peer
 			peer.update({state: 2});
-			expect(peer.state).to.equal(2);
+			peer.state.should.equal(2);
 			peer.state = initialState;
 		});
 
@@ -162,10 +162,10 @@ describe('peer', function () {
 				height: 3,
 				nonce: 'ABCD123'
 			};
-			expect(_.difference(_.keys(updateData), peer.headers)).to.have.lengthOf(0);
+			_.difference(_.keys(updateData), peer.headers).should.have.lengthOf(0);
 			peer.update(updateData);
 			peer.headers.forEach(function (header) {
-				expect(peer[header]).to.exist.and.equals(updateData[header]);
+				peer[header].should.exist.and.equals(updateData[header]);
 			});
 		});
 
@@ -178,10 +178,11 @@ describe('peer', function () {
 				string: prefixedPeer.ip + ':' + prefixedPeer.wsPort
 			};
 
-			expect(_.isEqual(_.keys(updateImmutableData), peer.immutable)).to.be.ok;
+			_.isEqual(_.keys(updateImmutableData), peer.immutable).should.be.ok;
 			peer.update(updateImmutableData);
 			peer.headers.forEach(function (header) {
-				expect(peer[header]).equals(peerBeforeUpdate[header]).and.not.equal(updateImmutableData);
+				should.equal(peer[header], peerBeforeUpdate[header]);
+				should.not.equal(peer[header], updateImmutableData);
 			});
 		});
 
@@ -198,7 +199,7 @@ describe('peer', function () {
 			var peerBeforeUpdate = _.clone(peer);
 			peer.update({height: peer.height += 1});
 			peer.height -= 1;
-			expect(_.isEqual(peer, peerBeforeUpdate)).to.be.ok;
+			_.isEqual(peer, peerBeforeUpdate).should.be.ok;
 		});
 	});
 
@@ -210,7 +211,7 @@ describe('peer', function () {
 			_.keys(prefixedPeer).forEach(function (property) {
 				if (__peer.properties.indexOf(property) !== -1) {
 					if (typeof prefixedPeer[property] !== 'object') {
-						expect(peerCopy[property]).to.equal(prefixedPeer[property]);
+						peerCopy[property].should.equal(prefixedPeer[property]);
 					}
 				}
 			});
@@ -220,7 +221,7 @@ describe('peer', function () {
 			var initialState = peer.state;
 			peer.update({state: 'unreadable'});
 			var peerCopy = peer.object();
-			expect(peerCopy.state).to.equal(1);
+			peerCopy.state.should.equal(1);
 			peer.state = initialState;
 		});
 

--- a/test/unit/logic/peers.js
+++ b/test/unit/logic/peers.js
@@ -51,7 +51,7 @@ describe('peers', function () {
 			peers.remove(peer);
 		});
 
-		expect(peers.list()).that.is.an('array').and.to.be.empty;
+		peers.list().should.be.an('array').and.to.be.empty;
 	}
 
 	function arePeersEqual (peerA, peerB) {
@@ -82,9 +82,9 @@ describe('peers', function () {
 
 	describe('create', function () {
 		it('should always return Peer instance', function () {
-			expect(peers.create()).to.be.an.instanceof(Peer);
-			expect(peers.create(validPeer)).to.be.an.instanceof(Peer);
-			expect(peers.create(new Peer(validPeer))).to.be.an.instanceof(Peer);
+			peers.create().should.be.an.instanceof(Peer);
+			peers.create(validPeer).should.be.an.instanceof(Peer);
+			peers.create(new Peer(validPeer)).should.be.an.instanceof(Peer);
 		});
 	});
 
@@ -97,14 +97,14 @@ describe('peers', function () {
 		it('should list peers as Peer instances', function () {
 			peers.upsert(validPeer);
 			peers.list().forEach(function (peer) {
-				expect(peer).to.be.an.instanceof(Peer);
+				peer.should.be.an.instanceof(Peer);
 			});
 		});
 
 		it('should list peers with rpc', function () {
 			peers.upsert(validPeer);
 			peers.list().forEach(function (peer) {
-				expect(peer).have.property('rpc');
+				peer.should.have.property('rpc');
 			});
 		});
 
@@ -112,14 +112,14 @@ describe('peers', function () {
 			it('should list peers as objects when normalized', function () {
 				peers.upsert(validPeer);
 				peers.list(true).forEach(function (peer) {
-					expect(peer).to.be.an('object');
+					peer.should.be.an('object');
 				});
 			});
 
 			it('should not contain rpc property when normalized', function () {
 				peers.upsert(validPeer);
 				peers.list(true).forEach(function (peer) {
-					expect(peer).not.to.have.property('rpc');
+					peer.should.not.to.have.property('rpc');
 				});
 			});
 		});
@@ -133,24 +133,24 @@ describe('peers', function () {
 
 		it('should insert new peers', function () {
 			peers.upsert(validPeer);
-			expect(peers.list().length).equal(1);
+			peers.list().length.should.equal(1);
 		});
 
 		it('should update height of existing peer', function () {
 			peers.upsert(validPeer);
 			var list = peers.list();
 			var inserted = list[0];
-			expect(list.length).equal(1);
-			expect(arePeersEqual(inserted, validPeer)).to.be.ok;
+			list.length.should.equal(1);
+			arePeersEqual(inserted, validPeer).should.be.ok;
 
 			var modifiedPeer = _.clone(validPeer);
 			modifiedPeer.height += 1;
 			peers.upsert(modifiedPeer);
 			list = peers.list();
 			var updated = list[0];
-			expect(list.length).equal(1);
-			expect(arePeersEqual(updated, modifiedPeer)).to.be.ok;
-			expect(arePeersEqual(updated, validPeer)).to.be.not.ok;
+			list.length.should.equal(1);
+			arePeersEqual(updated, modifiedPeer).should.be.ok;
+			arePeersEqual(updated, validPeer).should.be.not.ok;
 
 		});
 
@@ -158,39 +158,39 @@ describe('peers', function () {
 			peers.upsert(validPeer);
 			var list = peers.list();
 			var inserted = list[0];
-			expect(list.length).equal(1);
-			expect(arePeersEqual(inserted, validPeer)).to.be.ok;
+			list.length.should.equal(1);
+			arePeersEqual(inserted, validPeer).should.be.ok;
 
 			var modifiedPeer = _.clone(validPeer);
 			modifiedPeer.height += 1;
 			peers.upsert(modifiedPeer, true);
 			list = peers.list();
 			var updated = list[0];
-			expect(list.length).equal(1);
-			expect(arePeersEqual(updated, modifiedPeer)).to.be.not.ok;
-			expect(arePeersEqual(updated, validPeer)).to.be.ok;
+			list.length.should.equal(1);
+			arePeersEqual(updated, modifiedPeer).should.be.not.ok;
+			arePeersEqual(updated, validPeer).should.be.ok;
 		});
 
 		it('should insert peer with different ports', function () {
 			peers.upsert(validPeer);
-			expect(peers.list().length).equal(1);
+			peers.list().length.should.equal(1);
 
 			var differentPortPeer = _.clone(validPeer);
 			differentPortPeer.nonce = 'differentNonce';
 			differentPortPeer.wsPort += 1;
 			peers.upsert(differentPortPeer);
 			var list = peers.list();
-			expect(list.length).equal(2);
+			list.length.should.equal(2);
 
 			var demandedPorts = _.map([validPeer, differentPortPeer], 'wsPort');
 			var listPorts = _.map(list, 'wsPort');
 
-			expect(_.isEqual(demandedPorts.sort(), listPorts.sort())).to.be.ok;
+			_.isEqual(demandedPorts.sort(), listPorts.sort()).should.be.ok;
 		});
 
 		it('should insert peer with different ips', function () {
 			peers.upsert(validPeer);
-			expect(peers.list().length).equal(1);
+			peers.list().length.should.equal(1);
 
 			var differentIpPeer = _.clone(validPeer);
 			delete differentIpPeer.string;
@@ -199,29 +199,29 @@ describe('peers', function () {
 
 			peers.upsert(differentIpPeer);
 			var list = peers.list();
-			expect(list.length).equal(2);
+			list.length.should.equal(2);
 
 			var demandedIps = _.map([validPeer, differentIpPeer], 'ip');
 			var listIps = _.map(list, 'ip');
 
-			expect(_.isEqual(demandedIps.sort(), listIps.sort())).to.be.ok;
+			_.isEqual(demandedIps.sort(), listIps.sort()).should.be.ok;
 		});
 
 		describe('should fail with valid error code', function () {
 
 			it('INSERT_ONLY_FAILURE when insertOnly flag is present and peer already exists', function () {
 				peers.upsert(validPeer);
-				expect(peers.upsert(validPeer, true)).to.equal(failureCodes.ON_MASTER.INSERT.INSERT_ONLY_FAILURE);
+				peers.upsert(validPeer, true).should.equal(failureCodes.ON_MASTER.INSERT.INSERT_ONLY_FAILURE);
 			});
 
 			it('INVALID_PEER when called with invalid peer', function () {
-				expect(peers.upsert({})).to.equal(failureCodes.ON_MASTER.UPDATE.INVALID_PEER);
+				peers.upsert({}).should.equal(failureCodes.ON_MASTER.UPDATE.INVALID_PEER);
 			});
 
 			it('NOT_ACCEPTED when called with the same as node nonce', function () {
 				peersModuleMock.acceptable = sinonSandbox.stub().returns([]);
 				validPeer.nonce = validNodeNonce;
-				expect(peers.upsert(validPeer)).to.equal(failureCodes.ON_MASTER.INSERT.NOT_ACCEPTED);
+				peers.upsert(validPeer).should.equal(failureCodes.ON_MASTER.INSERT.NOT_ACCEPTED);
 			});
 		});
 	});
@@ -233,32 +233,32 @@ describe('peers', function () {
 		});
 
 		it('should return false if peer is not on the list', function () {
-			expect(peers.exists({
+			peers.exists({
 				ip: '41.41.41.41',
 				wsPort: '4444',
 				nonce: 'another_nonce'
-			})).not.to.be.ok;
+			}).should.not.be.ok;
 		});
 
 		it('should return true if peer is on the list', function () {
 			peers.upsert(validPeer);
 			var list = peers.list(true);
-			expect(list.length).equal(1);
-			expect(peers.exists(validPeer)).to.be.ok;
+			list.length.should.equal(1);
+			peers.exists(validPeer).should.be.ok;
 		});
 
 		it('should return true if peer with same nonce is on the list', function () {
 			var res = peers.upsert(validPeer);
 			var list = peers.list(true);
-			expect(list.length).equal(1);
-			expect(peers.exists({ip: validPeer.ip, wsPort: validPeer.wsPort, nonce: validPeer.nonce})).to.be.ok;
+			list.length.should.equal(1);
+			peers.exists({ip: validPeer.ip, wsPort: validPeer.wsPort, nonce: validPeer.nonce}).should.be.ok;
 		});
 
 		it('should return true if peer with same address is on the list', function () {
 			peers.upsert(validPeer);
 			var list = peers.list(true);
-			expect(list.length).equal(1);
-			expect(peers.exists({ip: validPeer.ip, wsPort: validPeer.wsPort})).to.be.ok;
+			list.length.should.equal(1);
+			peers.exists({ip: validPeer.ip, wsPort: validPeer.wsPort}).should.be.ok;
 		});
 	});
 
@@ -271,18 +271,18 @@ describe('peers', function () {
 		it('should return inserted peer', function () {
 			peers.upsert(validPeer);
 			var insertedPeer = peers.get(validPeer);
-			expect(arePeersEqual(insertedPeer, validPeer)).to.be.ok;
+			arePeersEqual(insertedPeer, validPeer).should.be.ok;
 		});
 
 		it('should return inserted peer by address', function () {
 			peers.upsert(validPeer);
 			var insertedPeer = peers.get(validPeer.ip + ':' + validPeer.wsPort);
-			expect(arePeersEqual(insertedPeer, validPeer)).to.be.ok;
+			arePeersEqual(insertedPeer, validPeer).should.be.ok;
 
 		});
 
 		it('should return undefined if peer is not inserted', function () {
-			expect(peers.get(validPeer)).to.be.undefined;
+			should.not.exist(peers.get(validPeer));
 		});
 	});
 
@@ -294,16 +294,16 @@ describe('peers', function () {
 
 		it('should remove added peer', function () {
 			peers.upsert(validPeer);
-			expect(peers.list().length).equal(1);
+			peers.list().length.should.equal(1);
 			var result = peers.remove(validPeer);
-			expect(result).to.be.ok;
-			expect(peers.list().length).equal(0);
+			result.should.be.ok;
+			peers.list().length.should.equal(0);
 		});
 
 		it('should return an error when trying to remove a non-existent peer', function () {
 			var result = peers.remove(validPeer);
-			expect(result).to.be.a('number').equal(failureCodes.ON_MASTER.REMOVE.NOT_ON_LIST);
-			expect(peers.list().length).equal(0);
+			result.should.be.a('number').equal(failureCodes.ON_MASTER.REMOVE.NOT_ON_LIST);
+			peers.list().length.should.equal(0);
 		});
 	});
 });

--- a/test/unit/logic/signature.js
+++ b/test/unit/logic/signature.js
@@ -131,11 +131,11 @@ describe('signature', function () {
 			});
 
 			it('should attach schema to library variable', function () {
-				expect(library.schema).to.eql(modulesLoader.scope.schema);
+				library.schema.should.eql(modulesLoader.scope.schema);
 			});
 
 			it('should attach logger to library variable', function () {
-				expect(library.logger).to.eql(modulesLoader.scope.logger);
+				library.logger.should.eql(modulesLoader.scope.logger);
 			});
 		});
 
@@ -146,7 +146,7 @@ describe('signature', function () {
 				it('should assign accounts', function () {
 					signature.bind(accountsMock);
 					var modules = Signature.__get__('modules');
-					expect(modules).to.eql({
+					modules.should.eql({
 						accounts: accountsMock
 					});
 				});
@@ -162,7 +162,7 @@ describe('signature', function () {
 			});
 
 			it('should return constants.fees.secondSignature', function () {
-				expect(fee).to.equal(constants.fees.secondSignature);
+				fee.should.equal(constants.fees.secondSignature);
 			});
 		});
 
@@ -176,7 +176,7 @@ describe('signature', function () {
 						delete transaction.asset;
 
 						signature.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid transaction asset');
+							err.should.equal('Invalid transaction asset');
 							done();
 						});
 					});
@@ -188,7 +188,7 @@ describe('signature', function () {
 						delete transaction.asset.signature;
 
 						signature.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid transaction asset');
+							err.should.equal('Invalid transaction asset');
 							done();
 						});
 					});
@@ -200,7 +200,7 @@ describe('signature', function () {
 						transaction.amount = 1;
 
 						signature.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid transaction amount');
+							err.should.equal('Invalid transaction amount');
 							done();
 						});
 					});
@@ -212,7 +212,7 @@ describe('signature', function () {
 						delete transaction.asset.signature.publicKey;
 
 						signature.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid public key');
+							err.should.equal('Invalid public key');
 							done();
 						});
 					});
@@ -224,7 +224,7 @@ describe('signature', function () {
 						transaction.asset.signature.publicKey = 'invalid-public-key';
 
 						signature.verify(transaction, sender, function (err) {
-							expect(err).to.equal('Invalid public key');
+							err.should.equal('Invalid public key');
 							done();
 						});
 					});
@@ -247,7 +247,7 @@ describe('signature', function () {
 
 			it('should call callback with result = transaction', function (done) {
 				signature.process(transaction, sender, function (err, res) {
-					expect(res).to.eql(transaction);
+					res.should.eql(transaction);
 					done();
 				});
 			});
@@ -266,7 +266,7 @@ describe('signature', function () {
 					});
 
 					it('should throw', function () {
-						expect(signature.getBytes.bind(transaction)).to.throw();
+						signature.getBytes.bind(transaction).should.throw();
 					});
 				});
 
@@ -277,7 +277,7 @@ describe('signature', function () {
 					});
 
 					it('should throw', function () {
-						expect(signature.getBytes.bind(transaction)).to.throw();
+						signature.getBytes.bind(transaction).should.throw();
 					});
 				});
 			});
@@ -293,11 +293,11 @@ describe('signature', function () {
 					});
 
 					it('should return bytes in hex format', function () {
-						expect(signatureBytes).to.eql(Buffer.from(transaction.asset.signature.publicKey, 'hex'));
+						signatureBytes.should.eql(Buffer.from(transaction.asset.signature.publicKey, 'hex'));
 					});
 
 					it('should return bytes of length 32', function () {
-						expect(signatureBytes.length).to.equal(32);
+						signatureBytes.length.should.equal(32);
 					});
 				});
 			});
@@ -310,23 +310,23 @@ describe('signature', function () {
 			});
 
 			it('should call modules.accounts.setAccountAndGet', function () {
-				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true;
+				accountsMock.setAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with address = sender.address', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with secondSignature = 1', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondSignature: 1}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondSignature: 1})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with u_secondSignature = 0', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 0}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 0})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with secondPublicKey = validTransaction.asset.signature.publicKey', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondPublicKey: validTransaction.asset.signature.publicKey}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondPublicKey: validTransaction.asset.signature.publicKey})).should.be.true;
 			});
 		});
 
@@ -337,23 +337,23 @@ describe('signature', function () {
 			});
 
 			it('should call modules.accounts.setAccountAndGet', function () {
-				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true;
+				accountsMock.setAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with address = sender.address', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with secondSignature = 0', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondSignature: 0}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondSignature: 0})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with u_secondSignature = 1', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 1}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 1})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with secondPublicKey = null', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondPublicKey: null}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({secondPublicKey: null})).should.be.true;
 			});
 		});
 
@@ -367,7 +367,7 @@ describe('signature', function () {
 
 				it('should call callback with error', function (done) {
 					signature.applyUnconfirmed.call(transactionMock, transaction, sender, function (err) {
-						expect(err).to.equal('Second signature already enabled');
+						err.should.equal('Second signature already enabled');
 						done();
 					});
 				});
@@ -382,7 +382,7 @@ describe('signature', function () {
 
 				it('should call callback with error', function (done) {
 					signature.applyUnconfirmed.call(transactionMock, transaction, sender, function (err) {
-						expect(err).to.equal('Second signature already enabled');
+						err.should.equal('Second signature already enabled');
 						done();
 					});
 				});
@@ -393,15 +393,15 @@ describe('signature', function () {
 			});
 
 			it('should call modules.accounts.setAccountAndGet', function () {
-				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true;
+				accountsMock.setAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with address = sender.address', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with u_secondSignature = 1', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 1}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 1})).should.be.true;
 			});
 		});
 
@@ -412,15 +412,15 @@ describe('signature', function () {
 			});
 
 			it('should call modules.accounts.setAccountAndGet', function () {
-				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true;
+				accountsMock.setAccountAndGet.calledOnce.should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with address = sender.address', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({address: sender.address})).should.be.true;
 			});
 
 			it('should call modules.accounts.setAccountAndGet with u_secondSignature = 0', function () {
-				expect(accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 0}))).to.be.true;
+				accountsMock.setAccountAndGet.calledWith(sinonSandbox.match({u_secondSignature: 0})).should.be.true;
 			});
 		});
 
@@ -442,11 +442,11 @@ describe('signature', function () {
 				});
 
 				it('call schema validate once', function () {
-					expect(schemaSpy.calledOnce).to.equal(true);
+					schemaSpy.calledOnce.should.equal(true);
 				});
 
 				it('signature schema', function () {
-					expect(schemaSpy.calledWithExactly(transaction.asset.signature, Signature.prototype.schema)).to.equal(true);
+					schemaSpy.calledWithExactly(transaction.asset.signature, Signature.prototype.schema).should.equal(true);
 				});
 			});
 
@@ -459,9 +459,9 @@ describe('signature', function () {
 					nonStrings.forEach(function (type) {
 						it('should throw when username type is ' + type.description, function () {
 							transaction.asset.signature.publicKey = type.input;
-							expect(function () {
+							(function () {
 								signature.objectNormalize(transaction);
-							}).to.throw('Failed to validate signature schema: Expected type string but found type ' + type.expectation);
+							}).should.throw('Failed to validate signature schema: Expected type string but found type ' + type.expectation);
 						});
 					});
 				});
@@ -473,9 +473,9 @@ describe('signature', function () {
 					nonEmptyStrings.forEach(function (type) {
 						it('should throw when username is: ' + type.description, function () {
 							transaction.asset.signature.publicKey = type.input;
-							expect(function () {
+							(function () {
 								signature.objectNormalize(transaction);
-							}).to.throw('Failed to validate signature schema: Object didn\'t pass validation for format publicKey: ' + type.input);
+							}).should.throw('Failed to validate signature schema: Object didn\'t pass validation for format publicKey: ' + type.input);
 						});
 					});
 				});
@@ -484,7 +484,7 @@ describe('signature', function () {
 			describe('when library.schema.validate succeeds', function () {
 
 				it('should return transaction', function () {
-					expect(signature.objectNormalize(transaction)).to.eql(transaction);
+					signature.objectNormalize(transaction).should.eql(transaction);
 				});
 			});
 		});
@@ -498,7 +498,7 @@ describe('signature', function () {
 				});
 
 				it('should return null', function () {
-					expect(signature.dbRead(rawTransaction)).to.eql(null);
+					should.not.exist(signature.dbRead(rawTransaction));
 				});
 			});
 
@@ -508,11 +508,11 @@ describe('signature', function () {
 				var transactionId = '5197781214824378819';
 
 				it('should return publicKey property', function () {
-					expect(signature.dbRead(rawTransaction).signature.publicKey).to.equal(publicKey);
+					signature.dbRead(rawTransaction).signature.publicKey.should.equal(publicKey);
 				});
 
 				it('should return transactionId', function () {
-					expect(signature.dbRead(rawTransaction).signature.transactionId).to.eql(transactionId);
+					signature.dbRead(rawTransaction).signature.transactionId.should.eql(transactionId);
 				});
 			});
 		});
@@ -520,13 +520,13 @@ describe('signature', function () {
 		describe('ready', function () {
 
 			it('should return true for single signature transaction', function () {
-				expect(signature.ready(transaction, sender)).to.equal(true);
+				signature.ready(transaction, sender).should.equal(true);
 			});
 
 			it('should return false for multi signature transaction with less signatures', function () {
 				sender.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-				expect(signature.ready(transaction, sender)).to.equal(false);
+				signature.ready(transaction, sender).should.equal(false);
 			});
 
 			it('should return true for multi signature transaction with at least min signatures', function () {
@@ -538,7 +538,7 @@ describe('signature', function () {
 				transaction.signature = crypto.randomBytes(64).toString('hex');;
 				transaction.signatures = [crypto.randomBytes(64).toString('hex')];
 
-				expect(signature.ready(transaction, sender)).to.equal(true);
+				signature.ready(transaction, sender).should.equal(true);
 			});
 		});
 	});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -166,44 +166,44 @@ describe('transaction', function () {
 		it('should attach all transaction types', function () {
 			var appliedLogic;
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.VOTE, new Vote());
-			expect(appliedLogic).to.be.an.instanceof(Vote);
+			appliedLogic.should.be.an.instanceof(Vote);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.SEND, new Transfer(modulesLoader.scope.logger, modulesLoader.scope.schema));
-			expect(appliedLogic).to.be.an.instanceof(Transfer);
+			appliedLogic.should.be.an.instanceof(Transfer);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.DELEGATE, new Delegate());
-			expect(appliedLogic).to.be.an.instanceof(Delegate);
+			appliedLogic.should.be.an.instanceof(Delegate);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.SIGNATURE, new Signature());
-			expect(appliedLogic).to.be.an.instanceof(Signature);
+			appliedLogic.should.be.an.instanceof(Signature);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.MULTI, new Multisignature());
-			expect(appliedLogic).to.be.an.instanceof(Multisignature);
+			appliedLogic.should.be.an.instanceof(Multisignature);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.DAPP, new Dapp());
-			expect(appliedLogic).to.be.an.instanceof(Dapp);
+			appliedLogic.should.be.an.instanceof(Dapp);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.IN_TRANSFER, new InTransfer());
-			expect(appliedLogic).to.be.an.instanceof(InTransfer);
+			appliedLogic.should.be.an.instanceof(InTransfer);
 			appliedLogic = transactionLogic.attachAssetType(transactionTypes.OUT_TRANSFER, new OutTransfer());
-			expect(appliedLogic).to.be.an.instanceof(OutTransfer);
+			appliedLogic.should.be.an.instanceof(OutTransfer);
 			return transactionLogic;
 		});
 
 		it('should throw an error on invalid asset', function () {
-			expect(function () {
+			(function () {
 				var invalidAsset = {};
 				transactionLogic.attachAssetType(-1, invalidAsset);
-			}).to.throw('Invalid instance interface');
+			}).should.throw('Invalid instance interface');
 		});
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.attachAssetType).to.throw();
+			transactionLogic.attachAssetType.should.throw();
 		});
 	});
 
 	describe('sign', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.sign).to.throw();
+			transactionLogic.sign.should.throw();
 		});
 
 		it('should sign transaction', function () {
-			expect(transactionLogic.sign(senderKeypair, validTransaction)).to.be.a('string').which.is.equal('8f9c4242dc562599f95f5481469d22567987536112663156761e4b2b3f1142c4f5355a2a7c7b254f40d370bef7e76b4a11c8a1836e0c9b0bcab3e834ca1e7502');
+			transactionLogic.sign(senderKeypair, validTransaction).should.be.a('string').which.is.equal('8f9c4242dc562599f95f5481469d22567987536112663156761e4b2b3f1142c4f5355a2a7c7b254f40d370bef7e76b4a11c8a1836e0c9b0bcab3e834ca1e7502');
 		});
 
 		it('should update signature when data is changed', function () {
@@ -211,29 +211,29 @@ describe('transaction', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.data = '123';
 
-			expect(transactionLogic.sign(senderKeypair, transaction)).to.be.a('string').which.is.not.equal(originalSignature);
+			transactionLogic.sign(senderKeypair, transaction).should.be.a('string').which.is.not.equal(originalSignature);
 		});
 	});
 
 	describe('multisign', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.multisign).to.throw();
+			transactionLogic.multisign.should.throw();
 		});
 
 		it('should multisign the transaction', function () {
-			expect(transactionLogic.multisign(senderKeypair, validTransaction)).to.equal(validTransaction.signature);
+			transactionLogic.multisign(senderKeypair, validTransaction).should.equal(validTransaction.signature);
 		});
 	});
 
 	describe('getId', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.getId).to.throw();
+			transactionLogic.getId.should.throw();
 		});
 
 		it('should generate the id of the transaction', function () {
-			expect(transactionLogic.getId(validTransaction)).to.be.a('string').which.is.equal(validTransaction.id);
+			transactionLogic.getId(validTransaction).should.be.a('string').which.is.equal(validTransaction.id);
 		});
 
 		it('should update id if a field in transaction value changes', function () {
@@ -241,21 +241,21 @@ describe('transaction', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.amount = 4000;
 
-			expect(transactionLogic.getId(transaction)).to.not.equal(id);
+			transactionLogic.getId(transaction).should.not.equal(id);
 		});
 	});
 
 	describe('getHash', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.getHash).to.throw();
+			transactionLogic.getHash.should.throw();
 		});
 
 		it('should return hash for transaction', function () {
 			var transaction = validTransaction;
 			var expectedHash = '5164ef55fccefddf72360ea6e05f19eed7c8d2653c5069df4db899c47246dd2f';
 
-			expect(transactionLogic.getHash(transaction).toString('hex')).to.be.a('string').which.is.equal(expectedHash);
+			transactionLogic.getHash(transaction).toString('hex').should.be.a('string').which.is.equal(expectedHash);
 		});
 
 		it('should update hash if a field is transaction value changes', function () {
@@ -263,41 +263,41 @@ describe('transaction', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.amount = 4000;
 
-			expect(transactionLogic.getHash(transaction).toString('hex')).to.not.equal(originalTransactionHash);
+			transactionLogic.getHash(transaction).toString('hex').should.not.equal(originalTransactionHash);
 		});
 	});
 
 	describe('getBytes', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.getBytes).to.throw();
+			transactionLogic.getBytes.should.throw();
 		});
 
 		it('should return same result when called multiple times (without data field)', function () {
 			var firstCalculation = transactionLogic.getBytes(validTransaction);
 			var secondCalculation = transactionLogic.getBytes(validTransaction);
 
-			expect(firstCalculation.equals(secondCalculation)).to.be.ok;
+			firstCalculation.equals(secondCalculation).should.be.ok;
 		});
 
 		it('should return same result of getBytes using /logic/transaction and lisk-js package (without data field)', function () {
 			var transactionBytesFromLogic = transactionLogic.getBytes(validTransaction);
 			var transactionBytesFromLiskJs = lisk.crypto.getBytes(validTransaction);
 
-			expect(transactionBytesFromLogic.equals(transactionBytesFromLiskJs)).to.be.ok;
+			transactionBytesFromLogic.equals(transactionBytesFromLiskJs).should.be.ok;
 		});
 
 		it('should skip signature, second signature for getting bytes', function () {
 			var transactionBytes = transactionLogic.getBytes(validTransaction, true);
 
-			expect(transactionBytes.length).to.equal(53);
+			transactionBytes.length.should.equal(53);
 		});
 	});
 
 	describe('ready', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.ready).to.throw();
+			transactionLogic.ready.should.throw();
 		});
 
 		it('should throw error when transaction type is invalid', function () {
@@ -305,38 +305,38 @@ describe('transaction', function () {
 			var invalidTransactionType = -1;
 			transaction.type = invalidTransactionType;
 
-			expect(function () {
+			(function () {
 				transactionLogic.ready(transaction, sender);
-			}).to.throw('Unknown transaction type ' + invalidTransactionType);
+			}).should.throw('Unknown transaction type ' + invalidTransactionType);
 		});
 
 		it('should return false when sender not provided', function () {
-			expect(transactionLogic.ready(validTransaction)).to.equal(false);
+			transactionLogic.ready(validTransaction).should.equal(false);
 		});
 
 		it('should return true for valid transaction and sender', function () {
-			expect(transactionLogic.ready(validTransaction, sender)).to.equal(true);
+			transactionLogic.ready(validTransaction, sender).should.equal(true);
 		});
 	});
 
 	describe('countById', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.countById).to.throw();
+			transactionLogic.countById.should.throw();
 		});
 
 		it('should return count of transaction in db with transaction id', function (done) {
 			transactionLogic.countById(validTransaction, function (err, count) {
-				expect(err).to.not.exist;
-				expect(count).to.equal(0);
+				should.not.exist(err);
+				count.should.equal(0);
 				done();
 			});
 		});
 
 		it('should return 1 for transaction from genesis block', function (done) {
 			transactionLogic.countById(genesisTransaction, function (err, count) {
-				expect(err).to.not.exist;
-				expect(count).to.equal(1);
+				should.not.exist(err);
+				count.should.equal(1);
 				done();
 			});
 		});
@@ -345,14 +345,14 @@ describe('transaction', function () {
 	describe('checkConfirmed', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.checkConfirmed).to.throw();
+			transactionLogic.checkConfirmed.should.throw();
 		});
 
 		it('should not return error when transaction is not confirmed', function (done) {
 			var transaction = lisk.transaction.createTransaction(transactionData.recipientId, transactionData.amount, transactionData.secret);
 
 			transactionLogic.checkConfirmed(transaction, function (err) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				done();
 			});
 		});
@@ -363,7 +363,7 @@ describe('transaction', function () {
 			};
 
 			transactionLogic.checkConfirmed(dummyConfirmedTransaction, function (err) {
-				expect(err).to.include('Transaction is already confirmed');
+				err.should.include('Transaction is already confirmed');
 				done();
 			});
 		});
@@ -372,7 +372,7 @@ describe('transaction', function () {
 	describe('checkBalance', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.checkBalance).to.throw();
+			transactionLogic.checkBalance.should.throw();
 		});
 
 		it('should return error when sender has insufficiant balance', function () {
@@ -380,8 +380,8 @@ describe('transaction', function () {
 			var balanceKey = 'balance';
 			var res = transactionLogic.checkBalance(amount, balanceKey, validTransaction, sender);
 
-			expect(res.exceeded).to.equal(true);
-			expect(res.error).to.include('Account does not have enough LSK:');
+			res.exceeded.should.equal(true);
+			res.error.should.include('Account does not have enough LSK:');
 		});
 
 		it('should be okay if insufficient balance from genesis account', function () {
@@ -389,28 +389,28 @@ describe('transaction', function () {
 			var balanceKey = 'balance';
 			var res = transactionLogic.checkBalance(amount, balanceKey, genesisTransaction, sender);
 
-			expect(res.exceeded).to.equal(false);
-			expect(res.error).to.not.exist;
+			res.exceeded.should.equal(false);
+			should.not.exist(res.error);
 		});
 
 		it('should be okay if sender has sufficient balance', function () {
 			var balanceKey = 'balance';
 			var res = transactionLogic.checkBalance(validTransaction.amount, balanceKey, validTransaction, sender);
 
-			expect(res.exceeded).to.equal(false);
-			expect(res.error).to.not.exist;
+			res.exceeded.should.equal(false);
+			should.not.exist(res.error);
 		});
 	});
 
 	describe('process', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.process).to.throw();
+			transactionLogic.process.should.throw();
 		});
 
 		it('should return error sender is not supplied', function (done) {
 			transactionLogic.process(validTransaction, null, function (err, res) {
-				expect(err).to.equal('Missing sender');
+				err.should.equal('Missing sender');
 				done();
 			});
 		});
@@ -420,7 +420,7 @@ describe('transaction', function () {
 			transaction.id = 'invalid transaction id';
 
 			transactionLogic.process(transaction, sender, function (err, res) {
-				expect(err).to.equal('Invalid transaction id');
+				err.should.equal('Invalid transaction id');
 				done();
 			});
 		});
@@ -431,16 +431,16 @@ describe('transaction', function () {
 			};
 
 			transactionLogic.process(transaction, sender, function (err, res) {
-				expect(err).to.equal('Failed to get transaction id');
+				err.should.equal('Failed to get transaction id');
 				done();
 			});
 		});
 
 		it('should process the transaction', function (done) {
 			transactionLogic.process(validTransaction, sender, function (err, res) {
-				expect(err).to.not.be.ok;
-				expect(res).to.be.an('object');
-				expect(res.senderId).to.be.a('string').which.is.equal(sender.address);
+				should.not.exist(err);
+				res.should.be.an('object');
+				res.senderId.should.be.a('string').which.is.equal(sender.address);
 				done();
 			});
 		});
@@ -458,7 +458,7 @@ describe('transaction', function () {
 
 		it('should return error when sender is missing', function (done) {
 			transactionLogic.verify(validTransaction, null, {}, function (err) {
-				expect(err).to.equal('Missing sender');
+				err.should.equal('Missing sender');
 				done();
 			});
 		});
@@ -468,7 +468,7 @@ describe('transaction', function () {
 			transaction.type = -1;
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.include('Unknown transaction type');
+				err.should.include('Unknown transaction type');
 				done();
 			});
 		});
@@ -479,7 +479,7 @@ describe('transaction', function () {
 			vs.secondSignature = '839eba0f811554b9f935e39a68b3078f90bea22c5424d3ad16630f027a48362f78349ddc3948360045d6460404f5bc8e25b662d4fd09e60c89453776962df40d';
 
 			transactionLogic.verify(transaction, vs, {}, function (err) {
-				expect(err).to.include('Missing sender second signature');
+				err.should.include('Missing sender second signature');
 				done();
 			});
 		});
@@ -489,7 +489,7 @@ describe('transaction', function () {
 			transaction.signSignature = [transactionLogic.sign(validKeypair, transaction)];
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.include('Sender does not have a second signature');
+				err.should.include('Sender does not have a second signature');
 				done();
 			});
 		});
@@ -502,7 +502,7 @@ describe('transaction', function () {
 			transaction.requesterPublicKey = '839eba0f811554b9f935e39a68b3078f90bea22c5424d3ad16630f027a48362f78349ddc3948360045d6460404f5bc8e25b662d4fd09e60c89453776962df40d';
 
 			transactionLogic.verify(transaction, sender, dummyRequester, function (err) {
-				expect(err).to.include('Missing requester second signature');
+				err.should.include('Missing requester second signature');
 				done();
 			});
 		});
@@ -513,7 +513,7 @@ describe('transaction', function () {
 			transaction.senderPublicKey = invalidPublicKey;
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.include(['Invalid sender public key:', invalidPublicKey, 'expected:', sender.publicKey].join(' '));
+				err.should.include(['Invalid sender public key:', invalidPublicKey, 'expected:', sender.publicKey].join(' '));
 				done();
 			});
 		});
@@ -526,7 +526,7 @@ describe('transaction', function () {
 			vs.publicKey = 'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8';
 
 			transactionLogic.verify(transaction, vs, {}, function (err) {
-				expect(err).to.include('Invalid sender. Can not send from genesis account');
+				err.should.include('Invalid sender. Can not send from genesis account');
 				done();
 			});
 		});
@@ -536,7 +536,7 @@ describe('transaction', function () {
 			transaction.senderId = '2581762640681118072L';
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.include('Invalid sender address');
+				err.should.include('Invalid sender address');
 				done();
 			});
 		});
@@ -551,7 +551,7 @@ describe('transaction', function () {
 			transaction.signature = transactionLogic.sign(validKeypair, transaction);
 
 			transactionLogic.verify(transaction, vs, {}, function (err) {
-				expect(err).to.equal('Account does not belong to multisignature group');
+				err.should.equal('Account does not belong to multisignature group');
 				done();
 			});
 		});
@@ -562,7 +562,7 @@ describe('transaction', function () {
 			transaction.signature = transactionLogic.sign(validKeypair, transaction);
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.equal('Failed to verify signature');
+				err.should.equal('Failed to verify signature');
 				done();
 			});
 		});
@@ -575,7 +575,7 @@ describe('transaction', function () {
 			transaction.signatures = Array.apply(null, Array(2)).map(function () { return transactionLogic.sign(validKeypair, transaction); });
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transactionLogic.verify(transaction, vs, {}, function (err) {
-				expect(err).to.equal('Encountered duplicate signature in transaction');
+				err.should.equal('Encountered duplicate signature in transaction');
 				done();
 			});
 		});
@@ -591,7 +591,7 @@ describe('transaction', function () {
 			transaction.signature = transactionLogic.sign(validKeypair, transaction);
 
 			transactionLogic.verify(transaction, vs, {}, function (err) {
-				expect(err).to.equal('Failed to verify multisignature');
+				err.should.equal('Failed to verify multisignature');
 				done();
 			});
 		});
@@ -605,7 +605,7 @@ describe('transaction', function () {
 			transaction.signatures = [transactionLogic.multisign(validKeypair, transaction)];
 
 			transactionLogic.verify(transaction, vs, {}, function (err) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				done();
 			});
 		});
@@ -622,7 +622,7 @@ describe('transaction', function () {
 			createAndProcess(transactionDataClone, vs, function (err, transaction) {
 				transaction.signSignature = '7af5f0ee2c4d4c83d6980a46efe31befca41f7aa8cda5f7b4c2850e4942d923af058561a6a3312005ddee566244346bdbccf004bc8e2c84e653f9825c20be008';
 				transactionLogic.verify(transaction, vs, function (err) {
-					expect(err).to.equal('Failed to verify second signature');
+					err.should.equal('Failed to verify second signature');
 					done();
 				});
 			});
@@ -639,7 +639,7 @@ describe('transaction', function () {
 
 			createAndProcess(transactionDataClone, vs, function (err, transaction) {
 				transactionLogic.verify(transaction, vs, {}, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					done();
 				});
 			});
@@ -650,7 +650,7 @@ describe('transaction', function () {
 			transaction.fee = -100;
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.include('Invalid transaction fee');
+				err.should.include('Invalid transaction fee');
 				done();
 			});
 		});
@@ -663,14 +663,14 @@ describe('transaction', function () {
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should verify transaction with correct fee (without data field)', function (done) {
 			transactionLogic.verify(validTransaction, sender, {}, function (err) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				done();
 			});
 		});
@@ -681,7 +681,7 @@ describe('transaction', function () {
 
 			createAndProcess(transactionDataClone, sender, function (err, transaction) {
 				transactionLogic.verify(transaction, sender, {}, function (err) {
-					expect(err).to.include('Invalid transaction amount');
+					err.should.include('Invalid transaction amount');
 					done();
 				});
 			});
@@ -693,7 +693,7 @@ describe('transaction', function () {
 
 			createAndProcess(transactionDataClone, sender, function (err, transaction) {
 				transactionLogic.verify(transaction, sender, {}, function (err) {
-					expect(err).to.include('Account does not have enough LSK:');
+					err.should.include('Account does not have enough LSK:');
 					done();
 				});
 			});
@@ -707,27 +707,27 @@ describe('transaction', function () {
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 
 			transactionLogic.verify(transaction, sender, {}, function (err) {
-				expect(err).to.include('Invalid transaction timestamp');
+				err.should.include('Invalid transaction timestamp');
 				done();
 			});
 		});
 
 		it('should verify proper transaction with proper sender', function (done) {
 			transactionLogic.verify(validTransaction, sender, {}, function (err) {
-				expect(err).to.not.be.ok;
+				should.not.exist(err);
 				done();
 			});
 		});
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.verify).to.throw();
+			transactionLogic.verify.should.throw();
 		});
 	});
 
 	describe('verifySignature', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.verifySignature).to.throw();
+			transactionLogic.verifySignature.should.throw();
 		});
 
 		it('should return false if transaction is changed', function () {
@@ -735,67 +735,67 @@ describe('transaction', function () {
 			// change transaction value
 			transaction.amount = 1001;
 
-			expect(transactionLogic.verifySignature(transaction, sender.publicKey, transaction.signature)).to.equal(false);
+			transactionLogic.verifySignature(transaction, sender.publicKey, transaction.signature).should.equal(false);
 		});
 
 		it('should return false if signature not provided', function () {
-			expect(transactionLogic.verifySignature(validTransaction, sender.publicKey, null)).to.equal(false);
+			transactionLogic.verifySignature(validTransaction, sender.publicKey, null).should.equal(false);
 		});
 
 		it('should return valid signature for correct transaction', function () {
-			expect(transactionLogic.verifySignature(validTransaction, sender.publicKey, validTransaction.signature)).to.equal(true);
+			transactionLogic.verifySignature(validTransaction, sender.publicKey, validTransaction.signature).should.equal(true);
 		});
 
 		it('should throw if public key is invalid', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			var invalidPublicKey = '123123123';
 
-			expect(function () {
+			(function () {
 				transactionLogic.verifySignature(transaction, invalidPublicKey, transaction.signature);
-			}).to.throw();
+			}).should.throw();
 		});
 	});
 
 	describe('verifySecondSignature', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.verifySecondSignature).to.throw();
+			transactionLogic.verifySecondSignature.should.throw();
 		});
 
 		it('should verify the second signature correctly', function () {
 			var signature = transactionLogic.sign(validKeypair, validTransaction);
 
-			expect(transactionLogic.verifySecondSignature(validTransaction, validKeypair.publicKey.toString('hex'), signature)).to.equal(true);
+			transactionLogic.verifySecondSignature(validTransaction, validKeypair.publicKey.toString('hex'), signature).should.equal(true);
 		});
 	});
 
 	describe('verifyBytes', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.verifyBytes).to.throw();
+			transactionLogic.verifyBytes.should.throw();
 		});
 
 		it('should return when sender public is different', function () {
 			var transactionBytes = transactionLogic.getBytes(validTransaction);
 			var invalidPublicKey = 'addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9';
 
-			expect(transactionLogic.verifyBytes(transactionBytes, invalidPublicKey, validTransaction.signature)).to.equal(false);
+			transactionLogic.verifyBytes(transactionBytes, invalidPublicKey, validTransaction.signature).should.equal(false);
 		});
 
 		it('should throw when publickey is not in the right format', function () {
 			var transactionBytes = transactionLogic.getBytes(validTransaction);
 			var invalidPublicKey = 'iddb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9';
 
-			expect(function () {
+			(function () {
 				transactionLogic.verifyBytes(transactionBytes, invalidPublicKey, validTransaction.signature);
-			}).to.throw();
+			}).should.throw();
 		});
 
 		it('should be okay for valid bytes', function () {
 			var transactionBytes = transactionLogic.getBytes(validTransaction, true, true);
 			var res = transactionLogic.verifyBytes(transactionBytes, validTransaction.senderPublicKey, validTransaction.signature);
 
-			expect(res).to.equal(true);
+			res.should.equal(true);
 		});
 	});
 
@@ -811,7 +811,7 @@ describe('transaction', function () {
 		}
 
 		it('should throw an error with no param', function () {
-			expect(function () { transactionLogic.apply(); }).to.throw();
+			(function () { transactionLogic.apply(); }).should.throw();
 		});
 
 		it('should be okay with valid params', function (done) {
@@ -823,7 +823,7 @@ describe('transaction', function () {
 			transaction.amount = '9850458911801908';
 
 			transactionLogic.apply(transaction, dummyBlock, sender, function (err) {
-				expect(err).to.include('Account does not have enough ');
+				err.should.include('Account does not have enough ');
 				done();
 			});
 		});
@@ -835,11 +835,11 @@ describe('transaction', function () {
 
 				transactionLogic.apply(validTransaction, dummyBlock, sender, function (err) {
 					accountModule.getAccount({publicKey: validTransaction.senderPublicKey}, function (err, accountAfter) {
-						expect(err).to.not.exist;
+						should.not.exist(err);
 						var balanceAfter = new bignum(accountAfter.balance.toString());
 
-						expect(err).to.not.exist;
-						expect(balanceAfter.plus(amount).toString()).to.equal(balanceBefore.toString());
+						should.not.exist(err);
+						balanceAfter.plus(amount).toString().should.equal(balanceBefore.toString());
 						undoTransaction(validTransaction, sender, done);
 					});
 				});
@@ -859,7 +859,7 @@ describe('transaction', function () {
 		}
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.undo).to.throw();
+			transactionLogic.undo.should.throw();
 		});
 
 		it('should not update sender balance when transaction is invalid', function (done) {
@@ -874,8 +874,8 @@ describe('transaction', function () {
 					accountModule.getAccount({publicKey: transaction.senderPublicKey}, function (err, accountAfter) {
 						var balanceAfter = new bignum(accountAfter.balance.toString());
 
-						expect(balanceBefore.plus(amount.mul(2)).toString()).to.not.equal(balanceAfter.toString());
-						expect(balanceBefore.toString()).to.equal(balanceAfter.toString());
+						balanceBefore.plus(amount.mul(2)).toString().should.not.equal(balanceAfter.toString());
+						balanceBefore.toString().should.equal(balanceAfter.toString());
 						done();
 					});
 				});
@@ -893,8 +893,8 @@ describe('transaction', function () {
 					accountModule.getAccount({publicKey: transaction.senderPublicKey}, function (err, accountAfter) {
 						var balanceAfter = new bignum(accountAfter.balance.toString());
 
-						expect(err).to.not.exist;
-						expect(balanceBefore.plus(amount).toString()).to.equal(balanceAfter.toString());
+						should.not.exist(err);
+						balanceBefore.plus(amount).toString().should.equal(balanceAfter.toString());
 						applyTransaction(transaction, sender, done);
 					});
 				});
@@ -909,7 +909,7 @@ describe('transaction', function () {
 		}
 
 		it('should throw an error with no param', function () {
-			expect(function () { transactionLogic.applyUnconfirmed(); }).to.throw();
+			(function () { transactionLogic.applyUnconfirmed(); }).should.throw();
 		});
 
 		it('should be okay with valid params', function (done) {
@@ -922,14 +922,14 @@ describe('transaction', function () {
 			transaction.amount = '9850458911801908';
 
 			transactionLogic.applyUnconfirmed(transaction, sender, function (err) {
-				expect(err).to.include('Account does not have enough ');
+				err.should.include('Account does not have enough ');
 				done();
 			});
 		});
 
 		it('should okay for valid params', function (done) {
 			transactionLogic.applyUnconfirmed(validTransaction, sender, function (err) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				undoUnconfirmedTransaction(validTransaction, sender, done);
 			});
 		});
@@ -942,12 +942,12 @@ describe('transaction', function () {
 		}
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.undoUnconfirmed).to.throw();
+			transactionLogic.undoUnconfirmed.should.throw();
 		});
 
 		it('should be okay with valid params', function (done) {
 			transactionLogic.undoUnconfirmed(validTransaction, sender, function (err) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 				applyUnconfirmedTransaction(validTransaction, sender, done);
 			});
 		});
@@ -956,7 +956,7 @@ describe('transaction', function () {
 	describe('afterSave', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.afterSave).to.throw();
+			transactionLogic.afterSave.should.throw();
 		});
 
 		it('should invoke the passed callback', function (done) {
@@ -967,18 +967,18 @@ describe('transaction', function () {
 	describe('objectNormalize', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.objectNormalize).to.throw();
+			transactionLogic.objectNormalize.should.throw();
 		});
 
 		it('should remove keys with null or undefined attribute', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.amount = null;
 
-			expect(_.keys(transactionLogic.objectNormalize(transaction))).to.not.include('amount');
+			_.keys(transactionLogic.objectNormalize(transaction)).should.not.include('amount');
 		});
 
 		it('should not remove any keys with valid entries', function () {
-			expect(_.keys(transactionLogic.objectNormalize(validTransaction))).to.have.length(11);
+			_.keys(transactionLogic.objectNormalize(validTransaction)).should.have.length(11);
 		});
 
 		it('should not remove data field after normalization', function () {
@@ -988,7 +988,7 @@ describe('transaction', function () {
 			};
 			var normalizedTransaction = transactionLogic.objectNormalize(transaction);
 
-			expect(normalizedTransaction).to.have.property('asset').which.is.eql(transaction.asset);
+			normalizedTransaction.should.have.property('asset').which.is.eql(transaction.asset);
 		});
 
 		it('should throw error for invalid schema types', function () {
@@ -996,24 +996,24 @@ describe('transaction', function () {
 			transaction.amount = 'Invalid value';
 			transaction.data = 124;
 
-			expect(function () {
+			(function () {
 				transactionLogic.objectNormalize(transaction);
-			}).to.throw();
+			}).should.throw();
 		});
 	});
 
 	describe('dbRead', function () {
 
 		it('should throw an error with no param', function () {
-			expect(transactionLogic.dbRead).to.throw();
+			transactionLogic.dbRead.should.throw();
 		});
 
 		it('should return transaction object with data field', function () {
 			var rawTransactionClone = _.cloneDeep(rawTransaction);
 			var transactionFromDb = transactionLogic.dbRead(rawTransactionClone);
 
-			expect(transactionFromDb).to.be.an('object');
-			expect(transactionFromDb.asset).to.have.property('data');
+			transactionFromDb.should.be.an('object');
+			transactionFromDb.asset.should.have.property('data');
 		});
 
 		it('should return null if id field is not present', function () {
@@ -1022,7 +1022,7 @@ describe('transaction', function () {
 
 			var transaction = transactionLogic.dbRead(rawTransactionClone);
 
-			expect(transaction).to.be.a('null');
+			should.not.exist(transaction);
 		});
 
 		it('should return transaction object with correct fields', function () {
@@ -1047,9 +1047,9 @@ describe('transaction', function () {
 				'asset'
 			];
 
-			expect(transaction).to.be.an('object');
-			expect(transaction).to.have.keys(expectedKeys);
-			expect(transaction.asset).to.have.property('data').which.is.equal(rawTransaction.tf_data);
+			transaction.should.be.an('object');
+			transaction.should.have.keys(expectedKeys);
+			transaction.asset.should.have.property('data').which.is.equal(rawTransaction.tf_data);
 		});
 	});
 });

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -53,22 +53,22 @@ describe('txPool', function () {
 
 		it('should return empty array when using empty array', function (done) {
 			txPool.receiveTransactions([], false, function (err, data) {
-				expect(err).to.not.exist;
-				expect(data).to.be.an('array').that.is.empty;
+				should.not.exist(err);
+				data.should.be.an('array').that.is.empty;
 				done();
 			});
 		});
 
 		it('should return error when using empty object', function (done) {
 			txPool.receiveTransactions([{}], false, function (err) {
-				expect(err).to.equal('Invalid public key');
+				err.should.equal('Invalid public key');
 				done();
 			});
 		});
 
 		it('should return error when using invalid transaction', function (done) {
 			txPool.receiveTransactions([{ id: '123' }], false, function (err) {
-				expect(err).to.exist;
+				err.should.exist;
 				done();
 			});
 		});
@@ -78,8 +78,8 @@ describe('txPool', function () {
 			var transaction = lisk.transaction.createTransaction(account.address, 100000000000, accountFixtures.genesis.password);
 
 			txPool.receiveTransactions([transaction], false, function (err) {
-				expect(err).to.not.exist;
-				expect(txPool.transactionInPool(transaction.id)).to.be.true;
+				should.not.exist(err);
+				txPool.transactionInPool(transaction.id).should.be.true;
 				done();
 			});
 		});
@@ -88,7 +88,7 @@ describe('txPool', function () {
 	describe('transactionInPool', function () {
 
 		it('should return false for an unknown id', function () {
-			expect(txPool.transactionInPool('11111')).to.be.false;
+			txPool.transactionInPool('11111').should.be.false;
 		});
 	});
 });

--- a/test/unit/logic/transfer.js
+++ b/test/unit/logic/transfer.js
@@ -129,9 +129,9 @@ describe('transfer', function () {
 	describe('bind', function () {
 
 		it('should be okay with correct params', function () {
-			expect(function () {
+			(function () {
 				transfer.bind(transferBindings.account);
-			}).to.not.throw();
+			}).should.not.throw();
 		});
 
 		after(function () {
@@ -142,11 +142,11 @@ describe('transfer', function () {
 	describe('calculateFee', function () {
 
 		it('should throw error if given no params', function () {
-			expect(transfer.calculateFee).to.throw();
+			transfer.calculateFee.should.throw();
 		});
 
 		it('should return the correct fee when data field is not set', function () {
-			expect(transfer.calculateFee.call(transactionLogic, validTransaction)).to.equal(constants.fees.send);
+			transfer.calculateFee.call(transactionLogic, validTransaction).should.equal(constants.fees.send);
 		});
 
 		it('should return the correct fee when data field is set', function () {
@@ -155,7 +155,7 @@ describe('transfer', function () {
 				data: '0'
 			};
 
-			expect(transfer.calculateFee.call(transactionLogic, transaction)).to.equal(constants.fees.send + constants.fees.data);
+			transfer.calculateFee.call(transactionLogic, transaction).should.equal(constants.fees.send + constants.fees.data);
 		});
 	});
 
@@ -166,7 +166,7 @@ describe('transfer', function () {
 			delete transaction.recipientId;
 
 			transfer.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Missing recipient');
+				err.should.equal('Missing recipient');
 				done();
 			});
 		});
@@ -176,7 +176,7 @@ describe('transfer', function () {
 			transaction.amount = -10;
 
 			transfer.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Invalid transaction amount');
+				err.should.equal('Invalid transaction amount');
 				done();
 			});
 		});
@@ -196,7 +196,7 @@ describe('transfer', function () {
 	describe('getBytes', function () {
 
 		it('should return null for empty asset', function () {
-			expect(transfer.getBytes(validTransaction)).to.eql(null);
+			should.not.exist(transfer.getBytes(validTransaction));
 		});
 
 		it('should return bytes of data asset', function () {
@@ -206,7 +206,7 @@ describe('transfer', function () {
 				data: data
 			};
 
-			expect(transfer.getBytes(transaction)).to.eql(Buffer.from(data, 'utf8'));
+			transfer.getBytes(transaction).should.eql(Buffer.from(data, 'utf8'));
 		});
 
 		it('should be okay for utf-8 data value', function () {
@@ -216,7 +216,7 @@ describe('transfer', function () {
 				data: data
 			};
 
-			expect(transfer.getBytes(transaction)).to.eql(Buffer.from(data, 'utf8'));
+			transfer.getBytes(transaction).should.eql(Buffer.from(data, 'utf8'));
 		});
 	});
 
@@ -235,28 +235,28 @@ describe('transfer', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			delete transaction.recipientId;
 			transfer.apply.call(transactionLogic, transaction, dummyBlock, validSender, function (err) {
-				expect(err).to.equal('Invalid public key');
+				err.should.equal('Invalid public key');
 				done();
 			});
 		});
 
 		it('should be okay for a valid transaction', function (done) {
 			accountModule.getAccount({address: validTransaction.recipientId}, function (err, accountBefore) {
-				expect(err).to.not.exist;
-				expect(accountBefore).to.exist;
+				should.not.exist(err);
+				accountBefore.should.exist;
 
 				var amount = new bignum(validTransaction.amount.toString());
 				var balanceBefore = new bignum(accountBefore.balance.toString());
 
 				transfer.apply.call(transactionLogic, validTransaction, dummyBlock, validSender, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 
 					accountModule.getAccount({address: validTransaction.recipientId}, function (err, accountAfter) {
-						expect(err).to.not.exist;
-						expect(accountAfter).to.exist;
+						should.not.exist(err);
+						accountAfter.should.exist;
 
 						var balanceAfter = new bignum(accountAfter.balance.toString());
-						expect(balanceBefore.plus(amount).toString()).to.equal(balanceAfter.toString());
+						balanceBefore.plus(amount).toString().should.equal(balanceAfter.toString());
 						undoTransaction(validTransaction, validSender, done);
 					});
 				});
@@ -280,26 +280,26 @@ describe('transfer', function () {
 			delete transaction.recipientId;
 
 			transfer.undo.call(transactionLogic, transaction, dummyBlock, validSender, function (err) {
-				expect(err).to.equal('Invalid public key');
+				err.should.equal('Invalid public key');
 				done();
 			});
 		});
 
 		it('should be okay for a valid transaction', function (done) {
 			accountModule.getAccount({address: validTransaction.recipientId}, function (err, accountBefore) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 
 				var amount = new bignum(validTransaction.amount.toString());
 				var balanceBefore = new bignum(accountBefore.balance.toString());
 
 				transfer.undo.call(transactionLogic, validTransaction, dummyBlock, validSender, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 
 					accountModule.getAccount({address: validTransaction.recipientId}, function (err, accountAfter) {
 						var balanceAfter = new bignum(accountAfter.balance.toString());
 
-						expect(err).to.not.exist;
-						expect(balanceAfter.plus(amount).toString()).to.equal(balanceBefore.toString());
+						should.not.exist(err);
+						balanceAfter.plus(amount).toString().should.equal(balanceBefore.toString());
 						applyTransaction(validTransaction, validSender, done);
 					});
 				});
@@ -327,7 +327,7 @@ describe('transfer', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.blockId = '9314232245035524467';
 
-			expect(transfer.objectNormalize(transaction)).to.not.have.key('blockId');
+			transfer.objectNormalize(transaction).should.not.have.key('blockId');
 		});
 
 		it('should not remove data field', function () {
@@ -336,7 +336,7 @@ describe('transfer', function () {
 				data: '123'
 			};
 
-			expect(transfer.objectNormalize(transaction).asset).to.eql(transaction.asset);
+			transfer.objectNormalize(transaction).asset.should.eql(transaction.asset);
 		});
 
 		it('should throw error if value is null', function () {
@@ -345,9 +345,9 @@ describe('transfer', function () {
 				data: null
 			};
 
-			expect(function () {
+			(function () {
 				transfer.objectNormalize(transaction);
-			}).to.throw('Failed to validate transfer schema: Expected type string but found type null');
+			}).should.throw('Failed to validate transfer schema: Expected type string but found type null');
 		});
 
 		it('should throw error if value is undefined', function () {
@@ -356,9 +356,9 @@ describe('transfer', function () {
 				data: undefined
 			};
 
-			expect(function () {
+			(function () {
 				transfer.objectNormalize(transaction);
-			}).to.throw('Failed to validate transfer schema: Expected type string but found type undefined');
+			}).should.throw('Failed to validate transfer schema: Expected type string but found type undefined');
 		});
 
 		it('should throw error if data field length is greater than ' + constants.additionalData.maxLength +  ' characters', function () {
@@ -368,9 +368,9 @@ describe('transfer', function () {
 				data: invalidString
 			};
 
-			expect(function () {
+			(function () {
 				transfer.objectNormalize(transaction);
-			}).to.throw('Failed to validate transfer schema: Object didn\'t pass validation for format additionalData: ' + invalidString);
+			}).should.throw('Failed to validate transfer schema: Object didn\'t pass validation for format additionalData: ' + invalidString);
 		});
 
 		it('should throw error if data field length is greater than ' + constants.additionalData.maxLength + ' bytes', function () {
@@ -380,16 +380,16 @@ describe('transfer', function () {
 				data: invalidString
 			};
 
-			expect(function () {
+			(function () {
 				transfer.objectNormalize(transaction);
-			}).to.throw('Failed to validate transfer schema: Object didn\'t pass validation for format additionalData: ' + invalidString);
+			}).should.throw('Failed to validate transfer schema: Object didn\'t pass validation for format additionalData: ' + invalidString);
 		});
 	});
 
 	describe('dbRead', function () {
 
 		it('should return null when data field is not set', function () {
-			expect(transfer.dbRead(rawValidTransaction)).to.eql(null);
+			should.not.exist(transfer.dbRead(rawValidTransaction));
 		});
 
 		it('should be okay when data field is set', function () {
@@ -397,7 +397,7 @@ describe('transfer', function () {
 			var data = '123';
 			rawTransaction.tf_data = data;
 
-			expect(transfer.dbRead(rawTransaction)).to.eql({
+			transfer.dbRead(rawTransaction).should.eql({
 				data: data
 			});
 		});
@@ -406,7 +406,7 @@ describe('transfer', function () {
 	describe('ready', function () {
 
 		it('should return true for single signature transaction', function () {
-			expect(transfer.ready(validTransaction, validSender)).to.equal(true);
+			transfer.ready(validTransaction, validSender).should.equal(true);
 		});
 
 		it('should return false for multi signature transaction with less signatures', function () {
@@ -414,7 +414,7 @@ describe('transfer', function () {
 			var vs = _.cloneDeep(validSender);
 			vs.multisignatures = [validKeypair.publicKey.toString('hex')];
 
-			expect(transactionLogic.ready(transaction, vs)).to.equal(false);
+			transactionLogic.ready(transaction, vs).should.equal(false);
 		});
 
 		it('should return true for multi signature transaction with alteast min signatures', function () {
@@ -427,7 +427,7 @@ describe('transfer', function () {
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transaction.signatures = [transactionLogic.multisign(validKeypair, transaction)];
 
-			expect(transactionLogic.ready(transaction, vs)).to.equal(true);
+			transactionLogic.ready(transaction, vs).should.equal(true);
 		});
 	});
 });

--- a/test/unit/logic/vote.js
+++ b/test/unit/logic/vote.js
@@ -124,12 +124,12 @@ describe('vote', function () {
 				return groupedVotes['+'] && groupedVotes['+'].indexOf('+' + v) != -1;
 			});
 			// added one because expect doesn't have greaterThanEqualTo condition
-			expect(delegates.filter(function (v) {
+			(delegates.filter(function (v) {
 				return groupedVotes['+'] && groupedVotes['+'].indexOf('+' + v) != -1;
-			}).length + 1).to.be.above(groupedVotes['+'] ? groupedVotes['+'].length : 0);
-			expect(delegates.filter(function (v) {
+			}).length + 1).should.be.above(groupedVotes['+'] ? groupedVotes['+'].length : 0);
+			delegates.filter(function (v) {
 				return groupedVotes['-'] && groupedVotes['-'].indexOf('-' + v) != -1;
-			}).length).to.equal(0);
+			}).length.should.equal(0);
 			done();
 		});
 	}
@@ -203,9 +203,9 @@ describe('vote', function () {
 	describe('bind', function () {
 
 		it('should be okay with correct params', function () {
-			expect(function () {
+			(function () {
 				vote.bind(voteBindings.delegate);
-			}).to.not.throw();
+			}).should.not.throw();
 		});
 
 		after(function () {
@@ -215,7 +215,7 @@ describe('vote', function () {
 
 	describe('calculateFee', function () {
 		it('should return the correct fee', function () {
-			expect(vote.calculateFee()).to.equal(constants.fees.vote);
+			vote.calculateFee().should.equal(constants.fees.vote);
 		});
 	});
 
@@ -224,7 +224,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.recipientId = accountFixtures.genesis.address;
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Invalid recipient');
+				err.should.equal('Invalid recipient');
 				done();
 			});
 		});
@@ -233,7 +233,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			delete transaction.asset.votes;
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Invalid transaction asset');
+				err.should.equal('Invalid transaction asset');
 				done();
 			});
 		});
@@ -242,7 +242,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = '+' + votedDelegates[0];
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Invalid votes. Must be an array');
+				err.should.equal('Invalid votes. Must be an array');
 				done();
 			});
 		});
@@ -254,7 +254,7 @@ describe('vote', function () {
 			});
 
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Multiple votes for same delegate are not allowed');
+				err.should.equal('Multiple votes for same delegate are not allowed');
 				done();
 			});
 		});
@@ -263,7 +263,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = [];
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Invalid votes. Must not be empty');
+				err.should.equal('Invalid votes. Must not be empty');
 				done();
 			});
 		});
@@ -272,7 +272,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = ['-' + accountFixtures.existingDelegate.publicKey];
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Failed to remove vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" was not voted for');
+				err.should.equal('Failed to remove vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" was not voted for');
 				done();
 			});
 		});
@@ -323,7 +323,7 @@ describe('vote', function () {
 				'-01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398db746'
 			];
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Voting limit exceeded. Maximum is 33 votes per transaction');
+				err.should.equal('Voting limit exceeded. Maximum is 33 votes per transaction');
 				done();
 			});
 		});
@@ -334,7 +334,7 @@ describe('vote', function () {
 				return '+904c294899819cce0283d8d351cb10febfa0e9f0acd90a820ec8eb90a7084c37';
 			});
 			vote.verify(transaction, validSender, function (err) {
-				expect(err).to.equal('Multiple votes for same delegate are not allowed');
+				err.should.equal('Multiple votes for same delegate are not allowed');
 				done();
 			});
 		});
@@ -351,7 +351,7 @@ describe('vote', function () {
 		it('should throw if vote is of invalid length', function (done) {
 			var invalidVote = '-01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d746';
 			vote.verifyVote(invalidVote, function (err) {
-				expect(err).to.equal('Invalid vote format');
+				err.should.equal('Invalid vote format');
 				done();
 			});
 		});
@@ -374,7 +374,7 @@ describe('vote', function () {
 				return '+' + v;
 			});
 			vote.checkConfirmedDelegates(transaction, function (err) {
-				expect(err).to.equal('Failed to add vote, delegate "genesis_99" already voted for');
+				err.should.equal('Failed to add vote, delegate "genesis_99" already voted for');
 				done();
 			});
 		});
@@ -383,7 +383,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = ['+' + accountFixtures.genesis.publicKey];
 			vote.checkConfirmedDelegates(transaction, function (err) {
-				expect(err).to.equal('Delegate not found');
+				err.should.equal('Delegate not found');
 				done();
 			});
 		});
@@ -402,7 +402,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = ['-9f2fcc688518324273da230afff9756312bf23592174896fab669c2d78b1533c'];
 			vote.checkConfirmedDelegates(transaction, function (err) {
-				expect(err).to.equal('Failed to remove vote, delegate "genesis_86" was not voted for');
+				err.should.equal('Failed to remove vote, delegate "genesis_86" was not voted for');
 				done();
 			});
 		});
@@ -424,7 +424,7 @@ describe('vote', function () {
 				return '+' + v;
 			});
 			vote.checkUnconfirmedDelegates(transaction, function (err) {
-				expect(err).to.equal('Failed to add vote, delegate "genesis_99" already voted for');
+				err.should.equal('Failed to add vote, delegate "genesis_99" already voted for');
 
 				done();
 			});
@@ -434,7 +434,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = ['+' + accountFixtures.genesis.publicKey];
 			vote.checkUnconfirmedDelegates(transaction, function (err) {
-				expect(err).to.equal('Delegate not found');
+				err.should.equal('Delegate not found');
 				done();
 			});
 		});
@@ -453,7 +453,7 @@ describe('vote', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes = ['-9f2fcc688518324273da230afff9756312bf23592174896fab669c2d78b1533c'];
 			vote.checkUnconfirmedDelegates(transaction, function (err) {
-				expect(err).to.equal('Failed to remove vote, delegate "genesis_86" was not voted for');
+				err.should.equal('Failed to remove vote, delegate "genesis_86" was not voted for');
 				done();
 			});
 		});
@@ -552,15 +552,15 @@ describe('vote', function () {
 	describe('objectNormalize', function () {
 
 		it('should normalize object for valid transaction', function () {
-			expect(vote.objectNormalize.call(transactionLogic, validTransaction)).to.eql(validTransaction);
+			vote.objectNormalize.call(transactionLogic, validTransaction).should.eql(validTransaction);
 		});
 
 		it('should throw error for duplicate votes in a transaction', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.asset.votes.push(transaction.asset.votes[0]);
-			expect(function () {
+			(function () {
 				vote.objectNormalize.call(transactionLogic, transaction);
-			}).to.throw('Failed to validate vote schema: Array items are not unique (indexes 0 and 3)');
+			}).should.throw('Failed to validate vote schema: Array items are not unique (indexes 0 and 3)');
 		});
 
 		it('should return error when votes array is longer than maximum acceptable', function () {
@@ -568,9 +568,9 @@ describe('vote', function () {
 			transaction.asset.votes = Array.apply(null, Array(constants.maxVotesPerTransaction + 1)).map(function () {
 				return '+' + lisk.crypto.getKeys(randomUtil.password()).publicKey;
 			});
-			expect(function () {
+			(function () {
 				vote.objectNormalize.call(transactionLogic, transaction);
-			}).to.throw('Failed to validate vote schema: Array is too long (34), maximum 33');
+			}).should.throw('Failed to validate vote schema: Array is too long (34), maximum 33');
 		});
 	});
 
@@ -578,31 +578,31 @@ describe('vote', function () {
 
 		it('should read votes correct', function () {
 			var rawVotes = '+9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f,+141b16ac8d5bd150f16b1caa08f689057ca4c4434445e56661831f4e671b7c0a,+3ff32442bb6da7d60c1b7752b24e6467813c9b698e0f278d48c43580da972135';
-			expect(vote.dbRead({
+			vote.dbRead({
 				v_votes: rawVotes
-			})).to.eql({
+			}).should.eql({
 				votes: rawVotes.split(',')
 			});
 		});
 
 		it('should return null if no votes are supplied', function () {
-			expect(vote.dbRead({
+			should.not.exist(vote.dbRead({
 				v_votes: null
-			})).to.eql(null);
+			}));
 		});
 	});
 
 	describe('ready', function () {
 
 		it('should return true for single signature transaction', function () {
-			expect(vote.ready(validTransaction, validSender)).to.equal(true);
+			vote.ready(validTransaction, validSender).should.equal(true);
 		});
 
 		it('should return false for multi signature transaction with less signatures', function () {
 			var transaction = _.cloneDeep(validTransaction);
 			var vs = _.cloneDeep(validSender);
 			vs.multisignatures = [validKeypair.publicKey.toString('hex')];
-			expect(transactionLogic.ready(transaction, vs)).to.equal(false);
+			transactionLogic.ready(transaction, vs).should.equal(false);
 		});
 
 		it('should return true for multi signature transaction with alteast min signatures', function () {
@@ -613,7 +613,7 @@ describe('vote', function () {
 			delete transaction.signature;
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transaction.signatures = [transactionLogic.multisign(validKeypair, transaction)];
-			expect(transactionLogic.ready(transaction, vs)).to.equal(true);
+			transactionLogic.ready(transaction, vs).should.equal(true);
 		});
 	});
 });

--- a/test/unit/modules/accounts.js
+++ b/test/unit/modules/accounts.js
@@ -77,25 +77,25 @@ describe('accounts', function () {
 	describe('constructor', function () {
 
 		it('should throw with no params', function () {
-			expect(function () {
+			(function () {
 				new AccountModule();
-			}).to.throw();
+			}).should.throw();
 		});
 	});
 
 	describe('generateAddressByPublicKey', function () {
 
 		it('should generate correct address for the publicKey provided', function () {
-			expect(accounts.generateAddressByPublicKey(validAccount.publicKey)).to.equal(validAccount.address);
+			accounts.generateAddressByPublicKey(validAccount.publicKey).should.equal(validAccount.address);
 		});
 
 		// TODO: Design a throwable test
 		it.skip('should throw error for invalid publicKey', function () {
 			var invalidPublicKey = 'invalidPublicKey';
 
-			expect(function () {
+			(function () {
 				accounts.generateAddressByPublicKey(invalidPublicKey);
-			}).to.throw('Invalid public key: ', invalidPublicKey);
+			}).should.throw('Invalid public key: ', invalidPublicKey);
 		});
 	});
 
@@ -105,18 +105,18 @@ describe('accounts', function () {
 			var getAccountStub = sinonSandbox.stub(accountLogic, 'get');
 
 			accounts.getAccount({publicKey: validAccount.publicKey});
-			expect(getAccountStub.calledOnce).to.be.ok;
-			expect(getAccountStub.calledWith({address: validAccount.address})).to.be.ok;
+			getAccountStub.calledOnce.should.be.ok;
+			getAccountStub.calledWith({address: validAccount.address}).should.be.ok;
 			getAccountStub.restore();
 			done();
 		});
 
 		it('should get correct account for address', function (done) {
 			accounts.getAccount({address: validAccount.address}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res.address).to.equal(validAccount.address);
-				expect(res.publicKey).to.equal(validAccount.publicKey);
-				expect(res.username).to.equal(validAccount.username);
+				should.not.exist(err);
+				res.address.should.equal(validAccount.address);
+				res.publicKey.should.equal(validAccount.publicKey);
+				res.username.should.equal(validAccount.username);
 				done();
 			});
 		});
@@ -126,11 +126,11 @@ describe('accounts', function () {
 
 		it('should get accounts for the filter provided', function (done) {
 			accounts.getAccounts({secondSignature: 0}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.an('Array');
-				expect(res.filter(function (a) {
+				should.not.exist(err);
+				res.should.be.an('Array');
+				res.filter(function (a) {
 					return a.secondSignature != 0;
-				}).length).to.equal(0);
+				}).length.should.equal(0);
 				done();
 			});
 		});
@@ -139,9 +139,9 @@ describe('accounts', function () {
 			var getAllSpy = sinonSandbox.spy(accountLogic, 'getAll');
 
 			accounts.getAccounts({address : validAccount.address}, function (err, res) {
-				expect(err).to.not.exist;
-				expect(res).to.be.an('Array').to.have.length(1);
-				expect(getAllSpy.withArgs({address : validAccount.address})).to.be.ok;
+				should.not.exist(err);
+				res.should.be.an('Array').to.have.length(1);
+				getAllSpy.withArgs({address : validAccount.address}).should.be.ok;
 				getAllSpy.restore();
 				done();
 			});
@@ -151,14 +151,14 @@ describe('accounts', function () {
 	describe('onBind', function () {
 
 		it('should throw error with empty params', function () {
-			expect(accounts.onBind).to.throw();
+			accounts.onBind.should.throw();
 		});
 	});
 
 	describe('isLoaded', function () {
 
 		it('should return true when modules are loaded', function () {
-			expect(accounts.isLoaded).to.be.ok;
+			accounts.isLoaded.should.be.ok;
 		});
 	});
 
@@ -170,8 +170,8 @@ describe('accounts', function () {
 				accounts.shared.getAccounts({
 					address: randomUtil.account().address
 				}, function (err, res){
-					expect(err).to.not.exist;
-					expect(res).be.an('array').which.has.length(0);
+					should.not.exist(err);
+					res.should.be.an('array').which.has.length(0);
 					done();
 				});
 			});
@@ -180,8 +180,8 @@ describe('accounts', function () {
 				accounts.shared.getAccounts({
 					publicKey: validAccount.publicKey
 				}, function (err, res){
-					expect(err).to.not.exist;
-					expect(res).to.be.an('array');
+					should.not.exist(err);
+					res.should.be.an('array');
 					done();
 				});
 			});
@@ -190,8 +190,8 @@ describe('accounts', function () {
 				accounts.shared.getAccounts({
 					address: validAccount.address
 				}, function (err, res){
-					expect(err).to.not.exist;
-					expect(res).to.be.an('array');
+					should.not.exist(err);
+					res.should.be.an('array');
 					done();
 				});
 			});
@@ -204,10 +204,10 @@ describe('accounts', function () {
 					limit: limit,
 					sort: sort
 				}, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.length(10);
+					should.not.exist(err);
+					res.should.have.length(10);
 					for (var i = 0; i < limit - 1; i++) {
-						expect(new bignum(res[i].balance).gte(new bignum(res[i + 1].balance))).to.equal(true);
+						new bignum(res[i].balance).gte(new bignum(res[i + 1].balance)).should.equal(true);
 					}
 					done();
 				});
@@ -223,10 +223,10 @@ describe('accounts', function () {
 					offset: offset,
 					sort: sort
 				}, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.length(10);
+					should.not.exist(err);
+					res.should.have.length(10);
 					for (var i = 0; i < limit - 1; i++) {
-						expect(new bignum(res[i].balance).gte(new bignum(res[i + 1].balance))).to.equal(true);
+						new bignum(res[i].balance).gte(new bignum(res[i + 1].balance)).should.equal(true);
 					}
 					done();
 				});

--- a/test/unit/modules/blocks.js
+++ b/test/unit/modules/blocks.js
@@ -156,25 +156,25 @@ describe('blocks', function () {
 		it('should logs correctly', function () {
 			var tracker = blocks.utils.getBlockProgressLogger(5, 2, '');
 			tracker.log = sinonSandbox.spy();
-			expect(tracker.applied).to.equals(0);
-			expect(tracker.step).to.equals(2);
+			tracker.applied.should.equals(0);
+			tracker.step.should.equals(2);
 			tracker.applyNext();
-			expect(tracker.log.calledOnce).to.ok;
-			expect(tracker.applied).to.equals(1);
+			tracker.log.calledOnce.should.ok;
+			tracker.applied.should.equals(1);
 			tracker.applyNext();
-			expect(tracker.log.calledTwice).to.not.ok;
-			expect(tracker.applied).to.equals(2);
+			tracker.log.calledTwice.should.not.ok;
+			tracker.applied.should.equals(2);
 			tracker.applyNext();
-			expect(tracker.log.calledTwice).to.ok;
-			expect(tracker.applied).to.equals(3);
+			tracker.log.calledTwice.should.ok;
+			tracker.applied.should.equals(3);
 			tracker.applyNext();
-			expect(tracker.log.calledThrice).to.not.ok;
-			expect(tracker.applied).to.equals(4);
+			tracker.log.calledThrice.should.not.ok;
+			tracker.applied.should.equals(4);
 			tracker.applyNext();
-			expect(tracker.log.calledThrice).to.ok;
-			expect(tracker.applied).to.equals(5);
+			tracker.log.calledThrice.should.ok;
+			tracker.applied.should.equals(5);
 
-			expect(tracker.applyNext.bind(tracker)).to.throw('Cannot apply transaction over the limit: 5');
+			tracker.applyNext.bind(tracker).should.throw('Cannot apply transaction over the limit: 5');
 		});
 	});
 });

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -116,7 +116,7 @@ describe('blocks/process', function () {
 				}
 
 				blocks.lastBlock.set(loadedBlock);
-				expect(loadedBlock.height).to.equal(2);
+				loadedBlock.height.should.equal(2);
 				done();
 			});
 		});
@@ -128,7 +128,7 @@ describe('blocks/process', function () {
 				}
 
 				blocks.lastBlock.set(loadedBlock);
-				expect(loadedBlock.height).to.equal(3);
+				loadedBlock.height.should.equal(3);
 				done();
 			});
 		});
@@ -139,7 +139,7 @@ describe('blocks/process', function () {
 		it('should load block 4 from db and return blockSignature error', function (done) {
 			blocksProcess.loadBlocksOffset(1, 4, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Failed to verify block signature');
+					err.should.equal('Failed to verify block signature');
 					return done();
 				}
 
@@ -152,7 +152,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 5, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Invalid payload hash');
+					err.should.equal('Invalid payload hash');
 					return done();
 				}
 
@@ -165,7 +165,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 6, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Invalid block timestamp');
+					err.should.equal('Invalid block timestamp');
 					return done();
 				}
 
@@ -178,7 +178,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 7, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Blocks#loadBlocksOffset error: Unknown transaction type 99');
+					err.should.equal('Blocks#loadBlocksOffset error: Unknown transaction type 99');
 					return done();
 				}
 
@@ -191,7 +191,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 8, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Invalid block version');
+					err.should.equal('Invalid block version');
 					return done();
 				}
 
@@ -204,7 +204,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 9, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Invalid previous block: 15335393038826825161 expected: 13068833527549895884');
+					err.should.equal('Invalid previous block: 15335393038826825161 expected: 13068833527549895884');
 					return done();
 				}
 
@@ -217,7 +217,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 10, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Failed to validate vote schema: Array items are not unique (indexes 0 and 4)');
+					err.should.equal('Failed to validate vote schema: Array items are not unique (indexes 0 and 4)');
 					return done();
 				}
 
@@ -249,8 +249,8 @@ describe('blocks/process', function () {
 					return done(err);
 				}
 
-				expect(loadedBlock.id).equal(loadTables[0].data[2].id);
-				expect(loadedBlock.previousBlock).equal(loadTables[0].data[2].previousBlock);
+				loadedBlock.id.should.equal(loadTables[0].data[2].id);
+				loadedBlock.previousBlock.should.equal(loadTables[0].data[2].previousBlock);
 				done();
 			});
 		});
@@ -263,8 +263,8 @@ describe('blocks/process', function () {
 					return done(err);
 				}
 
-				expect(loadedBlock.id).equal(loadTables[0].data[3].id);
-				expect(loadedBlock.previousBlock).equal(loadTables[0].data[3].previousBlock);
+				loadedBlock.id.should.equal(loadTables[0].data[3].id);
+				loadedBlock.previousBlock.should.equal(loadTables[0].data[3].previousBlock);
 				done();
 			});
 		});
@@ -277,8 +277,8 @@ describe('blocks/process', function () {
 					done(err);
 				}
 
-				expect(loadedBlock.id).equal(loadTables[0].data[4].id);
-				expect(loadedBlock.previousBlock).equal(loadTables[0].data[4].previousBlock);
+				loadedBlock.id.should.equal(loadTables[0].data[4].id);
+				loadedBlock.previousBlock.should.equal(loadTables[0].data[4].previousBlock);
 				done();
 			});
 		});
@@ -288,7 +288,7 @@ describe('blocks/process', function () {
 
 			blocksProcess.loadBlocksOffset(1, 7, true, function (err, loadedBlock) {
 				if (err) {
-					expect(err).equal('Blocks#loadBlocksOffset error: Unknown transaction type 99');
+					err.should.equal('Blocks#loadBlocksOffset error: Unknown transaction type 99');
 					return done();
 				}
 
@@ -304,8 +304,8 @@ describe('blocks/process', function () {
 					done(err);
 				}
 
-				expect(loadedBlock.id).equal(loadTables[0].data[6].id);
-				expect(loadedBlock.previousBlock).equal(loadTables[0].data[6].previousBlock);
+				loadedBlock.id.should.equal(loadTables[0].data[6].id);
+				loadedBlock.previousBlock.should.equal(loadTables[0].data[6].previousBlock);
 				done();
 			});
 		});
@@ -318,8 +318,8 @@ describe('blocks/process', function () {
 					done(err);
 				}
 
-				expect(loadedBlock.id).equal(loadTables[0].data[7].id);
-				expect(loadedBlock.previousBlock).equal(loadTables[0].data[7].previousBlock);
+				loadedBlock.id.should.equal(loadTables[0].data[7].id);
+				loadedBlock.previousBlock.should.equal(loadTables[0].data[7].previousBlock);
 				done();
 			});
 		});
@@ -332,8 +332,8 @@ describe('blocks/process', function () {
 					done(err);
 				}
 
-				expect(loadedBlock.id).equal(loadTables[0].data[8].id);
-				expect(loadedBlock.previousBlock).equal(loadTables[0].data[8].previousBlock);
+				loadedBlock.id.should.equal(loadTables[0].data[8].id);
+				loadedBlock.previousBlock.should.equal(loadTables[0].data[8].previousBlock);
 				done();
 			});
 		});

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -298,10 +298,10 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifySignature(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(2);
+				result.errors.should.be.an('array').with.lengthOf(2);
 
-				expect(result.errors[0]).to.equal('TypeError: Invalid hex string');
-				expect(result.errors[1]).to.equal('Failed to verify block signature');
+				result.errors[0].should.equal('TypeError: Invalid hex string');
+				result.errors[1].should.equal('Failed to verify block signature');
 
 				validBlock.blockSignature = blockSignature;
 			});
@@ -312,8 +312,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifySignature(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Failed to verify block signature');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Failed to verify block signature');
 
 				validBlock.blockSignature = blockSignature;
 			});
@@ -324,9 +324,9 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifySignature(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(2);
-				expect(result.errors[0]).to.equal('TypeError: Invalid hex string');
-				expect(result.errors[1]).to.equal('Failed to verify block signature');
+				result.errors.should.be.an('array').with.lengthOf(2);
+				result.errors[0].should.equal('TypeError: Invalid hex string');
+				result.errors[1].should.equal('Failed to verify block signature');
 
 				validBlock.generatorPublicKey = generatorPublicKey;
 			});
@@ -337,8 +337,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifySignature(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Failed to verify block signature');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Failed to verify block signature');
 
 				validBlock.generatorPublicKey = generatorPublicKey;
 			});
@@ -352,8 +352,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPreviousBlock(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Invalid previous block');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Invalid previous block');
 
 				validBlock.previousBlock = previousBlock;
 			});
@@ -367,8 +367,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyVersion(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Invalid block version');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Invalid block version');
 
 				validBlock.version = version;
 			});
@@ -381,8 +381,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyReward(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal(['Invalid block reward:', 99, 'expected:', 0].join(' '));
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal(['Invalid block reward:', 99, 'expected:', 0].join(' '));
 
 				validBlock.reward = 0;
 			});
@@ -396,8 +396,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyId(validBlock, results);
 
-				expect(validBlock.id).to.equal(blockId);
-				expect(validBlock.id).to.not.equal('invalid-block-id');
+				validBlock.id.should.equal(blockId);
+				validBlock.id.should.not.equal('invalid-block-id');
 			});
 
 			it('should reset block id when block id is an invalid numeric string value', function () {
@@ -406,8 +406,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyId(validBlock, results);
 
-				expect(validBlock.id).to.equal(blockId);
-				expect(validBlock.id).to.not.equal('11850828211026019526');
+				validBlock.id.should.equal(blockId);
+				validBlock.id.should.not.equal('11850828211026019526');
 			});
 
 			it('should reset block id when block id is an invalid integer value', function () {
@@ -416,8 +416,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyId(validBlock, results);
 
-				expect(validBlock.id).to.equal(blockId);
-				expect(validBlock.id).to.not.equal(11850828211026019526);
+				validBlock.id.should.equal(blockId);
+				validBlock.id.should.not.equal(11850828211026019526);
 			});
 
 			it('should reset block id when block id is a valid integer value', function () {
@@ -426,8 +426,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyId(validBlock, results);
 
-				expect(validBlock.id).to.equal(blockId);
-				expect(validBlock.id).to.not.equal(11850828211026019525);
+				validBlock.id.should.equal(blockId);
+				validBlock.id.should.not.equal(11850828211026019525);
 			});
 		});
 
@@ -439,8 +439,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Payload length is too long');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Payload length is too long');
 
 				validBlock.payloadLength = payloadLength;
 			});
@@ -450,8 +450,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Included transactions do not match block transactions count');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Included transactions do not match block transactions count');
 
 				validBlock.numberOfTransactions = validBlock.transactions.length;
 			});
@@ -463,10 +463,10 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(3);
-				expect(result.errors[0]).to.equal('Number of transactions exceeds maximum per block');
-				expect(result.errors[1]).to.equal('Invalid payload hash');
-				expect(result.errors[2]).to.equal('Invalid total amount');
+				result.errors.should.be.an('array').with.lengthOf(3);
+				result.errors[0].should.equal('Number of transactions exceeds maximum per block');
+				result.errors[1].should.equal('Invalid payload hash');
+				result.errors[2].should.equal('Invalid total amount');
 
 				validBlock.transactions = transactions;
 				validBlock.numberOfTransactions = transactions.length;
@@ -478,9 +478,9 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(2);
-				expect(result.errors[0]).to.equal('Unknown transaction type ' + validBlock.transactions[0].type);
-				expect(result.errors[1]).to.equal('Invalid payload hash');
+				result.errors.should.be.an('array').with.lengthOf(2);
+				result.errors[0].should.equal('Unknown transaction type ' + validBlock.transactions[0].type);
+				result.errors[1].should.equal('Invalid payload hash');
 
 				validBlock.transactions[0].type = transactionType;
 			});
@@ -491,10 +491,10 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(3);
-				expect(result.errors[0]).to.equal('Encountered duplicate transaction: ' + validBlock.transactions[1].id);
-				expect(result.errors[1]).to.equal('Invalid payload hash');
-				expect(result.errors[2]).to.equal('Invalid total amount');
+				result.errors.should.be.an('array').with.lengthOf(3);
+				result.errors[0].should.equal('Encountered duplicate transaction: ' + validBlock.transactions[1].id);
+				result.errors[1].should.equal('Invalid payload hash');
+				result.errors[2].should.equal('Invalid total amount');
 
 				validBlock.transactions[1] = secondTransaction;
 			});
@@ -505,8 +505,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Invalid payload hash');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Invalid payload hash');
 
 				validBlock.payloadHash = payloadHash;
 			});
@@ -517,8 +517,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Invalid total amount');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Invalid total amount');
 
 				validBlock.totalAmount = totalAmount;
 			});
@@ -529,8 +529,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyPayload(validBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Invalid total fee');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Invalid total fee');
 
 				validBlock.totalFee = totalFee;
 			});
@@ -543,8 +543,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyForkOne(validBlock, previousBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal(['Invalid previous block:', validBlock.previousBlock, 'expected:', previousBlock.id].join(' '));
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal(['Invalid previous block:', validBlock.previousBlock, 'expected:', previousBlock.id].join(' '));
 
 				validBlock.previousBlock = previousBlock;
 			});
@@ -558,8 +558,8 @@ describe.skip('blocks/verify', function () {
 
 				var result = privateFunctions.verifyBlockSlot(validBlock, previousBlock, results);
 
-				expect(result.errors).to.be.an('array').with.lengthOf(1);
-				expect(result.errors[0]).to.equal('Invalid block timestamp');
+				result.errors.should.be.an('array').with.lengthOf(1);
+				result.errors[0].should.equal('Invalid block timestamp');
 
 				validBlock.timestamp  = timestamp;
 			});
@@ -606,7 +606,7 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(newaccount.address).to.equal(testAccount.account.address);
+				newaccount.address.should.equal(testAccount.account.address);
 				done();
 			});
 		});
@@ -615,15 +615,15 @@ describe.skip('blocks/verify', function () {
 			var secret = 'lend crime turkey diary muscle donkey arena street industry innocent network lunar';
 
 			block1 = createBlock(blocks, blockLogic, secret, 32578370, transactionsBlock1, previousBlock1);
-			expect(block1.version).to.equal(0);
-			expect(block1.timestamp).to.equal(32578370);
-			expect(block1.numberOfTransactions).to.equal(1);
-			expect(block1.reward).to.equal(0);
-			expect(block1.totalFee).to.equal(10000000);
-			expect(block1.totalAmount).to.equal(10000000000000000);
-			expect(block1.payloadLength).to.equal(117);
-			expect(block1.transactions).to.deep.equal(transactionsBlock1);
-			expect(block1.previousBlock).to.equal(previousBlock1.id);
+			block1.version.should.equal(0);
+			block1.timestamp.should.equal(32578370);
+			block1.numberOfTransactions.should.equal(1);
+			block1.reward.should.equal(0);
+			block1.totalFee.should.equal(10000000);
+			block1.totalAmount.should.equal(10000000000000000);
+			block1.payloadLength.should.equal(117);
+			block1.transactions.should.deep.equal(transactionsBlock1);
+			block1.previousBlock.should.equal(previousBlock1.id);
 			done();
 		});
 
@@ -633,14 +633,14 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				var onMessage = modulesLoader.scope.bus.getMessages();
-				expect(onMessage[0]).to.equal('broadcastBlock');
-				expect(onMessage[1].version).to.be.undefined;
-				expect(onMessage[1].numberOfTransactions).to.be.undefined;
-				expect(onMessage[2]).to.be.true;
-				expect(onMessage[3]).to.equal('transactionsSaved');
-				expect(onMessage[4]).to.deep.equal(block1.transactions);
+				onMessage[0].should.equal('broadcastBlock');
+				should.not.exist(onMessage[1].version);
+				should.not.exist(onMessage[1].numberOfTransactions);
+				onMessage[2].should.be.true;
+				onMessage[3].should.equal('transactionsSaved');
+				onMessage[4].should.deep.equal(block1.transactions);
 				modulesLoader.scope.bus.clearMessages();
 				done();
 			});
@@ -653,7 +653,7 @@ describe.skip('blocks/verify', function () {
 			blocks.lastBlock.set(previousBlock1);
 
 			blocksVerify.processBlock(block1, true, true, function (err, result) {
-				expect(err).to.equal(['Block', block1.id, 'already exists'].join(' '));
+				err.should.equal(['Block', block1.id, 'already exists'].join(' '));
 				done();
 				modulesLoader.scope.bus.clearMessages();
 			});
@@ -669,15 +669,15 @@ describe.skip('blocks/verify', function () {
 			var secret = 'latin swamp simple bridge pilot become topic summer budget dentist hollow seed';
 
 			block2 = createBlock(blocks, blockLogic, secret, 33772882, transactionsBlock2, block1);
-			expect(block2.version).to.equal(0);
-			expect(block2.timestamp).to.equal(33772882);
-			expect(block2.numberOfTransactions).to.equal(1);
-			expect(block2.reward).to.equal(0);
-			expect(block2.totalFee).to.equal(10000000);
-			expect(block2.totalAmount).to.equal(100000000);
-			expect(block2.payloadLength).to.equal(117);
-			expect(block2.transactions).to.deep.equal(transactionsBlock2);
-			expect(block2.previousBlock).to.equal(block1.id);
+			block2.version.should.equal(0);
+			block2.timestamp.should.equal(33772882);
+			block2.numberOfTransactions.should.equal(1);
+			block2.reward.should.equal(0);
+			block2.totalFee.should.equal(10000000);
+			block2.totalAmount.should.equal(100000000);
+			block2.payloadLength.should.equal(117);
+			block2.transactions.should.deep.equal(transactionsBlock2);
+			block2.previousBlock.should.equal(block1.id);
 			done();
 		});
 
@@ -690,7 +690,7 @@ describe.skip('blocks/verify', function () {
 
 				blocksVerify.processBlock(block2, false, true, function (err, result) {
 					if (err) {
-						expect(err).equal('Failed to validate block schema: Missing required property: timestamp');
+						err.should.equal('Failed to validate block schema: Missing required property: timestamp');
 						block2.timestamp = timestamp;
 						done();
 					}
@@ -703,7 +703,7 @@ describe.skip('blocks/verify', function () {
 
 				blocksVerify.processBlock(block2, false, true, function (err, result) {
 					if (err) {
-						expect(err).equal('Invalid total fee');
+						err.should.equal('Invalid total fee');
 						block2.transactions = transactions;
 						done();
 					}
@@ -716,7 +716,7 @@ describe.skip('blocks/verify', function () {
 
 				blocksVerify.processBlock(block2, false, true, function (err, result) {
 					if (err) {
-						expect(err).equal('Unknown transaction type undefined');
+						err.should.equal('Unknown transaction type undefined');
 						block2.transactions[0].type = transactionType;
 						done();
 					}
@@ -729,7 +729,7 @@ describe.skip('blocks/verify', function () {
 
 				blocksVerify.processBlock(block2, false, true, function (err, result) {
 					if (err) {
-						expect(err).equal('Failed to validate transaction schema: Missing required property: timestamp');
+						err.should.equal('Failed to validate transaction schema: Missing required property: timestamp');
 						block2.transactions[0].timestamp = transactionTimestamp;
 						done();
 					}
@@ -740,7 +740,7 @@ describe.skip('blocks/verify', function () {
 		it('should fail when block generator is invalid (fork:3)', function (done) {
 			blocksVerify.processBlock(block2, false, true, function (err, result) {
 				if (err) {
-					expect(err).equal('Failed to verify slot: 3377288');
+					err.should.equal('Failed to verify slot: 3377288');
 					done();
 				}
 			});
@@ -750,15 +750,15 @@ describe.skip('blocks/verify', function () {
 			var secret = 'latin swamp simple bridge pilot become topic summer budget dentist hollow seed';
 
 			block2 = createBlock(blocks, blockLogic, secret, 33772862, transactionsBlock1, block1);
-			expect(block2.version).to.equal(0);
-			expect(block2.timestamp).to.equal(33772862);
-			expect(block2.numberOfTransactions).to.equal(1);
-			expect(block2.reward).to.equal(0);
-			expect(block2.totalFee).to.equal(10000000);
-			expect(block2.totalAmount).to.equal(10000000000000000);
-			expect(block2.payloadLength).to.equal(117);
-			expect(block2.transactions).to.deep.equal(transactionsBlock1);
-			expect(block2.previousBlock).to.equal(block1.id);
+			block2.version.should.equal(0);
+			block2.timestamp.should.equal(33772862);
+			block2.numberOfTransactions.should.equal(1);
+			block2.reward.should.equal(0);
+			block2.totalFee.should.equal(10000000);
+			block2.totalAmount.should.equal(10000000000000000);
+			block2.payloadLength.should.equal(117);
+			block2.transactions.should.deep.equal(transactionsBlock1);
+			block2.previousBlock.should.equal(block1.id);
 			done();
 		});
 
@@ -767,7 +767,7 @@ describe.skip('blocks/verify', function () {
 
 			blocksVerify.processBlock(block2, false, true, function (err, result) {
 				if (err) {
-					expect(err).to.equal(['Transaction is already confirmed:', transactionsBlock1[0].id].join(' '));
+					err.should.equal(['Transaction is already confirmed:', transactionsBlock1[0].id].join(' '));
 					done();
 				}
 			});
@@ -780,15 +780,15 @@ describe.skip('blocks/verify', function () {
 			var secret = 'latin swamp simple bridge pilot become topic summer budget dentist hollow seed';
 
 			block2 = createBlock(blocks, blockLogic, secret, 33772862, transactionsBlock2, block1);
-			expect(block2.version).to.equal(0);
-			expect(block2.timestamp).to.equal(33772862);
-			expect(block2.numberOfTransactions).to.equal(1);
-			expect(block2.reward).to.equal(0);
-			expect(block2.totalFee).to.equal(10000000);
-			expect(block2.totalAmount).to.equal(100000000);
-			expect(block2.payloadLength).to.equal(117);
-			expect(block2.transactions).to.deep.equal(transactionsBlock2);
-			expect(block2.previousBlock).to.equal(block1.id);
+			block2.version.should.equal(0);
+			block2.timestamp.should.equal(33772862);
+			block2.numberOfTransactions.should.equal(1);
+			block2.reward.should.equal(0);
+			block2.totalFee.should.equal(10000000);
+			block2.totalAmount.should.equal(100000000);
+			block2.payloadLength.should.equal(117);
+			block2.transactions.should.deep.equal(transactionsBlock2);
+			block2.previousBlock.should.equal(block1.id);
 			done();
 		});
 
@@ -799,10 +799,10 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				var onMessage = modulesLoader.scope.bus.getMessages();
-				expect(onMessage[0]).to.equal('transactionsSaved');
-				expect(onMessage[1][0].id).to.equal(block2.transactions[0].id);
+				onMessage[0].should.equal('transactionsSaved');
+				onMessage[1][0].id.should.equal(block2.transactions[0].id);
 				modulesLoader.scope.bus.clearMessages();
 				done();
 			});
@@ -812,7 +812,7 @@ describe.skip('blocks/verify', function () {
 			blocks.lastBlock.set(block1);
 
 			blocksVerify.processBlock(block2, false, true, function (err, result) {
-				expect(err).to.equal(['Block', block2.id, 'already exists'].join(' '));
+				err.should.equal(['Block', block2.id, 'already exists'].join(' '));
 				done();
 			});
 		});
@@ -826,7 +826,7 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(newaccount.address).to.equal(userAccount.account.address);
+				newaccount.address.should.equal(userAccount.account.address);
 				done();
 			});
 		});
@@ -835,7 +835,7 @@ describe.skip('blocks/verify', function () {
 			var secret = 'term stable snap size half hotel unique biology amateur fortune easily tribe';
 
 			block3 = createBlock(blocks, blockLogic, secret, 33942637, [], block2);
-			expect(block3.version).to.equal(0);
+			block3.version.should.equal(0);
 			done();
 		});
 
@@ -844,18 +844,18 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				var onMessage = modulesLoader.scope.bus.getMessages();
-				expect(onMessage[0]).to.equal('broadcastBlock');
-				expect(onMessage[1].version).to.be.undefined;
-				expect(onMessage[1].numberOfTransactions).to.be.undefined;
-				expect(onMessage[1].totalAmount).to.be.undefined;
-				expect(onMessage[1].totalFee).to.be.undefined;
-				expect(onMessage[1].payloadLength).to.be.undefined;
-				expect(onMessage[1].reward).to.be.undefined;
-				expect(onMessage[1].transactions).to.be.undefined;
-				expect(onMessage[2]).to.be.true;
-				expect(onMessage[3]).to.equal('newBlock');
+				onMessage[0].should.equal('broadcastBlock');
+				should.not.exist(onMessage[1].version);
+				should.not.exist(onMessage[1].numberOfTransactions);
+				should.not.exist(onMessage[1].totalAmount);
+				should.not.exist(onMessage[1].totalFee);
+				should.not.exist(onMessage[1].payloadLength);
+				should.not.exist(onMessage[1].reward);
+				should.not.exist(onMessage[1].transactions);
+				onMessage[2].should.be.true;
+				onMessage[3].should.equal('newBlock');
 				modulesLoader.scope.bus.clearMessages();
 				done();
 			});
@@ -868,18 +868,18 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				var onMessage = modulesLoader.scope.bus.getMessages();
-				expect(onMessage[0]).to.equal('broadcastBlock');
-				expect(onMessage[1].version).to.be.undefined;
-				expect(onMessage[1].numberOfTransactions).to.be.undefined;
-				expect(onMessage[1].totalAmount).to.be.undefined;
-				expect(onMessage[1].totalFee).to.be.undefined;
-				expect(onMessage[1].payloadLength).to.be.undefined;
-				expect(onMessage[1].reward).to.be.undefined;
-				expect(onMessage[1].transactions).to.be.undefined;
-				expect(onMessage[2]).to.be.true;
-				expect(onMessage[3]).to.equal('newBlock');
+				onMessage[0].should.equal('broadcastBlock');
+				should.not.exist(onMessage[1].version);
+				should.not.exist(onMessage[1].numberOfTransactions);
+				should.not.exist(onMessage[1].totalAmount);
+				should.not.exist(onMessage[1].totalFee);
+				should.not.exist(onMessage[1].payloadLength);
+				should.not.exist(onMessage[1].reward);
+				should.not.exist(onMessage[1].transactions);
+				onMessage[2].should.be.true;
+				onMessage[3].should.equal('newBlock');
 				modulesLoader.scope.bus.clearMessages();
 				done();
 			});
@@ -897,9 +897,9 @@ describe.skip('blocks/verify', function () {
 				if (err) {
 					return done(err);
 				}
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				var onMessage = modulesLoader.scope.bus.getMessages();
-				expect(onMessage).to.be.an('array').that.does.not.include('broadcastBlock');
+				onMessage.should.be.an('array').that.does.not.include('broadcastBlock');
 				modulesLoader.scope.bus.clearMessages();
 				done();
 			});
@@ -910,9 +910,9 @@ describe.skip('blocks/verify', function () {
 			block3 = blocksVerify.deleteBlockProperties(block3);
 
 			blocksVerify.processBlock(block3, false, false, function (err, result) {
-				expect(result).to.be.undefined;
+				should.not.exist(result);
 				var onMessage = modulesLoader.scope.bus.getMessages();
-				expect(onMessage).to.be.an('array').that.does.not.include('broadcastBlock');
+				onMessage.should.be.an('array').that.does.not.include('broadcastBlock');
 				modulesLoader.scope.bus.clearMessages();
 				done();
 			});

--- a/test/unit/modules/cache.js
+++ b/test/unit/modules/cache.js
@@ -31,8 +31,8 @@ describe('cache', function () {
 		__testContext.config.cacheEnabled = true;
 		modulesLoader.initCache(function (err, __cache) {
 			cache = __cache;
-			expect(err).to.not.exist;
-			expect(__cache).to.be.an('object');
+			should.not.exist(err);
+			__cache.should.be.an('object');
 			cache = __cache;
 			return done();
 		});
@@ -40,8 +40,8 @@ describe('cache', function () {
 
 	afterEach(function (done) {
 		cache.flushDb(function (err, status) {
-			expect(err).to.not.exist;
-			expect(status).to.equal('OK');
+			should.not.exist(err);
+			status.should.equal('OK');
 			done(err, status);
 		});
 	});
@@ -57,11 +57,11 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				cache.getJsonForKey(key, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.eql(value);
+					should.not.exist(err);
+					res.should.eql(value);
 					done(err, value);
 				});
 			});
@@ -75,8 +75,8 @@ describe('cache', function () {
 			var key = 'test_key';
 
 			cache.getJsonForKey(key, function (err, value) {
-				expect(err).to.not.exist;
-				expect(value).to.equal(null);
+				should.not.exist(err);
+				should.not.exist(value);
 				done(err, value);
 			});
 		});
@@ -86,11 +86,11 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				cache.getJsonForKey(key, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.eql(value);
+					should.not.exist(err);
+					res.should.eql(value);
 					done(err, value);
 				});
 			});
@@ -109,16 +109,16 @@ describe('cache', function () {
 					async.map([key1, key2], function (key, cb) {
 						cache.setJsonForKey(key, dummyValue, cb);
 					}, function (err, result) {
-						expect(err).to.not.exist;
-						expect(result).to.be.an('array');
+						should.not.exist(err);
+						result.should.be.an('array');
 						return callback(err, result);
 					});
 				},
 				// flush cache database
 				function (callback) {
 					cache.flushDb(function (err, status) {
-						expect(err).to.not.exist;
-						expect(status).to.equal('OK');
+						should.not.exist(err);
+						status.should.equal('OK');
 						return callback(err, status);
 					});
 				},
@@ -127,11 +127,11 @@ describe('cache', function () {
 					async.map([key1, key2], function (key, cb) {
 						cache.getJsonForKey(key, cb);
 					}, function (err, result) {
-						expect(err).to.not.exist;
-						expect(result).to.be.an('array');
-						expect(result).to.have.length(2);
+						should.not.exist(err);
+						result.should.be.an('array');
+						result.should.have.length(2);
 						result.forEach(function (value) {
-							expect(value).to.eql(null);
+							should.not.exist(value);
 						});
 						return callback(err, result);
 					});
@@ -151,13 +151,13 @@ describe('cache', function () {
 			var pattern = '/api/transactions*';
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				cache.removeByPattern(pattern, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.equal(null);
+						should.not.exist(err);
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -170,13 +170,13 @@ describe('cache', function () {
 			var pattern = '/api/delegate*';
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				cache.removeByPattern(pattern, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});
@@ -191,13 +191,13 @@ describe('cache', function () {
 			var key = '/api/transactions?123';
 			var value = {testObject: 'testValue'};
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				cache.onNewBlock(function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.equal(null);
+						should.not.exist(err);
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -209,14 +209,14 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 
 				cache.onNewBlock(function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.equal(null);
+						should.not.exist(err);
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -228,14 +228,14 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 
 				cache.onNewBlock(function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});
@@ -247,16 +247,16 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 
 				cache.onSyncStarted();
 				cache.onNewBlock(function (err) {
-					expect(err).to.equal('Cache Unavailable');
+					err.should.equal('Cache Unavailable');
 					cache.onSyncFinished();
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});
@@ -271,13 +271,13 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				cache.onFinishRound(null, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.equal(null);
+						should.not.exist(err);
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -289,14 +289,14 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 
 				cache.onFinishRound(null, function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});
@@ -308,16 +308,16 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 
 				cache.onSyncStarted();
 				cache.onFinishRound(null, function (err) {
-					expect(err).to.equal('Cache Unavailable');
+					err.should.equal('Cache Unavailable');
 					cache.onSyncFinished();
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});
@@ -332,14 +332,14 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				var transaction = lisk.transaction.createTransaction('1L', 1, accountFixtures.genesis.password, accountFixtures.genesis.secondPassword);
 
 				cache.onTransactionsSaved([transaction], function (err) {
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});
@@ -351,14 +351,14 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				var transaction = lisk.delegate.createDelegate(randomUtil.password(), randomUtil.delegateName().toLowerCase());
 
 				cache.onTransactionsSaved([transaction], function (err) {
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.equal(null);
+						should.not.exist(err);
+						should.not.exist(res);
 						done();
 					});
 				});
@@ -370,17 +370,17 @@ describe('cache', function () {
 			var value = {testObject: 'testValue'};
 
 			cache.setJsonForKey(key, value, function (err, status) {
-				expect(err).to.not.exist;
-				expect(status).to.equal('OK');
+				should.not.exist(err);
+				status.should.equal('OK');
 				var transaction = lisk.delegate.createDelegate(randomUtil.password(), randomUtil.delegateName().toLowerCase());
 
 				cache.onSyncStarted();
 				cache.onTransactionsSaved([transaction], function (err) {
-					expect(err).to.equal('Cache Unavailable');
+					err.should.equal('Cache Unavailable');
 					cache.onSyncFinished();
 					cache.getJsonForKey(key, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql(value);
+						should.not.exist(err);
+						res.should.eql(value);
 						done();
 					});
 				});

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -83,8 +83,8 @@ describe('delegates', function () {
 				config.forging.secret = encryptedSecret;
 
 				loadDelegates(function (err) {
-					expect(err).to.not.exist;
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					should.not.exist(err);
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -93,8 +93,8 @@ describe('delegates', function () {
 				config.forging.secret = [];
 
 				loadDelegates(function (err) {
-					expect(err).to.not.exist;
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					should.not.exist(err);
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -103,8 +103,8 @@ describe('delegates', function () {
 				config.forging.secret = undefined;
 
 				loadDelegates(function (err) {
-					expect(err).to.not.exist;
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					should.not.exist(err);
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -118,8 +118,8 @@ describe('delegates', function () {
 				config.forging.secret = [accountDetails];
 
 				loadDelegates(function (err) {
-					expect(err).to.equal('Invalid encryptedSecret for publicKey: ' + accountDetails.publicKey);
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					err.should.equal('Invalid encryptedSecret for publicKey: ' + accountDetails.publicKey);
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -133,8 +133,8 @@ describe('delegates', function () {
 				config.forging.secret = [accountDetails];
 
 				loadDelegates(function (err) {
-					expect(err).to.equal('Public keys do not match');
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					err.should.equal('Public keys do not match');
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -154,8 +154,8 @@ describe('delegates', function () {
 				config.forging.secret = [accountDetails];
 
 				loadDelegates(function (err) {
-					expect(err).to.equal(['Account with public key:', accountDetails.publicKey.toString('hex'), 'not found'].join(' '));
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					err.should.equal(['Account with public key:', accountDetails.publicKey.toString('hex'), 'not found'].join(' '));
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -167,8 +167,8 @@ describe('delegates', function () {
 				}];
 
 				loadDelegates(function (err) {
-					expect(err).to.not.exist;
-					expect(Object.keys(__private.keypairs).length).to.equal(0);
+					should.not.exist(err);
+					Object.keys(__private.keypairs).length.should.equal(0);
 					done();
 				});
 			});
@@ -177,8 +177,8 @@ describe('delegates', function () {
 				config.forging.secret = encryptedSecret;
 
 				loadDelegates(function (err) {
-					expect(err).to.not.exist;
-					expect(Object.keys(__private.keypairs).length).to.equal(encryptedSecret.length);
+					should.not.exist(err);
+					Object.keys(__private.keypairs).length.should.equal(encryptedSecret.length);
 					done();
 				});
 			});
@@ -192,8 +192,8 @@ describe('delegates', function () {
 				});
 
 				loadDelegates(function (err) {
-					expect(err).to.not.exist;
-					expect(Object.keys(__private.keypairs).length).to.equal(101);
+					should.not.exist(err);
+					Object.keys(__private.keypairs).length.should.equal(101);
 					done();
 				});
 			});

--- a/test/unit/modules/loader.js
+++ b/test/unit/modules/loader.js
@@ -106,9 +106,9 @@ describe('loader', function () {
 			];
 
 			var goodPeers = loaderModule.findGoodPeers(peers);
-			expect(goodPeers).to.have.property('height').equal(HEIGHT_TWO); // Good peers - above my height (above and equal 2)
-			expect(goodPeers).to.have.property('peers').to.be.an('array').to.have.lengthOf(3);
-			expect(_.isEqualWith(goodPeers.peers, [
+			goodPeers.should.have.property('height').equal(HEIGHT_TWO); // Good peers - above my height (above and equal 2)
+			goodPeers.should.have.property('peers').to.be.an('array').to.have.lengthOf(3);
+			_.isEqualWith(goodPeers.peers, [
 				{
 					ip: '4.4.4.4',
 					wsPort: '4000',
@@ -126,7 +126,7 @@ describe('loader', function () {
 				}
 			], function (a, b) {
 				return a.ip === b.ip &&  a.wsPort === b.wsPort &&  a.height === b.height;
-			})).to.be.ok;
+			}).should.be.ok;
 		});
 	});
 });

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -97,7 +97,7 @@ describe('node', function () {
 
 			it('should return error with invalid key', function (done) {
 				node_module.internal.toggleForgingStatus(testDelegate.publicKey, 'Invalid key', function (err) {
-					expect(err).to.equal('Invalid key and public key combination');
+					err.should.equal('Invalid key and public key combination');
 					done();
 				});
 			});
@@ -106,25 +106,25 @@ describe('node', function () {
 				var invalidPublicKey = '9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9fff0a';
 
 				node_module.internal.toggleForgingStatus(invalidPublicKey, defaultKey, function (err) {
-					expect(err).equal('Delegate with publicKey: 9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9fff0a not found');
+					err.should.equal('Delegate with publicKey: 9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9fff0a not found');
 					done();
 				});
 			});
 
 			it('should return error with non delegate account', function (done) {
 				node_module.internal.toggleForgingStatus(accountFixtures.genesis.publicKey, accountFixtures.genesis.password, function (err) {
-					expect(err).equal('Delegate with publicKey: c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f not found');
+					err.should.equal('Delegate with publicKey: c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f not found');
 					done();
 				});
 			});
 
 			it('should toggle forging from enabled to disabled', function (done) {
 				updateForgingStatus(testDelegate, 'enable', function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 
 					node_module.internal.toggleForgingStatus(testDelegate.publicKey, defaultKey, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql({
+						should.not.exist(err);
+						res.should.eql({
 							publicKey: testDelegate.publicKey,
 							forging: false
 						});
@@ -135,11 +135,11 @@ describe('node', function () {
 
 			it('should toggle forging from disabled to enabled', function (done) {
 				updateForgingStatus(testDelegate, 'disable', function (err) {
-					expect(err).to.not.exist;
+					should.not.exist(err);
 
 					node_module.internal.toggleForgingStatus(testDelegate.publicKey, defaultKey, function (err, res) {
-						expect(err).to.not.exist;
-						expect(res).to.eql({
+						should.not.exist(err);
+						res.should.eql({
 							publicKey: testDelegate.publicKey,
 							forging: true
 						});

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -112,7 +112,7 @@ describe('peers', function () {
 			});
 
 			it('should return an empty array', function () {
-				expect(listResult).to.be.an('array').and.to.be.empty;
+				listResult.should.be.an('array').and.to.be.empty;
 			});
 		});
 
@@ -126,7 +126,7 @@ describe('peers', function () {
 			});
 
 			it('should return all 1000 peers', function () {
-				expect(listResult).be.an('array').and.have.lengthOf(100);
+				listResult.should.be.an('array').and.have.lengthOf(100);
 			});
 
 			describe('options.limit', function () {
@@ -145,14 +145,14 @@ describe('peers', function () {
 					});
 
 					it('should return up to [options.limit] results', function () {
-						expect(listResult).be.an('array').and.have.lengthOf(validLimit);
+						listResult.should.be.an('array').and.have.lengthOf(validLimit);
 					});
 				});
 
 				describe('when no options.limit passed', function () {
 
 					it('should return [constants.maxPeers] results', function () {
-						expect(listResult).be.an('array').and.have.lengthOf(constants.maxPeers);
+						listResult.should.be.an('array').and.have.lengthOf(constants.maxPeers);
 					});
 				});
 			});
@@ -188,13 +188,13 @@ describe('peers', function () {
 						});
 
 						it('should return 100 results', function () {
-							expect(listResult).be.an('array').and.have.lengthOf(100);
+							listResult.should.be.an('array').and.have.lengthOf(100);
 						});
 
 						it('should return 100 results with the same broadhash', function () {
-							expect(listResult.filter(function (peer) {
+							listResult.filter(function (peer) {
 								return peer.broadhash === validBroadhash;
-							})).be.an('array').and.have.lengthOf(100);
+							}).should.be.an('array').and.have.lengthOf(100);
 						});
 					});
 
@@ -206,19 +206,19 @@ describe('peers', function () {
 						});
 
 						it('should return 500 results', function () {
-							expect(listResult).be.an('array').and.have.lengthOf(500);
+							listResult.should.be.an('array').and.have.lengthOf(500);
 						});
 
 						it('should return 250 results with the same broadhash', function () {
-							expect(listResult.filter(function (peer) {
+							listResult.filter(function (peer) {
 								return peer.broadhash === validBroadhash;
-							})).be.an('array').and.have.lengthOf(250);
+							}).should.be.an('array').and.have.lengthOf(250);
 						});
 
 						it('should return 250 results with different broadhash', function () {
-							expect(listResult.filter(function (peer) {
+							listResult.filter(function (peer) {
 								return peer.broadhash !== validBroadhash;
-							})).be.an('array').and.have.lengthOf(250);
+							}).should.be.an('array').and.have.lengthOf(250);
 						});
 
 						describe('options.attempt', function () {
@@ -234,12 +234,12 @@ describe('peers', function () {
 								});
 
 								it('should return 250 results', function () {
-									expect(listResult).to.have.lengthOf(250);
+									listResult.should.have.lengthOf(250);
 								});
 
 								it('should return only peers matching broadhash', function () {
 									listResult.forEach(function (peer) {
-										expect(peer.broadhash).eql(validBroadhash);
+										peer.broadhash.should.eql(validBroadhash);
 									});
 								});
 							});
@@ -251,12 +251,12 @@ describe('peers', function () {
 								});
 
 								it('should return 500 results', function () {
-									expect(listResult).to.have.lengthOf(500);
+									listResult.should.have.lengthOf(500);
 								});
 
 								it('should return only peers not matching broadhash', function () {
 									listResult.forEach(function (peer) {
-										expect(peer.broadhash).not.eql(validBroadhash);
+										should.not.equal(peer.broadhash, validBroadhash);
 									});
 								});
 							});
@@ -267,7 +267,7 @@ describe('peers', function () {
 				describe('when no options.limit passed', function () {
 
 					it('should return [constants.maxPeers] results', function () {
-						expect(listResult).be.an('array').and.have.lengthOf(constants.maxPeers);
+						listResult.should.be.an('array').and.have.lengthOf(constants.maxPeers);
 					});
 				});
 			});
@@ -296,8 +296,8 @@ describe('peers', function () {
 				});
 
 				it('should return only connected peers', function () {
-					expect(_.uniqBy(listResult, 'state')).be.an('array').and.have.lengthOf(1);
-					expect(listResult[0].state).equal(CONNECTED_STATE);
+					_.uniqBy(listResult, 'state').should.be.an('array').and.have.lengthOf(1);
+					listResult[0].state.should.equal(CONNECTED_STATE);
 				});
 
 				describe('when options.allowedStates = [1]', function () {
@@ -311,8 +311,8 @@ describe('peers', function () {
 					});
 
 					it('should return only banned peers', function () {
-						expect(_.uniqBy(listResult, 'state')).be.an('array').and.have.lengthOf(1);
-						expect(listResult[0].state).equal(BANNED_STATE);
+						_.uniqBy(listResult, 'state').should.be.an('array').and.have.lengthOf(1);
+						listResult[0].state.should.equal(BANNED_STATE);
 					});
 				});
 
@@ -327,8 +327,8 @@ describe('peers', function () {
 					});
 
 					it('should return only disconnected peers', function () {
-						expect(_.uniqBy(listResult, 'state')).be.an('array').and.have.lengthOf(1);
-						expect(listResult[0].state).equal(DISCONNECTED_STATE);
+						_.uniqBy(listResult, 'state').should.be.an('array').and.have.lengthOf(1);
+						listResult[0].state.should.equal(DISCONNECTED_STATE);
 					});
 				});
 
@@ -343,9 +343,9 @@ describe('peers', function () {
 					});
 
 					it('should return disconnected and banned peers', function () {
-						expect(_.uniqBy(listResult, 'state')).be.an('array').and.have.length.at.least(1);
+						_.uniqBy(listResult, 'state').should.be.an('array').and.have.length.at.least(1);
 						listResult.forEach(function (state) {
-							expect(state).not.to.equal(CONNECTED_STATE);
+							state.should.not.to.equal(CONNECTED_STATE);
 						});
 					});
 				});
@@ -370,15 +370,15 @@ describe('peers', function () {
 		});
 
 		it('should call logic.peers.upsert', function () {
-			expect(peersLogicMock.upsert.calledOnce).to.be.true;
+			peersLogicMock.upsert.calledOnce.should.be.true;
 		});
 
 		it('should call logic.peers.upsert with peer', function () {
-			expect(peersLogicMock.upsert.calledWith(validPeer)).to.be.true;
+			peersLogicMock.upsert.calledWith(validPeer).should.be.true;
 		});
 
 		it('should return library.logic.peers.upsert result', function () {
-			expect(updateResult).equal(validUpsertResult);
+			updateResult.should.equal(validUpsertResult);
 		});
 	});
 
@@ -418,34 +418,34 @@ describe('peers', function () {
 			});
 
 			it('should not call logic.peers.remove', function () {
-				expect(peersLogicMock.remove.called).to.be.false;
+				peersLogicMock.remove.called.should.be.false;
 			});
 
 			it('should call logger.debug with message = "Cannot remove frozen peer"', function () {
-				expect(loggerDebugSpy.calledWith('Cannot remove frozen peer')).to.be.true;
+				loggerDebugSpy.calledWith('Cannot remove frozen peer').should.be.true;
 			});
 
 			it('should call logger.debug with message = [ip:port]', function () {
-				expect(loggerDebugSpy.args[0][1]).eql(validPeer.ip + ':' + validPeer.wsPort);
+				loggerDebugSpy.args[0][1].should.eql(validPeer.ip + ':' + validPeer.wsPort);
 			});
 		});
 
 		describe('when removable peer is not frozen', function () {
 
 			it('should call logic.peers.remove', function () {
-				expect(peersLogicMock.remove.calledOnce).to.be.true;
+				peersLogicMock.remove.calledOnce.should.be.true;
 			});
 
 			it('should call logic.peers.remove with object containing expected ip', function () {
-				expect(peersLogicMock.remove.calledWith(sinonSandbox.match({ip: validPeer.ip}))).to.be.true;
+				peersLogicMock.remove.calledWith(sinonSandbox.match({ip: validPeer.ip})).should.be.true;
 			});
 
 			it('should call logic.peers.remove with object containing expected port', function () {
-				expect(peersLogicMock.remove.calledWith(sinonSandbox.match({wsPort: validPeer.wsPort}))).to.be.true;
+				peersLogicMock.remove.calledWith(sinonSandbox.match({wsPort: validPeer.wsPort})).should.be.true;
 			});
 
 			it('should return library.logic.peers.remove result', function () {
-				expect(removeResult).equal(validLogicRemoveResult);
+				removeResult.should.equal(validLogicRemoveResult);
 			});
 		});
 	});
@@ -485,7 +485,7 @@ describe('peers', function () {
 			});
 
 			it('should return undefined', function () {
-				expect(getConsensusResult).to.be.undefined;
+				should.not.exist(getConsensusResult);
 			});
 		});
 
@@ -503,15 +503,15 @@ describe('peers', function () {
 			describe('when active peers not passed', function () {
 
 				it('should call logic.peers.list', function () {
-					expect(peersLogicMock.list.called).to.be.true;
+					peersLogicMock.list.called.should.be.true;
 				});
 
 				it('should call logic.peers.list with true', function () {
-					expect(peersLogicMock.list.calledWith(true)).to.be.true;
+					peersLogicMock.list.calledWith(true).should.be.true;
 				});
 
 				it('should return consensus as a number', function () {
-					expect(getConsensusResult).to.be.a('number');
+					getConsensusResult.should.be.a('number');
 				});
 			});
 
@@ -546,7 +546,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 0', function () {
-						expect(getConsensusResult).to.equal(0);
+						getConsensusResult.should.equal(0);
 					});
 				});
 
@@ -559,7 +559,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -572,7 +572,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 50', function () {
-						expect(getConsensusResult).equal(50);
+						getConsensusResult.should.equal(50);
 					});
 				});
 			});
@@ -587,7 +587,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -599,7 +599,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -611,7 +611,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -623,7 +623,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -635,7 +635,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -647,7 +647,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 50', function () {
-						expect(getConsensusResult).equal(50);
+						getConsensusResult.should.equal(50);
 					});
 				});
 			});
@@ -662,19 +662,19 @@ describe('peers', function () {
 		});
 
 		it('should accept peer with public ip', function () {
-			expect(peers.acceptable([prefixedPeer])).that.is.an('array').and.to.deep.equal([prefixedPeer]);
+			peers.acceptable([prefixedPeer]).should.be.an('array').and.to.deep.equal([prefixedPeer]);
 		});
 
 		it('should not accept peer with private ip', function () {
 			var privatePeer = _.clone(prefixedPeer);
 			privatePeer.ip = '127.0.0.1';
-			expect(peers.acceptable([privatePeer])).that.is.an('array').and.to.be.empty;
+			peers.acceptable([privatePeer]).should.be.an('array').and.to.be.empty;
 		});
 
 		it('should not accept peer with host\'s nonce', function () {
 			var peer = _.clone(prefixedPeer);
 			peer.nonce = NONCE;
-			expect(peers.acceptable([peer])).that.is.an('array').and.to.be.empty;
+			peers.acceptable([peer]).should.be.an('array').and.to.be.empty;
 		});
 
 		it('should not accept peer with different ip but the same nonce', function () {
@@ -684,7 +684,7 @@ describe('peers', function () {
 				wsPort: 4001,
 				nonce: NONCE
 			};
-			expect(peers.acceptable([meAsPeer])).that.is.an('array').and.to.be.empty;
+			peers.acceptable([meAsPeer]).should.be.an('array').and.to.be.empty;
 		});
 
 		after(function () {
@@ -711,7 +711,7 @@ describe('peers', function () {
 		it('should update peers during onBlockchainReady', function (done) {
 			peers.onBlockchainReady();
 			setTimeout(function () {
-				expect(peers.discover.calledOnce).to.be.ok;
+				peers.discover.calledOnce.should.be.ok;
 				done();
 			}, 100);
 		});
@@ -729,7 +729,7 @@ describe('peers', function () {
 
 			peers.onBlockchainReady();
 			setTimeout(function () {
-				expect(peersLogicMock.upsert.calledWith(peerStub, false)).to.be.true;
+				peersLogicMock.upsert.calledWith(peerStub, false).should.be.true;
 				done();
 			}, 100);
 		});
@@ -749,7 +749,7 @@ describe('peers', function () {
 		it('should update peers during onBlockchainReady', function (done) {
 			peers.onPeersReady();
 			setTimeout(function () {
-				expect(peers.discover.calledOnce).to.be.ok;
+				peers.discover.calledOnce.should.be.ok;
 				done();
 			}, 100);
 		});
@@ -781,8 +781,8 @@ describe('peers', function () {
 
 		it('should not call randomPeer.rpc.list if randomPeer.rpc.status operation has failed', function (done) {
 			peers.discover(function (err) {
-				expect(err).to.equal('Failed to get peer status');
-				expect(randomPeerStub.rpc.list.called).to.be.false;
+				err.should.equal('Failed to get peer status');
+				randomPeerStub.rpc.list.called.should.be.false;
 				done();
 			});
 		});

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -524,7 +524,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 100', function () {
-						expect(getConsensusResult).to.equal(100);
+						getConsensusResult.should.equal(100);
 					});
 				});
 
@@ -538,7 +538,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 0', function () {
-						expect(getConsensusResult).to.equal(0);
+						getConsensusResult.should.equal(0);
 					});
 				});
 
@@ -552,7 +552,7 @@ describe('peers', function () {
 					});
 
 					it('should return consensus = 0', function () {
-						expect(getConsensusResult).to.equal(0);
+						getConsensusResult.should.equal(0);
 					});
 				});
 			});

--- a/test/unit/modules/transactions.js
+++ b/test/unit/modules/transactions.js
@@ -53,34 +53,34 @@ describe('transactions', function () {
 	function attachAllAssets (transactionLogic, accountLogic, delegatesModule, accountsModule) {
 		var sendLogic = transactionLogic.attachAssetType(transactionTypes.SEND, new TransferLogic());
 		sendLogic.bind(accountsModule);
-		expect(sendLogic).to.be.an.instanceof(TransferLogic);
+		sendLogic.should.be.an.instanceof(TransferLogic);
 
 		var voteLogic = transactionLogic.attachAssetType(transactionTypes.VOTE, new VoteLogic(modulesLoader.logger, modulesLoader.scope.schema));
 		voteLogic.bind(delegatesModule);
-		expect(voteLogic).to.be.an.instanceof(VoteLogic);
+		voteLogic.should.be.an.instanceof(VoteLogic);
 
 		var delegateLogic = transactionLogic.attachAssetType(transactionTypes.DELEGATE, new DelegateLogic(modulesLoader.scope.schema));
 		delegateLogic.bind(accountsModule);
-		expect(delegateLogic).to.be.an.instanceof(DelegateLogic);
+		delegateLogic.should.be.an.instanceof(DelegateLogic);
 
 		var signatureLogic = transactionLogic.attachAssetType(transactionTypes.SIGNATURE, new SignatureLogic(modulesLoader.logger, modulesLoader.scope.schema));
 		signatureLogic.bind(accountsModule);
-		expect(signatureLogic).to.be.an.instanceof(SignatureLogic);
+		signatureLogic.should.be.an.instanceof(SignatureLogic);
 
 		var multiLogic = transactionLogic.attachAssetType(transactionTypes.MULTI, new MultisignatureLogic(modulesLoader.scope.schema, modulesLoader.scope.network, transactionLogic, accountLogic, modulesLoader.logger));
 		multiLogic.bind(accountsModule);
-		expect(multiLogic).to.be.an.instanceof(MultisignatureLogic);
+		multiLogic.should.be.an.instanceof(MultisignatureLogic);
 
 		var dappLogic = transactionLogic.attachAssetType(transactionTypes.DAPP, new DappLogic(modulesLoader.db, modulesLoader.logger, modulesLoader.scope.schema, modulesLoader.scope.network));
-		expect(dappLogic).to.be.an.instanceof(DappLogic);
+		dappLogic.should.be.an.instanceof(DappLogic);
 
 		var inTransferLogic = transactionLogic.attachAssetType(transactionTypes.IN_TRANSFER, new InTransferLogic(modulesLoader.db, modulesLoader.scope.schema));
 		inTransferLogic.bind(accountsModule, /* sharedApi */ null);
-		expect(inTransferLogic).to.be.an.instanceof(InTransferLogic);
+		inTransferLogic.should.be.an.instanceof(InTransferLogic);
 
 		var outTransfer = transactionLogic.attachAssetType(transactionTypes.OUT_TRANSFER, new OutTransferLogic(modulesLoader.db, modulesLoader.scope.schema, modulesLoader.logger));
 		outTransfer.bind(accountsModule, /* sharedApi */ null);
-		expect(outTransfer).to.be.an.instanceof(OutTransferLogic);
+		outTransfer.should.be.an.instanceof(OutTransferLogic);
 		return transactionLogic;
 	}
 
@@ -152,9 +152,9 @@ describe('transactions', function () {
 				}, cb);
 			}]
 		}, function (err, result){
-			expect(err).to.not.exist;
+			should.not.exist(err);
 			modulesLoader.initModule(TransactionModule, {db: dbStub, logic: {transaction: result.transactionLogic}}, function (err, __transactionModule) {
-				expect(err).to.not.exist;
+				should.not.exist(err);
 
 				transactionsModule = __transactionModule;
 
@@ -396,19 +396,19 @@ describe('transactions', function () {
 				}]);
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('Array');
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].recipientId).to.equal(transaction.recipientId);
-					expect(res.transactions[0].timestamp).to.equal(transaction.timestamp);
-					expect(res.transactions[0].asset).to.eql(transaction.asset);
-					expect(res.transactions[0].senderPublicKey).to.equal(transaction.senderPublicKey);
-					expect(res.transactions[0].signature).to.equal(transaction.signature);
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.SEND);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('Array');
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].amount.should.equal(transaction.amount);
+					res.transactions[0].fee.should.equal(transaction.fee);
+					res.transactions[0].recipientId.should.equal(transaction.recipientId);
+					res.transactions[0].timestamp.should.equal(transaction.timestamp);
+					res.transactions[0].asset.should.eql(transaction.asset);
+					res.transactions[0].senderPublicKey.should.equal(transaction.senderPublicKey);
+					res.transactions[0].signature.should.equal(transaction.signature);
+					res.transactions[0].id.should.equal(transaction.id);
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].type.should.equal(transactionTypes.SEND);
 					done();
 				});
 			});
@@ -443,14 +443,14 @@ describe('transactions', function () {
 				}]);
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].asset.signature.publicKey).to.equal(transaction.asset.signature.publicKey);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.SIGNATURE);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('array');
+					res.transactions[0].id.should.equal(transaction.id);
+					res.transactions[0].amount.should.equal(transaction.amount);
+					res.transactions[0].asset.signature.publicKey.should.equal(transaction.asset.signature.publicKey);
+					res.transactions[0].fee.should.equal(transaction.fee);
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].type.should.equal(transactionTypes.SIGNATURE);
 					done();
 				});
 			});
@@ -485,16 +485,16 @@ describe('transactions', function () {
 				}]);
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].asset.username).to.equal(transaction.asset.username);
-					expect(res.transactions[0].asset.publicKey).to.equal(transaction.asset.publicKey);
-					expect(res.transactions[0].asset.address).to.equal(transaction.asset.address);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.DELEGATE);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('array');
+					should.equal(res.transactions[0].id, transaction.id);
+					should.equal(res.transactions[0].amount, transaction.amount);
+					should.equal(res.transactions[0].asset.username, transaction.asset.username);
+					should.equal(res.transactions[0].asset.publicKey, transaction.asset.publicKey);
+					should.equal(res.transactions[0].asset.address, transaction.asset.address);
+					should.equal(res.transactions[0].fee, transaction.fee);
+					should.equal(res.transactions[0].type, transaction.type);
+					should.equal(res.transactions[0].type, transactionTypes.DELEGATE);
 					done();
 				});
 			});
@@ -529,14 +529,14 @@ describe('transactions', function () {
 				}]);
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].asset.votes).to.eql(transaction.asset.votes);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.VOTE);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('array');
+					res.transactions[0].id.should.equal(transaction.id);
+					res.transactions[0].amount.should.equal(transaction.amount);
+					res.transactions[0].asset.votes.should.eql(transaction.asset.votes);
+					res.transactions[0].fee.should.equal(transaction.fee);
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].type.should.equal(transactionTypes.VOTE);
 					done();
 				});
 			});
@@ -573,16 +573,16 @@ describe('transactions', function () {
 				}]);
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].asset.multisignature.lifetime).to.equal(transaction.asset.multisignature.lifetime);
-					expect(res.transactions[0].asset.multisignature.min).to.equal(transaction.asset.multisignature.min);
-					expect(res.transactions[0].asset.multisignature.keysgroup).to.eql(transaction.asset.multisignature.keysgroup);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.MULTI);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('array');
+					res.transactions[0].id.should.equal(transaction.id);
+					res.transactions[0].amount.should.equal(transaction.amount);
+					res.transactions[0].asset.multisignature.lifetime.should.equal(transaction.asset.multisignature.lifetime);
+					res.transactions[0].asset.multisignature.min.should.equal(transaction.asset.multisignature.min);
+					res.transactions[0].asset.multisignature.keysgroup.should.eql(transaction.asset.multisignature.keysgroup);
+					res.transactions[0].fee.should.equal(transaction.fee);
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].type.should.equal(transactionTypes.MULTI);
 					done();
 				});
 			});
@@ -623,17 +623,17 @@ describe('transactions', function () {
 				}]);
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].asset.dapp.name).to.equal(transaction.asset.dapp.name);
-					expect(res.transactions[0].asset.dapp.category).to.equal(transaction.asset.dapp.category);
-					expect(res.transactions[0].asset.dapp.link).to.equal(transaction.asset.dapp.link);
-					expect(res.transactions[0].asset.dapp.type).to.equal(transaction.asset.dapp.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.DAPP);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('array');
+					res.transactions[0].id.should.equal(transaction.id);
+					res.transactions[0].amount.should.equal(transaction.amount);
+					res.transactions[0].fee.should.equal(transaction.fee);
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].asset.dapp.name.should.equal(transaction.asset.dapp.name);
+					res.transactions[0].asset.dapp.category.should.equal(transaction.asset.dapp.category);
+					res.transactions[0].asset.dapp.link.should.equal(transaction.asset.dapp.link);
+					res.transactions[0].asset.dapp.type.should.equal(transaction.asset.dapp.type);
+					res.transactions[0].type.should.equal(transactionTypes.DAPP);
 					done();
 				});
 			});
@@ -643,14 +643,14 @@ describe('transactions', function () {
 				var transaction = transactionsByType[transactionTypes.IN_TRANSFER].transaction;
 
 				getTransactionsById(transactionId, function (err, res) {
-					expect(err).to.not.exist;
-					expect(res).to.have.property('transactions').which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount).to.equal(transaction.amount);
-					expect(res.transactions[0].fee).to.equal(transaction.fee);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].asset.inTransfer.dappId).to.equal(transaction.asset.inTransfer.dappId);
-					expect(res.transactions[0].type).to.equal(transactionTypes.IN_TRANSFER);
+					should.not.exist(err);
+					res.should.have.property('transactions').which.is.an('array');
+					res.transactions[0].id.should.equal(transaction.id);
+					res.transactions[0].amount.should.equal(transaction.amount);
+					res.transactions[0].fee.should.equal(transaction.fee);
+					res.transactions[0].type.should.equal(transaction.type);
+					res.transactions[0].asset.inTransfer.dappId.should.equal(transaction.asset.inTransfer.dappId);
+					res.transactions[0].type.should.equal(transactionTypes.IN_TRANSFER);
 					done();
 				});
 			});

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -112,21 +112,21 @@ describe('transport', function () {
 					library = TransportModule.__get__('library');
 					__private = TransportModule.__get__('__private');
 
-					expect(library).to.have.property('db').which.is.equal(dbStub);
-					expect(library).to.have.property('logger').which.is.equal(loggerStub);
-					expect(library).to.have.property('bus').which.is.equal(busStub);
-					expect(library).to.have.property('schema').which.is.equal(schemaStub);
-					expect(library).to.have.property('network').which.is.equal(networkStub);
-					expect(library).to.have.property('balancesSequence').which.is.equal(balancesSequenceStub);
-					expect(library).to.have.nested.property('logic.block').which.is.equal(blockStub);
-					expect(library).to.have.nested.property('logic.transaction').which.is.equal(transactionStub);
-					expect(library).to.have.nested.property('logic.peers').which.is.equal(peersStub);
-					expect(library).to.have.nested.property('config.peers.options.timeout').which.is.equal(1234);
+					library.should.have.property('db').which.is.equal(dbStub);
+					library.should.have.property('logger').which.is.equal(loggerStub);
+					library.should.have.property('bus').which.is.equal(busStub);
+					library.should.have.property('schema').which.is.equal(schemaStub);
+					library.should.have.property('network').which.is.equal(networkStub);
+					library.should.have.property('balancesSequence').which.is.equal(balancesSequenceStub);
+					library.should.have.nested.property('logic.block').which.is.equal(blockStub);
+					library.should.have.nested.property('logic.transaction').which.is.equal(transactionStub);
+					library.should.have.nested.property('logic.peers').which.is.equal(peersStub);
+					library.should.have.nested.property('config.peers.options.timeout').which.is.equal(1234);
 
-					expect(__private).to.have.property('broadcaster').which.is.equal(broadcasterStubRef);
+					__private.should.have.property('broadcaster').which.is.equal(broadcasterStubRef);
 
-					expect(err).to.equal(null);
-					expect(transportSelf).to.equal(localTransportInstance);
+					should.not.exist(err);
+					transportSelf.should.equal(localTransportInstance);
 
 					transportSelf.onBind(defaultScope);
 
@@ -175,14 +175,14 @@ describe('transport', function () {
 
 				it('should call library.logger.debug with "Cannot remove empty peer"', function (done) {
 					__private.removePeer({}, 'Custom peer remove message');
-					expect(loggerStub.debug.called).to.be.true;
-					expect(loggerStub.debug.calledWith('Cannot remove empty peer')).to.be.true;
+					loggerStub.debug.called.should.be.true;
+					loggerStub.debug.calledWith('Cannot remove empty peer').should.be.true;
 					done();
 				});
 
 				it('should return false', function (done) {
 					var result = __private.removePeer({}, 'Custom peer remove message');
-					expect(result).to.be.false;
+					result.should.be.false;
 					done();
 				});
 			});
@@ -217,7 +217,7 @@ describe('transport', function () {
 					__private.removePeer({
 						peer: peerData
 					}, 'Custom peer remove message');
-					expect(loggerStub.debug.called).to.be.true;
+					loggerStub.debug.called.should.be.true;
 					done();
 				});
 
@@ -225,14 +225,14 @@ describe('transport', function () {
 					__private.removePeer({
 						peer: peerData
 					}, 'Custom peer remove message');
-					expect(removeSpy.calledWith(peerData)).to.be.true;
+					removeSpy.calledWith(peerData).should.be.true;
 					done();
 				});
 			});
 		});
 
 		describe('receiveSignatures', function () {
-			
+
 			beforeEach(function (done) {
 				__private.receiveSignature = sinon.stub().callsArg(1);
 				library.schema.validate = sinon.stub().callsArg(2);
@@ -243,7 +243,7 @@ describe('transport', function () {
 				__private.receiveSignatures({
 					signatures: []
 				}, function (err) {
-					expect(library.schema.validate.called).to.be.true;
+					library.schema.validate.called.should.be.true;
 					done();
 				});
 			});
@@ -252,7 +252,7 @@ describe('transport', function () {
 				__private.receiveSignatures({
 					signatures: ['SIGNATURE123', 'SIGNATURE456'] // TODO: Use realistic signatures
 				}, function (err) {
-					expect(library.schema.validate.called).to.be.true;
+					library.schema.validate.called.should.be.true;
 					done();
 				});
 			});
@@ -278,7 +278,7 @@ describe('transport', function () {
 				__private.receiveSignatures({
 					signatures: ['SIGNATURE123', 'SIGNATURE456']
 				}, function (err) {
-					expect(library.schema.validate.called).to.be.true;
+					library.schema.validate.called.should.be.true;
 
 					restoreRewiredDeps();
 					done();
@@ -296,8 +296,8 @@ describe('transport', function () {
 					__private.receiveSignatures({
 						signatures: ['SIGNATURE123', 'SIGNATURE456']
 					}, function (err) {
-						expect(library.schema.validate.called).to.be.true;
-						expect(err).to.equal('Invalid signatures body');
+						library.schema.validate.called.should.be.true;
+						err.should.equal('Invalid signatures body');
 						done();
 					});
 				});
@@ -312,10 +312,10 @@ describe('transport', function () {
 						__private.receiveSignatures({
 							signatures: ['SIGNATURE123', 'SIGNATURE456']
 						}, function (err) {
-							expect(library.schema.validate.called).to.be.true;
-							expect(__private.receiveSignature.calledTwice).to.be.true;
-							expect(__private.receiveSignature.calledWith('SIGNATURE123')).to.be.true;
-							expect(__private.receiveSignature.calledWith('SIGNATURE456')).to.be.true;
+							library.schema.validate.called.should.be.true;
+							__private.receiveSignature.calledTwice.should.be.true;
+							__private.receiveSignature.calledWith('SIGNATURE123').should.be.true;
+							__private.receiveSignature.calledWith('SIGNATURE456').should.be.true;
 							done();
 						});
 					});
@@ -330,11 +330,11 @@ describe('transport', function () {
 							__private.receiveSignatures({
 								signatures: ['SIGNATURE123', 'SIGNATURE456']
 							}, function (err) {
-								expect(library.schema.validate.called).to.be.true;
+								library.schema.validate.called.should.be.true;
 								// If any of the __private.receiveSignature calls fail, the whole
 								// receiveSignatures operation should fail immediately.
-								expect(__private.receiveSignature.calledOnce).to.be.true;
-								expect(library.logger.debug.calledWith(err, 'SIGNATURE123')).to.be.true;
+								__private.receiveSignature.calledOnce.should.be.true;
+								library.logger.debug.calledWith(err, 'SIGNATURE123').should.be.true;
 								done();
 							});
 						});
@@ -347,7 +347,7 @@ describe('transport', function () {
 							__private.receiveSignatures({
 								signatures: ['SIGNATURE123', 'SIGNATURE456']
 							}, function (err) {
-								expect(err).to.be.equal(err);
+								err.should.be.equal(err);
 								done();
 							});
 						});
@@ -359,7 +359,7 @@ describe('transport', function () {
 							__private.receiveSignatures({
 								signatures: ['SIGNATURE123', 'SIGNATURE456']
 							}, function (err) {
-								expect(err).to.be.equal(null);
+								should.not.exist(err);
 								done();
 							});
 						});

--- a/test/unit/sql/blockRewards.js
+++ b/test/unit/sql/blockRewards.js
@@ -20,13 +20,13 @@ var modulesLoader = require('../../common/modulesLoader');
 
 function calcBlockReward (height, reward, done) {
 	return db.query(sql.calcBlockReward, {height: height}).then(function (rows) {
-		expect(rows).to.be.an('array');
-		expect(rows.length).to.equal(1);
-		expect(rows[0]).to.be.an('object');
+		rows.should.be.an('array');
+		rows.length.should.equal(1);
+		rows[0].should.be.an('object');
 		if (rows[0].reward == null) {
-			expect(rows[0].reward).to.equal(reward);
+			should.equal(rows[0].reward, reward);
 		} else {
-			expect(Number(rows[0].reward)).to.equal(reward);
+			Number(rows[0].reward).should.equal(reward);
 		}
 		done();
 	}).catch(done);
@@ -34,13 +34,13 @@ function calcBlockReward (height, reward, done) {
 
 function calcSupply (height, supply, done) {
 	return db.query(sql.calcSupply, {height: height}).then(function (rows) {
-		expect(rows).to.be.an('array');
-		expect(rows.length).to.equal(1);
-		expect(rows[0]).to.be.an('object');
+		rows.should.be.an('array');
+		rows.length.should.equal(1);
+		rows[0].should.be.an('object');
 		if (rows[0].supply == null) {
-			expect(rows[0].supply).to.equal(supply);
+			should.equal(rows[0].supply, supply);
 		} else {
-			expect(Number(rows[0].supply)).to.equal(supply);
+			Number(rows[0].supply).should.equal(supply);
 		}
 		done();
 	}).catch(done);
@@ -48,30 +48,30 @@ function calcSupply (height, supply, done) {
 
 function calcSupply_test (height_start, height_end, expected_reward, done) {
 	return db.query(sql.calcSupply_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
-		expect(rows).to.be.an('array');
-		expect(rows.length).to.equal(1);
-		expect(rows[0]).to.be.an('object');
-		expect(rows[0].result).to.equal(true);
+		rows.should.be.an('array');
+		rows.length.should.equal(1);
+		rows[0].should.be.an('object');
+		rows[0].result.should.equal(true);
 		done();
 	}).catch(done);
 }
 
 function calcSupply_test_fail (height_start, height_end, expected_reward, done) {
 	return db.query(sql.calcSupply_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
-		expect(rows).to.be.an('array');
-		expect(rows.length).to.equal(1);
-		expect(rows[0]).to.be.an('object');
-		expect(rows[0].result).to.equal(false);
+		rows.should.be.an('array');
+		rows.length.should.equal(1);
+		rows[0].should.be.an('object');
+		rows[0].result.should.equal(false);
 		done();
 	}).catch(done);
 }
 
 function calcBlockReward_test (height_start, height_end, expected_reward, done) {
 	return db.query(sql.calcBlockReward_test, {height_start: height_start, height_end: height_end, expected_reward: expected_reward}).then(function (rows) {
-		expect(rows).to.be.an('array');
-		expect(rows.length).to.equal(1);
-		expect(rows[0]).to.be.an('object');
-		expect(Number(rows[0].result)).to.equal(0);
+		rows.should.be.an('array');
+		rows.length.should.equal(1);
+		rows[0].should.be.an('object');
+		Number(rows[0].result).should.equal(0);
 		done();
 	}).catch(done);
 }
@@ -101,21 +101,21 @@ describe('BlockRewardsSQL @slow', function () {
 
 		it('SQL rewards should be equal to those in constants', function (done) {
 			db.query(sql.getBlockRewards).then(function (rows) {
-				expect(rows).to.be.an('array');
-				expect(rows.length).to.equal(1);
-				expect(rows[0]).to.be.an('object');
+				rows.should.be.an('array');
+				rows.length.should.equal(1);
+				rows[0].should.be.an('object');
 				// Checking supply
-				expect(Number(rows[0].supply)).to.equal(constants.totalAmount);
+				Number(rows[0].supply).should.equal(constants.totalAmount);
 				// Checking reward start
-				expect(Number(rows[0].start)).to.equal(constants.rewards.offset);
+				Number(rows[0].start).should.equal(constants.rewards.offset);
 				// Checking distance between milestones
-				expect(Number(rows[0].distance)).to.equal(constants.rewards.distance);
+				Number(rows[0].distance).should.equal(constants.rewards.distance);
 				// Checking milestones
-				expect(Number(rows[0].milestones[0])).to.equal(constants.rewards.milestones[0]);
-				expect(Number(rows[0].milestones[1])).to.equal(constants.rewards.milestones[1]);
-				expect(Number(rows[0].milestones[2])).to.equal(constants.rewards.milestones[2]);
-				expect(Number(rows[0].milestones[3])).to.equal(constants.rewards.milestones[3]);
-				expect(Number(rows[0].milestones[4])).to.equal(constants.rewards.milestones[4]);
+				Number(rows[0].milestones[0]).should.equal(constants.rewards.milestones[0]);
+				Number(rows[0].milestones[1]).should.equal(constants.rewards.milestones[1]);
+				Number(rows[0].milestones[2]).should.equal(constants.rewards.milestones[2]);
+				Number(rows[0].milestones[3]).should.equal(constants.rewards.milestones[3]);
+				Number(rows[0].milestones[4]).should.equal(constants.rewards.milestones[4]);
 				done();
 			}).catch(done);
 		});
@@ -231,8 +231,8 @@ describe('BlockRewardsSQL @slow', function () {
 			db.query(sql.calcBlockReward, {height: (13451520 * 1000)}).then(function (rows) {
 				done('Should not pass');
 			}).catch(function (err) {
-				expect(err).to.be.an('error');
-				expect(err.message).to.contain('function calcblockreward(bigint) does not exist');
+				err.should.be.an('error');
+				err.message.should.contain('function calcblockreward(bigint) does not exist');
 				done();
 			});
 		});
@@ -346,8 +346,8 @@ describe('BlockRewardsSQL @slow', function () {
 			db.query(sql.calcSupply, {height: (13451520 * 1000)}).then(function (rows) {
 				done('Should not pass');
 			}).catch(function (err) {
-				expect(err).to.be.an('error');
-				expect(err.message).to.contain('function calcsupply(bigint) does not exist');
+				err.should.be.an('error');
+				err.message.should.contain('function calcsupply(bigint) does not exist');
 				done();
 			});
 		});
@@ -359,10 +359,10 @@ describe('BlockRewardsSQL @slow', function () {
 
 			it('calcBlockReward_test should return 1000 for 1000 not matching block rewards', function (done) {
 				db.query(sql.calcBlockReward_test, {height_start: 1, height_end: 1000, expected_reward: 1}).then(function (rows) {
-					expect(rows).to.be.an('array');
-					expect(rows.length).to.equal(1);
-					expect(rows[0]).to.be.an('object');
-					expect(Number(rows[0].result)).to.equal(1000);
+					rows.should.be.an('array');
+					rows.length.should.equal(1);
+					rows[0].should.be.an('object');
+					Number(rows[0].result).should.equal(1000);
 					done();
 				}).catch(done);
 			});

--- a/test/unit/sql/memAccountsProtection.js
+++ b/test/unit/sql/memAccountsProtection.js
@@ -117,7 +117,7 @@ describe('mem_accounts protection', function () {
 
 			before(function (done) {
 				queries.getAccountByAddress(validAccount.address, function (err, account) {
-					expect(account).to.be.an('object').and.to.be.not.empty;
+					account.should.be.an('object').and.to.be.not.empty;
 					validAccount = account;
 					done(err);
 				});
@@ -133,7 +133,7 @@ describe('mem_accounts protection', function () {
 
 				it('should leave the old username', function (done) {
 					queries.getAccountByAddress(validAccount.address, function (err, updatedAccount) {
-						expect(updatedAccount).to.have.property('username').equal(validAccount.username);
+						updatedAccount.should.have.property('username').equal(validAccount.username);
 						return done(err);
 					});
 				});
@@ -147,8 +147,8 @@ describe('mem_accounts protection', function () {
 
 				it('should set username = null', function (done) {
 					queries.getAccountByAddress(validAccount.address, function (err, updatedAccount) {
-						expect(err).to.be.null;
-						expect(updatedAccount).to.have.property('username').to.be.null;
+						should.not.exist(err);
+						updatedAccount.should.have.property('username').to.be.null;
 						done();
 					});
 				});
@@ -181,8 +181,8 @@ describe('mem_accounts protection', function () {
 
 				it('should set the new value', function (done) {
 					queries.getAccountByAddress(noUsernameAccount.address, function (err, updatedAccount) {
-						expect(err).to.be.null;
-						expect(updatedAccount).to.have.property('username').equal(validUsername);
+						should.not.exist(err);
+						updatedAccount.should.have.property('username').equal(validUsername);
 						done();
 					});
 				});
@@ -196,7 +196,7 @@ describe('mem_accounts protection', function () {
 
 			before(function (done) {
 				queries.getAccountByAddress(validAccount.address, function (err, account) {
-					expect(account).to.be.an('object').and.to.be.not.empty;
+					account.should.be.an('object').and.to.be.not.empty;
 					validAccount = account;
 					done(err);
 				});
@@ -212,8 +212,8 @@ describe('mem_accounts protection', function () {
 
 				it('should leave the old username', function (done) {
 					queries.getAccountByAddress(validAccount.address, function (err, updatedAccount) {
-						expect(err).to.be.null;
-						expect(updatedAccount).to.have.property('u_username').equal(validAccount.u_username);
+						should.not.exist(err);
+						updatedAccount.should.have.property('u_username').equal(validAccount.u_username);
 						done();
 					});
 				});
@@ -227,8 +227,8 @@ describe('mem_accounts protection', function () {
 
 				it('should set u_username = null', function (done) {
 					queries.getAccountByAddress(validAccount.address, function (err, updatedAccount) {
-						expect(err).to.be.null;
-						expect(updatedAccount).to.have.property('u_username').to.be.null;
+						should.not.exist(err);
+						updatedAccount.should.have.property('u_username').to.be.null;
 						done();
 					});
 				});
@@ -261,8 +261,8 @@ describe('mem_accounts protection', function () {
 
 				it('should set the new value', function (done) {
 					queries.getAccountByAddress(noU_usernameAccount.address, function (err, updatedAccount) {
-						expect(err).to.be.null;
-						expect(updatedAccount).to.have.property('u_username').equal(validU_username);
+						should.not.exist(err);
+						updatedAccount.should.have.property('u_username').equal(validU_username);
 						done();
 					});
 				});


### PR DESCRIPTION
### What was the problem?

We are not standardizing our should/expect usage in tests

### How did I fix it?

Replaced all occurrences of expect with should, mostly using find/replace and a few manual updates:

```
find: expect\((.+?)\)\.to\.not\.exist
replace: should.not.exist($1)

find: expect\((.+?)\)\.to\.(eq|eql|equal)\(null\)
replace: should.not.exist($1)

find: expect\((.+?)\)\.to\.be\.(undefined|null)
replace: should.not.exist($1)

find: expect\((.+?)\)\.to\.
replace: $1.should.

find: ^([\s]+)expect\((.+?)\)\.not(\.to)?\.exist
replace: $1should.not.exist($2)

find: ^([\s]+)expect\((.+?)\)\.(not|eql|be|equal|have)
replace: $1$2.should.$3

find: ^([\s]+)expect\((.+?)\)\.that\.is\.
replace: $1$2.should.be.

find: ^([\s]+)expect\((.+?)\)\.and\.to\.
replace: $1$2.should.
```

### How to test it?

Run the tests!

### Review checklist

* The PR solves #1295 
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages do not follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages) but they will next time!
