### PR TITLE
Switch `should` for `expect` in tests - Closes #1295

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,6 @@
 		"__testContext": true,
 		"expect": true,
 		"gc": true,
-		"should": true,
 		"sinonSandbox": true
 	},
 	"plugins": []

--- a/test/common/helpers/api.js
+++ b/test/common/helpers/api.js
@@ -268,8 +268,8 @@ function getBlocks (params, cb) {
  * @param {string} param - Param name to check
  */
 function expectSwaggerParamError (res, param) {
-	res.body.message.should.be.eql('Validation errors');
-	res.body.errors.map(function (p) { return p.name; }).should.contain(param);
+	expect(res.body.message).to.be.eql('Validation errors');
+	expect(res.body.errors.map(function (p) { return p.name; })).to.contain(param);
 }
 
 /**

--- a/test/common/swaggerSpec.js
+++ b/test/common/swaggerSpec.js
@@ -28,7 +28,7 @@ validator.options.assumeAdditional = true;
 
 // Extend Chai assertion with a new method validResponse
 // to facilitate the validation of swagger response body
-// e.g. res.body.should.be.validResponse
+// e.g. expect(res.body).to.be.validResponse
 chai.use(function (chai, utils) {
 	chai.Assertion.addMethod('validResponse', function (responsePath) {
 		var result = validator.validate(utils.flag(this,'object'), apiSpec, {schemaPath: responsePath});
@@ -201,9 +201,9 @@ SwaggerTestSpec.prototype.makeRequest = function (parameters, responseCode){
 
 		var expectedResponseCode = responseCode || self.responseCode;
 
-		res.statusCode.should.be.eql(expectedResponseCode);
-		res.headers['content-type'].should.match(/json/);
-		res.body.should.be.validResponse(self.getResponseSpecPath(expectedResponseCode));
+		expect(res.statusCode).to.be.eql(expectedResponseCode);
+		expect(res.headers['content-type']).to.match(/json/);
+		expect(res.body).to.be.validResponse(self.getResponseSpecPath(expectedResponseCode));
 
 		return res;
 	})

--- a/test/functional/common/phases.js
+++ b/test/functional/common/phases.js
@@ -32,7 +32,7 @@ function confirmation (goodTransactions, badTransactions, pendingMultisignatures
 					'id=' + transaction.id
 				];
 				return apiHelpers.getTransactionsPromise(params).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 		});
@@ -40,7 +40,7 @@ function confirmation (goodTransactions, badTransactions, pendingMultisignatures
 		it('good transactions should not be unconfirmed', function () {
 			return Promise.map(goodTransactions, function (transaction) {
 				return apiHelpers.getUnconfirmedTransactionPromise(transaction.id).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 		});
@@ -51,7 +51,7 @@ function confirmation (goodTransactions, badTransactions, pendingMultisignatures
 					'id=' + transaction.id
 				];
 				return apiHelpers.getTransactionsPromise(params).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 				});
 			});
 		});
@@ -64,8 +64,8 @@ function confirmation (goodTransactions, badTransactions, pendingMultisignatures
 					];
 
 					return apiHelpers.getPendingMultisignaturesPromise(params).then(function (res) {
-						res.body.data.should.have.length(1);
-						res.body.data[0].id.should.be.equal(transaction.id);
+						expect(res.body.data).to.have.length(1);
+						expect(res.body.data[0].id).to.be.equal(transaction.id);
 					});
 				});
 			});
@@ -76,7 +76,7 @@ function confirmation (goodTransactions, badTransactions, pendingMultisignatures
 						'id=' + transaction.id
 					];
 					return apiHelpers.getTransactionsPromise(params).then(function (res) {
-						res.body.data.should.have.length(0);
+						expect(res.body.data).to.have.length(0);
 					});
 				});
 			});

--- a/test/functional/http/get/accounts.js
+++ b/test/functional/http/get/accounts.js
@@ -40,7 +40,7 @@ describe('GET /accounts', function () {
 
 			it('using known address and empty publicKey should return empty result', function () {
 				return accountsEndpoint.makeRequest({address: accountFixtures.genesis.address, publicKey: ''}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 
@@ -50,7 +50,7 @@ describe('GET /accounts', function () {
 
 			it('using unknown address should return empty result', function () {
 				return accountsEndpoint.makeRequest({address: account.address}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 
@@ -81,7 +81,7 @@ describe('GET /accounts', function () {
 
 			it('using unknown publicKey should return empty result', function () {
 				return accountsEndpoint.makeRequest({publicKey: account.publicKey}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 
@@ -99,7 +99,7 @@ describe('GET /accounts', function () {
 
 			it('using empty publicKey should return empty results', function () {
 				return accountsEndpoint.makeRequest({publicKey: ''}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 
@@ -111,15 +111,15 @@ describe('GET /accounts', function () {
 
 			it('using known address and matching publicKey should be ok', function () {
 				return accountsEndpoint.makeRequest({publicKey: accountFixtures.genesis.publicKey, address: accountFixtures.genesis.address}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].address.should.be.eql(accountFixtures.genesis.address);
-					res.body.data[0].publicKey.should.be.eql(accountFixtures.genesis.publicKey);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].address).to.be.eql(accountFixtures.genesis.address);
+					expect(res.body.data[0].publicKey).to.be.eql(accountFixtures.genesis.publicKey);
 				});
 			});
 
 			it('using known address and not matching publicKey should return empty result', function () {
 				return accountsEndpoint.makeRequest({publicKey: account.publicKey, address: accountFixtures.genesis.address}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 		});
@@ -132,25 +132,25 @@ describe('GET /accounts', function () {
 
 			before(function () {
 				return apiHelpers.sendTransactionPromise(creditTransaction).then(function (res) {
-					res.statusCode.should.be.eql(200);
+					expect(res.statusCode).to.be.eql(200);
 					return waitFor.confirmations([creditTransaction.id]);
 				}).then(function () {
 					return apiHelpers.sendTransactionPromise(signatureTransaction);
 				}).then(function (res) {
-					res.statusCode.should.be.eql(200);
+					expect(res.statusCode).to.be.eql(200);
 					return waitFor.confirmations([signatureTransaction.id]);
 				});
 			});
 
 			it('using known secondPublicKey should be ok', function () {
 				return accountsEndpoint.makeRequest({secondPublicKey: secondPublicKeyAccount.secondPublicKey}, 200).then(function (res) {
-					res.body.data[0].secondPublicKey.should.be.eql(secondPublicKeyAccount.secondPublicKey);
+					expect(res.body.data[0].secondPublicKey).to.be.eql(secondPublicKeyAccount.secondPublicKey);
 				});
 			});
 
 			it('using unknown secondPublicKey should return empty result', function () {
 				return accountsEndpoint.makeRequest({secondPublicKey: account.secondPublicKey}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 
@@ -177,10 +177,10 @@ describe('GET /accounts', function () {
 
 			it('using valid username name should result account', function () {
 				return accountsEndpoint.makeRequest({username: accountFixtures.existingDelegate.delegateName}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].address.should.be.eql(accountFixtures.existingDelegate.address);
-					res.body.data[0].publicKey.should.be.eql(accountFixtures.existingDelegate.publicKey);
-					res.body.data[0].delegate.username.should.to.eql(accountFixtures.existingDelegate.delegateName);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].address).to.be.eql(accountFixtures.existingDelegate.address);
+					expect(res.body.data[0].publicKey).to.be.eql(accountFixtures.existingDelegate.publicKey);
+					expect(res.body.data[0].delegate.username).to.to.eql(accountFixtures.existingDelegate.delegateName);
 				});
 			});
 		});
@@ -201,7 +201,7 @@ describe('GET /accounts', function () {
 
 			it('using limit = 5 should return return 5 accounts', function () {
 				return accountsEndpoint.makeRequest({limit: 5}, 200).then(function (res) {
-					res.body.data.should.have.length(5);
+					expect(res.body.data).to.have.length(5);
 				});
 			});
 		});
@@ -214,21 +214,21 @@ describe('GET /accounts', function () {
 			it('using no sort return accounts sorted by balance in asending order as default behavior', function () {
 				return accountsEndpoint.makeRequest({sort: 'balance:asc'}, 200).then(function (res) {
 					var balances = _(res.body.data).map('balance').value();
-					_.clone(balances).sort().should.be.eql(balances);
+					expect(_.clone(balances).sort()).to.be.eql(balances);
 				});
 			});
 
 			it('using sort = balance:asc should return accounts in ascending order by balance', function () {
 				return accountsEndpoint.makeRequest({sort: 'balance:asc'}, 200).then(function (res) {
 					var balances = _(res.body.data).map('balance').value();
-					_.clone(balances).sort().should.be.eql(balances);
+					expect(_.clone(balances).sort()).to.be.eql(balances);
 				});
 			});
 
 			it('using sort = balance:desc should return accounts in descending order by balance', function () {
 				return accountsEndpoint.makeRequest({sort: 'balance:desc'}, 200).then(function (res) {
 					var balances = _(res.body.data).map('balance').value();
-					_.clone(balances).sort().reverse().should.be.eql(balances);
+					expect(_.clone(balances).sort().reverse()).to.be.eql(balances);
 				});
 			});
 		});
@@ -248,7 +248,7 @@ describe('GET /accounts', function () {
 					res1 = res;
 					return accountsEndpoint.makeRequest({offset: 5}, 200);
 				}).then(function (res2) {
-					res2.body.data.should.include.deep.members(res1.body.data.slice(-5));
+					expect(res2.body.data).to.include.deep.members(res1.body.data.slice(-5));
 				});
 			});
 		});
@@ -259,25 +259,25 @@ describe('GET /accounts', function () {
 				return accountsEndpoint.makeRequest({sort: 'balance:asc', offset: 1, limit: 5}, 200).then(function (res) {
 					var balances = _(res.body.data).map('balance').value();
 
-					res.body.data.should.have.length(5);
-					_.clone(balances).sort().reverse().should.be.eql(balances);
+					expect(res.body.data).to.have.length(5);
+					expect(_.clone(balances).sort().reverse()).to.be.eql(balances);
 				});
 			});
 		});
 
 		it('should return delegate properties for a delegate account', function () {
 			return accountsEndpoint.makeRequest({address: accountFixtures.existingDelegate.address}, 200).then(function (res) {
-				res.body.data[0].address.should.be.eql(accountFixtures.existingDelegate.address);
-				res.body.data[0].publicKey.should.be.eql(accountFixtures.existingDelegate.publicKey);
-				res.body.data[0].delegate.username.should.be.eql(accountFixtures.existingDelegate.delegateName);
+				expect(res.body.data[0].address).to.be.eql(accountFixtures.existingDelegate.address);
+				expect(res.body.data[0].publicKey).to.be.eql(accountFixtures.existingDelegate.publicKey);
+				expect(res.body.data[0].delegate.username).to.be.eql(accountFixtures.existingDelegate.delegateName);
 			});
 		});
 
 		it('should return empty delegate property for a non delegate account', function () {
 			return accountsEndpoint.makeRequest({address: accountFixtures.genesis.address}, 200).then(function (res) {
-				res.body.data[0].address.should.be.eql(accountFixtures.genesis.address);
-				res.body.data[0].publicKey.should.be.eql(accountFixtures.genesis.publicKey);
-				res.body.data[0].should.not.have.property('delegate');
+				expect(res.body.data[0].address).to.be.eql(accountFixtures.genesis.address);
+				expect(res.body.data[0].publicKey).to.be.eql(accountFixtures.genesis.publicKey);
+				expect(res.body.data[0]).to.not.have.property('delegate');
 			});
 		});
 	});

--- a/test/functional/http/get/accounts.multisignatures.js
+++ b/test/functional/http/get/accounts.multisignatures.js
@@ -55,7 +55,7 @@ describe('GET /api/accounts', function () {
 
 				return signatureEndpoint.makeRequest({signatures: signatures}, 200);
 			}).then(function (res) {
-				res.body.meta.status.should.be.true;
+				expect(res.body.meta.status).to.be.true;
 				return waitFor.confirmations([scenario.multiSigTransaction.id]);
 			});
 	});
@@ -68,29 +68,29 @@ describe('GET /api/accounts', function () {
 
 			it('using known address should respond with its multisignature_group', function () {
 				return multisigGroupsEndpoint.makeRequest({address: account.address}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 					var group = res.body.data[0];
-					group.address.should.be.equal(account.address);
-					group.publicKey.should.be.equal(account.publicKey);
-					group.members.should.have.length(scenario.members.length);
-					_.map(group.members, 'address').sort().should.be.eql(_.map(scenario.members, 'address').sort());
+					expect(group.address).to.be.equal(account.address);
+					expect(group.publicKey).to.be.equal(account.publicKey);
+					expect(group.members).to.have.length(scenario.members.length);
+					expect(_.map(group.members, 'address').sort()).to.be.eql(_.map(scenario.members, 'address').sort());
 				});
 			});
 
 			it('using known lowercase address should respond with its multisignature_group', function () {
 				return multisigGroupsEndpoint.makeRequest({address: account.address.toLowerCase()}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 					var group = res.body.data[0];
-					group.address.should.be.equal(account.address);
-					group.publicKey.should.be.equal(account.publicKey);
-					group.members.should.have.length(scenario.members.length);
-					_.map(group.members, 'address').sort().should.be.eql(_.map(scenario.members, 'address').sort());
+					expect(group.address).to.be.equal(account.address);
+					expect(group.publicKey).to.be.equal(account.publicKey);
+					expect(group.members).to.have.length(scenario.members.length);
+					expect(_.map(group.members, 'address').sort()).to.be.eql(_.map(scenario.members, 'address').sort());
 				});
 			});
 
 			it('using unknown address should return empty result', function () {
 				return multisigGroupsEndpoint.makeRequest({address: accountFixtures.existingDelegate.address}, 404).then(function (res) {
-					res.body.message.should.be.equal('Multisignature account not found');
+					expect(res.body.message).to.be.equal('Multisignature account not found');
 				});
 			});
 
@@ -116,46 +116,46 @@ describe('GET /api/accounts', function () {
 
 			it('using master group account address should respond with empty multisignature memberships', function () {
 				return multisigMembersEndpoint.makeRequest({address: account.address}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 
 			it('using known member address should respond with its multisignature memberships', function () {
 				return multisigMembersEndpoint.makeRequest({address: scenario.members[0].address}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 					var group = res.body.data[0];
-					group.address.should.be.equal(account.address);
-					group.publicKey.should.be.equal(account.publicKey);
-					group.members.should.have.length(scenario.members.length);
-					_.map(group.members, 'address').should.include(scenario.members[0].address);
+					expect(group.address).to.be.equal(account.address);
+					expect(group.publicKey).to.be.equal(account.publicKey);
+					expect(group.members).to.have.length(scenario.members.length);
+					expect(_.map(group.members, 'address')).to.include(scenario.members[0].address);
 				});
 			});
 
 			it('using known other member address should respond with its multisignature memberships', function () {
 				return multisigMembersEndpoint.makeRequest({address: scenario.members[1].address}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 					var group = res.body.data[0];
-					group.address.should.be.equal(account.address);
-					group.publicKey.should.be.equal(account.publicKey);
-					group.members.should.have.length(scenario.members.length);
-					_.map(group.members, 'address').should.include(scenario.members[1].address);
+					expect(group.address).to.be.equal(account.address);
+					expect(group.publicKey).to.be.equal(account.publicKey);
+					expect(group.members).to.have.length(scenario.members.length);
+					expect(_.map(group.members, 'address')).to.include(scenario.members[1].address);
 				});
 			});
 
 			it('using known lowercase address should respond with its multisignature_group', function () {
 				return multisigMembersEndpoint.makeRequest({address: scenario.members[0].address}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 					var group = res.body.data[0];
-					group.address.should.be.equal(account.address);
-					group.publicKey.should.be.equal(account.publicKey);
-					group.members.should.have.length(scenario.members.length);
-					_.map(group.members, 'address').should.include(scenario.members[0].address);
+					expect(group.address).to.be.equal(account.address);
+					expect(group.publicKey).to.be.equal(account.publicKey);
+					expect(group.members).to.have.length(scenario.members.length);
+					expect(_.map(group.members, 'address')).to.include(scenario.members[0].address);
 				});
 			});
 
 			it('using unknown address should return empty result', function () {
 				return multisigMembersEndpoint.makeRequest({address: accountFixtures.existingDelegate.address}, 200).then(function (res) {
-					res.body.data.should.have.length(0);
+					expect(res.body.data).to.have.length(0);
 				});
 			});
 

--- a/test/functional/http/get/blocks.js
+++ b/test/functional/http/get/blocks.js
@@ -40,7 +40,7 @@ describe('GET /blocks', function () {
 	function expectHeightCheck (res) {
 		res.body.data.forEach(function (block) {
 			if (block.height === 1) {
-				block.previousBlockId.should.be.empty;
+				expect(block.previousBlockId).to.be.empty;
 			}
 		});
 	}
@@ -59,14 +59,14 @@ describe('GET /blocks', function () {
 				var id = '6524861224470851795';
 
 				return blocksEndpoint.makeRequest({blockId: id}, 200).then(function (res) {
-					res.body.data[0].id.should.equal(id);
+					expect(res.body.data[0].id).to.equal(id);
 					expectHeightCheck(res);
 				});
 			});
 
 			it('using unknown id should return empty blocks array', function () {
 				return blocksEndpoint.makeRequest({blockId: '9928719876370886655'}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 					expectHeightCheck(res);
 				});
 			});
@@ -88,7 +88,7 @@ describe('GET /blocks', function () {
 
 			it('using correct params should be ok', function () {
 				return blocksEndpoint.makeRequest({height: block.blockHeight}, 200).then(function (res) {
-					res.body.data[0].height.should.equal(block.blockHeight);
+					expect(res.body.data[0].height).to.equal(block.blockHeight);
 					expectHeightCheck(res);
 				});
 			});
@@ -99,7 +99,7 @@ describe('GET /blocks', function () {
 				}
 
 				return blocksEndpoint.makeRequest({height: 10}, 200).then(function (res) {
-					res.body.data[0].height.should.equal(10);
+					expect(res.body.data[0].height).to.equal(10);
 					expectHeightCheck(res);
 				});
 			});
@@ -115,7 +115,7 @@ describe('GET /blocks', function () {
 
 			it('using correct params should be ok', function () {
 				return blocksEndpoint.makeRequest({generatorPublicKey: block.generatorPublicKey}, 200).then(function (res) {
-					res.body.data[0].generatorPublicKey.should.equal(block.generatorPublicKey);
+					expect(res.body.data[0].generatorPublicKey).to.equal(block.generatorPublicKey);
 					expectHeightCheck(res);
 				});
 			});
@@ -128,21 +128,21 @@ describe('GET /blocks', function () {
 				it('using "height:asc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'height:asc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('height').sortNumbers().should.be.eql(_.map(res.body.data, 'height'));
+						expect(_(res.body.data).map('height').sortNumbers()).to.be.eql(_.map(res.body.data, 'height'));
 					});
 				});
 
 				it('using "height:desc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'height:desc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('height').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'height'));
+						expect(_(res.body.data).map('height').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'height'));
 					});
 				});
 
 				it('using empty params should sort results by descending height', function () {
 					return blocksEndpoint.makeRequest({}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('height').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'height'));
+						expect(_(res.body.data).map('height').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'height'));
 					});
 				});
 			});
@@ -152,14 +152,14 @@ describe('GET /blocks', function () {
 				it('using "totalAmount:asc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'totalAmount:asc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('totalAmount').map(_.toInteger).sortNumbers().should.be.eql(_(res.body.data).map('totalAmount').map(_.toInteger).value());
+						expect(_(res.body.data).map('totalAmount').map(_.toInteger).sortNumbers()).to.be.eql(_(res.body.data).map('totalAmount').map(_.toInteger).value());
 					});
 				});
 
 				it('using "totalAmount:desc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'totalAmount:desc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('totalAmount').map(_.toInteger).sortNumbers('desc').should.be.eql(_(res.body.data).map('totalAmount').map(_.toInteger).value());
+						expect(_(res.body.data).map('totalAmount').map(_.toInteger).sortNumbers('desc')).to.be.eql(_(res.body.data).map('totalAmount').map(_.toInteger).value());
 					});
 				});
 			});
@@ -169,14 +169,14 @@ describe('GET /blocks', function () {
 				it('using "totalFee:asc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'totalFee:asc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('totalFee').map(_.toInteger).sortNumbers().should.be.eql(_(res.body.data).map('totalFee').map(_.toInteger).value());
+						expect(_(res.body.data).map('totalFee').map(_.toInteger).sortNumbers()).to.be.eql(_(res.body.data).map('totalFee').map(_.toInteger).value());
 					});
 				});
 
 				it('using "totalFee:desc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'totalFee:desc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('totalFee').map(_.toInteger).sortNumbers('desc').should.be.eql(_(res.body.data).map('totalFee').map(_.toInteger).value());
+						expect(_(res.body.data).map('totalFee').map(_.toInteger).sortNumbers('desc')).to.be.eql(_(res.body.data).map('totalFee').map(_.toInteger).value());
 					});
 				});
 			});
@@ -186,14 +186,14 @@ describe('GET /blocks', function () {
 				it('using "timestamp:asc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'timestamp:asc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('timestamp').sortNumbers().should.be.eql(_.map(res.body.data, 'timestamp'));
+						expect(_(res.body.data).map('timestamp').sortNumbers()).to.be.eql(_.map(res.body.data, 'timestamp'));
 					});
 				});
 
 				it('using "timestamp:desc" should be ok', function () {
 					return blocksEndpoint.makeRequest({sort: 'timestamp:desc'}, 200).then(function (res) {
 						expectHeightCheck(res);
-						_(res.body.data).map('timestamp').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'timestamp'));
+						expect(_(res.body.data).map('timestamp').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 					});
 				});
 			});
@@ -221,13 +221,13 @@ describe('GET /blocks', function () {
 
 			it('using 1 should be ok', function () {
 				return blocksEndpoint.makeRequest({limit: 1}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 				});
 			});
 
 			it('using 100 should be ok', function () {
 				return blocksEndpoint.makeRequest({limit: 100}, 200).then(function (res) {
-					res.body.data.length.should.be.at.most(100);
+					expect(res.body.data.length).to.be.at.most(100);
 				});
 			});
 
@@ -254,7 +254,7 @@ describe('GET /blocks', function () {
 
 			it('using 1 should be ok', function () {
 				return blocksEndpoint.makeRequest({offset: 1}, 200).then(function (res) {
-					res.body.data[0].height.should.be.above(1);
+					expect(res.body.data[0].height).to.be.above(1);
 				});
 			});
 		});

--- a/test/functional/http/get/cache.js
+++ b/test/functional/http/get/cache.js
@@ -109,7 +109,7 @@ describe('cached endpoints', function () {
 					});
 				}));
 			}).then(function (responses) {
-				responses.should.deep.include(initialResponse.body);
+				expect(responses).to.deep.include(initialResponse.body);
 			});
 		});
 
@@ -143,7 +143,7 @@ describe('cached endpoints', function () {
 					});
 				}));
 			}).then(function (responses) {
-				responses.should.deep.include(initialResponse.body);
+				expect(responses).to.deep.include(initialResponse.body);
 			}).then(function () {
 				return waitForBlocksPromise(1);
 			}).then(function () {
@@ -168,7 +168,7 @@ describe('cached endpoints', function () {
 						return getJsonForKeyPromise(res.req.path);
 					});
 				})).then(function (responses) {
-					responses.should.deep.include(res.body);
+					expect(responses).to.deep.include(res.body);
 				});
 			});
 		});
@@ -199,7 +199,7 @@ describe('cached endpoints', function () {
 						return getJsonForKeyPromise(res.req.path);
 					});
 				})).then(function (responses) {
-					responses.should.deep.include(res.body);
+					expect(responses).to.deep.include(res.body);
 					return onNewRoundPromise().then(function () {
 						return getJsonForKeyPromise(urlPath).then(function (result) {
 							expect(result).to.not.exist;

--- a/test/functional/http/get/dapps.js
+++ b/test/functional/http/get/dapps.js
@@ -68,7 +68,7 @@ describe('GET /dapps', function () {
 
 		it('should return all results', function () {
 			return dappsEndpoint.makeRequest({}, 200).then(function (res) {
-				res.body.data.length.should.be.at.least(registeredDappsAmount);
+				expect(res.body.data.length).to.be.at.least(registeredDappsAmount);
 			});
 		});
 	});
@@ -103,14 +103,14 @@ describe('GET /dapps', function () {
 
 			it('using unknown id should return an empty array', function () {
 				return dappsEndpoint.makeRequest({transactionId: '8713095156789756398'}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 
 			it('using known ids should be ok', function () {
 				return Promise.map(transactionsToWaitFor, function (transaction) {
 					return dappsEndpoint.makeRequest({transactionId: transaction}, 200).then(function (res) {
-						res.body.data[0].transactionId.should.be.eql(transaction);
+						expect(res.body.data[0].transactionId).to.be.eql(transaction);
 					});
 				});
 			});
@@ -132,21 +132,21 @@ describe('GET /dapps', function () {
 
 			it('using string = "Unknown" should be ok', function () {
 				return dappsEndpoint.makeRequest({name: 'Unknown'}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 
 			it('using registered dapp1 name should be ok', function () {
 				return dappsEndpoint.makeRequest({name: dapp1.name}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].name.should.be.eql(dapp1.name);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].name).to.be.eql(dapp1.name);
 				});
 			});
 
 			it('using registered dapp2 name should be ok', function () {
 				return dappsEndpoint.makeRequest({name: dapp2.name}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].name.should.be.eql(dapp2.name);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].name).to.be.eql(dapp2.name);
 				});
 			});
 		});
@@ -167,13 +167,13 @@ describe('GET /dapps', function () {
 
 			it('using 1 should be ok', function () {
 				return dappsEndpoint.makeRequest({limit: 1}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 				});
 			});
 
 			it('using 100 should be ok', function () {
 				return dappsEndpoint.makeRequest({limit: 100}, 200).then(function (res) {
-					res.body.data.should.have.length.at.most(100);
+					expect(res.body.data).to.have.length.at.most(100);
 				});
 			});
 		});
@@ -188,17 +188,17 @@ describe('GET /dapps', function () {
 
 			it('using offset 0 should be ok', function () {
 				return dappsEndpoint.makeRequest({limit: 1, offset: 0}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.meta.limit.should.be.eql(1);
-					res.body.meta.offset.should.be.eql(0);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.meta.limit).to.be.eql(1);
+					expect(res.body.meta.offset).to.be.eql(0);
 				});
 			});
 
 			it('using offset 1 should be ok', function () {
 				return dappsEndpoint.makeRequest({limit: 1, offset: 1}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.meta.limit.should.be.eql(1);
-					res.body.meta.offset.should.be.eql(1);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.meta.limit).to.be.eql(1);
+					expect(res.body.meta.offset).to.be.eql(1);
 				});
 			});
 		});
@@ -207,8 +207,8 @@ describe('GET /dapps', function () {
 
 			it('using offset 0 should return different result than offset 1', function () {
 				return dappsEndpoint.makeRequests([{offset: 0}, {offset: 1}], 200).then(function (responses) {
-					responses.should.have.length(2);
-					responses[0].body.data[0].name.should.not.equal(responses[1].body.data[0].name);
+					expect(responses).to.have.length(2);
+					expect(responses[0].body.data[0].name).to.not.equal(responses[1].body.data[0].name);
 				});
 			});
 		});
@@ -275,13 +275,13 @@ describe('GET /dapps', function () {
 
 			it('using empty string should return all results', function () {
 				return dappsEndpoint.makeRequest({unknown: ''}, 200).then(function (res) {
-					res.body.data.should.have.length.at.least(registeredDappsAmount);
+					expect(res.body.data).to.have.length.at.least(registeredDappsAmount);
 				});
 			});
 
 			it('using "unknown" should return all results', function () {
 				return dappsEndpoint.makeRequest({unknown: 'unknown'}, 200).then(function (res) {
-					res.body.data.should.have.length.at.least(registeredDappsAmount);
+					expect(res.body.data).to.have.length.at.least(registeredDappsAmount);
 				});
 			});
 		});

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -213,14 +213,14 @@ describe('GET /delegates', function () {
 			it('using search="genesis_1" should return 13 delegates', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_1', limit: 20}, 200).then(function (res) {
 					expect(res.body.data).to.have.length(13);
-					expect(res.body.data.map(function (d) { /^genesis_1.*/.test(d.username); })).to.be.true;
+					res.body.data.map(function (d) { expect(/^genesis_1.*/.test(d.username)).to.be.true; });
 				});
 			});
 
 			it('using search="genesis_10" should return 3 delegates', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_10'}, 200).then(function (res) {
 					expect(res.body.data).to.have.length(3);
-					expect(res.body.data.map(function (d) { /^genesis_10.*/.test(d.username); })).to.be.true;
+					res.body.data.map(function (d) { expect(/^genesis_10.*/.test(d.username)).to.be.true; });
 				});
 			});
 
@@ -234,7 +234,7 @@ describe('GET /delegates', function () {
 			it('using higher limit should return 101 delegates', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_', limit: 100}, 200).then(function (res) {
 					expect(res.body.data).to.have.length(100);
-					expect(res.body.data.map(function (d) { /^genesis_.*/.test(d.username); })).to.be.true;
+					res.body.data.map(function (d) { expect(/^genesis_.*/.test(d.username)).to.be.true; });
 				});
 			});
 		});

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -37,7 +37,7 @@ describe('GET /delegates', function () {
 
 		it('using no params should return genesis delegates with default limit', function () {
 			return delegatesEndpoint.makeRequest({}, 200).then(function (res) {
-				res.body.data.should.have.lengthOf(10);
+				expect(res.body.data).to.have.lengthOf(10);
 			});
 		});
 
@@ -51,7 +51,7 @@ describe('GET /delegates', function () {
 			}).then(function (res) {
 				data.push.apply(data, res.body.data);
 
-				data.should.have.lengthOf.at.least(101);
+				expect(data).to.have.lengthOf.at.least(101);
 			});
 		});
 
@@ -59,7 +59,7 @@ describe('GET /delegates', function () {
 
 			it('using no publicKey should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({publicKey: ''}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 
@@ -71,14 +71,14 @@ describe('GET /delegates', function () {
 
 			it('using valid existing publicKey of genesis delegate should return the result', function () {
 				return delegatesEndpoint.makeRequest({publicKey: validDelegate.publicKey}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].account.publicKey.should.be.eql(validDelegate.publicKey);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].account.publicKey).to.be.eql(validDelegate.publicKey);
 				});
 			});
 
 			it('using valid not existing publicKey should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({publicKey: validNotExistingPublicKey}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 		});
@@ -93,20 +93,20 @@ describe('GET /delegates', function () {
 
 			before(function () {
 				return apiHelpers.sendTransactionPromise(creditTransaction).then(function (res) {
-					res.statusCode.should.be.eql(200);
+					expect(res.statusCode).to.be.eql(200);
 					return waitFor.confirmations([creditTransaction.id]);
 				}).then(function () {
 					return apiHelpers.sendTransactionsPromise([signatureTransaction, delegateTransaction]);
 				}).then(function (res) {
-					res[0].statusCode.should.be.eql(200);
-					res[1].statusCode.should.be.eql(200);
+					expect(res[0].statusCode).to.be.eql(200);
+					expect(res[1].statusCode).to.be.eql(200);
 					return waitFor.confirmations([signatureTransaction.id, delegateTransaction.id]);
 				});
 			});
 
 			it.only('using no secondPublicKey should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({secondPublicKey: ''}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 
@@ -118,14 +118,14 @@ describe('GET /delegates', function () {
 
 			it('using valid existing secondPublicKey of delegate should return the result', function () {
 				return delegatesEndpoint.makeRequest({secondPublicKey: secondSecretAccount.secondPublicKey}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].account.secondPublicKey.should.be.eql(secondSecretAccount.secondPublicKey);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].account.secondPublicKey).to.be.eql(secondSecretAccount.secondPublicKey);
 				});
 			});
 
 			it('using valid not existing secondPublicKey should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({secondPublicKey: validNotExistingPublicKey}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 		});
@@ -146,13 +146,13 @@ describe('GET /delegates', function () {
 
 			it('using valid existing address of genesis delegate should return the result', function () {
 				return delegatesEndpoint.makeRequest({address: validDelegate.address}, 200).then(function (res) {
-					res.body.data[0].account.address.should.eql(validDelegate.address);
+					expect(res.body.data[0].account.address).to.eql(validDelegate.address);
 				});
 			});
 
 			it('using valid not existing address should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({address: '1111111111111111111L'}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 		});
@@ -171,13 +171,13 @@ describe('GET /delegates', function () {
 
 			it('using valid existing username of genesis delegate should return the result', function () {
 				return delegatesEndpoint.makeRequest({username: validDelegate.username}, 200).then(function (res) {
-					res.body.data[0].username.should.eql(validDelegate.username);
+					expect(res.body.data[0].username).to.eql(validDelegate.username);
 				});
 			});
 
 			it('using valid not existing username should return an empty array', function () {
 				return delegatesEndpoint.makeRequest({username: 'unknownusername'}, 200).then(function (res) {
-					res.body.data.should.be.empty;
+					expect(res.body.data).to.be.empty;
 				});
 			});
 		});
@@ -192,7 +192,7 @@ describe('GET /delegates', function () {
 
 			it('using the special match all character should return all results', function () {
 				return delegatesEndpoint.makeRequest({search: '%'}, 200).then(function (res) {
-					res.body.data.should.have.length.of.at.least(10);
+					expect(res.body.data).to.have.length.of.at.least(10);
 				});
 			});
 
@@ -212,29 +212,29 @@ describe('GET /delegates', function () {
 
 			it('using search="genesis_1" should return 13 delegates', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_1', limit: 20}, 200).then(function (res) {
-					res.body.data.should.have.length(13);
-					res.body.data.map(function (d) { /^genesis_1.*/.test(d.username).should.be.true; });
+					expect(res.body.data).to.have.length(13);
+					expect(res.body.data.map(function (d) { /^genesis_1.*/.test(d.username); })).to.be.true;
 				});
 			});
 
 			it('using search="genesis_10" should return 3 delegates', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_10'}, 200).then(function (res) {
-					res.body.data.should.have.length(3);
-					res.body.data.map(function (d) { /^genesis_10.*/.test(d.username).should.be.true; });
+					expect(res.body.data).to.have.length(3);
+					expect(res.body.data.map(function (d) { /^genesis_10.*/.test(d.username); })).to.be.true;
 				});
 			});
 
 			it('using search="genesis_101" should return 1 delegate', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_101'}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].username.should.eql('genesis_101');
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].username).to.eql('genesis_101');
 				});
 			});
 
 			it('using higher limit should return 101 delegates', function () {
 				return delegatesEndpoint.makeRequest({search: 'genesis_', limit: 100}, 200).then(function (res) {
-					res.body.data.should.have.length(100);
-					res.body.data.map(function (d) { /^genesis_.*/.test(d.username).should.be.true; });
+					expect(res.body.data).to.have.length(100);
+					expect(res.body.data.map(function (d) { /^genesis_.*/.test(d.username); })).to.be.true;
 				});
 			});
 		});
@@ -249,49 +249,49 @@ describe('GET /delegates', function () {
 
 			it('using sort="rank:asc" should sort results in ascending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'rank:asc'}, 200).then(function (res) {
-					_.map(res.data, 'rank').sort().should.eql(_.map(res.data, 'rank'));
+					expect(_.map(res.data, 'rank').sort()).to.eql(_.map(res.data, 'rank'));
 				});
 			});
 
 			it('using sort="rank:desc" should sort results in descending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'rank:asc'}, 200).then(function (res) {
-					_.map(res.data, 'rank').sort().reverse().should.eql(_.map(res.data, 'rank'));
+					expect(_.map(res.data, 'rank').sort().reverse()).to.eql(_.map(res.data, 'rank'));
 				});
 			});
 
 			it('using sort="username:asc" should sort results in ascending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'username:asc'}, 200).then(function (res) {
-					_(res.data).map('username').dbSort().should.eql(_.map(res.data, 'username'));
+					expect(_(res.data).map('username').dbSort()).to.eql(_.map(res.data, 'username'));
 				});
 			});
 
 			it('using sort="username:desc" should sort results in descending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'username:desc'}, 200).then(function (res) {
-					_(res.data).map('username').dbSort('desc').should.eql(_.map(res.data, 'username'));
+					expect(_(res.data).map('username').dbSort('desc')).to.eql(_.map(res.data, 'username'));
 				});
 			});
 
 			it('using sort="missedBlocks:asc" should sort results in ascending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'missedBlocks:asc'}, 200).then(function (res) {
-					_.map(res.data, 'missedBlocks').sort().should.eql(_.map(res.data, 'missedBlocks'));
+					expect(_.map(res.data, 'missedBlocks').sort()).to.eql(_.map(res.data, 'missedBlocks'));
 				});
 			});
 
 			it('using sort="missedBlocks:desc" should sort results in descending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'missedBlocks:desc'}, 200).then(function (res) {
-					_.map(res.data, 'missedBlocks').sort().reverse().should.eql(_.map(res.data, 'missedBlocks'));
+					expect(_.map(res.data, 'missedBlocks').sort().reverse()).to.eql(_.map(res.data, 'missedBlocks'));
 				});
 			});
 
 			it('using sort="productivity:asc" should sort results in ascending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'productivity:asc'}, 200).then(function (res) {
-					_.map(res.data, 'productivity').sort().should.eql(_.map(res.data, 'productivity'));
+					expect(_.map(res.data, 'productivity').sort()).to.eql(_.map(res.data, 'productivity'));
 				});
 			});
 
 			it('using sort="productivity:desc" should sort results in descending order', function () {
 				return delegatesEndpoint.makeRequest({sort: 'productivity:desc'}, 200).then(function (res) {
-					_.map(res.data, 'productivity').sort().reverse().should.eql(_.map(res.data, 'productivity'));
+					expect(_.map(res.data, 'productivity').sort().reverse()).to.eql(_.map(res.data, 'productivity'));
 				});
 			});
 
@@ -327,13 +327,13 @@ describe('GET /delegates', function () {
 
 			it('using limit=1 should be ok', function () {
 				return delegatesEndpoint.makeRequest({limit: 1}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
+					expect(res.body.data).to.have.length(1);
 				});
 			});
 
 			it('using limit=101 should be ok', function () {
 				return delegatesEndpoint.makeRequest({limit: 100}, 200).then(function (res) {
-					res.body.data.should.have.length(100);
+					expect(res.body.data).to.have.length(100);
 				});
 			});
 
@@ -354,7 +354,7 @@ describe('GET /delegates', function () {
 
 			it('using offset=1 should be ok', function () {
 				return delegatesEndpoint.makeRequest({offset: 1, limit: 10}, 200).then(function (res) {
-					res.body.data.should.have.lengthOf.at.least(10);
+					expect(res.body.data).to.have.lengthOf.at.least(10);
 				});
 			});
 
@@ -372,19 +372,19 @@ describe('GET /delegates', function () {
 
 		it('using no params should be ok', function () {
 			return forgersEndpoint.makeRequest({}, 200).then(function (res) {
-				res.body.data.should.have.length(10);
+				expect(res.body.data).to.have.length(10);
 			});
 		});
 
 		it('using limit=1 should be ok', function () {
 			return forgersEndpoint.makeRequest({limit: 1}, 200).then(function (res) {
-				res.body.data.should.have.length(1);
+				expect(res.body.data).to.have.length(1);
 			});
 		});
 
 		it('using offset=1 limit=10 should be ok', function () {
 			return forgersEndpoint.makeRequest({limit: 10, offset: 1}, 200).then(function (res) {
-				res.body.data.should.have.length(10);
+				expect(res.body.data).to.have.length(10);
 			});
 		});
 
@@ -399,12 +399,12 @@ describe('GET /delegates', function () {
 			});
 
 			it('lastBlockSlot should be less or equal to currentSlot', function () {
-				forgersData.meta.lastBlockSlot.should.be.at.most(forgersData.meta.currentSlot);
+				expect(forgersData.meta.lastBlockSlot).to.be.at.most(forgersData.meta.currentSlot);
 			});
 
 			it('every forger nextSlot should be greater than currentSlot', function () {
 				forgersData.data.forEach(function (forger) {
-					forgersData.meta.currentSlot.should.be.at.most(forger.nextSlot);
+					expect(forgersData.meta.currentSlot).to.be.at.most(forger.nextSlot);
 				});
 			});
 		});

--- a/test/functional/http/get/node.js
+++ b/test/functional/http/get/node.js
@@ -33,60 +33,60 @@ describe('GET /node', function () {
 		});
 
 		it('should return a result containing nethash = "198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d"', function () {
-			constantsResponse.nethash.should.be.equal('198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d');
+			expect(constantsResponse.nethash).to.be.equal('198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d');
 		});
 
 
 		it('should return a result containing milestone that is a number <= 500000000', function () {
-			parseInt(constantsResponse.milestone).should.at.most(500000000);
+			expect(parseInt(constantsResponse.milestone)).to.at.most(500000000);
 		});
 
 		it('should return a result containing reward that is a number <= 500000000', function () {
-			parseInt(constantsResponse.reward).should.at.most(500000000);
+			expect(parseInt(constantsResponse.reward)).to.at.most(500000000);
 		});
 
 		it('should return a result containing supply that is a number = 10000000000000000', function () {
-			constantsResponse.supply.should.be.equal('10000000000000000');
+			expect(constantsResponse.supply).to.be.equal('10000000000000000');
 		});
 
 		it('should return a result containing version = "0.0.1"', function () {
-			constantsResponse.should.have.property('version').equal('0.0.1');
+			expect(constantsResponse).to.have.property('version').equal('0.0.1');
 		});
 
 		it('should return a result containing fees.send = 10000000', function () {
-			constantsResponse.fees.send.should.be.equal('10000000');
+			expect(constantsResponse.fees.send).to.be.equal('10000000');
 		});
 
 		it('should return a result containing fees.vote = 100000000', function () {
-			constantsResponse.fees.vote.should.be.equal('100000000');
+			expect(constantsResponse.fees.vote).to.be.equal('100000000');
 		});
 
 		it('should return a result containing fees.secondSignature = 500000000', function () {
-			constantsResponse.fees.secondSignature.should.be.equal('500000000');
+			expect(constantsResponse.fees.secondSignature).to.be.equal('500000000');
 		});
 
 		it('should return a result containing fees.delegate = 2500000000', function () {
-			constantsResponse.fees.delegate.should.be.equal('2500000000');
+			expect(constantsResponse.fees.delegate).to.be.equal('2500000000');
 		});
 
 		it('should return a result containing fees.multisignature = 500000000', function () {
-			constantsResponse.fees.multisignature.should.be.equal('500000000');
+			expect(constantsResponse.fees.multisignature).to.be.equal('500000000');
 		});
 
 		it('should return a result containing fees.dappRegistration = 2500000000', function () {
-			constantsResponse.fees.dappRegistration.should.be.equal('2500000000');
+			expect(constantsResponse.fees.dappRegistration).to.be.equal('2500000000');
 		});
 
 		it('should return a result containing fees.dappWithdrawal = 10000000', function () {
-			constantsResponse.fees.dappWithdrawal.should.be.equal('10000000');
+			expect(constantsResponse.fees.dappWithdrawal).to.be.equal('10000000');
 		});
 
 		it('should return a result containing fees.dappDeposit = 10000000', function () {
-			constantsResponse.fees.dappDeposit.should.be.equal('10000000');
+			expect(constantsResponse.fees.dappDeposit).to.be.equal('10000000');
 		});
 
 		it('should return a result containing fees.data = 10000000', function () {
-			constantsResponse.fees.data.should.be.equal('10000000');
+			expect(constantsResponse.fees.data).to.be.equal('10000000');
 		});
 	});
 
@@ -107,7 +107,7 @@ describe('GET /node', function () {
 
 			it('using no params should return full list of internal forgers', function () {
 				return forgingEndpoint.makeRequest({}, 200).then(function (res) {
-					res.body.data.length.should.be.eql(__testContext.config.forging.secret.length);
+					expect(res.body.data.length).to.be.eql(__testContext.config.forging.secret.length);
 				});
 			});
 
@@ -127,8 +127,8 @@ describe('GET /node', function () {
 				var publicKey = __testContext.config.forging.secret[0].publicKey;
 
 				return forgingEndpoint.makeRequest({publicKey: publicKey}, 200).then(function (res) {
-					res.body.data.should.have.length(1);
-					res.body.data[0].publicKey.should.be.eql(publicKey);
+					expect(res.body.data).to.have.length(1);
+					expect(res.body.data[0].publicKey).to.be.eql(publicKey);
 				});
 			});
 
@@ -136,8 +136,8 @@ describe('GET /node', function () {
 				var publicKey = __testContext.config.forging.secret[0].publicKey;
 
 				return forgingEndpoint.makeRequest({publicKey: publicKey}, 200).then(function (res) {
-					res.body.data[0].publicKey.should.be.eql(publicKey);
-					res.body.data[0].forging.should.be.true;
+					expect(res.body.data[0].publicKey).to.be.eql(publicKey);
+					expect(res.body.data[0].forging).to.be.true;
 				});
 			});
 		});

--- a/test/functional/http/get/node.transactions.unconfirmed.js
+++ b/test/functional/http/get/node.transactions.unconfirmed.js
@@ -48,7 +48,7 @@ describe('GET /api/node', function () {
 					return sendTransactionPromise(transaction);
 				}).then(function (responses) {
 					responses.map(function (res) {
-						res.body.data.message.should.be.equal('Transaction(s) accepted');
+						expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					});
 				});
 			});
@@ -106,7 +106,7 @@ describe('GET /api/node', function () {
 
 			it.skip('using no params should be ok', function () {
 				return UnconfirmedEndpoint.makeRequest({}, 200).then(function (res) {
-					res.body.meta.count.should.be.at.least(numOfTransactions);
+					expect(res.body.meta.count).to.be.at.least(numOfTransactions);
 				});
 			});
 
@@ -122,15 +122,15 @@ describe('GET /api/node', function () {
 					var transactionInCheck = transactionList[0];
 
 					return UnconfirmedEndpoint.makeRequest({id: transactionInCheck.id}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.should.has.length(1);
-						res.body.data[0].id.should.be.equal(transactionInCheck.id);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data).to.has.length(1);
+						expect(res.body.data[0].id).to.be.equal(transactionInCheck.id);
 					});
 				});
 
 				it('using valid but unknown id should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({id: '1111111111111111'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -147,10 +147,10 @@ describe('GET /api/node', function () {
 					var transactionInCheck = transactionList[0];
 
 					return UnconfirmedEndpoint.makeRequest({type: transactionInCheck.type}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.type.should.be.equal(transactionInCheck.type);
+							expect(transaction.type).to.be.equal(transactionInCheck.type);
 						});
 					});
 				});
@@ -166,17 +166,17 @@ describe('GET /api/node', function () {
 
 				it.skip('using valid senderId should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({ senderId: accountFixtures.genesis.address}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.senderId.should.be.equal(accountFixtures.genesis.address);
+							expect(transaction.senderId).to.be.equal(accountFixtures.genesis.address);
 						});
 					});
 				});
 
 				it('using valid but unknown senderId should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({ senderId: '1631373961111634666L'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -191,17 +191,17 @@ describe('GET /api/node', function () {
 
 				it.skip('using valid senderPublicKey should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({senderPublicKey: accountFixtures.genesis.publicKey}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.senderPublicKey.should.be.equal(accountFixtures.genesis.publicKey);
+							expect(transaction.senderPublicKey).to.be.equal(accountFixtures.genesis.publicKey);
 						});
 					});
 				});
 
 				it('using valid but unknown senderPublicKey should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({senderPublicKey: 'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -216,17 +216,17 @@ describe('GET /api/node', function () {
 
 				it.skip('using valid recipientId should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({recipientId: account.address}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.recipientId.should.be.equal(account.address);
+							expect(transaction.recipientId).to.be.equal(account.address);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientId should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({recipientId: '1631373961111634666L'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -241,18 +241,18 @@ describe('GET /api/node', function () {
 
 				it.skip('using valid recipientPublicKey should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({recipientPublicKey: account.publicKey}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
 							// TODO: Unprocessed transactions don't have recipientPublicKey attribute, so matched address
-							transaction.recipientId.should.be.equal(account.address);
+							expect(transaction.recipientId).to.be.equal(account.address);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientPublicKey should be ok', function () {
 					return UnconfirmedEndpoint.makeRequest({recipientPublicKey: 'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -273,8 +273,8 @@ describe('GET /api/node', function () {
 
 				it.skip('using limit = 2 should return 2 transactions', function () {
 					return UnconfirmedEndpoint.makeRequest({limit: 2}, 200).then(function (res) {
-						res.body.data.should.not.be.empty;
-						res.body.data.length.should.be.at.most(2);
+						expect(res.body.data).to.not.be.empty;
+						expect(res.body.data.length).to.be.at.most(2);
 					});
 				});
 			});
@@ -296,7 +296,7 @@ describe('GET /api/node', function () {
 						return UnconfirmedEndpoint.makeRequest({offset: 1, limit: 2}, 200);
 					}).then(function (res) {
 						res.body.data.forEach(function (transaction) {
-							transaction.id.should.not.equal(firstTransaction.id);
+							expect(transaction.id).to.not.equal(firstTransaction.id);
 						});
 					});
 				});
@@ -308,21 +308,21 @@ describe('GET /api/node', function () {
 
 					it('sorted by amount:asc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'amount:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 						});
 					});
 
 					it('sorted by amount:desc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'amount:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 						});
 					});
 				});
@@ -331,21 +331,21 @@ describe('GET /api/node', function () {
 
 					it('sorted by fee:asc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'fee:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 						});
 					});
 
 					it('sorted by fee:desc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'fee:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 						});
 					});
 				});
@@ -354,17 +354,17 @@ describe('GET /api/node', function () {
 
 					it('sorted by fee:asc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'type:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('type').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'type'));
+							expect(_(res.body.data).map('type').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'type'));
 						});
 					});
 
 					it('sorted by fee:desc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'type:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('type').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'type'));
+							expect(_(res.body.data).map('type').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'type'));
 						});
 					});
 				});
@@ -373,17 +373,17 @@ describe('GET /api/node', function () {
 
 					it('sorted by timestamp:asc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'timestamp:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('timestamp').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'timestamp'));
+							expect(_(res.body.data).map('timestamp').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 						});
 					});
 
 					it('sorted by timestamp:desc should be ok', function () {
 						return UnconfirmedEndpoint.makeRequest({sort: 'timestamp:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('timestamp').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'timestamp'));
+							expect(_(res.body.data).map('timestamp').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 						});
 					});
 				});

--- a/test/functional/http/get/node.transactions.unprocessed.js
+++ b/test/functional/http/get/node.transactions.unprocessed.js
@@ -48,7 +48,7 @@ describe('GET /api/node', function () {
 					return sendTransactionPromise(transaction);
 				}).then(function (responses) {
 					responses.map(function (res) {
-						res.body.data.message.should.be.equal('Transaction(s) accepted');
+						expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					});
 				});
 			});
@@ -105,7 +105,7 @@ describe('GET /api/node', function () {
 
 			it('using no params should be ok', function () {
 				return UnProcessedEndpoint.makeRequest({}, 200).then(function (res) {
-					res.body.meta.count.should.be.at.least(numOfTransactions);
+					expect(res.body.meta.count).to.be.at.least(numOfTransactions);
 				});
 			});
 
@@ -121,15 +121,15 @@ describe('GET /api/node', function () {
 					var transactionInCheck = transactionList[0];
 
 					return UnProcessedEndpoint.makeRequest({id: transactionInCheck.id}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.should.has.length(1);
-						res.body.data[0].id.should.be.equal(transactionInCheck.id);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data).to.has.length(1);
+						expect(res.body.data[0].id).to.be.equal(transactionInCheck.id);
 					});
 				});
 
 				it('using valid but unknown id should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({id: '1111111111111111'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -146,10 +146,10 @@ describe('GET /api/node', function () {
 					var transactionInCheck = transactionList[0];
 
 					return UnProcessedEndpoint.makeRequest({type: transactionInCheck.type}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.type.should.be.equal(transactionInCheck.type);
+							expect(transaction.type).to.be.equal(transactionInCheck.type);
 						});
 					});
 				});
@@ -165,17 +165,17 @@ describe('GET /api/node', function () {
 
 				it('using valid senderId should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({ senderId: accountFixtures.genesis.address}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.senderId.should.be.equal(accountFixtures.genesis.address);
+							expect(transaction.senderId).to.be.equal(accountFixtures.genesis.address);
 						});
 					});
 				});
 
 				it('using valid but unknown senderId should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({ senderId: '1631373961111634666L'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -190,17 +190,17 @@ describe('GET /api/node', function () {
 
 				it('using valid senderPublicKey should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({senderPublicKey: accountFixtures.genesis.publicKey}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.senderPublicKey.should.be.equal(accountFixtures.genesis.publicKey);
+							expect(transaction.senderPublicKey).to.be.equal(accountFixtures.genesis.publicKey);
 						});
 					});
 				});
 
 				it('using valid but unknown senderPublicKey should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({senderPublicKey: 'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -216,17 +216,17 @@ describe('GET /api/node', function () {
 				it('using valid recipientId should be ok', function () {
 
 					return UnProcessedEndpoint.makeRequest({recipientId: account.address}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.recipientId.should.be.equal(account.address);
+							expect(transaction.recipientId).to.be.equal(account.address);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientId should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({recipientId: '1631373961111634666L'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -241,18 +241,18 @@ describe('GET /api/node', function () {
 
 				it('using valid recipientPublicKey should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({recipientPublicKey: account.publicKey}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
 							// TODO: Unprocessed transactions don't have recipientPublicKey attribute, so matched address
-							transaction.recipientId.should.be.equal(account.address);
+							expect(transaction.recipientId).to.be.equal(account.address);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientPublicKey should be ok', function () {
 					return UnProcessedEndpoint.makeRequest({recipientPublicKey: 'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -273,8 +273,8 @@ describe('GET /api/node', function () {
 
 				it('using limit = 2 should return 2 transactions', function () {
 					return UnProcessedEndpoint.makeRequest({limit: 2}, 200).then(function (res) {
-						res.body.data.should.not.be.empty;
-						res.body.data.length.should.be.at.most(2);
+						expect(res.body.data).to.not.be.empty;
+						expect(res.body.data.length).to.be.at.most(2);
 					});
 				});
 			});
@@ -296,7 +296,7 @@ describe('GET /api/node', function () {
 						return UnProcessedEndpoint.makeRequest({offset: 1, limit: 2}, 200);
 					}).then(function (res) {
 						res.body.data.forEach(function (transaction) {
-							transaction.id.should.not.equal(firstTransaction.id);
+							expect(transaction.id).to.not.equal(firstTransaction.id);
 						});
 					});
 				});
@@ -308,21 +308,21 @@ describe('GET /api/node', function () {
 
 					it('sorted by amount:asc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'amount:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 						});
 					});
 
 					it('sorted by amount:desc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'amount:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 						});
 					});
 				});
@@ -331,21 +331,21 @@ describe('GET /api/node', function () {
 
 					it('sorted by fee:asc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'fee:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 						});
 					});
 
 					it('sorted by fee:desc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'fee:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 						});
 					});
 				});
@@ -354,17 +354,17 @@ describe('GET /api/node', function () {
 
 					it('sorted by fee:asc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'type:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('type').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'type'));
+							expect(_(res.body.data).map('type').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'type'));
 						});
 					});
 
 					it('sorted by fee:desc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'type:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('type').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'type'));
+							expect(_(res.body.data).map('type').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'type'));
 						});
 					});
 				});
@@ -373,17 +373,17 @@ describe('GET /api/node', function () {
 
 					it('sorted by timestamp:asc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'timestamp:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('timestamp').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'timestamp'));
+							expect(_(res.body.data).map('timestamp').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 						});
 					});
 
 					it('sorted by timestamp:desc should be ok', function () {
 						return UnProcessedEndpoint.makeRequest({sort: 'timestamp:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('timestamp').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'timestamp'));
+							expect(_(res.body.data).map('timestamp').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 						});
 					});
 				});

--- a/test/functional/http/get/node.transactions.unsigned.js
+++ b/test/functional/http/get/node.transactions.unsigned.js
@@ -45,7 +45,7 @@ describe('GET /api/node', function () {
 				transaction = lisk.transaction.createTransaction(senderAccount.address, 1000 * normalizer, accountFixtures.genesis.password);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					return waitFor.confirmations([transaction.id]);
 				}).then(function () {
@@ -54,7 +54,7 @@ describe('GET /api/node', function () {
 
 					return sendTransactionPromise(transaction);
 				}).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					return waitFor.confirmations([transaction.id]);
 				}).then(function () {
@@ -63,13 +63,13 @@ describe('GET /api/node', function () {
 
 					return sendTransactionPromise(transaction);
 				}).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					var signature = apiHelpers.createSignatureObject(transaction, accountFixtures.existingDelegate);
 
 					return signatureEndpoint.makeRequest({signatures: [signature]}, 200);
 				}).then(function (res) {
-					res.body.data.message.should.be.equal('Signature Accepted');
+					expect(res.body.data.message).to.be.equal('Signature Accepted');
 
 					return waitFor.confirmations([transaction.id]);
 				}).then(function () {
@@ -83,7 +83,7 @@ describe('GET /api/node', function () {
 					});
 				}).then(function (responses) {
 					responses.map(function (res) {
-						res.body.data.message.should.be.equal('Transaction(s) accepted');
+						expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					});
 				});
 			});
@@ -140,7 +140,7 @@ describe('GET /api/node', function () {
 
 			it('using no params should be ok', function () {
 				return UnsignedEndpoint.makeRequest({}, 200).then(function (res) {
-					res.body.meta.count.should.be.at.least(numOfTransactions);
+					expect(res.body.meta.count).to.be.at.least(numOfTransactions);
 				});
 			});
 
@@ -156,15 +156,15 @@ describe('GET /api/node', function () {
 					var transactionInCheck = transactionList[0];
 
 					return UnsignedEndpoint.makeRequest({id: transactionInCheck.id}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.should.has.length(1);
-						res.body.data[0].id.should.be.equal(transactionInCheck.id);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data).to.has.length(1);
+						expect(res.body.data[0].id).to.be.equal(transactionInCheck.id);
 					});
 				});
 
 				it('using valid but unknown id should be ok', function () {
 					return UnsignedEndpoint.makeRequest({id: '1111111111111111'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -181,10 +181,10 @@ describe('GET /api/node', function () {
 					var transactionInCheck = transactionList[0];
 
 					return UnsignedEndpoint.makeRequest({type: transactionInCheck.type}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.type.should.be.equal(transactionInCheck.type);
+							expect(transaction.type).to.be.equal(transactionInCheck.type);
 						});
 					});
 				});
@@ -201,17 +201,17 @@ describe('GET /api/node', function () {
 				it('using valid senderId should be ok', function () {
 
 					return UnsignedEndpoint.makeRequest({ senderId: senderAccount.address}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.senderId.should.be.equal(senderAccount.address);
+							expect(transaction.senderId).to.be.equal(senderAccount.address);
 						});
 					});
 				});
 
 				it('using valid but unknown senderId should be ok', function () {
 					return UnsignedEndpoint.makeRequest({ senderId: '1631373961111634666L'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -226,17 +226,17 @@ describe('GET /api/node', function () {
 
 				it('using valid senderPublicKey should be ok', function () {
 					return UnsignedEndpoint.makeRequest({senderPublicKey: senderAccount.publicKey}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.senderPublicKey.should.be.equal(senderAccount.publicKey);
+							expect(transaction.senderPublicKey).to.be.equal(senderAccount.publicKey);
 						});
 					});
 				});
 
 				it('using valid but unknown senderPublicKey should be ok', function () {
 					return UnsignedEndpoint.makeRequest({senderPublicKey: 'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -251,17 +251,17 @@ describe('GET /api/node', function () {
 
 				it('using valid recipientId should be ok', function () {
 					return UnsignedEndpoint.makeRequest({recipientId: recipientAccount.address}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
-							transaction.recipientId.should.be.equal(recipientAccount.address);
+							expect(transaction.recipientId).to.be.equal(recipientAccount.address);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientId should be ok', function () {
 					return UnsignedEndpoint.makeRequest({recipientId: '1631373961111634666L'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -276,18 +276,18 @@ describe('GET /api/node', function () {
 
 				it('using valid recipientPublicKey should be ok', function () {
 					return UnsignedEndpoint.makeRequest({recipientPublicKey: recipientAccount.publicKey}, 200).then(function (res) {
-						res.body.data.should.not.empty;
-						res.body.data.length.should.be.at.least(numOfTransactions);
+						expect(res.body.data).to.not.empty;
+						expect(res.body.data.length).to.be.at.least(numOfTransactions);
 						res.body.data.map(function (transaction) {
 							// TODO: Unprocessed transactions don't have recipientPublicKey attribute, so matched address
-							transaction.recipientId.should.be.equal(recipientAccount.address);
+							expect(transaction.recipientId).to.be.equal(recipientAccount.address);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientPublicKey should be ok', function () {
 					return UnsignedEndpoint.makeRequest({recipientPublicKey: 'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f'}, 200).then(function (res) {
-						res.body.data.should.be.empty;
+						expect(res.body.data).to.be.empty;
 					});
 				});
 			});
@@ -308,8 +308,8 @@ describe('GET /api/node', function () {
 
 				it('using limit = 2 should return 2 transactions', function () {
 					return UnsignedEndpoint.makeRequest({limit: 2}, 200).then(function (res) {
-						res.body.data.should.not.be.empty;
-						res.body.data.length.should.be.at.most(2);
+						expect(res.body.data).to.not.be.empty;
+						expect(res.body.data.length).to.be.at.most(2);
 					});
 				});
 			});
@@ -331,7 +331,7 @@ describe('GET /api/node', function () {
 						return UnsignedEndpoint.makeRequest({offset: 1, limit: 2}, 200);
 					}).then(function (res) {
 						res.body.data.forEach(function (transaction) {
-							transaction.id.should.not.equal(firstTransaction.id);
+							expect(transaction.id).to.not.equal(firstTransaction.id);
 						});
 					});
 				});
@@ -343,21 +343,21 @@ describe('GET /api/node', function () {
 
 					it('sorted by amount:asc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'amount:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 						});
 					});
 
 					it('sorted by amount:desc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'amount:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 						});
 					});
 				});
@@ -366,21 +366,21 @@ describe('GET /api/node', function () {
 
 					it('sorted by fee:asc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'fee:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 						});
 					});
 
 					it('sorted by fee:desc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'fee:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
 							var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-							_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+							expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 						});
 					});
 				});
@@ -389,17 +389,17 @@ describe('GET /api/node', function () {
 
 					it('sorted by fee:asc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'type:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('type').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'type'));
+							expect(_(res.body.data).map('type').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'type'));
 						});
 					});
 
 					it('sorted by fee:desc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'type:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('type').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'type'));
+							expect(_(res.body.data).map('type').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'type'));
 						});
 					});
 				});
@@ -408,17 +408,17 @@ describe('GET /api/node', function () {
 
 					it('sorted by timestamp:asc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'timestamp:asc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('timestamp').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'timestamp'));
+							expect(_(res.body.data).map('timestamp').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 						});
 					});
 
 					it('sorted by timestamp:desc should be ok', function () {
 						return UnsignedEndpoint.makeRequest({sort: 'timestamp:desc'}, 200).then(function (res) {
-							res.body.data.should.not.be.empty;
+							expect(res.body.data).to.not.be.empty;
 
-							_(res.body.data).map('timestamp').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'timestamp'));
+							expect(_(res.body.data).map('timestamp').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 						});
 					});
 				});

--- a/test/functional/http/get/peers.js
+++ b/test/functional/http/get/peers.js
@@ -92,7 +92,7 @@ describe('GET /peers', function () {
 					return peersEndpoint.makeRequest(params, 200).then(function (res) {
 						if(paramSet[param].checkResponse) {
 							res.body.data.forEach(function (peer) {
-								peer[param].should.be.eql(val);
+								expect(peer[param]).to.be.eql(val);
 							});
 						}
 					});
@@ -106,28 +106,28 @@ describe('GET /peers', function () {
 		it('using a valid httpPort = ' + validHeaders.httpPort + ' should return the result', function () {
 			return peersEndpoint.makeRequest({httpPort: validHeaders.httpPort}, 200)
 				.then(function (res) {
-					res.body.data[0].httpPort.should.be.eql(validHeaders.httpPort);
+					expect(res.body.data[0].httpPort).to.be.eql(validHeaders.httpPort);
 				});
 		});
 
 		it('using state = ' + validHeaders.state + ' should return the result', function () {
 			return peersEndpoint.makeRequest({state: validHeaders.state}, 200)
 				.then(function (res) {
-					res.body.data[0].state.should.be.eql(2);
+					expect(res.body.data[0].state).to.be.eql(2);
 				});
 		});
 
 		it('using version = "' + validHeaders.version + '" should return the result', function () {
 			return peersEndpoint.makeRequest({version: validHeaders.version}, 200)
 				.then(function (res) {
-					res.body.data[0].version.should.be.eql(validHeaders.version);
+					expect(res.body.data[0].version).to.be.eql(validHeaders.version);
 				});
 		});
 
 		it('using valid broadhash = "' + validHeaders.broadhash + '" should return the result', function () {
 			return peersEndpoint.makeRequest({broadhash: validHeaders.broadhash}, 200)
 				.then(function (res) {
-					res.body.data[0].broadhash.should.be.eql(validHeaders.broadhash);
+					expect(res.body.data[0].broadhash).to.be.eql(validHeaders.broadhash);
 				});
 		});
 
@@ -135,7 +135,7 @@ describe('GET /peers', function () {
 			return peersEndpoint.makeRequest({sort: 'version:asc'}, 200)
 				.then(function (res) {
 					var versions = _(res.body.data).map('version').value();
-					_.clone(versions).sort().should.be.eql(versions);
+					expect(_.clone(versions).sort()).to.be.eql(versions);
 				});
 		});
 
@@ -143,7 +143,7 @@ describe('GET /peers', function () {
 			return peersEndpoint.makeRequest({sort: 'version:desc'}, 200)
 				.then(function (res) {
 					var versions = _(res.body.data).map('version').value();
-					_.clone(versions).sort().reverse().should.be.eql(versions);
+					expect(_.clone(versions).sort().reverse()).to.be.eql(versions);
 				});
 		});
 
@@ -153,14 +153,14 @@ describe('GET /peers', function () {
 
 			return peersEndpoint.makeRequest({limit: limit}, 200)
 				.then(function (res) {
-					res.body.data.length.should.be.at.most(limit);
+					expect(res.body.data.length).to.be.at.most(limit);
 					firstObject = res.body.data[0];
 
 					return peersEndpoint.makeRequest({limit: limit, offset: 1}, 200);
 				})
 				.then(function (res) {
-					res.body.data.length.should.be.at.most(limit);
-					res.body.data[0].should.not.equal(firstObject);
+					expect(res.body.data.length).to.be.at.most(limit);
+					expect(res.body.data[0]).to.not.equal(firstObject);
 				});
 		});
 	});

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -143,7 +143,7 @@ describe('GET /api/transactions', function () {
 
 		it('using no params should be ok', function () {
 			return transactionsEndpoint.makeRequest({}, 200).then(function (res) {
-				res.body.data.should.not.empty;
+				expect(res.body.data).to.not.empty;
 			});
 		});
 
@@ -153,9 +153,9 @@ describe('GET /api/transactions', function () {
 				var transactionInCheck = transactionList[0];
 
 				return transactionsEndpoint.makeRequest({id: transactionInCheck.id}, 200).then(function (res) {
-					res.body.data.should.not.empty;
-					res.body.data.should.has.length(1);
-					res.body.data[0].id.should.be.equal(transactionInCheck.id);
+					expect(res.body.data).to.not.empty;
+					expect(res.body.data).to.has.length(1);
+					expect(res.body.data[0].id).to.be.equal(transactionInCheck.id);
 				});
 			});
 
@@ -172,19 +172,19 @@ describe('GET /api/transactions', function () {
 				});
 
 				return transactionsEndpoint.makeRequest({id: transactionInCheck.id}, 200).then(function (res) {
-					res.body.data.should.not.empty;
-					res.body.data.should.has.length(1);
+					expect(res.body.data).to.not.empty;
+					expect(res.body.data).to.has.length(1);
 
 					var transaction = res.body.data[0];
 
-					transaction.id.should.be.equal(transactionInCheck.id);
-					transaction.type.should.be.equal(transactionTypes.VOTE);
-					transaction.type.should.be.equal(transactionInCheck.type);
-					transaction.amount.should.be.equal(transactionInCheck.amount.toString());
-					transaction.fee.should.be.equal(transactionInCheck.fee.toString());
-					transaction.recipientId.should.be.equal(transactionInCheck.recipientId);
-					transaction.senderId.should.be.equal(transactionInCheck.senderId);
-					transaction.asset.should.be.eql(transactionInCheck.asset);
+					expect(transaction.id).to.be.equal(transactionInCheck.id);
+					expect(transaction.type).to.be.equal(transactionTypes.VOTE);
+					expect(transaction.type).to.be.equal(transactionInCheck.type);
+					expect(transaction.amount).to.be.equal(transactionInCheck.amount.toString());
+					expect(transaction.fee).to.be.equal(transactionInCheck.fee.toString());
+					expect(transaction.recipientId).to.be.equal(transactionInCheck.recipientId);
+					expect(transaction.senderId).to.be.equal(transactionInCheck.senderId);
+					expect(transaction.asset).to.be.eql(transactionInCheck.asset);
 				});
 			});
 		});
@@ -199,9 +199,9 @@ describe('GET /api/transactions', function () {
 
 			it('using type should be ok', function () {
 				return transactionsEndpoint.makeRequest({type: transactionTypes.SEND}, 200).then(function (res) {
-					res.body.data.should.not.empty;
+					expect(res.body.data).to.not.empty;
 					res.body.data.map(function (transaction) {
-						transaction.type.should.be.equal(transactionTypes.SEND);
+						expect(transaction.type).to.be.equal(transactionTypes.SEND);
 					});
 				});
 			});
@@ -217,10 +217,10 @@ describe('GET /api/transactions', function () {
 
 			it('using one senderId should return transactions', function () {
 				return transactionsEndpoint.makeRequest({senderId: accountFixtures.genesis.address}, 200).then(function (res) {
-					res.body.data.should.not.empty;
+					expect(res.body.data).to.not.empty;
 
 					res.body.data.map(function (transaction) {
-						transaction.senderId.should.be.equal(accountFixtures.genesis.address);
+						expect(transaction.senderId).to.be.equal(accountFixtures.genesis.address);
 					});
 				});
 			});
@@ -242,10 +242,10 @@ describe('GET /api/transactions', function () {
 
 			it('using one senderPublicKey should return transactions', function () {
 				return transactionsEndpoint.makeRequest({senderPublicKey: accountFixtures.genesis.publicKey}, 200).then(function (res) {
-					res.body.data.should.not.empty;
+					expect(res.body.data).to.not.empty;
 
 					res.body.data.map(function (transaction) {
-						transaction.senderPublicKey.should.be.equal(accountFixtures.genesis.publicKey);
+						expect(transaction.senderPublicKey).to.be.equal(accountFixtures.genesis.publicKey);
 					});
 				});
 			});
@@ -267,10 +267,10 @@ describe('GET /api/transactions', function () {
 
 			it('using one recipientId should return transactions', function () {
 				return transactionsEndpoint.makeRequest({recipientId: accountFixtures.genesis.address}, 200).then(function (res) {
-					res.body.data.should.not.empty;
+					expect(res.body.data).to.not.empty;
 
 					res.body.data.map(function (transaction) {
-						transaction.recipientId.should.be.equal(accountFixtures.genesis.address);
+						expect(transaction.recipientId).to.be.equal(accountFixtures.genesis.address);
 					});
 				});
 			});
@@ -292,10 +292,10 @@ describe('GET /api/transactions', function () {
 
 			it('using one recipientPublicKey should return transactions', function () {
 				return transactionsEndpoint.makeRequest({recipientPublicKey: accountFixtures.genesis.publicKey}, 200).then(function (res) {
-					res.body.data.should.not.empty;
+					expect(res.body.data).to.not.empty;
 
 					res.body.data.map(function (transaction) {
-						transaction.recipientPublicKey.should.be.equal(accountFixtures.genesis.publicKey);
+						expect(transaction.recipientPublicKey).to.be.equal(accountFixtures.genesis.publicKey);
 					});
 				});
 			});
@@ -320,7 +320,7 @@ describe('GET /api/transactions', function () {
 
 				return transactionsEndpoint.makeRequest({blockId: blockId}, 200).then(function (res) {
 					res.body.data.map(function (transaction) {
-						transaction.blockId.should.be.equal(blockId);
+						expect(transaction.blockId).to.be.equal(blockId);
 					});
 				});
 			});
@@ -337,7 +337,7 @@ describe('GET /api/transactions', function () {
 			it('using one height should return transactions', function () {
 				return transactionsEndpoint.makeRequest({height: 1}, 200).then(function (res) {
 					res.body.data.map(function (transaction) {
-						transaction.height.should.be.equal(1);
+						expect(transaction.height).to.be.equal(1);
 					});
 				});
 			});
@@ -348,7 +348,7 @@ describe('GET /api/transactions', function () {
 			it('should get transactions with amount more than minAmount', function () {
 				return transactionsEndpoint.makeRequest({minAmount: minAmount}, 200).then(function (res) {
 					res.body.data.map(function (transaction) {
-						parseInt(transaction.amount).should.be.at.least(minAmount);
+						expect(parseInt(transaction.amount)).to.be.at.least(minAmount);
 					});
 				});
 			});
@@ -359,7 +359,7 @@ describe('GET /api/transactions', function () {
 			it('should get transactions with amount less than maxAmount', function () {
 				return transactionsEndpoint.makeRequest({maxAmount: maxAmount}, 200).then(function (res) {
 					res.body.data.map(function (transaction) {
-						parseInt(transaction.amount).should.be.at.most(maxAmount);
+						expect(parseInt(transaction.amount)).to.be.at.most(maxAmount);
 					});
 				});
 			});
@@ -379,7 +379,7 @@ describe('GET /api/transactions', function () {
 
 				return transactionsEndpoint.makeRequest({fromTimestamp: queryTime}, 200).then(function (res) {
 					res.body.data.forEach(function (transaction) {
-						transaction.timestamp.should.be.at.least(queryTime);
+						expect(transaction.timestamp).to.be.at.least(queryTime);
 					});
 				});
 			});
@@ -399,7 +399,7 @@ describe('GET /api/transactions', function () {
 
 				return transactionsEndpoint.makeRequest({toTimestamp: queryTime}, 200).then(function (res) {
 					res.body.data.forEach(function (transaction) {
-						transaction.timestamp.should.be.at.most(queryTime);
+						expect(transaction.timestamp).to.be.at.most(queryTime);
 					});
 				});
 			});
@@ -421,7 +421,7 @@ describe('GET /api/transactions', function () {
 
 			it('using limit = 10 should return 10 transactions', function () {
 				return transactionsEndpoint.makeRequest({limit: 10}, 200).then(function (res) {
-					res.body.data.should.have.length(10);
+					expect(res.body.data).to.have.length(10);
 				});
 			});
 		});
@@ -443,7 +443,7 @@ describe('GET /api/transactions', function () {
 					return transactionsEndpoint.makeRequest({offset: 1}, 200);
 				}).then(function (res) {
 					res.body.data.forEach(function (transaction) {
-						transaction.id.should.not.equal(firstTransaction.id);
+						expect(transaction.id).to.not.equal(firstTransaction.id);
 					});
 				});
 			});
@@ -457,7 +457,7 @@ describe('GET /api/transactions', function () {
 					return transactionsEndpoint.makeRequest({sort: 'amount:asc', minAmount: 100}, 200).then(function (res) {
 						var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-						_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+						expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 					});
 				});
 
@@ -465,7 +465,7 @@ describe('GET /api/transactions', function () {
 					return transactionsEndpoint.makeRequest({sort: 'amount:desc'}, 200).then(function (res) {
 						var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-						_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+						expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 					});
 				});
 			});
@@ -476,7 +476,7 @@ describe('GET /api/transactions', function () {
 					return transactionsEndpoint.makeRequest({sort: 'fee:asc', minAmount: 100}, 200).then(function (res) {
 						var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-						_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+						expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 					});
 				});
 
@@ -484,7 +484,7 @@ describe('GET /api/transactions', function () {
 					return transactionsEndpoint.makeRequest({sort: 'fee:desc'}, 200).then(function (res) {
 						var values = _.map(res.body.data, 'fee').map(function (value) { return parseInt(value); });
 
-						_(_.clone(values)).sortNumbers('desc').should.be.eql(values);
+						expect(_(_.clone(values)).sortNumbers('desc')).to.be.eql(values);
 					});
 				});
 			});
@@ -493,13 +493,13 @@ describe('GET /api/transactions', function () {
 
 				it('sorted by fee:asc should be ok', function () {
 					return transactionsEndpoint.makeRequest({sort: 'type:asc', minAmount: 100}, 200).then(function (res) {
-						_(res.body.data).map('type').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'type'));
+						expect(_(res.body.data).map('type').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'type'));
 					});
 				});
 
 				it('sorted by fee:desc should be ok', function () {
 					return transactionsEndpoint.makeRequest({sort: 'type:desc'}, 200).then(function (res) {
-						_(res.body.data).map('type').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'type'));
+						expect(_(res.body.data).map('type').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'type'));
 					});
 				});
 			});
@@ -508,13 +508,13 @@ describe('GET /api/transactions', function () {
 
 				it('sorted by timestamp:asc should be ok', function () {
 					return transactionsEndpoint.makeRequest({sort: 'timestamp:asc', minAmount: 100}, 200).then(function (res) {
-						_(res.body.data).map('timestamp').sortNumbers('asc').should.be.eql(_.map(res.body.data, 'timestamp'));
+						expect(_(res.body.data).map('timestamp').sortNumbers('asc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 					});
 				});
 
 				it('sorted by timestamp:desc should be ok', function () {
 					return transactionsEndpoint.makeRequest({sort: 'timestamp:desc'}, 200).then(function (res) {
-						_(res.body.data).map('timestamp').sortNumbers('desc').should.be.eql(_.map(res.body.data, 'timestamp'));
+						expect(_(res.body.data).map('timestamp').sortNumbers('desc')).to.be.eql(_.map(res.body.data, 'timestamp'));
 					});
 				});
 			});
@@ -559,11 +559,11 @@ describe('GET /api/transactions', function () {
 				}, 200).then(function (res) {
 					var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
 
-					_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+					expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 
 					values.forEach(function (value) {
-						value.should.be.at.most(maxAmount);
-						value.should.be.at.least(minAmount);
+						expect(value).to.be.at.most(maxAmount);
+						expect(value).to.be.at.least(minAmount);
 					});
 				});
 			});
@@ -581,11 +581,11 @@ describe('GET /api/transactions', function () {
 				}, 200).then(function (res) {
 
 					var values = _.map(res.body.data, 'amount').map(function (value) { return parseInt(value); });
-					_(_.clone(values)).sortNumbers('asc').should.be.eql(values);
+					expect(_(_.clone(values)).sortNumbers('asc')).to.be.eql(values);
 
 					res.body.data.forEach(function (transaction) {
-						transaction.senderId.should.be.eql(accountFixtures.genesis.address);
-						transaction.recipientId.should.be.eql(account.address);
+						expect(transaction.senderId).to.be.eql(accountFixtures.genesis.address);
+						expect(transaction.recipientId).to.be.eql(account.address);
 					});
 				});
 			});
@@ -597,7 +597,7 @@ describe('GET /api/transactions', function () {
 
 				it('should return count of the transactions with response', function () {
 					return transactionsEndpoint.makeRequest({}, 200).then(function (res) {
-						res.body.meta.count.should.be.a('number');
+						expect(res.body.meta.count).to.be.a('number');
 					});
 				});
 			});

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -36,12 +36,12 @@ describe('GET /api/voters', function () {
 	var validNotExistingAddress = '11111111111111111111L';
 
 	function expectValidVotedDelegateResponse (res) {
-		res.body.data.votes.should.be.least(res.body.data.voters.length);
+		expect(res.body.data.votes).to.be.least(res.body.data.voters.length);
 	}
 
 	function expectValidNotVotedDelegateResponse (res) {
-		res.body.data.votes.should.be.equal(0);
-		res.body.data.voters.should.be.empty;
+		expect(res.body.data.votes).to.be.equal(0);
+		expect(res.body.data.voters).to.be.empty;
 	}
 
 	describe('?', function () {
@@ -52,7 +52,7 @@ describe('GET /api/voters', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votersEndpoint.makeRequest({}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -65,7 +65,7 @@ describe('GET /api/voters', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votersEndpoint.makeRequest({sort: 'username:asc'}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -78,7 +78,7 @@ describe('GET /api/voters', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votersEndpoint.makeRequest({offset: 1}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -91,7 +91,7 @@ describe('GET /api/voters', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votersEndpoint.makeRequest({sort: 'username:asc'}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -253,16 +253,16 @@ describe('GET /api/voters', function () {
 					it('should return voters in ascending order', function () {
 						return votersEndpoint.makeRequest({sort: 'username:asc', username: validVotedDelegate.delegateName}, 200).then(function (res) {
 							expectValidVotedDelegateResponse(res);
-							res.body.data.username.should.equal(validVotedDelegate.delegateName);
-							_(res.body.data.voters).sortBy('username').map('username').value().should.to.be.eql(_.map(res.body.data.voters, 'username'));
+							expect(res.body.data.username).to.equal(validVotedDelegate.delegateName);
+							expect(_(res.body.data.voters).sortBy('username').map('username').value()).to.to.be.eql(_.map(res.body.data.voters, 'username'));
 						});
 					});
 
 					it('should return voters in descending order', function () {
 						return votersEndpoint.makeRequest({sort: 'username:desc', username: validVotedDelegate.delegateName}, 200).then(function (res) {
 							expectValidVotedDelegateResponse(res);
-							res.body.data.username.should.equal(validVotedDelegate.delegateName);
-							_(res.body.data.voters).sortBy('username').reverse().map('username').value().should.to.be.eql(_.map(res.body.data.voters, 'username'));
+							expect(res.body.data.username).to.equal(validVotedDelegate.delegateName);
+							expect(_(res.body.data.voters).sortBy('username').reverse().map('username').value()).to.to.be.eql(_.map(res.body.data.voters, 'username'));
 						});
 					});
 				});
@@ -272,16 +272,16 @@ describe('GET /api/voters', function () {
 					it('should return voters in ascending order', function () {
 						return votersEndpoint.makeRequest({sort: 'balance:asc', username: validVotedDelegate.delegateName}, 200).then(function (res) {
 							expectValidVotedDelegateResponse(res);
-							res.body.data.username.should.equal(validVotedDelegate.delegateName);
-							_.map(res.body.data.voters, 'balance').sort().should.to.be.eql(_.map(res.body.data.voters, 'balance'));
+							expect(res.body.data.username).to.equal(validVotedDelegate.delegateName);
+							expect(_.map(res.body.data.voters, 'balance').sort()).to.to.be.eql(_.map(res.body.data.voters, 'balance'));
 						});
 					});
 
 					it('should return voters in descending order', function () {
 						return votersEndpoint.makeRequest({sort: 'balance:desc', username: validVotedDelegate.delegateName}, 200).then(function (res) {
 							expectValidVotedDelegateResponse(res);
-							res.body.data.username.should.equal(validVotedDelegate.delegateName);
-							_.map(res.body.data.voters, 'balance').sort().reverse().should.to.be.eql(_.map(res.body.data.voters, 'balance'));
+							expect(res.body.data.username).to.equal(validVotedDelegate.delegateName);
+							expect(_.map(res.body.data.voters, 'balance').sort().reverse()).to.to.be.eql(_.map(res.body.data.voters, 'balance'));
 						});
 					});
 				});
@@ -294,7 +294,7 @@ describe('GET /api/voters', function () {
 
 				it('should return 2 voters', function () {
 					return votersEndpoint.makeRequest({limit: 2, username: validVotedDelegate.delegateName}, 200).then(function (res) {
-						res.body.data.voters.should.have.length(2);
+						expect(res.body.data.voters).to.have.length(2);
 					});
 				});
 			});
@@ -305,13 +305,13 @@ describe('GET /api/voters', function () {
 					var voters = null;
 
 					return votersEndpoint.makeRequest({limit: 2, offset: 0, username: validVotedDelegate.delegateName}, 200).then(function (res) {
-						res.body.data.voters.should.have.length(2);
+						expect(res.body.data.voters).to.have.length(2);
 
 						voters = _.map(res.body.data.voters, 'address');
 
 						return votersEndpoint.makeRequest({limit: 2, offset: 1, username: validVotedDelegate.delegateName}, 200);
 					}).then(function (res) {
-						_.intersection(voters, _.map(res.body.data.voters, 'address')).should.have.length(1);
+						expect(_.intersection(voters, _.map(res.body.data.voters, 'address'))).to.have.length(1);
 					});
 				});
 			});

--- a/test/functional/http/get/votes.js
+++ b/test/functional/http/get/votes.js
@@ -37,14 +37,14 @@ describe('GET /api/votes', function () {
 	var validNotExistingAddress = '11111111111111111111L';
 
 	function expectValidVoterDelegateResponse (res) {
-		res.body.data.votesUsed.should.be.least(res.body.data.votes.length);
-		constants.maxVotesPerAccount.should.be.equal(res.body.data.votesUsed + res.body.data.votesAvailable);
+		expect(res.body.data.votesUsed).to.be.least(res.body.data.votes.length);
+		expect(constants.maxVotesPerAccount).to.be.equal(res.body.data.votesUsed + res.body.data.votesAvailable);
 	}
 
 	function expectValidNonVoterDelegateResponse (res) {
-		res.body.data.votesUsed.should.be.equal(0);
-		res.body.data.votes.should.be.empty;
-		constants.maxVotesPerAccount.should.be.equal(res.body.data.votesUsed + res.body.data.votesAvailable);
+		expect(res.body.data.votesUsed).to.be.equal(0);
+		expect(res.body.data.votes).to.be.empty;
+		expect(constants.maxVotesPerAccount).to.be.equal(res.body.data.votesUsed + res.body.data.votesAvailable);
 	}
 
 	describe('?', function () {
@@ -55,7 +55,7 @@ describe('GET /api/votes', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votesEndpoint.makeRequest({}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -68,7 +68,7 @@ describe('GET /api/votes', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votesEndpoint.makeRequest({sort: 'username:asc'}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -81,7 +81,7 @@ describe('GET /api/votes', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votesEndpoint.makeRequest({offset: 1}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -94,7 +94,7 @@ describe('GET /api/votes', function () {
 
 				it('should fail with error message requiring any of param', function () {
 					return votesEndpoint.makeRequest({sort: 'username:asc'}, 400).then(function (res) {
-						res.body.errors.should.have.length(4);
+						expect(res.body.errors).to.have.length(4);
 						expectSwaggerParamError(res, 'username');
 						expectSwaggerParamError(res, 'address');
 						expectSwaggerParamError(res, 'publicKey');
@@ -220,14 +220,14 @@ describe('GET /api/votes', function () {
 					it('should return votes in ascending order', function () {
 						return votesEndpoint.makeRequest({sort: 'username:asc', publicKey: voterDelegate.publicKey}, 200).then(function (res) {
 							expectValidVoterDelegateResponse(res);
-							_(res.body.data.votes).sortBy('username').map('username').value().should.to.be.eql(_.map(res.body.data.votes, 'username'));
+							expect(_(res.body.data.votes).sortBy('username').map('username').value()).to.to.be.eql(_.map(res.body.data.votes, 'username'));
 						});
 					});
 
 					it('should return votes in descending order', function () {
 						return votesEndpoint.makeRequest({sort: 'username:desc', publicKey: voterDelegate.publicKey}, 200).then(function (res) {
 							expectValidVoterDelegateResponse(res);
-							_(res.body.data.votes).sortBy('username').reverse().map('username').value().should.to.be.eql(_.map(res.body.data.votes, 'username'));
+							expect(_(res.body.data.votes).sortBy('username').reverse().map('username').value()).to.to.be.eql(_.map(res.body.data.votes, 'username'));
 						});
 					});
 				});
@@ -237,14 +237,14 @@ describe('GET /api/votes', function () {
 					it('should return votes in ascending order', function () {
 						return votesEndpoint.makeRequest({sort: 'balance:asc', publicKey: voterDelegate.publicKey}, 200).then(function (res) {
 							expectValidVoterDelegateResponse(res);
-							_.map(res.body.data.votes, 'balance').sort().should.to.be.eql(_.map(res.body.data.votes, 'balance'));
+							expect(_.map(res.body.data.votes, 'balance').sort()).to.to.be.eql(_.map(res.body.data.votes, 'balance'));
 						});
 					});
 
 					it('should return votes in descending order', function () {
 						return votesEndpoint.makeRequest({sort: 'balance:desc', publicKey: voterDelegate.publicKey}, 200).then(function (res) {
 							expectValidVoterDelegateResponse(res);
-							_.map(res.body.data.votes, 'balance').sort().reverse().should.to.be.eql(_.map(res.body.data.votes, 'balance'));
+							expect(_.map(res.body.data.votes, 'balance').sort().reverse()).to.to.be.eql(_.map(res.body.data.votes, 'balance'));
 						});
 					});
 				});
@@ -257,7 +257,7 @@ describe('GET /api/votes', function () {
 
 				it('should return 2 voters', function () {
 					return votesEndpoint.makeRequest({limit: 2, publicKey: voterDelegate.publicKey}, 200).then(function (res) {
-						res.body.data.votes.should.have.length(2);
+						expect(res.body.data.votes).to.have.length(2);
 					});
 				});
 			});
@@ -268,13 +268,13 @@ describe('GET /api/votes', function () {
 					var votes = null;
 
 					return votesEndpoint.makeRequest({limit: 2, offset: 0, publicKey: voterDelegate.publicKey}, 200).then(function (res) {
-						res.body.data.votes.should.have.length(2);
+						expect(res.body.data.votes).to.have.length(2);
 
 						votes = _.map(res.body.data.votes, 'address');
 
 						return votesEndpoint.makeRequest({limit: 2, offset: 1, publicKey: voterDelegate.publicKey}, 200);
 					}).then(function (res) {
-						_.intersection(votes, _.map(res.body.data.votes, 'address')).should.have.length(1);
+						expect(_.intersection(votes, _.map(res.body.data.votes, 'address'))).to.have.length(1);
 					});
 				});
 			});
@@ -306,9 +306,9 @@ describe('GET /api/votes', function () {
 					return votesEndpoint.makeRequest({address: account.address}, 200);
 				}).then(function (res) {
 					expectValidNonVoterDelegateResponse(res);
-					res.body.data.address.should.be.equal(account.address);
-					res.body.data.votesUsed.should.be.equal(0);
-					res.body.data.votesAvailable.should.be.equal(constants.maxVotesPerAccount);
+					expect(res.body.data.address).to.be.equal(account.address);
+					expect(res.body.data.votesUsed).to.be.equal(0);
+					expect(res.body.data.votesAvailable).to.be.equal(constants.maxVotesPerAccount);
 				}).then(function (res) {
 					return apiHelpers.sendTransactionPromise(voteTransaction);
 				}).then(function (res) {
@@ -317,8 +317,8 @@ describe('GET /api/votes', function () {
 					return votesEndpoint.makeRequest({address: account.address}, 200);
 				}).then(function (res) {
 					expectValidVoterDelegateResponse(res);
-					res.body.data.votesUsed.should.be.equal(1);
-					_.map(res.body.data.votes, 'publicKey').should.be.eql([nonVoterDelegate.publicKey]);
+					expect(res.body.data.votesUsed).to.be.equal(1);
+					expect(_.map(res.body.data.votes, 'publicKey')).to.be.eql([nonVoterDelegate.publicKey]);
 				});
 			});
 		});

--- a/test/functional/http/post/0.transfer.js
+++ b/test/functional/http/post/0.transfer.js
@@ -56,7 +56,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			transaction.timestamp += 1;
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid transaction id');
+				expect(res.body.message).to.be.equal('Invalid transaction id');
 				badTransactions.push(transaction);
 			});
 		});
@@ -65,7 +65,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			transaction = lisk.transaction.createTransaction(account.address, 0, accountFixtures.genesis.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid transaction amount');
+				expect(res.body.message).to.be.equal('Invalid transaction amount');
 				badTransactions.push(transaction);
 			});
 		});
@@ -74,7 +74,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			transaction = lisk.transaction.createTransaction('1L', 1, account.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account does not have enough LSK: ' + account.address + ' balance: 0');
+				expect(res.body.message).to.be.equal('Account does not have enough LSK: ' + account.address + ' balance: 0');
 				badTransactions.push(transaction);
 			});
 		});
@@ -83,7 +83,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			transaction = lisk.transaction.createTransaction(account.address, Math.floor(accountFixtures.genesis.balance) , accountFixtures.genesis.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.match(/^Account does not have enough LSK: [0-9]+L balance: /);
+				expect(res.body.message).to.match(/^Account does not have enough LSK: [0-9]+L balance: /);
 				badTransactions.push(transaction);
 			});
 		});
@@ -103,21 +103,21 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			};
 
 			return sendTransactionPromise(signedTransactionFromGenesis, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid sender. Can not send from genesis account');
+				expect(res.body.message).to.be.equal('Invalid sender. Can not send from genesis account');
 				badTransactions.push(signedTransactionFromGenesis);
 			});
 		});
 
 		it('when sender has funds should be ok', function () {
 			return sendTransactionPromise(goodTransaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(goodTransaction);
 			});
 		});
 
 		it('sending transaction with same id twice should fail', function () {
 			return sendTransactionPromise(goodTransaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Transaction is already processed: ' + goodTransaction.id);
+				expect(res.body.message).to.be.equal('Transaction is already processed: ' + goodTransaction.id);
 			});
 		});
 
@@ -125,7 +125,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			cloneGoodTransaction.timestamp += 1;
 
 			return sendTransactionPromise(cloneGoodTransaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Transaction is already processed: ' + cloneGoodTransaction.id);
+				expect(res.body.message).to.be.equal('Transaction is already processed: ' + cloneGoodTransaction.id);
 			});
 		});
 
@@ -133,7 +133,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 			cloneGoodTransaction.timestamp -= 1;
 
 			return sendTransactionPromise(cloneGoodTransaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Transaction is already processed: ' + cloneGoodTransaction.id);
+				expect(res.body.message).to.be.equal('Transaction is already processed: ' + cloneGoodTransaction.id);
 			});
 		});
 
@@ -143,7 +143,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 				transaction = lisk.transaction.createTransaction(accountOffset.address, 1, accountFixtures.genesis.password, null, null, -10000);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -152,7 +152,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 				transaction = lisk.transaction.createTransaction(accountOffset.address, 1, accountFixtures.genesis.password, null, null, 10000);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction timestamp. Timestamp is in the future');
+					expect(res.body.message).to.be.equal('Invalid transaction timestamp. Timestamp is in the future');
 					badTransactions.push(transaction);
 				});
 			});
@@ -172,7 +172,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 						transaction.asset.data = test.input;
 
 						return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-							res.body.message.should.not.be.empty;
+							expect(res.body.message).to.not.be.empty;
 							badTransactions.push(transaction);
 						});
 					});
@@ -190,7 +190,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 						transaction = lisk.transaction.createTransaction(accountAdditionalData.address, 1, accountFixtures.genesis.password, null, test.input);
 
 						return sendTransactionPromise(transaction).then(function (res) {
-							res.body.data.message.should.be.equal('Transaction(s) accepted');
+							expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 							goodTransactions.push(transaction);
 						});
 					});
@@ -208,7 +208,7 @@ describe('POST /api/transactions (type 0) transfer funds', function () {
 
 		it('sending already confirmed transaction should fail', function () {
 			return sendTransactionPromise(goodTransaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Transaction is already confirmed: ' + goodTransaction.id);
+				expect(res.body.message).to.be.equal('Transaction is already confirmed: ' + goodTransaction.id);
 			});
 		});
 	});

--- a/test/functional/http/post/1.second.secret.js
+++ b/test/functional/http/post/1.second.secret.js
@@ -54,7 +54,7 @@ describe('POST /api/transactions (type 1) register second secret', function () {
 		return Promise.all(promises)
 			.then(function (results) {
 				results.forEach(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				});
 
 				transactionsToWaitFor.push(transaction1.id, transaction2.id, transaction3.id);
@@ -73,7 +73,7 @@ describe('POST /api/transactions (type 1) register second secret', function () {
 			transaction = lisk.transaction.createTransaction(accountFixtures.existingDelegate.address, 1, accountNoSecondPassword.password, accountNoSecondPassword.secondPassword);
 
 			return apiHelpers.sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Sender does not have a second signature');
+				expect(res.body.message).to.be.equal('Sender does not have a second signature');
 				badTransactions.push(transaction);
 			});
 		});
@@ -82,7 +82,7 @@ describe('POST /api/transactions (type 1) register second secret', function () {
 			transaction = lisk.signature.createSignature(accountNoFunds.password, accountNoFunds.secondPassword);
 
 			return apiHelpers.sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
+				expect(res.body.message).to.be.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
 				badTransactions.push(transaction);
 			});
 		});
@@ -91,7 +91,7 @@ describe('POST /api/transactions (type 1) register second secret', function () {
 			transaction = lisk.signature.createSignature(accountMinimalFunds.password, accountMinimalFunds.secondPassword, -1);
 
 			return apiHelpers.sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -100,7 +100,7 @@ describe('POST /api/transactions (type 1) register second secret', function () {
 			transaction = lisk.signature.createSignature(account.password, account.secondPassword);
 
 			return apiHelpers.sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});

--- a/test/functional/http/post/2.delegate.js
+++ b/test/functional/http/post/2.delegate.js
@@ -83,7 +83,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(accountNoFunds.password, accountNoFunds.username);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
+				expect(res.body.message).to.be.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
 				badTransactions.push(transaction);
 			});
 		});
@@ -92,7 +92,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(accountMinimalFunds.password, accountMinimalFunds.username);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -101,7 +101,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(account.password, '');
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Username is undefined');
+				expect(res.body.message).to.be.equal('Username is undefined');
 				badTransactions.push(transaction);
 			});
 		});
@@ -111,7 +111,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(account.password, username);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid transaction body - Failed to validate delegate schema: Object didn\'t pass validation for format username: ' + username);
+				expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate delegate schema: Object didn\'t pass validation for format username: ' + username);
 				badTransactions.push(transaction);
 			});
 		});
@@ -121,7 +121,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(account.password, delegateName);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Username is too long. Maximum is 20 characters');
+				expect(res.body.message).to.be.equal('Username is too long. Maximum is 20 characters');
 				badTransactions.push(transaction);
 			});
 		});
@@ -130,7 +130,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(accountUpperCase.password, accountUpperCase.username.toUpperCase());
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Username must be lowercase');
+				expect(res.body.message).to.be.equal('Username must be lowercase');
 				badTransactions.push(transaction);
 			});
 		});
@@ -139,7 +139,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(account.password, account.username);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -156,7 +156,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(account.password, account.username);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account is already a delegate');
+				expect(res.body.message).to.be.equal('Account is already a delegate');
 				badTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -165,7 +165,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(accountFormerDelegate.password, account.username);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Username ' + account.username + ' already exists');
+				expect(res.body.message).to.be.equal('Username ' + account.username + ' already exists');
 				badTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -174,7 +174,7 @@ describe('POST /api/transactions (type 2) register delegate', function () {
 			transaction = lisk.delegate.createDelegate(account.password, 'newusername');
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account is already a delegate');
+				expect(res.body.message).to.be.equal('Account is already a delegate');
 				badTransactionsEnforcement.push(transaction);
 			});
 		});

--- a/test/functional/http/post/3.votes.js
+++ b/test/functional/http/post/3.votes.js
@@ -81,7 +81,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 		return Promise.all(promises)
 			.then(function (res) {
 				res.forEach(function (result, index) {
-					result.body.data.message.should.equal('Transaction(s) accepted');
+					expect(result.body.data.message).to.equal('Transaction(s) accepted');
 					transactionsToWaitFor.push(transactions[index].id);
 				});
 
@@ -97,7 +97,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 
 				return Promise.all(promisesCreditsMaxVotesPerTransaction).then(function (results) {
 					results.forEach(function (result, index) {
-						result.body.data.message.should.equal('Transaction(s) accepted');
+						expect(result.body.data.message).to.equal('Transaction(s) accepted');
 						transactionsToWaitFor.push(transactionsCreditMaxVotesPerTransaction[index].id);
 					});
 				});
@@ -115,7 +115,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 
 				return Promise.all(promisesCreditsMaxVotesPerAccount).then(function (results) {
 					results.forEach(function (result, index) {
-						result.body.data.message.should.equal('Transaction(s) accepted');
+						expect(result.body.data.message).to.equal('Transaction(s) accepted');
 						transactionsToWaitFor.push(transactionsCreditMaxVotesPerAccount[index].id);
 					});
 				});
@@ -127,7 +127,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 				transactionsToWaitFor = [];
 				var transaction = lisk.delegate.createDelegate(delegateAccount.password, delegateAccount.username);
 				return sendTransactionPromise(transaction).then(function (result) {
-					result.body.data.message.should.equal('Transaction(s) accepted');
+					expect(result.body.data.message).to.equal('Transaction(s) accepted');
 					transactionsToWaitFor.push(transaction.id);
 				});
 			})
@@ -142,7 +142,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 
 				return Promise.all(promisesDelegatesMaxVotesPerTransaction).then(function (results) {
 					results.forEach(function (result, index) {
-						result.body.data.message.should.equal('Transaction(s) accepted');
+						expect(result.body.data.message).to.equal('Transaction(s) accepted');
 						transactionsToWaitFor.push(transactionsDelegateMaxForPerTransaction[index].id);
 					});
 				});
@@ -158,7 +158,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 
 				return Promise.all(promisesDelegatesMaxVotesPerAccount).then(function (results) {
 					results.forEach(function (result, index) {
-						result.body.data.message.should.equal('Transaction(s) accepted');
+						expect(result.body.data.message).to.equal('Transaction(s) accepted');
 						transactionsToWaitFor.push(transactionsDelegateMaxVotesPerAccount[index].id);
 					});
 				});
@@ -179,7 +179,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['+L' + accountFixtures.existingDelegate.publicKey.slice(0, -1)]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid vote at index 0 - Invalid vote format');
+				expect(res.body.message).to.be.equal('Invalid vote at index 0 - Invalid vote format');
 				badTransactions.push(transaction);
 			});
 		});
@@ -188,7 +188,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['-1' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid vote at index 0 - Invalid vote length');
+				expect(res.body.message).to.be.equal('Invalid vote at index 0 - Invalid vote length');
 				badTransactions.push(transaction);
 			});
 		});
@@ -197,7 +197,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['x' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid vote at index 0 - Invalid vote format');
+				expect(res.body.message).to.be.equal('Invalid vote at index 0 - Invalid vote format');
 				badTransactions.push(transaction);
 			});
 		});
@@ -206,7 +206,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, [accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid vote at index 0 - Invalid vote format');
+				expect(res.body.message).to.be.equal('Invalid vote at index 0 - Invalid vote format');
 				badTransactions.push(transaction);
 			});
 		});
@@ -215,7 +215,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, [null]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid vote at index 0 - Invalid vote type');
+				expect(res.body.message).to.be.equal('Invalid vote at index 0 - Invalid vote type');
 				badTransactions.push(transaction);
 			});
 		});
@@ -225,7 +225,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(accountNoFunds.password, ['+' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
+				expect(res.body.message).to.be.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
 				badTransactions.push(transaction);
 			});
 		});
@@ -234,7 +234,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(accountMinimalFunds.password, ['+' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -243,7 +243,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['-' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Failed to remove vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" was not voted for');
+				expect(res.body.message).to.be.equal('Failed to remove vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" was not voted for');
 				badTransactions.push(transaction);
 			});
 		});
@@ -252,7 +252,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['+' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -261,7 +261,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['+' + delegateAccount.publicKey]);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -272,7 +272,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			}));
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -283,7 +283,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			}));
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid transaction body - Failed to validate vote schema: Array is too long (34), maximum 33');
+				expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate vote schema: Array is too long (34), maximum 33');
 				badTransactions.push(transaction);
 			});
 		});
@@ -311,7 +311,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			return Promise.all(promises)
 				.then(function (res) {
 					res.forEach(function (result) {
-						result.body.data.message.should.equal('Transaction(s) accepted');
+						expect(result.body.data.message).to.equal('Transaction(s) accepted');
 					});
 					goodTransactions.push(transaction1, transaction2, transaction3, transaction4);
 				});
@@ -329,7 +329,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['+' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Failed to add vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" already voted for');
+				expect(res.body.message).to.be.equal('Failed to add vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" already voted for');
 				badTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -338,7 +338,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['-' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -347,7 +347,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(delegateAccount.password, ['-' + delegateAccount.publicKey]);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -356,7 +356,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			transaction = lisk.vote.createVote(accountMaxVotesPerAccount.password, ['+' + accountFixtures.existingDelegate.publicKey]);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Maximum number of ' + constants.activeDelegates + ' votes exceeded (1 too many)');
+				expect(res.body.message).to.be.equal('Maximum number of ' + constants.activeDelegates + ' votes exceeded (1 too many)');
 				badTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -367,7 +367,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			}));
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.equal('Transaction(s) accepted');
 				goodTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -378,7 +378,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			}));
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Invalid transaction body - Failed to validate vote schema: Array is too long ('+ (constants.maxVotesPerTransaction + 1) + '), maximum ' + constants.maxVotesPerTransaction);
+				expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate vote schema: Array is too long ('+ (constants.maxVotesPerTransaction + 1) + '), maximum ' + constants.maxVotesPerTransaction);
 				badTransactionsEnforcement.push(transaction);
 			});
 		});
@@ -406,7 +406,7 @@ describe('POST /api/transactions (type 3) votes', function () {
 			return Promise.all(promises)
 				.then(function (res) {
 					res.forEach(function (result) {
-						result.body.data.message.should.equal('Transaction(s) accepted');
+						expect(result.body.data.message).to.equal('Transaction(s) accepted');
 					});
 					goodTransactionsEnforcement.push(transaction1, transaction2, transaction3, transaction4);
 				});

--- a/test/functional/http/post/4.multisig.js
+++ b/test/functional/http/post/4.multisig.js
@@ -75,7 +75,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 
 		return apiHelpers.sendTransactionsPromise(transactions).then(function (responses) {
 			responses.map(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 			});
 			transactionsToWaitFor = transactionsToWaitFor.concat(_.map(transactions, 'id'));
 
@@ -93,7 +93,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, [], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate multisignature schema: Array is too short (0), minimum ' + constants.multisigConstraints.keysgroup.minItems);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate multisignature schema: Array is too short (0), minimum ' + constants.multisigConstraints.keysgroup.minItems);
 					badTransactions.push(transaction);
 				});
 			});
@@ -102,7 +102,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['+' + accountFixtures.existingDelegate.publicKey, '+' + scenarios.no_funds.account.publicKey, '+' + scenarios.minimal_funds.account.publicKey, null], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid member in keysgroup');
+					expect(res.body.message).to.be.equal('Invalid member in keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -111,7 +111,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['+' + accountFixtures.existingDelegate.publicKey, '+' + scenarios.regular.account.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid multisignature keysgroup. Can not contain sender');
+					expect(res.body.message).to.be.equal('Invalid multisignature keysgroup. Can not contain sender');
 					badTransactions.push(transaction);
 				});
 			});
@@ -120,7 +120,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['+' + accountFixtures.existingDelegate.publicKey, '+' + accountFixtures.existingDelegate.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Encountered duplicate public key in multisignature keysgroup');
+					expect(res.body.message).to.be.equal('Encountered duplicate public key in multisignature keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -129,7 +129,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['+L' + accountFixtures.existingDelegate.publicKey.slice(0, -1), '+' + scenarios.no_funds.account.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid public key in multisignature keysgroup');
+					expect(res.body.message).to.be.equal('Invalid public key in multisignature keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -138,7 +138,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, [accountFixtures.existingDelegate.publicKey, scenarios.no_funds.account.publicKey, scenarios.minimal_funds.account.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid math operator in multisignature keysgroup');
+					expect(res.body.message).to.be.equal('Invalid math operator in multisignature keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -147,7 +147,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['+', '+'], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid public key in multisignature keysgroup');
+					expect(res.body.message).to.be.equal('Invalid public key in multisignature keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -156,7 +156,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['-' + accountFixtures.existingDelegate.publicKey, '+' + scenarios.no_funds.account.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid math operator in multisignature keysgroup');
+					expect(res.body.message).to.be.equal('Invalid math operator in multisignature keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -165,7 +165,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, ['++' + accountFixtures.existingDelegate.publicKey, '+' + scenarios.no_funds.account.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid public key in multisignature keysgroup');
+					expect(res.body.message).to.be.equal('Invalid public key in multisignature keysgroup');
 					badTransactions.push(transaction);
 				});
 			});
@@ -174,7 +174,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.more_than_max_members.account.password, null, scenarios.more_than_max_members.keysgroup, 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate multisignature schema: Array is too long (' + (constants.multisigConstraints.keysgroup.maxItems + 1) + '), maximum ' + constants.multisigConstraints.keysgroup.maxItems);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate multisignature schema: Array is too long (' + (constants.multisigConstraints.keysgroup.maxItems + 1) + '), maximum ' + constants.multisigConstraints.keysgroup.maxItems);
 					badTransactions.push(transaction);
 				});
 			});
@@ -186,7 +186,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, [accountFixtures.existingDelegate.publicKey], 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid multisignature min. Must be less than or equal to keysgroup size');
+					expect(res.body.message).to.be.equal('Invalid multisignature min. Must be less than or equal to keysgroup size');
 					badTransactions.push(transaction);
 				});
 			});
@@ -195,7 +195,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.max_members_max_min.account.password, null, scenarios.max_members_max_min.keysgroup, 1, constants.multisigConstraints.min.maximum + 1);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.min.maximum + 1) + ' is greater than maximum ' + constants.multisigConstraints.min.maximum);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.min.maximum + 1) + ' is greater than maximum ' + constants.multisigConstraints.min.maximum);
 					badTransactions.push(transaction);
 				});
 			});
@@ -204,7 +204,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.max_members.account.password, null, scenarios.max_members.keysgroup, 1, constants.multisigConstraints.min.minimum - 1);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.min.minimum - 1) + ' is less than minimum ' + constants.multisigConstraints.min.minimum);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.min.minimum - 1) + ' is less than minimum ' + constants.multisigConstraints.min.minimum);
 					badTransactions.push(transaction);
 				});
 			});
@@ -216,7 +216,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, scenarios.regular.keysgroup, constants.multisigConstraints.lifetime.maximum + 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.lifetime.maximum + 1) + ' is greater than maximum ' + constants.multisigConstraints.lifetime.maximum);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.lifetime.maximum + 1) + ' is greater than maximum ' + constants.multisigConstraints.lifetime.maximum);
 					badTransactions.push(transaction);
 				});
 			});
@@ -225,7 +225,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				transaction = lisk.multisignature.createMultisignature(scenarios.regular.account.password, null, scenarios.regular.keysgroup, constants.multisigConstraints.lifetime.minimum - 1, 2);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.lifetime.minimum - 1) + ' is less than minimum ' + constants.multisigConstraints.lifetime.minimum);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate multisignature schema: Value ' + (constants.multisigConstraints.lifetime.minimum - 1) + ' is less than minimum ' + constants.multisigConstraints.lifetime.minimum);
 					badTransactions.push(transaction);
 				});
 			});
@@ -238,7 +238,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 			var scenario = scenarios.no_funds;
 
 			return sendTransactionPromise(scenario.multiSigTransaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Account does not have enough LSK: ' + scenarios.no_funds.account.address + ' balance: 0');
+				expect(res.body.message).to.be.equal('Account does not have enough LSK: ' + scenarios.no_funds.account.address + ' balance: 0');
 				badTransactions.push(scenario.multiSigTransaction);
 			});
 		});
@@ -247,7 +247,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 			var scenario = scenarios.minimal_funds;
 
 			return sendTransactionPromise(scenario.multiSigTransaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 			});
 		});
 
@@ -256,15 +256,15 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 
 			return sendTransactionPromise(scenario.multiSigTransaction)
 				.then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					var signatures = _.map(scenario.members, function (member) {
 						return apiHelpers.createSignatureObject(scenario.multiSigTransaction, member);
 					});
 
 					return signatureEndpoint.makeRequest({signatures: signatures}, 200).then(function (res) {
-						res.body.meta.status.should.be.true;
-						res.body.data.message.should.be.equal('Signature Accepted');
+						expect(res.body.meta.status).to.be.true;
+						expect(res.body.data.message).to.be.equal('Signature Accepted');
 
 						goodTransactions.push(scenario.multiSigTransaction);
 					});
@@ -277,7 +277,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 
 			return sendTransactionPromise(scenario.secondSignatureTransaction)
 				.then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					return waitFor.confirmations([scenario.secondSignatureTransaction.id]);
 				})
@@ -285,15 +285,15 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 					return sendTransactionPromise(multiSigSecondPasswordTransaction);
 				})
 				.then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					var signatures = _.map(scenario.members, function (member) {
 						return apiHelpers.createSignatureObject(multiSigSecondPasswordTransaction, member);
 					});
 
 					return signatureEndpoint.makeRequest({signatures: signatures}, 200).then(function (res) {
-						res.body.meta.status.should.be.true;
-						res.body.data.message.should.be.equal('Signature Accepted');
+						expect(res.body.meta.status).to.be.true;
+						expect(res.body.data.message).to.be.equal('Signature Accepted');
 
 						goodTransactions.push(multiSigSecondPasswordTransaction);
 					});
@@ -304,7 +304,7 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 			var scenario = scenarios.unsigned;
 
 			return sendTransactionPromise(scenario.multiSigTransaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 				pendingMultisignatures.push(scenario.multiSigTransaction);
 			});
@@ -315,15 +315,15 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 
 			return sendTransactionPromise(scenario.multiSigTransaction)
 				.then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					var signatures = _.map(scenario.members, function (member) {
 						return apiHelpers.createSignatureObject(scenario.multiSigTransaction, member);
 					});
 
 					return signatureEndpoint.makeRequest({signatures: signatures}, 200).then(function (res) {
-						res.body.meta.status.should.be.true;
-						res.body.data.message.should.be.equal('Signature Accepted');
+						expect(res.body.meta.status).to.be.true;
+						expect(res.body.data.message).to.be.equal('Signature Accepted');
 
 						goodTransactions.push(scenario.multiSigTransaction);
 					});
@@ -335,15 +335,15 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 
 			return sendTransactionPromise(scenario.multiSigTransaction)
 				.then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 					var signatures = _.map(scenario.members, function (member) {
 						return apiHelpers.createSignatureObject(scenario.multiSigTransaction, member);
 					});
 
 					return signatureEndpoint.makeRequest({signatures: signatures}, 200).then(function (res) {
-						res.body.meta.status.should.be.true;
-						res.body.data.message.should.be.equal('Signature Accepted');
+						expect(res.body.meta.status).to.be.true;
+						expect(res.body.data.message).to.be.equal('Signature Accepted');
 
 						goodTransactions.push(scenario.multiSigTransaction);
 					});
@@ -357,8 +357,8 @@ describe('POST /api/transactions (type 4) register multisignature', function () 
 				var signature = apiHelpers.createSignatureObject(scenario.multiSigTransaction, scenario.members[0]);
 
 				return signatureEndpoint.makeRequest({signatures: [signature]}, 200).then(function (res) {
-					res.body.meta.status.should.be.true;
-					res.body.data.message.should.be.equal('Signature Accepted');
+					expect(res.body.meta.status).to.be.true;
+					expect(res.body.data.message).to.be.equal('Signature Accepted');
 
 					return signatureEndpoint.makeRequest({signatures: [signature]}, apiCodes.PROCESSING_ERROR);
 				}).then(function (res) {

--- a/test/functional/http/post/5.dapps.js
+++ b/test/functional/http/post/5.dapps.js
@@ -54,7 +54,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			.then(function (results) {
 				results.forEach(function (res) {
 					expect(res).to.have.property('status').to.equal(200);
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				});
 
 				transactionsToWaitFor.push(transaction1.id, transaction2.id);
@@ -67,7 +67,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			})
 			.then(function (res) {
 				expect(res).to.have.property('status').to.equal(200);
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 				randomUtil.guestbookDapp.id = transaction.id;
 				transactionsToWaitFor.push(randomUtil.guestbookDapp.id);
@@ -86,7 +86,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				delete transaction.asset.dapp.category;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Missing required property: category$/);
+					expect(res.body.message).to.match(/Missing required property: category$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -96,7 +96,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.category = '0';
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate dapp schema: Expected type integer but found type string');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate dapp schema: Expected type integer but found type string');
 					badTransactions.push(transaction);
 				});
 			});
@@ -106,7 +106,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.category = -1;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Value -1 is less than minimum 0$/);
+					expect(res.body.message).to.match(/Value -1 is less than minimum 0$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -116,7 +116,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.category = 9;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Value 9 is greater than maximum 8$/);
+					expect(res.body.message).to.match(/Value 9 is greater than maximum 8$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -125,7 +125,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, randomUtil.application());
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -140,7 +140,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -150,7 +150,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.description = 0;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -162,7 +162,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -175,7 +175,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/String is too long \(161 chars\), maximum 160$/);
+					expect(res.body.message).to.match(/String is too long \(161 chars\), maximum 160$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -190,7 +190,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -200,7 +200,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.icon = 0;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
+					expect(res.body.message).to.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -212,7 +212,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid application icon link');
+					expect(res.body.message).to.equal('Invalid application icon link');
 					badTransactions.push(transaction);
 				});
 			});
@@ -224,7 +224,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid application icon file type');
+					expect(res.body.message).to.equal('Invalid application icon file type');
 					badTransactions.push(transaction);
 				});
 			});
@@ -239,7 +239,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid application link');
+					expect(res.body.message).to.equal('Invalid application link');
 					badTransactions.push(transaction);
 				});
 			});
@@ -249,7 +249,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.link = 0;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
+					expect(res.body.message).to.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -262,7 +262,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid application file type');
+					expect(res.body.message).to.equal('Invalid application file type');
 					badTransactions.push(transaction);
 				});
 			});
@@ -275,7 +275,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				delete transaction.asset.dapp.name;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Missing required property: name$/);
+					expect(res.body.message).to.match(/Missing required property: name$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -285,7 +285,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.name = 0;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
+					expect(res.body.message).to.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -295,7 +295,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.name = '';
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/String is too short \(0 chars\), minimum 1$/);
+					expect(res.body.message).to.match(/String is too short \(0 chars\), minimum 1$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -308,7 +308,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/String is too long \(33 chars\), maximum 32$/);
+					expect(res.body.message).to.match(/String is too long \(33 chars\), maximum 32$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -323,7 +323,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -333,7 +333,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.tags = 0;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
+					expect(res.body.message).to.equal('Invalid transaction body - Failed to validate dapp schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -345,7 +345,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -358,7 +358,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/String is too long \(161 chars\), maximum 160$/);
+					expect(res.body.message).to.match(/String is too long \(161 chars\), maximum 160$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -370,7 +370,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});
@@ -383,7 +383,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Encountered duplicate tag: ' + tag + ' in application');
+					expect(res.body.message).to.equal('Encountered duplicate tag: ' + tag + ' in application');
 					badTransactions.push(transaction);
 				});
 			});
@@ -396,7 +396,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				delete transaction.asset.dapp.type;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Missing required property: type$/);
+					expect(res.body.message).to.match(/Missing required property: type$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -406,7 +406,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.type = -1;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Value -1 is less than minimum 0$/);
+					expect(res.body.message).to.match(/Value -1 is less than minimum 0$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -416,7 +416,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction.asset.dapp.type = -1;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/Value -1 is less than minimum 0$/);
+					expect(res.body.message).to.match(/Value -1 is less than minimum 0$/);
 					badTransactions.push(transaction);
 				});
 			});
@@ -427,7 +427,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 				transaction = lisk.dapp.createDapp(account.password, null, application);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.equal('Invalid application type');
+					expect(res.body.message).to.equal('Invalid application type');
 					badTransactions.push(transaction);
 				});
 			});
@@ -442,7 +442,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			transaction = lisk.dapp.createDapp(account.password, null, dapp);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.equal('Application name already exists: ' + dapp.name);
+				expect(res.body.message).to.equal('Application name already exists: ' + dapp.name);
 				badTransactions.push(transaction);
 			});
 		});
@@ -453,7 +453,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			transaction = lisk.dapp.createDapp(account.password, null, dapp);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.equal('Application link already exists: ' + dapp.link);
+				expect(res.body.message).to.equal('Application link already exists: ' + dapp.link);
 				badTransactions.push(transaction);
 			});
 		});
@@ -462,7 +462,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			transaction = lisk.dapp.createDapp(accountNoFunds.password, null, randomUtil.application());
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
+				expect(res.body.message).to.equal('Account does not have enough LSK: ' + accountNoFunds.address + ' balance: 0');
 				badTransactions.push(transaction);
 			});
 		});
@@ -471,7 +471,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			transaction = lisk.dapp.createDapp(accountMinimalFunds.password, null, randomUtil.application());
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -480,7 +480,7 @@ describe('POST /api/transactions (type 5) register dapp', function () {
 			transaction = lisk.dapp.createDapp(account.password, null, randomUtil.application());
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});

--- a/test/functional/http/post/6.dapps.inTransfer.js
+++ b/test/functional/http/post/6.dapps.inTransfer.js
@@ -51,7 +51,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 		return Promise.all(promises)
 			.then(function (results) {
 				results.forEach(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				});
 
 				transactionsToWaitFor.push(transaction1.id, transaction2.id);
@@ -64,7 +64,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				return sendTransactionPromise(transaction);
 			})
 			.then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 				randomUtil.guestbookDapp.id = transaction.id;
 				transactionsToWaitFor.push(randomUtil.guestbookDapp.id);
@@ -73,7 +73,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				return sendTransactionPromise(transaction);
 			})
 			.then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 				randomUtil.blockDataDapp.id = transaction.id;
 				transactionsToWaitFor.push(randomUtil.blockDataDapp.id);
@@ -93,7 +93,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				delete transaction.asset.inTransfer.dappId;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Missing required property: dappId');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Missing required property: dappId');
 					badTransactions.push(transaction);
 				});
 			});
@@ -103,7 +103,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction.asset.inTransfer.dappId = 1;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type integer');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -113,7 +113,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction.asset.inTransfer.dappId = 1.2;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type number, Object didn\'t pass validation for format id: 1.2');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type number, Object didn\'t pass validation for format id: 1.2');
 					badTransactions.push(transaction);
 				});
 			});
@@ -123,7 +123,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction.asset.inTransfer.dappId = [];
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type array');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type array');
 					badTransactions.push(transaction);
 				});
 			});
@@ -133,7 +133,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction.asset.inTransfer.dappId = {};
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type object, Object didn\'t pass validation for format id: {}');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Expected type string but found type object, Object didn\'t pass validation for format id: {}');
 					badTransactions.push(transaction);
 				});
 			});
@@ -142,7 +142,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction = lisk.transfer.createInTransfer('', Date.now(), account.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: String is too short (0 chars), minimum 1');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: String is too short (0 chars), minimum 1');
 					badTransactions.push(transaction);
 				});
 			});
@@ -152,7 +152,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction = lisk.transfer.createInTransfer(invalidDappId, 1, accountFixtures.genesis.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Object didn\'t pass validation for format id: ' + invalidDappId);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate inTransfer schema: Object didn\'t pass validation for format id: ' + invalidDappId);
 					badTransactions.push(transaction);
 				});
 			});
@@ -164,7 +164,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction = lisk.transfer.createInTransfer(randomUtil.guestbookDapp.id, -1, accountFixtures.genesis.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate transaction schema: Value -1 is less than minimum 0');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate transaction schema: Value -1 is less than minimum 0');
 					badTransactions.push(transaction);
 				});
 			});
@@ -181,7 +181,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 						return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR);
 					})
 					.then(function (res) {
-						res.body.message.should.match(/^Account does not have enough LSK: /);
+						expect(res.body.message).to.match(/^Account does not have enough LSK: /);
 						badTransactions.push(transaction);
 					});
 			});
@@ -195,7 +195,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 			transaction = lisk.transfer.createInTransfer(unknownDappId, 1, accountFixtures.genesis.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Application not found: ' + unknownDappId);
+				expect(res.body.message).to.be.equal('Application not found: ' + unknownDappId);
 				badTransactions.push(transaction);
 			});
 		});
@@ -205,7 +205,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 			transaction = lisk.transfer.createInTransfer(inexistentId, 1, account.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Application not found: ' + inexistentId);
+				expect(res.body.message).to.be.equal('Application not found: ' + inexistentId);
 				badTransactions.push(transaction);
 			});
 		});
@@ -214,7 +214,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 			transaction = lisk.transfer.createInTransfer(transactionsToWaitFor[0], 1, accountFixtures.genesis.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Application not found: ' + transactionsToWaitFor[0]);
+				expect(res.body.message).to.be.equal('Application not found: ' + transactionsToWaitFor[0]);
 				badTransactions.push(transaction);
 			});
 		});
@@ -223,7 +223,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 			transaction = lisk.transfer.createInTransfer(randomUtil.guestbookDapp.id, 10 * normalizer, accountFixtures.genesis.password);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -234,7 +234,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction = lisk.transfer.createInTransfer(randomUtil.blockDataDapp.id, 1, accountMinimalFunds.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/^Account does not have enough LSK: /);
+					expect(res.body.message).to.match(/^Account does not have enough LSK: /);
 					badTransactions.push(transaction);
 				});
 			});
@@ -243,7 +243,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', function () {
 				transaction = lisk.transfer.createInTransfer(randomUtil.guestbookDapp.id, 10 * normalizer, account.password);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});

--- a/test/functional/http/post/7.dapps.outTransfer.js
+++ b/test/functional/http/post/7.dapps.outTransfer.js
@@ -52,7 +52,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 		return Promise.all(promises)
 			.then(function (results) {
 				results.forEach(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				});
 
 				transactionsToWaitFor.push(transaction1.id, transaction2.id);
@@ -65,7 +65,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				return sendTransactionPromise(transaction);
 			})
 			.then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 				randomUtil.guestbookDapp.id = transaction.id;
 				transactionsToWaitFor.push(randomUtil.guestbookDapp.id);
@@ -74,7 +74,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				return sendTransactionPromise(transaction);
 			})
 			.then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 
 				randomUtil.blockDataDapp.id = transaction.id;
 				transactionsToWaitFor.push(randomUtil.blockDataDapp.id);
@@ -94,7 +94,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				delete transaction.asset.outTransfer.dappId;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Missing required property: dappId');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Missing required property: dappId');
 					badTransactions.push(transaction);
 				});
 			});
@@ -104,7 +104,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.dappId = 1;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type integer');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -114,7 +114,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.dappId = 1.2;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type number, Object didn\'t pass validation for format id: 1.2');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type number, Object didn\'t pass validation for format id: 1.2');
 					badTransactions.push(transaction);
 				});
 			});
@@ -124,7 +124,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.dappId = [];
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type array');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type array');
 					badTransactions.push(transaction);
 				});
 			});
@@ -134,7 +134,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.dappId = {};
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type object, Object didn\'t pass validation for format id: {}');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type object, Object didn\'t pass validation for format id: {}');
 					badTransactions.push(transaction);
 				});
 			});
@@ -143,7 +143,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer('', randomUtil.transaction().id, accountFixtures.genesis.address, Date.now(), account.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: String is too short (0 chars), minimum 1');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: String is too short (0 chars), minimum 1');
 					badTransactions.push(transaction);
 				});
 			});
@@ -153,7 +153,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer(invalidDappId, randomUtil.transaction().id, accountFixtures.genesis.address, Date.now(), account.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Object didn\'t pass validation for format id: ' + invalidDappId);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Object didn\'t pass validation for format id: ' + invalidDappId);
 					badTransactions.push(transaction);
 				});
 			});
@@ -166,7 +166,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				delete transaction.asset.outTransfer.transactionId;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Missing required property: transactionId');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Missing required property: transactionId');
 					badTransactions.push(transaction);
 				});
 			});
@@ -176,7 +176,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.transactionId = 1;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type integer');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type integer');
 					badTransactions.push(transaction);
 				});
 			});
@@ -186,7 +186,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.transactionId = 1.2;
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type number, Object didn\'t pass validation for format id: 1.2');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type number, Object didn\'t pass validation for format id: 1.2');
 					badTransactions.push(transaction);
 				});
 			});
@@ -196,7 +196,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.transactionId = [];
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type array');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type array');
 					badTransactions.push(transaction);
 				});
 			});
@@ -206,7 +206,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction.asset.outTransfer.transactionId = {};
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type object, Object didn\'t pass validation for format id: {}');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Expected type string but found type object, Object didn\'t pass validation for format id: {}');
 					badTransactions.push(transaction);
 				});
 			});
@@ -215,7 +215,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer(randomUtil.guestbookDapp.id, '', accountFixtures.genesis.address, 1, account.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: String is too short (0 chars), minimum 1');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: String is too short (0 chars), minimum 1');
 					badTransactions.push(transaction);
 				});
 			});
@@ -225,7 +225,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer(randomUtil.guestbookDapp.id, invalidTransactionId, accountFixtures.genesis.address, Date.now(), account.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Object didn\'t pass validation for format id: ' + invalidTransactionId);
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate outTransfer schema: Object didn\'t pass validation for format id: ' + invalidTransactionId);
 					badTransactions.push(transaction);
 				});
 			});
@@ -293,7 +293,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer(randomUtil.guestbookDapp.id, randomUtil.transaction().id, accountFixtures.genesis.address, -1, account.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.be.equal('Invalid transaction body - Failed to validate transaction schema: Value -1 is less than minimum 0');
+					expect(res.body.message).to.be.equal('Invalid transaction body - Failed to validate transaction schema: Value -1 is less than minimum 0');
 					badTransactions.push(transaction);
 				});
 			});
@@ -314,7 +314,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 						return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR);
 					})
 					.then(function (res) {
-						res.body.message.should.match(/^Account does not have enough LSK: /);
+						expect(res.body.message).to.match(/^Account does not have enough LSK: /);
 						badTransactions.push(transaction);
 					});
 			});
@@ -328,7 +328,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 			transaction = lisk.transfer.createOutTransfer(unknownDappId, randomUtil.transaction().id, accountFixtures.genesis.address, 1, account.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Application not found: ' + unknownDappId);
+				expect(res.body.message).to.be.equal('Application not found: ' + unknownDappId);
 				badTransactions.push(transaction);
 			});
 		});
@@ -338,7 +338,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 			transaction = lisk.transfer.createOutTransfer(inexistentId, randomUtil.transaction().id, accountFixtures.genesis.address, 1, account.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Application not found: ' + inexistentId);
+				expect(res.body.message).to.be.equal('Application not found: ' + inexistentId);
 				badTransactions.push(transaction);
 			});
 		});
@@ -347,7 +347,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 			transaction = lisk.transfer.createOutTransfer(transactionsToWaitFor[0], randomUtil.transaction().id, accountFixtures.genesis.address, 1, account.password);
 
 			return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.be.equal('Application not found: ' + transactionsToWaitFor[0]);
+				expect(res.body.message).to.be.equal('Application not found: ' + transactionsToWaitFor[0]);
 				badTransactions.push(transaction);
 			});
 		});
@@ -356,7 +356,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 			transaction = lisk.transfer.createOutTransfer(randomUtil.guestbookDapp.id, randomUtil.transaction().id, accountFixtures.genesis.address, 10 * normalizer, account.password);
 
 			return sendTransactionPromise(transaction).then(function (res) {
-				res.body.data.message.should.be.equal('Transaction(s) accepted');
+				expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 				goodTransactions.push(transaction);
 			});
 		});
@@ -367,7 +367,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer(randomUtil.blockDataDapp.id, randomUtil.transaction().id, accountFixtures.genesis.address, 10 * normalizer, accountMinimalFunds.password);
 
 				return sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.match(/^Account does not have enough LSK: /);
+					expect(res.body.message).to.match(/^Account does not have enough LSK: /);
 					badTransactions.push(transaction);
 				});
 			});
@@ -376,7 +376,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', function () {
 				transaction = lisk.transfer.createOutTransfer(randomUtil.guestbookDapp.id, randomUtil.transaction().id, accountFixtures.genesis.address, 10 * normalizer, account.password);
 
 				return sendTransactionPromise(transaction).then(function (res) {
-					res.body.data.message.should.be.equal('Transaction(s) accepted');
+					expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
 					goodTransactions.push(transaction);
 				});
 			});

--- a/test/functional/http/post/common.js
+++ b/test/functional/http/post/common.js
@@ -61,7 +61,7 @@ function invalidAssets (option, badTransactions) {
 				var expectedResponse = (test.expectation === 'object' && test.description !== 'date' ? errorCodes.PROCESSING_ERROR : errorCodes.BAD_REQUEST);
 
 				return apiHelpers.sendTransactionPromise(transaction, expectedResponse).then(function (res) {
-					res.body.message.should.not.be.empty;
+					expect(res.body.message).to.not.be.empty;
 					badTransactions.push(transaction);
 				});
 			});
@@ -71,7 +71,7 @@ function invalidAssets (option, badTransactions) {
 			delete transaction.asset;
 
 			return apiHelpers.sendTransactionPromise(transaction, errorCodes.BAD_REQUEST).then(function (res) {
-				res.body.message.should.not.be.empty;
+				expect(res.body.message).to.not.be.empty;
 				badTransactions.push(transaction);
 			});
 		});
@@ -84,7 +84,7 @@ function invalidAssets (option, badTransactions) {
 				transaction.asset[option] = test.input;
 
 				return apiHelpers.sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-					res.body.message.should.not.be.empty;
+					expect(res.body.message).to.not.be.empty;
 					badTransactions.push(transaction);
 				});
 			});
@@ -94,7 +94,7 @@ function invalidAssets (option, badTransactions) {
 			delete transaction.asset[option];
 
 			return apiHelpers.sendTransactionPromise(transaction, errorCodes.PROCESSING_ERROR).then(function (res) {
-				res.body.message.should.not.be.empty;
+				expect(res.body.message).to.not.be.empty;
 				badTransactions.push(transaction);
 			});
 		});

--- a/test/functional/http/post/transactions.js
+++ b/test/functional/http/post/transactions.js
@@ -23,14 +23,14 @@ describe('POST /api/transactions (general)', function () {
 	it('should fail if empty transactions posted', function () {
 		return transactionsEndpoint.makeRequest({transactions: []}, 400).then(function (res) {
 			expectSwaggerParamError(res, 'transactions');
-			res.body.errors[0].errors[0].code.should.be.equal('ARRAY_LENGTH_SHORT');
+			expect(res.body.errors[0].errors[0].code).to.be.equal('ARRAY_LENGTH_SHORT');
 		});
 	});
 
 	it('should fail on more than one transactions at a time', function () {
 		return transactionsEndpoint.makeRequest({transactions: [randomUtil.transaction(), randomUtil.transaction()]}, 400).then(function (res) {
 			expectSwaggerParamError(res, 'transactions');
-			res.body.errors[0].errors[0].code.should.be.equal('ARRAY_LENGTH_LONG');
+			expect(res.body.errors[0].errors[0].code).to.be.equal('ARRAY_LENGTH_LONG');
 		});
 	});
 });

--- a/test/functional/http/put/node.js
+++ b/test/functional/http/put/node.js
@@ -30,8 +30,8 @@ describe('PUT /node/status/forging', function () {
 			if(!res.body.data[0].forging) {
 				return toggleForgingEndpoint.makeRequest({data: {publicKey: validDelegate.publicKey, decryptionKey: validDelegate.key}}, 200)
 					.then(function (res) {
-						res.body.data[0].publicKey.should.be.eql(validDelegate.publicKey);
-						res.body.data[0].forging.should.be.true;
+						expect(res.body.data[0].publicKey).to.be.eql(validDelegate.publicKey);
+						expect(res.body.data[0].forging).to.be.true;
 					});
 			}
 		});
@@ -54,7 +54,7 @@ describe('PUT /node/status/forging', function () {
 		};
 
 		return toggleForgingEndpoint.makeRequest({data: params}, 404).then(function (res) {
-			res.body.message.should.contains('not found');
+			expect(res.body.message).to.contains('not found');
 		});
 	});
 
@@ -65,7 +65,7 @@ describe('PUT /node/status/forging', function () {
 		};
 
 		return toggleForgingEndpoint.makeRequest({data: params}, 404).then(function (res) {
-			res.body.message.should.contain('Invalid key and public key combination');
+			expect(res.body.message).to.contain('Invalid key and public key combination');
 		});
 	});
 
@@ -76,8 +76,8 @@ describe('PUT /node/status/forging', function () {
 		};
 
 		return toggleForgingEndpoint.makeRequest({data: params}, 200).then(function (res) {
-			res.body.data.should.have.length(1);
-			res.body.data[0].publicKey.should.be.eql(validDelegate.publicKey);
+			expect(res.body.data).to.have.length(1);
+			expect(res.body.data[0].publicKey).to.be.eql(validDelegate.publicKey);
 		});
 	});
 
@@ -91,8 +91,8 @@ describe('PUT /node/status/forging', function () {
 			var currentStatus = res.body.data[0].forging;
 
 			return toggleForgingEndpoint.makeRequest({data: params}, 200).then(function (res) {
-				res.body.data[0].publicKey.should.eql(validDelegate.publicKey);
-				res.body.data[0].forging.should.not.eql(currentStatus);
+				expect(res.body.data[0].publicKey).to.eql(validDelegate.publicKey);
+				expect(res.body.data[0].forging).to.not.eql(currentStatus);
 			});
 		});
 	});

--- a/test/functional/system/0.0.transfer.js
+++ b/test/functional/system/0.0.transfer.js
@@ -47,7 +47,7 @@ describe('system test (type 0) - double transfers', function () {
 			it('adding to pool transfer should be ok', function (done) {
 				transaction1 = lisk.transaction.createTransaction(accountFixtures.genesis.address, 1000 * normalizer, account.password, null, null, -1);
 				localCommon.addTransaction(library, transaction1, function (err, res) {
-					res.should.equal(transaction1.id);
+					expect(res).to.equal(transaction1.id);
 					done();
 				});
 			});
@@ -55,7 +55,7 @@ describe('system test (type 0) - double transfers', function () {
 			it('adding to pool same transfer with different timestamp should be ok', function (done) {
 				transaction2 = lisk.transaction.createTransaction(accountFixtures.genesis.address, 1000 * normalizer, account.password);
 				localCommon.addTransaction(library, transaction2, function (err, res) {
-					res.should.equal(transaction2.id);
+					expect(res).to.equal(transaction2.id);
 					done();
 				});
 			});
@@ -73,9 +73,9 @@ describe('system test (type 0) - double transfers', function () {
 						id: transaction1.id
 					};
 					localCommon.getTransactionFromModule(library, filter, function (err, res) {
-						should.not.exist(err);
-						res.should.have.property('transactions').which.is.an('Array');
-						res.transactions.length.should.equal(0);
+						expect(err).to.be.null;
+						expect(res).to.have.property('transactions').which.is.an('Array');
+						expect(res.transactions.length).to.equal(0);
 						done();
 					});
 				});
@@ -85,17 +85,17 @@ describe('system test (type 0) - double transfers', function () {
 						id: transaction2.id
 					};
 					localCommon.getTransactionFromModule(library, filter, function (err, res) {
-						should.not.exist(err);
-						res.should.have.property('transactions').which.is.an('Array');
-						res.transactions.length.should.equal(1);
-						res.transactions[0].id.should.equal(transaction2.id);
+						expect(err).to.be.null;
+						expect(res).to.have.property('transactions').which.is.an('Array');
+						expect(res.transactions.length).to.equal(1);
+						expect(res.transactions[0].id).to.equal(transaction2.id);
 						done();
 					});
 				});
 
 				it('adding to pool transfer for same account should fail', function (done) {
 					localCommon.addTransaction(library, transaction1, function (err, res) {
-						err.should.match(/^Account does not have enough LSK: /);
+						expect(err).to.match(/^Account does not have enough LSK: /);
 						done();
 					});
 				});

--- a/test/functional/system/1.1.secondSignature.js
+++ b/test/functional/system/1.1.secondSignature.js
@@ -41,7 +41,7 @@ describe('system test (type 1) - double second signature registrations', functio
 	it('adding to pool second signature registration should be ok', function (done) {
 		transaction1 = lisk.signature.createSignature(account.password, account.secondPassword, -1);
 		localCommon.addTransaction(library, transaction1, function (err, res) {
-			res.should.equal(transaction1.id);
+			expect(res).to.equal(transaction1.id);
 			done();
 		});
 	});
@@ -49,7 +49,7 @@ describe('system test (type 1) - double second signature registrations', functio
 	it('adding to pool same second signature registration with different timestamp should be ok', function (done) {
 		transaction2 = lisk.signature.createSignature(account.password, account.secondPassword);
 		localCommon.addTransaction(library, transaction2, function (err, res) {
-			res.should.equal(transaction2.id);
+			expect(res).to.equal(transaction2.id);
 			done();
 		});
 	});
@@ -67,9 +67,9 @@ describe('system test (type 1) - double second signature registrations', functio
 				id: transaction1.id
 			};
 			localCommon.getTransactionFromModule(library, filter, function (err, res) {
-				should.not.exist(err);
-				res.should.have.property('transactions').which.is.an('Array');
-				res.transactions.length.should.equal(0);
+				expect(err).to.be.null;
+				expect(res).to.have.property('transactions').which.is.an('Array');
+				expect(res.transactions.length).to.equal(0);
 				done();
 			});
 		});
@@ -79,17 +79,17 @@ describe('system test (type 1) - double second signature registrations', functio
 				id: transaction2.id
 			};
 			localCommon.getTransactionFromModule(library, filter, function (err, res) {
-				should.not.exist(err);
-				res.should.have.property('transactions').which.is.an('Array');
-				res.transactions.length.should.equal(1);
-				res.transactions[0].id.should.equal(transaction2.id);
+				expect(err).to.be.null;
+				expect(res).to.have.property('transactions').which.is.an('Array');
+				expect(res.transactions.length).to.equal(1);
+				expect(res.transactions[0].id).to.equal(transaction2.id);
 				done();
 			});
 		});
 
 		it('adding to pool second signature registration for same account should fail', function (done) {
 			localCommon.addTransaction(library, transaction1, function (err, res) {
-				err.should.equal('Missing sender second signature');
+				expect(err).to.equal('Missing sender second signature');
 				done();
 			});
 		});

--- a/test/functional/system/1.X.secondSignature.unconfirmed.js
+++ b/test/functional/system/1.X.secondSignature.unconfirmed.js
@@ -48,7 +48,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 
 	it('adding to pool second signature registration should be ok', function (done) {
 		localCommon.addTransaction(library, transactionSecondSignature, function (err, res) {
-			res.should.equal(transactionSecondSignature.id);
+			expect(res).to.equal(transactionSecondSignature.id);
 			done();
 		});
 	});
@@ -61,7 +61,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 				if (key === 'SIGNATURE') {
 					it('type ' + index + ': ' + key + ' should fail', function (done) {
 						localCommon.addTransaction(library, transactionSecondSignature, function (err, res) {
-							err.should.equal('Transaction is already processed: ' + transactionSecondSignature.id);
+							expect(err).to.equal('Transaction is already processed: ' + transactionSecondSignature.id);
 							done();
 						});
 					});
@@ -69,7 +69,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 					it('type ' + index + ': ' + key + ' with different timestamp should be ok', function (done) {
 						transactionWith = lisk.signature.createSignature(account.password, account.secondPassword, -1);
 						localCommon.addTransaction(library, transactionWith, function (err, res) {
-							res.should.equal(transactionWith.id);
+							expect(res).to.equal(transactionWith.id);
 							done();
 						});
 					});
@@ -77,7 +77,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 					it('type ' + index + ': ' + key + ' should fail', function (done) {
 						localCommon.loadTransactionType(key, account, dapp, null, function (transaction) {
 							localCommon.addTransaction(library, transaction, function (err, res) {
-								err.should.equal('Sender does not have a second signature');
+								expect(err).to.equal('Sender does not have a second signature');
 								done();
 							});
 						});
@@ -93,7 +93,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 					it('type ' + index + ': ' + key + ' should be ok', function (done) {
 						localCommon.loadTransactionType(key, account, dapp, true, function (transaction) {
 							localCommon.addTransaction(library, transaction, function (err, res) {
-								res.should.equal(transaction.id);
+								expect(res).to.equal(transaction.id);
 								done();
 							});
 						});

--- a/test/functional/system/1.X.secondSignature.validated.js
+++ b/test/functional/system/1.X.secondSignature.validated.js
@@ -47,7 +47,7 @@ describe('system test (type 1) - checking validated second signature registratio
 
 	it('adding to pool second signature registration should be ok', function (done) {
 		localCommon.addTransaction(library, transaction, function (err, res) {
-			res.should.equal(transaction.id);
+			expect(res).to.equal(transaction.id);
 			done();
 		});
 	});
@@ -65,17 +65,17 @@ describe('system test (type 1) - checking validated second signature registratio
 				id: transaction.id
 			};
 			localCommon.getTransactionFromModule(library, filter, function (err, res) {
-				should.not.exist(err);
-				res.should.have.property('transactions').which.is.an('Array');
-				res.transactions.length.should.equal(1);
-				res.transactions[0].id.should.equal(transaction.id);
+				expect(err).to.be.null;
+				expect(res).to.have.property('transactions').which.is.an('Array');
+				expect(res.transactions.length).to.equal(1);
+				expect(res.transactions[0].id).to.equal(transaction.id);
 				done();
 			});
 		});
 
 		it('adding to pool second signature registration for same account should fail', function (done) {
 			localCommon.addTransaction(library, transaction, function (err, res) {
-				err.should.equal('Missing sender second signature');
+				expect(err).to.equal('Missing sender second signature');
 				done();
 			});
 		});
@@ -87,7 +87,7 @@ describe('system test (type 1) - checking validated second signature registratio
 					it('type ' + index + ': ' + key + ' without second signature should fail', function (done) {
 						localCommon.loadTransactionType(key, account, dapp, true, function (transaction) {
 							localCommon.addTransaction(library, transaction, function (err, res) {
-								err.should.equal('Missing sender second signature');
+								expect(err).to.equal('Missing sender second signature');
 								done();
 							});
 						});
@@ -96,7 +96,7 @@ describe('system test (type 1) - checking validated second signature registratio
 					it('type ' + index + ': ' + key + ' with second signature not matching registered second passphrase should fail', function (done) {
 						localCommon.loadTransactionType(key, account, dapp, false, function (transaction) {
 							localCommon.addTransaction(library, transaction, function (err, res) {
-								err.should.equal('Failed to verify second signature');
+								expect(err).to.equal('Failed to verify second signature');
 								done();
 							});
 						});
@@ -105,7 +105,7 @@ describe('system test (type 1) - checking validated second signature registratio
 					it('type ' + index + ': ' + key + ' with correct second signature should be ok', function (done) {
 						localCommon.loadTransactionType(key, account, dapp, null, function (transaction) {
 							localCommon.addTransaction(library, transaction, function (err, res) {
-								res.should.equal(transaction.id);
+								expect(res).to.equal(transaction.id);
 								done();
 							});
 						});

--- a/test/functional/system/2.2.delegates.js
+++ b/test/functional/system/2.2.delegates.js
@@ -53,7 +53,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 					it('adding to pool delegate registration should be ok', function (done) {
 						transaction1 = lisk.delegate.createDelegate(account.password, account.username, null, -1);
 						localCommon.addTransaction(library, transaction1, function (err, res) {
-							res.should.equal(transaction1.id);
+							expect(res).to.equal(transaction1.id);
 							done();
 						});
 					});
@@ -61,7 +61,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 					it('adding to pool delegate registration from same account with different id should be ok', function (done) {
 						transaction2 = lisk.delegate.createDelegate(account.password, account.username);
 						localCommon.addTransaction(library, transaction2, function (err, res) {
-							res.should.equal(transaction2.id);
+							expect(res).to.equal(transaction2.id);
 							done();
 						});
 					});
@@ -84,9 +84,9 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 								id: transaction1.id
 							};
 							localCommon.getTransactionFromModule(library, filter, function (err, res) {
-								should.not.exist(err);
-								res.should.have.property('transactions').which.is.an('Array');
-								res.transactions.length.should.equal(0);
+								expect(err).to.be.null;
+								expect(res).to.have.property('transactions').which.is.an('Array');
+								expect(res.transactions.length).to.equal(0);
 								done();
 							});
 						});
@@ -96,10 +96,10 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 								id: transaction2.id
 							};
 							localCommon.getTransactionFromModule(library, filter, function (err, res) {
-								should.not.exist(err);
-								res.should.have.property('transactions').which.is.an('Array');
-								res.transactions.length.should.equal(1);
-								res.transactions[0].id.should.equal(transaction2.id);
+								expect(err).to.be.null;
+								expect(res).to.have.property('transactions').which.is.an('Array');
+								expect(res.transactions.length).to.equal(1);
+								expect(res.transactions[0].id).to.equal(transaction2.id);
 								done();
 							});
 						});
@@ -107,7 +107,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 						it('adding to pool delegate registration from same account should fail', function (done) {
 							transaction2 = lisk.delegate.createDelegate(account.password, randomUtil.delegateName());
 							localCommon.addTransaction(library, transaction2, function (err, res) {
-								err.should.equal('Account is already a delegate');
+								expect(err).to.equal('Account is already a delegate');
 								done();
 							});
 						});
@@ -119,7 +119,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 					it('adding to pool delegate registration should be ok', function (done) {
 						transaction1 = lisk.delegate.createDelegate(account.password, differentDelegateName);
 						localCommon.addTransaction(library, transaction1, function (err, res) {
-							res.should.equal(transaction1.id);
+							expect(res).to.equal(transaction1.id);
 							done();
 						});
 					});
@@ -127,7 +127,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 					it('adding to pool delegate registration from same account and different name should be ok', function (done) {
 						transaction2 = lisk.delegate.createDelegate(account.password, account.username);
 						localCommon.addTransaction(library, transaction2, function (err, res) {
-							res.should.equal(transaction2.id);
+							expect(res).to.equal(transaction2.id);
 							done();
 						});
 					});
@@ -150,9 +150,9 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 								id: transaction1.id
 							};
 							localCommon.getTransactionFromModule(library, filter, function (err, res) {
-								should.not.exist(err);
-								res.should.have.property('transactions').which.is.an('Array');
-								res.transactions.length.should.equal(0);
+								expect(err).to.be.null;
+								expect(res).to.have.property('transactions').which.is.an('Array');
+								expect(res.transactions.length).to.equal(0);
 								done();
 							});
 						});
@@ -162,10 +162,10 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 								id: transaction2.id
 							};
 							localCommon.getTransactionFromModule(library, filter, function (err, res) {
-								should.not.exist(err);
-								res.should.have.property('transactions').which.is.an('Array');
-								res.transactions.length.should.equal(1);
-								res.transactions[0].id.should.equal(transaction2.id);
+								expect(err).to.be.null;
+								expect(res).to.have.property('transactions').which.is.an('Array');
+								expect(res.transactions.length).to.equal(1);
+								expect(res.transactions[0].id).to.equal(transaction2.id);
 								done();
 							});
 						});
@@ -173,7 +173,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 						it('adding to pool delegate registration from same account should fail', function (done) {
 							transaction2 = lisk.delegate.createDelegate(account.password, randomUtil.delegateName());
 							localCommon.addTransaction(library, transaction2, function (err, res) {
-								err.should.equal('Account is already a delegate');
+								expect(err).to.equal('Account is already a delegate');
 								done();
 							});
 						});
@@ -196,7 +196,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 				it('adding to pool delegate registration should be ok', function (done) {
 					transaction1 = lisk.delegate.createDelegate(account.password, account.username);
 					localCommon.addTransaction(library, transaction1, function (err, res) {
-						res.should.equal(transaction1.id);
+						expect(res).to.equal(transaction1.id);
 						done();
 					});
 				});
@@ -204,7 +204,7 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 				it('adding to pool delegate registration from different account and same username should be ok', function (done) {
 					transaction2 = lisk.delegate.createDelegate(account2.password, account.username);
 					localCommon.addTransaction(library, transaction2, function (err, res) {
-						res.should.equal(transaction2.id);
+						expect(res).to.equal(transaction2.id);
 						done();
 					});
 				});
@@ -227,9 +227,9 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 							id: transaction1.id
 						};
 						localCommon.getTransactionFromModule(library, filter, function (err, res) {
-							should.not.exist(err);
-							res.should.have.property('transactions').which.is.an('Array');
-							res.transactions.length.should.equal(0);
+							expect(err).to.be.null;
+							expect(res).to.have.property('transactions').which.is.an('Array');
+							expect(res.transactions.length).to.equal(0);
 							done();
 						});
 					});
@@ -239,24 +239,24 @@ describe('system test (type 2) - double delegate registrations @unstable', funct
 							id: transaction2.id
 						};
 						localCommon.getTransactionFromModule(library, filter, function (err, res) {
-							should.not.exist(err);
-							res.should.have.property('transactions').which.is.an('Array');
-							res.transactions.length.should.equal(1);
-							res.transactions[0].id.should.equal(transaction2.id);
+							expect(err).to.be.null;
+							expect(res).to.have.property('transactions').which.is.an('Array');
+							expect(res.transactions.length).to.equal(1);
+							expect(res.transactions[0].id).to.equal(transaction2.id);
 							done();
 						});
 					});
 
 					it('adding to pool delegate registration with already registered username should fail', function (done) {
 						localCommon.addTransaction(library, transaction1, function (err, res) {
-							err.should.equal('Username ' + account.username + ' already exists');
+							expect(err).to.equal('Username ' + account.username + ' already exists');
 							done();
 						});
 					});
 
 					it('adding to pool delegate registration from same account should fail', function (done) {
 						localCommon.addTransaction(library, transaction2, function (err, res) {
-							err.should.equal('Account is already a delegate');
+							expect(err).to.equal('Account is already a delegate');
 							done();
 						});
 					});

--- a/test/functional/system/3.3.votes.js
+++ b/test/functional/system/3.3.votes.js
@@ -49,7 +49,7 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 			it('adding to pool upvoting transaction should be ok', function (done) {
 				transaction1 = lisk.vote.createVote(account.password, ['+' + accountFixtures.existingDelegate.publicKey], null, -1);
 				localCommon.addTransaction(library, transaction1, function (err, res) {
-					res.should.equal(transaction1.id);
+					expect(res).to.equal(transaction1.id);
 					done();
 				});
 			});
@@ -57,7 +57,7 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 			it('adding to pool upvoting transaction for same delegate from same account with different id should be ok', function (done) {
 				transaction2 = lisk.vote.createVote(account.password, ['+' + accountFixtures.existingDelegate.publicKey]);
 				localCommon.addTransaction(library, transaction2, function (err, res) {
-					res.should.equal(transaction2.id);
+					expect(res).to.equal(transaction2.id);
 					done();
 				});
 			});
@@ -75,9 +75,9 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 						id: transaction1.id
 					};
 					localCommon.getTransactionFromModule(library, filter, function (err, res) {
-						should.not.exist(err);
-						res.should.have.property('transactions').which.is.an('Array');
-						res.transactions.length.should.equal(0);
+						expect(err).to.be.null;
+						expect(res).to.have.property('transactions').which.is.an('Array');
+						expect(res.transactions.length).to.equal(0);
 						done();
 					});
 				});
@@ -87,17 +87,17 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 						id: transaction2.id
 					};
 					localCommon.getTransactionFromModule(library, filter, function (err, res) {
-						should.not.exist(err);
-						res.should.have.property('transactions').which.is.an('Array');
-						res.transactions.length.should.equal(1);
-						res.transactions[0].id.should.equal(transaction2.id);
+						expect(err).to.be.null;
+						expect(res).to.have.property('transactions').which.is.an('Array');
+						expect(res.transactions.length).to.equal(1);
+						expect(res.transactions[0].id).to.equal(transaction2.id);
 						done();
 					});
 				});
 
 				it('adding to pool upvoting transaction to same delegate from same account should fail', function (done) {
 					localCommon.addTransaction(library, transaction1, function (err, res) {
-						err.should.equal('Failed to add vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" already voted for');
+						expect(err).to.equal('Failed to add vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" already voted for');
 						done();
 					});
 				});
@@ -105,7 +105,7 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 				it('adding to pool downvoting transaction to same delegate from same account should be ok', function (done) {
 					transaction3 = lisk.vote.createVote(account.password, ['-' + accountFixtures.existingDelegate.publicKey], null, -1);
 					localCommon.addTransaction(library, transaction3, function (err, res) {
-						res.should.equal(transaction3.id);
+						expect(res).to.equal(transaction3.id);
 						done();
 					});
 				});
@@ -113,7 +113,7 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 				it('adding to pool downvoting transaction to same delegate from same account with different id should be ok', function (done) {
 					transaction4 = lisk.vote.createVote(account.password, ['-' + accountFixtures.existingDelegate.publicKey]);
 					localCommon.addTransaction(library, transaction4, function (err, res) {
-						res.should.equal(transaction4.id);
+						expect(res).to.equal(transaction4.id);
 						done();
 					});
 				});
@@ -131,9 +131,9 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 							id: transaction3.id
 						};
 						localCommon.getTransactionFromModule(library, filter, function (err, res) {
-							should.not.exist(err);
-							res.should.have.property('transactions').which.is.an('Array');
-							res.transactions.length.should.equal(0);
+							expect(err).to.be.null;
+							expect(res).to.have.property('transactions').which.is.an('Array');
+							expect(res.transactions.length).to.equal(0);
 							done();
 						});
 					});
@@ -143,17 +143,17 @@ describe('system test (type 3) - voting with duplicate submissions @unstable', f
 							id: transaction4.id
 						};
 						localCommon.getTransactionFromModule(library, filter, function (err, res) {
-							should.not.exist(err);
-							res.should.have.property('transactions').which.is.an('Array');
-							res.transactions.length.should.equal(1);
-							res.transactions[0].id.should.equal(transaction4.id);
+							expect(err).to.be.null;
+							expect(res).to.have.property('transactions').which.is.an('Array');
+							expect(res.transactions.length).to.equal(1);
+							expect(res.transactions[0].id).to.equal(transaction4.id);
 							done();
 						});
 					});
 
 					it('adding to pool downvoting transaction to same delegate from same account should fail', function (done) {
 						localCommon.addTransaction(library, transaction4, function (err, res) {
-							err.should.equal('Failed to remove vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" was not voted for');
+							expect(err).to.equal('Failed to remove vote, delegate "' + accountFixtures.existingDelegate.delegateName + '" was not voted for');
 							done();
 						});
 					});

--- a/test/functional/system/4.4.multisig.js
+++ b/test/functional/system/4.4.multisig.js
@@ -54,14 +54,14 @@ describe('system test (type 4) - double multisignature registrations', function 
 
 	it('adding to pool multisig registration should be ok', function (done) {
 		localCommon.addTransaction(library, transactionToBeNotConfirmed, function (err, res) {
-			res.should.equal(transactionToBeNotConfirmed.id);
+			expect(res).to.equal(transactionToBeNotConfirmed.id);
 			done();
 		});
 	});
 
 	it('adding to pool same transaction with different timestamp should be ok', function (done) {
 		localCommon.addTransaction(library, scenarios.regular.multiSigTransaction, function (err, res) {
-			res.should.equal(scenarios.regular.multiSigTransaction.id);
+			expect(res).to.equal(scenarios.regular.multiSigTransaction.id);
 			done();
 		});
 	});
@@ -79,9 +79,9 @@ describe('system test (type 4) - double multisignature registrations', function 
 				id: transactionToBeNotConfirmed.id
 			};
 			localCommon.getTransactionFromModule(library, filter, function (err, res) {
-				should.not.exist(err);
-				res.should.have.property('transactions').which.is.an('Array');
-				res.transactions.length.should.equal(0);
+				expect(err).to.be.null;
+				expect(res).to.have.property('transactions').which.is.an('Array');
+				expect(res.transactions.length).to.equal(0);
 				done();
 			});
 		});
@@ -91,17 +91,17 @@ describe('system test (type 4) - double multisignature registrations', function 
 				id: scenarios.regular.multiSigTransaction.id
 			};
 			localCommon.getTransactionFromModule(library, filter, function (err, res) {
-				should.not.exist(err);
-				res.should.have.property('transactions').which.is.an('Array');
-				res.transactions.length.should.equal(1);
-				res.transactions[0].id.should.equal(scenarios.regular.multiSigTransaction.id);
+				expect(err).to.be.null;
+				expect(res).to.have.property('transactions').which.is.an('Array');
+				expect(res.transactions.length).to.equal(1);
+				expect(res.transactions[0].id).to.equal(scenarios.regular.multiSigTransaction.id);
 				done();
 			});
 		});
 
 		it('adding to pool multisignature registration for same account should fail', function (done) {
 			localCommon.addTransaction(library, scenarios.regular.multiSigTransaction, function (err, res) {
-				err.should.equal('Account already has multisignatures enabled');
+				expect(err).to.equal('Account already has multisignatures enabled');
 				done();
 			});
 		});

--- a/test/functional/system/4.X.multisig.unconfirmed.js
+++ b/test/functional/system/4.X.multisig.unconfirmed.js
@@ -47,7 +47,7 @@ describe('system test (type 4) - sending transactions on top of unconfirmed mult
 
 	it('adding to pool multisig registration should be ok', function (done) {
 		localCommon.addTransaction(library, scenarios.regular.multiSigTransaction, function (err, res) {
-			res.should.equal(scenarios.regular.multiSigTransaction.id);
+			expect(res).to.equal(scenarios.regular.multiSigTransaction.id);
 			done();
 		});
 	});
@@ -82,7 +82,7 @@ describe('system test (type 4) - sending transactions on top of unconfirmed mult
 					};
 
 					localCommon.addTransaction(library, transaction, function (err, res) {
-						res.should.equal(transaction.id);
+						expect(res).to.equal(transaction.id);
 						done();
 					});
 				});

--- a/test/functional/system/4.X.multisig.validated.js
+++ b/test/functional/system/4.X.multisig.validated.js
@@ -56,7 +56,7 @@ describe('system test (type 4) - checking registered multisignature transaction 
 
 	it('adding to pool multisignature registration should be ok', function (done) {
 		localCommon.addTransaction(library, scenarios.regular.multiSigTransaction, function (err, res) {
-			res.should.equal(scenarios.regular.multiSigTransaction.id);
+			expect(res).to.equal(scenarios.regular.multiSigTransaction.id);
 			done();
 		});
 	});
@@ -74,17 +74,17 @@ describe('system test (type 4) - checking registered multisignature transaction 
 				id: scenarios.regular.multiSigTransaction.id
 			};
 			localCommon.getTransactionFromModule(library, filter, function (err, res) {
-				should.not.exist(err);
-				res.should.have.property('transactions').which.is.an('Array');
-				res.transactions.length.should.equal(1);
-				res.transactions[0].id.should.equal(scenarios.regular.multiSigTransaction.id);
+				expect(err).to.be.null;
+				expect(res).to.have.property('transactions').which.is.an('Array');
+				expect(res.transactions.length).to.equal(1);
+				expect(res.transactions[0].id).to.equal(scenarios.regular.multiSigTransaction.id);
 				done();
 			});
 		});
 
 		it('adding to pool multisignature registration for same account should fail', function (done) {
 			localCommon.addTransaction(library, scenarios.regular.multiSigTransaction, function (err, res) {
-				err.should.equal('Account already has multisignatures enabled');
+				expect(err).to.equal('Account already has multisignatures enabled');
 				done();
 			});
 		});
@@ -119,7 +119,7 @@ describe('system test (type 4) - checking registered multisignature transaction 
 						};
 
 						localCommon.addTransaction(library, transaction, function (err, res) {
-							res.should.equal(transaction.id);
+							expect(res).to.equal(transaction.id);
 							done();
 						});
 					});

--- a/test/functional/system/4.multisig.account.js
+++ b/test/functional/system/4.multisig.account.js
@@ -74,30 +74,30 @@ describe('system test (type 4) - effect of multisignature registration on memory
 				var signKeysInDb = _.map(accountRow.mem_accounts2multisignatures, function (row) {
 					return row.dependentId;
 				});
-				signKeysInDb.should.include(signer1.publicKey, signer2.publicKey);
+				expect(signKeysInDb).to.include(signer1.publicKey, signer2.publicKey);
 			});
 
 			it('should set multimin field set on mem_accounts', function () {
-				accountRow.mem_accounts.multimin.should.eql(multisigTransaction.asset.multisignature.min);
+				expect(accountRow.mem_accounts.multimin).to.eql(multisigTransaction.asset.multisignature.min);
 			});
 
 			it('should set multilifetime field set on mem_accounts', function () {
-				accountRow.mem_accounts.multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
+				expect(accountRow.mem_accounts.multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
 			});
 
 			it('should include rows in mem_accounts2u_multisignatures', function () {
 				var signKeysInDb = _.map(accountRow.mem_accounts2u_multisignatures, function (row) {
 					return row.dependentId;
 				});
-				signKeysInDb.should.include(signer1.publicKey, signer2.publicKey);
+				expect(signKeysInDb).to.include(signer1.publicKey, signer2.publicKey);
 			});
 
 			it('should set u_multimin field set on mem_accounts', function () {
-				accountRow.mem_accounts.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
+				expect(accountRow.mem_accounts.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
 			});
 
 			it('should set u_multilifetime field set on mem_accounts', function () {
-				accountRow.mem_accounts.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
+				expect(accountRow.mem_accounts.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
 			});
 		});
 
@@ -107,34 +107,34 @@ describe('system test (type 4) - effect of multisignature registration on memory
 
 			before('get multisignature account', function (done) {
 				library.logic.account.get({ address: multisigAccount.address }, function (err, res) {
-					should.not.exist(err);
+					expect(err).to.be.null;
 					account = res;
 					done();
 				});
 			});
 
 			it('should have multisignatures field set on account', function () {
-				account.multisignatures.should.include(signer1.publicKey, signer2.publicKey);
+				expect(account.multisignatures).to.include(signer1.publicKey, signer2.publicKey);
 			});
 
 			it('should have multimin field set on account', function () {
-				account.multimin.should.eql(multisigTransaction.asset.multisignature.min);
+				expect(account.multimin).to.eql(multisigTransaction.asset.multisignature.min);
 			});
 
 			it('should have multilifetime field set on account', function () {
-				account.multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
+				expect(account.multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
 			});
 
 			it('should have u_multisignatures field set on account', function () {
-				account.u_multisignatures.should.include(signer1.publicKey, signer2.publicKey);
+				expect(account.u_multisignatures).to.include(signer1.publicKey, signer2.publicKey);
 			});
 
 			it('should have u_multimin field set on account', function () {
-				account.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
+				expect(account.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
 			});
 
 			it('should have u_multilifetime field set on account', function () {
-				account.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
+				expect(account.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
 			});
 		});
 
@@ -156,27 +156,27 @@ describe('system test (type 4) - effect of multisignature registration on memory
 				});
 
 				it('should have no rows in mem_accounts2multisignatures', function () {
-					accountRow.mem_accounts2multisignatures.should.eql([]);
+					expect(accountRow.mem_accounts2multisignatures).to.eql([]);
 				});
 
 				it('should have multimin field set to 0 on mem_accounts', function () {
-					accountRow.mem_accounts.multimin.should.eql(0);
+					expect(accountRow.mem_accounts.multimin).to.eql(0);
 				});
 
 				it('should have multilifetime field set to 0 on mem_accounts', function () {
-					accountRow.mem_accounts.multilifetime.should.eql(0);
+					expect(accountRow.mem_accounts.multilifetime).to.eql(0);
 				});
 
 				it('should have no rows in mem_accounts2u_multisignatures', function () {
-					accountRow.mem_accounts2u_multisignatures.should.eql([]);
+					expect(accountRow.mem_accounts2u_multisignatures).to.eql([]);
 				});
 
 				it('should have u_multimin field set to 0 on mem_accounts', function () {
-					accountRow.mem_accounts.u_multimin.should.eql(0);
+					expect(accountRow.mem_accounts.u_multimin).to.eql(0);
 				});
 
 				it('should have multilifetime field to 0 on mem_accounts', function () {
-					accountRow.mem_accounts.u_multilifetime.should.eql(0);
+					expect(accountRow.mem_accounts.u_multilifetime).to.eql(0);
 				});
 			});
 
@@ -186,34 +186,34 @@ describe('system test (type 4) - effect of multisignature registration on memory
 
 				before('get multisignature account', function (done) {
 					library.logic.account.get({ address: multisigAccount.address }, function (err, res) {
-						should.not.exist(err);
+						expect(err).to.be.null;
 						account = res;
 						done();
 					});
 				});
 
 				it('should set multisignatures field to null on account', function () {
-					should.not.exist(account.multisignatures);
+					expect(account.multisignatures).to.be.null;
 				});
 
 				it('should set multimin field to 0 on account', function () {
-					account.multimin.should.eql(0);
+					expect(account.multimin).to.eql(0);
 				});
 
 				it('should set multilifetime field to 0 on account', function () {
-					account.multilifetime.should.eql(0);
+					expect(account.multilifetime).to.eql(0);
 				});
 
 				it('should set u_multisignatures field to null on account', function () {
-					should.not.exist(account.u_multisignatures);
+					expect(account.u_multisignatures).to.be.null;
 				});
 
 				it('should set u_multimin field to null on account', function () {
-					account.u_multimin.should.eql(0);
+					expect(account.u_multimin).to.eql(0);
 				});
 
 				it('should set u_multilifetime field to null on account', function () {
-					account.u_multilifetime.should.eql(0);
+					expect(account.u_multilifetime).to.eql(0);
 				});
 			});
 		});
@@ -248,30 +248,30 @@ describe('system test (type 4) - effect of multisignature registration on memory
 			});
 
 			it('should have no rows in mem_accounts2multisignatures', function () {
-				accountRow.mem_accounts2multisignatures.should.eql([]);
+				expect(accountRow.mem_accounts2multisignatures).to.eql([]);
 			});
 
 			it('should have multimin field set to 0 on mem_accounts', function () {
-				accountRow.mem_accounts.multimin.should.eql(0);
+				expect(accountRow.mem_accounts.multimin).to.eql(0);
 			});
 
 			it('should have multilifetime field set to 0 on mem_accounts', function () {
-				accountRow.mem_accounts.multilifetime.should.eql(0);
+				expect(accountRow.mem_accounts.multilifetime).to.eql(0);
 			});
 
 			it('should include rows in mem_accounts2u_multisignatures', function () {
 				var signKeysInDb = _.map(accountRow.mem_accounts2u_multisignatures, function (row) {
 					return row.dependentId;
 				});
-				signKeysInDb.should.include(signer1.publicKey, signer2.publicKey);
+				expect(signKeysInDb).to.include(signer1.publicKey, signer2.publicKey);
 			});
 
 			it('should set u_multimin field set on mem_accounts', function () {
-				accountRow.mem_accounts.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
+				expect(accountRow.mem_accounts.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
 			});
 
 			it('should set u_multilifetime field set on mem_accounts', function () {
-				accountRow.mem_accounts.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
+				expect(accountRow.mem_accounts.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
 			});
 		});
 
@@ -281,22 +281,22 @@ describe('system test (type 4) - effect of multisignature registration on memory
 
 			before('get multisignature account', function (done) {
 				library.logic.account.get({ address: multisigAccount.address }, function (err, res) {
-					should.not.exist(err);
+					expect(err).to.be.null;
 					account = res;
 					done();
 				});
 			});
 
 			it('should have u_multisignatures field set on account', function () {
-				account.u_multisignatures.should.include(signer1.publicKey, signer2.publicKey);
+				expect(account.u_multisignatures).to.include(signer1.publicKey, signer2.publicKey);
 			});
 
 			it('should have multimin field set on account', function () {
-				account.u_multimin.should.eql(multisigTransaction.asset.multisignature.min);
+				expect(account.u_multimin).to.eql(multisigTransaction.asset.multisignature.min);
 			});
 
 			it('should have multilifetime field set on account', function () {
-				account.u_multilifetime.should.eql(multisigTransaction.asset.multisignature.lifetime);
+				expect(account.u_multilifetime).to.eql(multisigTransaction.asset.multisignature.lifetime);
 			});
 		});
 

--- a/test/functional/system/5.5.dapps.js
+++ b/test/functional/system/5.5.dapps.js
@@ -58,7 +58,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		transaction1 = lisk.dapp.createDapp(account.password, null, dappDuplicate, -1);
 		badTransactions.push(transaction1);
 		localCommon.addTransaction(library, transaction1, function (err, res) {
-			res.should.equal(transaction1.id);
+			expect(res).to.equal(transaction1.id);
 			done();
 		});
 	});
@@ -67,7 +67,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		transaction2 = lisk.dapp.createDapp(account.password, null, dappDuplicate);
 		goodTransactions.push(transaction2);
 		localCommon.addTransaction(library, transaction2, function (err, res) {
-			res.should.equal(transaction2.id);
+			expect(res).to.equal(transaction2.id);
 			done();
 		});
 	});
@@ -76,7 +76,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		transaction3 = lisk.dapp.createDapp(account.password, null, dappDuplicateNameFail, -1);
 		badTransactions.push(transaction3);
 		localCommon.addTransaction(library, transaction3, function (err, res) {
-			res.should.equal(transaction3.id);
+			expect(res).to.equal(transaction3.id);
 			done();
 		});
 	});
@@ -85,7 +85,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		transaction4 = lisk.dapp.createDapp(account.password, null, dappDuplicateNameSuccess);
 		goodTransactions.push(transaction4);
 		localCommon.addTransaction(library, transaction4, function (err, res) {
-			res.should.equal(transaction4.id);
+			expect(res).to.equal(transaction4.id);
 			done();
 		});
 	});
@@ -94,7 +94,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		transaction5 = lisk.dapp.createDapp(account.password, null, dappDuplicateLinkFail, -1);
 		badTransactions.push(transaction5);
 		localCommon.addTransaction(library, transaction5, function (err, res) {
-			res.should.equal(transaction5.id);
+			expect(res).to.equal(transaction5.id);
 			done();
 		});
 	});
@@ -103,7 +103,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		transaction6 = lisk.dapp.createDapp(account.password, null, dappDuplicateLinkSuccess);
 		goodTransactions.push(transaction6);
 		localCommon.addTransaction(library, transaction6, function (err, res) {
-			res.should.equal(transaction6.id);
+			expect(res).to.equal(transaction6.id);
 			done();
 		});
 	});
@@ -123,9 +123,9 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 				};
 
 				localCommon.getTransactionFromModule(library, filter, function (err, res) {
-					should.not.exist(err);
-					res.should.have.property('transactions').which.is.an('Array');
-					res.transactions.length.should.equal(0);
+					expect(err).to.be.null;
+					expect(res).to.have.property('transactions').which.is.an('Array');
+					expect(res.transactions.length).to.equal(0);
 					callback(null, !err);
 				});
 			}, function (err, result) {
@@ -140,10 +140,10 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 				};
 				
 				localCommon.getTransactionFromModule(library, filter, function (err, res) {
-					should.not.exist(err);
-					res.should.have.property('transactions').which.is.an('Array');
-					res.transactions.length.should.equal(1);
-					res.transactions[0].id.should.equal(transaction.id);
+					expect(err).to.be.null;
+					expect(res).to.have.property('transactions').which.is.an('Array');
+					expect(res.transactions.length).to.equal(1);
+					expect(res.transactions[0].id).to.equal(transaction.id);
 					callback(null, !err);
 				});
 			}, function (err, result) {
@@ -154,7 +154,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		it('adding to pool already registered dapp should fail', function (done) {
 			transaction2 = lisk.dapp.createDapp(account.password, null, dappDuplicate);
 			localCommon.addTransaction(library, transaction2, function (err, res) {
-				err.should.equal('Application name already exists: ' + dappDuplicate.name);
+				expect(err).to.equal('Application name already exists: ' + dappDuplicate.name);
 				done();
 			});
 		});
@@ -162,7 +162,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		it('adding to pool already registered dapp name should fail', function (done) {
 			transaction4 = lisk.dapp.createDapp(account.password, null, dappDuplicateNameFail);
 			localCommon.addTransaction(library, transaction4, function (err, res) {
-				err.should.equal('Application name already exists: ' + dappDuplicateNameFail.name);
+				expect(err).to.equal('Application name already exists: ' + dappDuplicateNameFail.name);
 				done();
 			});
 		});
@@ -170,7 +170,7 @@ describe('system test (type 5) - dapp registrations with repeated values', funct
 		it('adding to pool already registered dapp link should fail', function (done) {
 			transaction6 = lisk.dapp.createDapp(account.password, null, dappDuplicateLinkFail);
 			localCommon.addTransaction(library, transaction6, function (err, res) {
-				err.should.equal('Application link already exists: ' + dappDuplicateLinkFail.link);
+				expect(err).to.equal('Application link already exists: ' + dappDuplicateLinkFail.link);
 				done();
 			});
 		});

--- a/test/integration/setup/index.js
+++ b/test/integration/setup/index.js
@@ -46,6 +46,10 @@ module.exports = {
 				network.waitForAllNodesToBeReady(configurations, cbSeries);
 			},
 			function (cbSeries) {
+				utils.logger.log('Waiting 3 seconds for nodes to establish connections');
+				setTimeout(cbSeries, 3000);
+			},
+			function (cbSeries) {
 				utils.logger.log('Enabling forging with registered delegates');
 				network.enableForgingOnDelegates(configurations, cbSeries);
 			},

--- a/test/integration/setup/index.js
+++ b/test/integration/setup/index.js
@@ -46,10 +46,6 @@ module.exports = {
 				network.waitForAllNodesToBeReady(configurations, cbSeries);
 			},
 			function (cbSeries) {
-				utils.logger.log('Waiting 3 seconds for nodes to establish connections');
-				setTimeout(cbSeries, 3000);
-			},
-			function (cbSeries) {
 				utils.logger.log('Enabling forging with registered delegates');
 				network.enableForgingOnDelegates(configurations, cbSeries);
 			},

--- a/test/setup.js
+++ b/test/setup.js
@@ -105,7 +105,6 @@ _.mixin({
 }, { chain: false });
 
 global.expect = chai.expect;
-global.should = chai.should();
 global.sinonSandbox = sinon.createSandbox();
 global.__testContext = testContext;
 global._ = _;

--- a/test/unit/api/fittings/lisk_cors.js
+++ b/test/unit/api/fittings/lisk_cors.js
@@ -89,7 +89,7 @@ describe('lisk_cors', function () {
 
 		expect(next).to.have.not.been.called;
 		expect(context.response.statusCode).to.be.equal(204);
-		expect( context.response.getHeader('my-custom-header') ).to.be.undefined;
+		expect(context.response.getHeader('my-custom-header')).to.be.undefined;
 	});
 
 	it('should enable requests for X-MY-HEADER when provided allowedHeaders = X-MY-HEADER', function () {

--- a/test/unit/api/fittings/lisk_cors.js
+++ b/test/unit/api/fittings/lisk_cors.js
@@ -31,18 +31,18 @@ describe('lisk_cors', function () {
 	});
 
 	it('should be a factory function that names 2 arguments', function () {
-		fitting.should.be.a('function');
-		fitting.should.have.length(2);
+		expect(fitting).to.be.a('function');
+		expect(fitting).to.have.length(2);
 	});
 
 	it('should create a middleware accepting 2 arguments', function () {
-		cors_fititng.should.be.a('function');
-		cors_fititng.should.have.length(2);
+		expect(cors_fititng).to.be.a('function');
+		expect(cors_fititng).to.have.length(2);
 	});
 
 	it('should process context and call the callback function', function () {
 		cors_fititng(context, next);
-		next.should.have.been.calledOnce;
+		expect(next).to.have.been.calledOnce;
 	});
 
 	it('should enable pre-flight request wide open if specified no option', function () {
@@ -50,10 +50,10 @@ describe('lisk_cors', function () {
 
 		cors_fititng(context, next);
 
-		next.should.have.not.been.called;
-		context.response.statusCode.should.be.equal(204);
-		context.response.getHeader('Access-Control-Allow-Origin').should.be.equal('*');
-		context.response.getHeader('Access-Control-Allow-Methods').should.be.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
+		expect(context.response.getHeader('Access-Control-Allow-Origin')).to.be.equal('*');
+		expect(context.response.getHeader('Access-Control-Allow-Methods')).to.be.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
 	});
 
 	it('should enable requests for test.com when provided origin = test.com', function () {
@@ -62,10 +62,10 @@ describe('lisk_cors', function () {
 
 		cors_fititng(context, next);
 
-		next.should.have.not.been.called;
-		context.response.statusCode.should.be.equal(204);
-		context.response.getHeader('Access-Control-Allow-Origin').should.be.equal('test.com');
-		context.response.getHeader('Access-Control-Allow-Methods').should.be.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
+		expect(context.response.getHeader('Access-Control-Allow-Origin')).to.be.equal('test.com');
+		expect(context.response.getHeader('Access-Control-Allow-Methods')).to.be.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
 	});
 
 	it('should enable requests for GET, POST when provided methods = GET POST', function () {
@@ -74,10 +74,10 @@ describe('lisk_cors', function () {
 
 		cors_fititng(context, next);
 
-		next.should.have.not.been.called;
-		context.response.statusCode.should.be.equal(204);
-		context.response.getHeader('Access-Control-Allow-Origin').should.be.equal('*');
-		context.response.getHeader('Access-Control-Allow-Methods').should.be.equal('GET,POST');
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
+		expect(context.response.getHeader('Access-Control-Allow-Origin')).to.be.equal('*');
+		expect(context.response.getHeader('Access-Control-Allow-Methods')).to.be.equal('GET,POST');
 	});
 
 	it('should block custom headers if no "allowedHeaders" provided', function () {
@@ -87,9 +87,9 @@ describe('lisk_cors', function () {
 
 		cors_fititng(context, next);
 
-		next.should.have.not.been.called;
-		context.response.statusCode.should.be.equal(204);
-		should.not.exist( context.response.getHeader('my-custom-header') );
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
+		expect( context.response.getHeader('my-custom-header') ).to.be.undefined;
 	});
 
 	it('should enable requests for X-MY-HEADER when provided allowedHeaders = X-MY-HEADER', function () {
@@ -98,9 +98,9 @@ describe('lisk_cors', function () {
 
 		cors_fititng(context, next);
 
-		next.should.have.not.been.called;
-		context.response.statusCode.should.be.equal(204);
-		context.response.getHeader('Access-Control-Allow-Headers').should.include('X-MY-HEADER');
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
+		expect(context.response.getHeader('Access-Control-Allow-Headers')).to.include('X-MY-HEADER');
 	});
 
 	it('should enable requests for multiple headers when provided allowedHeaders with multiple values', function () {
@@ -109,10 +109,10 @@ describe('lisk_cors', function () {
 
 		cors_fititng(context, next);
 
-		next.should.have.not.been.called;
-		context.response.statusCode.should.be.equal(204);
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
 		var headers = context.response.getHeader('Access-Control-Allow-Headers').split(',');
-		headers.should.include('X-1-HEADER');
-		headers.should.include('X-2-HEADER');
+		expect(headers).to.include('X-1-HEADER');
+		expect(headers).to.include('X-2-HEADER');
 	});
 });

--- a/test/unit/api/fittings/lisk_request_limit.js
+++ b/test/unit/api/fittings/lisk_request_limit.js
@@ -32,17 +32,17 @@ describe('lisk_request_limit', function () {
 	});
 
 	it('should be a factory function that names 2 arguments', function () {
-		fitting.should.be.a('function');
-		fitting.should.have.length(2);
+		expect(fitting).to.be.a('function');
+		expect(fitting).to.have.length(2);
 	});
 
 	it('should create a middleware accepting 2 arguments', function () {
-		limit_fititng.should.be.a('function');
-		limit_fititng.should.have.length(2);
+		expect(limit_fititng).to.be.a('function');
+		expect(limit_fititng).to.have.length(2);
 	});
 
 	it('should set limits to default if not provided config', function () {
-		limit_fititng.limits.should.be.eql(limit_fititng.defaults);
+		expect(limit_fititng.limits).to.be.eql(limit_fititng.defaults);
 	});
 
 	it('should set limits to override if provided by config', function () {
@@ -53,7 +53,7 @@ describe('lisk_request_limit', function () {
 			windowMs: 60000
 		};
 		limit_fititng = fitting({limits: limits});
-		limit_fititng.limits.should.be.eql(limits);
+		expect(limit_fititng.limits).to.be.eql(limits);
 	});
 
 	it('should limit the number of request to 5 if limits.max = 5', function () {
@@ -72,7 +72,7 @@ describe('lisk_request_limit', function () {
 			limit_fititng(context, next);
 		}
 
-		next.should.have.callCount(limits.max);
+		expect(next).to.have.callCount(limits.max);
 	});
 
 	it('should limit the number of request to 5 every 2 seconds if limits.max = 5 and limits.windowMs = 2000', function (done) {
@@ -91,14 +91,14 @@ describe('lisk_request_limit', function () {
 			success = success + 1;
 			var lmitiHeader = context.response.getHeader('X-RateLimit-Limit');
 			var remainingLimitHeader = context.response.getHeader('X-RateLimit-Remaining') || 0;
-			lmitiHeader.should.be.equal(limits.max);
-			remainingLimitHeader.should.be.equal(limits.max - success);
+			expect(lmitiHeader).to.be.equal(limits.max);
+			expect(remainingLimitHeader).to.be.equal(limits.max - success);
 		}
 
 		for (var i = 0; i < limits.max + 5; i++) {
 			limit_fititng(context, cb);
 		}
-		success.should.be.equal(limits.max);
+		expect(success).to.be.equal(limits.max);
 
 		success = 0;
 
@@ -107,7 +107,7 @@ describe('lisk_request_limit', function () {
 			for (var i = 0; i < limits.max + 5; i++) {
 				limit_fititng(context, cb);
 			}
-			success.should.be.equal(limits.max);
+			expect(success).to.be.equal(limits.max);
 			done();
 		}, 2000);
 	});
@@ -136,7 +136,7 @@ describe('lisk_request_limit', function () {
 			limit_fititng(context2, next2);
 		}
 
-		next.should.have.callCount(limits.max);
-		next2.should.have.callCount(limits.max);
+		expect(next).to.have.callCount(limits.max);
+		expect(next2).to.have.callCount(limits.max);
 	});
 });

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -396,8 +396,8 @@ describe('blocks/chain', function () {
 				}
 
 				blocksModule.shared.getBlocks({id: block.id}, function (err, data) {
-					data.should.have.lengthOf(1);
-					data[0].id.should.be.equal(block.id);
+					expect(data).to.have.lengthOf(1);
+					expect(data[0].id).to.be.equal(block.id);
 					done(err);
 				});
 			});
@@ -424,8 +424,8 @@ describe('blocks/chain', function () {
 					done(err);
 				}
 
-				connect.calledOnce.should.be.true;
-				disconnect.calledOnce.should.be.true;
+				expect(connect.calledOnce).to.be.true;
+				expect(disconnect.calledOnce).to.be.true;
 
 				delete db.$config.options.connect;
 				delete db.$config.options.disconnect;


### PR DESCRIPTION
### What was the problem?

Inconsistent use of `should` and `expect` in tests

### How did I fix it?

Mostly via:

```
find: ^(\s+)([^\s].+)\.should\.
replace: $1expect($2).to.

find: ^(\s+)should\.not\.exist\(err\);
replace: $1expect(err).to.be.null;
```

### How to test it?

Run the tests!

### Review checklist

* The PR solves #1295 
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)