### PR TITLE
On transaction apply and undo, do not reset state of an account - Closes #1328

### DIFF
--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -232,15 +232,10 @@ Delegate.prototype.apply = function (trs, block, sender, cb) {
 	var data = {
 		publicKey: trs.senderPublicKey,
 		address: sender.address,
-		u_isDelegate: 0,
 		isDelegate: 1,
-		vote: 0
+		vote: 0,
+		username: trs.asset.delegate.username
 	};
-
-	if (trs.asset.delegate.username) {
-		data.u_username = null;
-		data.username = trs.asset.delegate.username;
-	}
 
 	async.series([
 		function (seriesCb) {
@@ -263,15 +258,11 @@ Delegate.prototype.apply = function (trs, block, sender, cb) {
 Delegate.prototype.undo = function (trs, block, sender, cb) {
 	var data = {
 		address: sender.address,
-		u_isDelegate: 1,
 		isDelegate: 0,
-		vote: 0
+		vote: 0,
+		username: null
 	};
 
-	if (!sender.nameexist && trs.asset.delegate.username) {
-		data.username = null;
-		data.u_username = trs.asset.delegate.username;
-	}
 
 	modules.accounts.setAccountAndGet(data, cb);
 };
@@ -288,13 +279,8 @@ Delegate.prototype.applyUnconfirmed = function (trs, sender, cb) {
 		publicKey: trs.senderPublicKey,
 		address: sender.address,
 		u_isDelegate: 1,
-		isDelegate: 0
+		u_username: trs.asset.delegate.username
 	};
-
-	if (trs.asset.delegate.username) {
-		data.username = null;
-		data.u_username = trs.asset.delegate.username;
-	}
 
 	async.series([
 		function (seriesCb) {
@@ -318,13 +304,9 @@ Delegate.prototype.undoUnconfirmed = function (trs, sender, cb) {
 	var data = {
 		address: sender.address,
 		u_isDelegate: 0,
-		isDelegate: 0
+		isDelegate: 0,
+		u_username: null
 	};
-
-	if (trs.asset.delegate.username) {
-		data.username = null;
-		data.u_username = null;
-	}
 
 	modules.accounts.setAccountAndGet(data, cb);
 };

--- a/logic/signature.js
+++ b/logic/signature.js
@@ -141,7 +141,6 @@ Signature.prototype.apply = function (trs, block, sender, cb) {
 	modules.accounts.setAccountAndGet({
 		address: sender.address,
 		secondSignature: 1,
-		u_secondSignature: 0,
 		secondPublicKey: trs.asset.signature.publicKey
 	}, cb);
 };
@@ -158,7 +157,6 @@ Signature.prototype.undo = function (trs, block, sender, cb) {
 	modules.accounts.setAccountAndGet({
 		address: sender.address,
 		secondSignature: 0,
-		u_secondSignature: 1,
 		secondPublicKey: null
 	}, cb);
 };

--- a/test/system/common.js
+++ b/test/system/common.js
@@ -1,0 +1,160 @@
+var node = require('../node.js');
+var Promise = require('bluebird');
+var slots = require('../../helpers/slots.js');
+var _ = require('lodash');
+
+function forge (library, cb) {
+	function getNextForger (offset, cb) {
+		offset = !offset ? 1 : offset;
+		var last_block = library.modules.blocks.lastBlock.get();
+		var slot = slots.getSlotNumber(last_block.timestamp);
+		library.modules.delegates.generateDelegateList(last_block.height, null, function (err, delegateList) {
+			if (err) { return cb (err); }
+			var nextForger = delegateList[(slot + offset) % slots.delegates];
+			return cb(nextForger);
+		});
+	}
+
+	var transactionPool = library.rewiredModules.transactions.__get__('__private.transactionPool');
+	var keypairs = library.rewiredModules.delegates.__get__('__private.keypairs');
+
+	node.async.waterfall([ 
+		transactionPool.fillPool,
+		function (cb) {
+			getNextForger(null, function (delegatePublicKey) {
+				cb(null, delegatePublicKey);
+			});
+		},
+		function (delegate, seriesCb) {
+			var last_block = library.modules.blocks.lastBlock.get();
+			var slot = slots.getSlotNumber(last_block.timestamp) + 1;
+			var keypair = keypairs[delegate];
+			node.debug('		Last block height: ' + last_block.height + ' Last block ID: ' + last_block.id + ' Last block timestamp: ' + last_block.timestamp + ' Next slot: ' + slot + ' Next delegate PK: ' + delegate + ' Next block timestamp: ' + slots.getSlotTime(slot));
+			library.modules.blocks.process.generateBlock(keypair, slots.getSlotTime(slot), function (err) {
+				if (err) { return seriesCb(err); }
+				last_block = library.modules.blocks.lastBlock.get();
+				node.debug('		New last block height: ' + last_block.height + ' New last block ID: ' + last_block.id);
+				return seriesCb(err);
+			});
+		}
+	], function (err) {
+		cb(err);
+	});
+}
+
+function addTransactionToUnconfirmedQueue (library, transaction, cb) {
+	// Add transaction to transactions pool - we use shortcut here to bypass transport module, but logic is the same
+	// See: modules.transport.__private.receiveTransaction
+	library.balancesSequence.add(function (sequenceCb) {
+		library.modules.transactions.processUnconfirmedTransaction(transaction, true, function (err) {
+			if (err) {
+				return setImmediate(sequenceCb, err.toString());
+			} else {
+				var transactionPool = library.rewiredModules.transactions.__get__('__private.transactionPool');
+				transactionPool.fillPool(sequenceCb);
+			}
+		});
+	}, cb);
+}
+
+function addTransaction (library, transaction, cb) {
+	// Add transaction to transactions pool - we use shortcut here to bypass transport module, but logic is the same
+	// See: modules.transport.__private.receiveTransaction
+	library.balancesSequence.add(function (sequenceCb) {
+		library.modules.transactions.processUnconfirmedTransaction(transaction, true, function (err) {
+			if (err) {
+				return setImmediate(sequenceCb, err.toString());
+			} else {
+				return setImmediate(sequenceCb, null, transaction.id);
+			}
+		});
+	}, cb);
+}
+
+function addTransactionsAndForge (library, transactions, cb) {
+	node.async.waterfall([
+		function addTransactions (waterCb) {
+			node.async.eachSeries(transactions, function (transaction, eachSeriesCb) {
+				addTransaction(library, transaction, eachSeriesCb);
+			}, waterCb);
+		},
+		function (waterCb) {
+			setTimeout(function () {
+				forge(library, waterCb);
+			}, 800);
+		}
+	], function (err) {
+		cb(err);
+	});
+}
+
+function getAccountFromDb (library, address) {
+	return Promise.all([
+		library.db.query('SELECT * FROM mem_accounts where address = \'' + address + '\''),
+		library.db.query('SELECT * FROM mem_accounts2multisignatures where "accountId" = \'' + address + '\''),
+		library.db.query('SELECT * FROM mem_accounts2u_multisignatures where "accountId" = \'' + address + '\'')
+	]).then(function (res) {
+		// Get the first row if resultant array is not empty
+		return {
+			mem_accounts: res[0].length > 0 ? res[0][0] : res[0],
+			mem_accounts2multisignatures: res[1],
+			mem_accounts2u_multisignatures: res[2]
+		};
+	});
+}
+
+function getBlocks (library, cb) {
+	library.sequence.add(function (sequenceCb) {
+		library.db.query('SELECT "id" FROM blocks ORDER BY "height" DESC LIMIT 10;').then(function (rows) {
+			sequenceCb();
+			cb(null, _.map(rows, 'id'));
+		}).catch(function (err) {
+			node.debug(err.stack);
+			cb(err);
+		});
+	});
+}
+
+function createBlock (library, transactions, timestamp, keypair, previousBlock) {
+	var block = library.logic.block.create({
+		keypair: keypair,
+		timestamp: timestamp,
+		previousBlock: previousBlock,
+		transactions: transactions
+	});
+
+	block.id = library.logic.block.getId(block);
+	block.height = previousBlock.height + 1;
+	return block;
+}
+
+function getDelegateForSlot (library, slot, cb) {
+	var lastBlock = library.modules.blocks.lastBlock.get();
+
+	library.modules.delegates.generateDelegateList(lastBlock.height, null, function (err, list) {
+		var delegatePublicKey = list[slot % slots.delegates];
+		return cb(err, delegatePublicKey);
+	});
+}
+
+function createValidBlock (library, transactions, cb) {
+	var lastBlock = library.modules.blocks.lastBlock.get();
+	var slot = slots.getSlotNumber();
+	var keypairs = library.rewiredModules.delegates.__get__('__private.keypairs');
+	getDelegateForSlot(library, slot, function (err, delegateKey) {
+		var block = createBlock(library, transactions, slots.getSlotTime(slot), keypairs[delegateKey], lastBlock);
+		cb(err, block);
+	});
+}
+
+module.exports = {
+	getAccountFromDb: getAccountFromDb,
+	addTransactionsAndForge: addTransactionsAndForge,
+	addTransaction: addTransaction,
+	forge: forge,
+	createBlock: createBlock,
+	getDelegateForSlot: getDelegateForSlot,
+	createValidBlock: createValidBlock,
+	addTransactionToUnconfirmedQueue: addTransactionToUnconfirmedQueue,
+	getBlocks: getBlocks
+};

--- a/test/system/delegate.js
+++ b/test/system/delegate.js
@@ -45,7 +45,7 @@ describe('delegate', function () {
 	describe('with funds inside account', function (done) {
 
 		var delegateAccount;
-		
+
 		beforeEach('send funds to delegate account', function (done) {
 			delegateAccount = node.randomAccount();
 			var sendTransaction = node.lisk.transaction.createTransaction(delegateAccount.address, 1000000000*100, node.gAccount.password);
@@ -106,6 +106,7 @@ describe('delegate', function () {
 			});
 
 			describe('when receiving block with delegate transaction with different Id', function () {
+
 				var delegateTransaction2;
 				var username2;
 

--- a/test/system/delegate.js
+++ b/test/system/delegate.js
@@ -42,7 +42,7 @@ describe('delegate', function () {
 		});
 	});
 
-	describe('with money inside the account', function (done) {
+	describe('with funds inside account', function (done) {
 
 		var delegateAccount;
 		

--- a/test/system/delegate.js
+++ b/test/system/delegate.js
@@ -1,0 +1,156 @@
+var node = require('../node.js');
+var async = require('async');
+var slots = require('../../helpers/slots.js');
+var sinon = require('sinon');
+var chai = require('chai');
+var expect = require('chai').expect;
+var Promise = require('bluebird');
+var _  = require('lodash');
+var common = require('./common.js');
+
+var genesisBlock = require('./../genesisBlock.json');
+var application = require('./../common/application');
+
+describe('delegate', function () {
+
+	var library;
+	var keypairs;
+	var db;
+
+	before('init sandboxed application', function (done) {
+		application.init({sandbox: {name: 'lisk_test_delegate'}}, function (scope) {
+			library = scope;
+			db = library.db;
+			keypairs = library.rewiredModules.delegates.__get__('__private.keypairs');
+			done();
+		});
+	});
+
+	after('cleanup sandboxed application', function (done) {
+		application.cleanup(done);
+	});
+
+	afterEach(function (done) {
+		db.task(function (t) {
+			return t.batch([
+				db.none('DELETE FROM blocks WHERE "height" > 1;'),
+				db.none('DELETE FROM forks_stat;')
+			]);
+		}).then(function () {
+			library.modules.blocks.lastBlock.set(genesisBlock);
+			done();
+		});
+	});
+
+	describe('with money inside the account', function (done) {
+
+		var delegateAccount;
+		
+		beforeEach('send funds to delegate account', function (done) {
+			delegateAccount = node.randomAccount();
+			var sendTransaction = node.lisk.transaction.createTransaction(delegateAccount.address, 1000000000*100, node.gAccount.password);
+			common.addTransactionsAndForge(library, [sendTransaction], done);
+		});
+
+		describe('with delegate transaction in unconfirmed state', function () {
+
+			var delegateTransaction;
+			var username;
+
+			beforeEach(function (done) {
+				username = node.randomUsername().toLowerCase();
+
+				delegateTransaction = node.lisk.delegate.createDelegate(delegateAccount.password, username);
+				common.addTransactionToUnconfirmedQueue(library, delegateTransaction, done);
+			});
+
+			describe('when receiving block with same transaction', function () {
+
+				beforeEach(function (done) {
+					common.createValidBlock(library, [delegateTransaction], function (err, block) {
+						expect(err).to.not.exist;
+						library.modules.blocks.process.onReceiveBlock(block);
+						done();
+					});
+				});
+
+				describe('unconfirmed state', function () {
+
+					it('should update unconfirmed columns related to delegate', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, delegateAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.u_username).to.equal(username);
+								expect(account.mem_accounts.u_isDelegate).to.equal(1);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+
+				describe('confirmed state', function () {
+
+					it('should update confirmed columns related to delegate', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, delegateAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.username).to.equal(username);
+								expect(account.mem_accounts.isDelegate).to.equal(1);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+			});
+
+			describe('when receiving block with delegate transaction with different Id', function () {
+				var delegateTransaction2;
+				var username2;
+
+				beforeEach(function (done) {
+
+					username2 = node.randomUsername().toLowerCase();
+					delegateTransaction2 = node.lisk.delegate.createDelegate(delegateAccount.password, username2);
+					delegateTransaction2.senderId = delegateAccount.address;
+					common.createValidBlock(library, [delegateTransaction2], function (err, block) {
+						expect(err).to.not.exist;
+						library.modules.blocks.process.onReceiveBlock(block);
+						done();
+					});
+				});
+
+				describe('unconfirmed state', function () {
+
+					it('should update unconfirmed columns related to delegate', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, delegateAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.u_username).to.equal(username2);
+								expect(account.mem_accounts.u_isDelegate).to.equal(1);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+
+				describe('confirmed state', function () {
+
+					it('should update confirmed columns related to delegate', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, delegateAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.username).to.equal(username2);
+								expect(account.mem_accounts.isDelegate).to.equal(1);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/system/multisignature.js
+++ b/test/system/multisignature.js
@@ -25,7 +25,7 @@ describe('multisignature', function () {
 		application.cleanup(done);
 	});
 
-	describe('with LISK sent to multisig account', function () {
+	describe('with funds sent to multisig account', function () {
 
 		var multisigAccount;
 
@@ -164,7 +164,7 @@ describe('multisignature', function () {
 		});
 	});
 
-	describe('with LISK sent to multisig account', function () {
+	describe('with funds sent to multisig account', function () {
 
 		var multisigAccount;
 
@@ -185,7 +185,7 @@ describe('multisignature', function () {
 				});
 			});
 
-			describe('after forging Block with multisig transaction', function () {
+			describe('after forging block with multisig transaction', function () {
 
 				var multisigTransaction;
 				var signer1 = node.randomAccount();

--- a/test/system/multisignature.js
+++ b/test/system/multisignature.js
@@ -6,6 +6,7 @@ var chai = require('chai');
 var expect = require('chai').expect;
 var Promise = require('bluebird');
 var _  = require('lodash');
+var common = require('./common.js');
 
 var application = require('./../common/application');
 
@@ -24,91 +25,6 @@ describe('multisignature', function () {
 		application.cleanup(done);
 	});
 
-	function forge (cb) {
-		function getNextForger (offset, cb) {
-			offset = !offset ? 1 : offset;
-			var last_block = library.modules.blocks.lastBlock.get();
-			var slot = slots.getSlotNumber(last_block.timestamp);
-			library.modules.delegates.generateDelegateList(last_block.height, null, function (err, delegateList) {
-				if (err) { return cb (err); }
-				var nextForger = delegateList[(slot + offset) % slots.delegates];
-				return cb(nextForger);
-			});
-		}
-
-		var transactionPool = library.rewiredModules.transactions.__get__('__private.transactionPool');
-		var keypairs = library.rewiredModules.delegates.__get__('__private.keypairs');
-
-		node.async.waterfall([ 
-			transactionPool.fillPool,
-			function (cb) {
-				getNextForger(null, function (delegatePublicKey) {
-					cb(null, delegatePublicKey);
-				});
-			},
-			function (delegate, seriesCb) {
-				var last_block = library.modules.blocks.lastBlock.get();
-				var slot = slots.getSlotNumber(last_block.timestamp) + 1;
-				var keypair = keypairs[delegate];
-				node.debug('		Last block height: ' + last_block.height + ' Last block ID: ' + last_block.id + ' Last block timestamp: ' + last_block.timestamp + ' Next slot: ' + slot + ' Next delegate PK: ' + delegate + ' Next block timestamp: ' + slots.getSlotTime(slot));
-				library.modules.blocks.process.generateBlock(keypair, slots.getSlotTime(slot), function (err) {
-					if (err) { return seriesCb(err); }
-					last_block = library.modules.blocks.lastBlock.get();
-					node.debug('		New last block height: ' + last_block.height + ' New last block ID: ' + last_block.id);
-					return seriesCb(err);
-				});
-			}
-		], function (err) {
-			cb(err);
-		});
-	}
-
-	function addTransaction (transaction, cb) {
-		// Add transaction to transactions pool - we use shortcut here to bypass transport module, but logic is the same
-		// See: modules.transport.__private.receiveTransaction
-		library.balancesSequence.add(function (sequenceCb) {
-			library.modules.transactions.processUnconfirmedTransaction(transaction, true, function (err) {
-				if (err) {
-					return setImmediate(sequenceCb, err.toString());
-				} else {
-					return setImmediate(sequenceCb, null, transaction.id);
-				}
-			});
-		}, cb);
-	}
-
-	function addTransactionsAndForge (transactions, cb) {
-		node.async.waterfall([
-			function addTransactions (waterCb) {
-				node.async.eachSeries(transactions, function (transaction, eachSeriesCb) {
-					addTransaction(transaction, eachSeriesCb);
-				}, waterCb);
-			},
-			function (waterCb) {
-				setTimeout(function () {
-					forge(waterCb);
-				}, 800);
-			}
-		], function (err) {
-			cb(err);
-		});
-	}
-
-	function getAccountFromDb (address) {
-		return Promise.all([
-			library.db.query('SELECT * FROM mem_accounts where address = \'' + address + '\''),
-			library.db.query('SELECT * FROM mem_accounts2multisignatures where "accountId" = \'' + address + '\''),
-			library.db.query('SELECT * FROM mem_accounts2u_multisignatures where "accountId" = \'' + address + '\'')
-		]).then(function (res) {
-			// Get the first row if resultant array is not empty
-			return {
-				mem_accounts: res[0].length > 0 ? res[0][0] : res[0],
-				mem_accounts2multisignatures: res[1],
-				mem_accounts2u_multisignatures: res[2]
-			};
-		});
-	}
-
 	describe('with LISK sent to multisig account', function () {
 
 		var multisigAccount;
@@ -116,7 +32,7 @@ describe('multisignature', function () {
 		before('send funds to multisig account', function (done) {
 			multisigAccount = node.randomAccount();
 			var sendTransaction = node.lisk.transaction.createTransaction(multisigAccount.address, 1000000000*100, node.gAccount.password);
-			addTransactionsAndForge([sendTransaction], done);
+			common.addTransactionsAndForge(library, [sendTransaction], done);
 		});
 
 		describe('from multisig account', function () {
@@ -154,7 +70,7 @@ describe('multisignature', function () {
 					var accountRow;
 
 					before('get mem_account, mem_account2multisignature and mem_account2u_multisignature rows', function () {
-						return getAccountFromDb(multisigAccount.address).then(function (res) {
+						return common.getAccountFromDb(library, multisigAccount.address).then(function (res) {
 							accountRow = res;
 						});
 					});
@@ -255,7 +171,7 @@ describe('multisignature', function () {
 		before('send funds to multisig account', function (done) {
 			multisigAccount = node.randomAccount();
 			var sendTransaction = node.lisk.transaction.createTransaction(multisigAccount.address, 1000000000*100, node.gAccount.password);
-			addTransactionsAndForge([sendTransaction], done);
+			common.addTransactionsAndForge(library, [sendTransaction], done);
 		});
 
 		describe('from multisig account', function () {
@@ -287,14 +203,14 @@ describe('multisignature', function () {
 
 					multisigTransaction.signatures = [sign1, sign2];
 					multisigTransaction.ready = true;
-					addTransactionsAndForge([multisigTransaction], done);
+					common.addTransactionsAndForge(library, [multisigTransaction], done);
 				});
 
 				describe('sender db rows', function () {
 					var accountRow;
 
 					before('get mem_account, mem_account2multisignature and mem_account2u_multisignature rows', function () {
-						return getAccountFromDb(multisigAccount.address).then(function (res) {
+						return common.getAccountFromDb(library, multisigAccount.address).then(function (res) {
 							accountRow = res;
 						});
 					});
@@ -378,7 +294,7 @@ describe('multisignature', function () {
 						var accountRow;
 
 						before('get mem_account, mem_account2multisignature and mem_account2u_multisignature rows', function () {
-							return getAccountFromDb(multisigAccount.address).then(function (res) {
+							return common.getAccountFromDb(library, multisigAccount.address).then(function (res) {
 								accountRow = res;
 							});
 						});

--- a/test/system/second_signature.js
+++ b/test/system/second_signature.js
@@ -103,11 +103,11 @@ describe('signature', function () {
 			});
 
 			describe('when receiving block with signature transaction with different Id', function () {
+
 				var signatureTransaction2;
 				var username2;
 
 				beforeEach(function (done) {
-
 					username2 = node.randomUsername().toLowerCase();
 					signatureTransaction2 = node.lisk.signature.createSignature(signatureAccount.password, node.randomPassword());
 					signatureTransaction2.senderId = signatureAccount.address;
@@ -147,7 +147,6 @@ describe('signature', function () {
 					});
 				});
 			});
-
 		});
 	});
 });

--- a/test/system/second_signature.js
+++ b/test/system/second_signature.js
@@ -42,7 +42,7 @@ describe('signature', function () {
 		});
 	});
 
-	describe('with money inside the account', function (done) {
+	describe('with funds inside account', function (done) {
 
 		var signatureAccount;
 		

--- a/test/system/second_signature.js
+++ b/test/system/second_signature.js
@@ -1,0 +1,153 @@
+var node = require('../node.js');
+var async = require('async');
+var slots = require('../../helpers/slots.js');
+var sinon = require('sinon');
+var chai = require('chai');
+var expect = require('chai').expect;
+var Promise = require('bluebird');
+var _  = require('lodash');
+var common = require('./common.js');
+
+var genesisBlock = require('./../genesisBlock.json');
+var application = require('./../common/application');
+
+describe('signature', function () {
+
+	var library;
+	var keypairs;
+	var db;
+
+	before('init sandboxed application', function (done) {
+		application.init({sandbox: {name: 'lisk_test_signature'}}, function (scope) {
+			library = scope;
+			db = library.db;
+			keypairs = library.rewiredModules.delegates.__get__('__private.keypairs');
+			done();
+		});
+	});
+
+	after('cleanup sandboxed application', function (done) {
+		application.cleanup(done);
+	});
+
+	afterEach(function (done) {
+		db.task(function (t) {
+			return t.batch([
+				db.none('DELETE FROM blocks WHERE "height" > 1;'),
+				db.none('DELETE FROM forks_stat;')
+			]);
+		}).then(function () {
+			library.modules.blocks.lastBlock.set(genesisBlock);
+			done();
+		});
+	});
+
+	describe('with money inside the account', function (done) {
+
+		var signatureAccount;
+		
+		beforeEach('send funds to signature account', function (done) {
+			signatureAccount = node.randomAccount();
+			var sendTransaction = node.lisk.transaction.createTransaction(signatureAccount.address, 1000000000*100, node.gAccount.password);
+			common.addTransactionsAndForge(library, [sendTransaction], done);
+		});
+
+		describe('with signature transaction in unconfirmed state', function () {
+
+			var signatureTransaction;
+
+			beforeEach(function (done) {
+				signatureTransaction = node.lisk.signature.createSignature(signatureAccount.password, signatureAccount.secondPassword);
+				common.addTransactionToUnconfirmedQueue(library, signatureTransaction, done);
+			});
+
+			describe('when receiving block with same transaction', function () {
+
+				beforeEach(function (done) {
+					common.createValidBlock(library, [signatureTransaction], function (err, block) {
+						expect(err).to.not.exist;
+						debugger;
+						library.modules.blocks.process.onReceiveBlock(block);
+						done();
+					});
+				});
+
+				describe('unconfirmed state', function () {
+
+					it('should update unconfirmed columns related to signature', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, signatureAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.u_secondSignature).to.equal(1);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+
+				describe('confirmed state', function () {
+
+					it('should update confirmed columns related to signature', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, signatureAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.secondSignature).to.equal(1);
+								expect(account.mem_accounts.secondPublicKey.toString('hex')).to.equal(signatureTransaction.asset.signature.publicKey);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+			});
+
+			describe('when receiving block with signature transaction with different Id', function () {
+				var signatureTransaction2;
+				var username2;
+
+				beforeEach(function (done) {
+
+					username2 = node.randomUsername().toLowerCase();
+					signatureTransaction2 = node.lisk.signature.createSignature(signatureAccount.password, node.randomPassword());
+					signatureTransaction2.senderId = signatureAccount.address;
+					common.createValidBlock(library, [signatureTransaction2], function (err, block) {
+						expect(err).to.not.exist;
+						library.modules.blocks.process.onReceiveBlock(block);
+						done();
+					});
+				});
+
+				describe('unconfirmed state', function () {
+
+					it('should update unconfirmed columns related to signature', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, signatureAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.u_secondSignature).to.equal(1);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+
+				describe('confirmed state', function () {
+
+					it('should update confirmed columns related to signature', function (done) {
+						library.sequence.add(function (seqCb) {
+							common.getAccountFromDb(library, signatureAccount.address).then(function (account) {
+								expect(account).to.exist;
+								expect(account.mem_accounts.secondSignature).to.equal(1);
+								expect(account.mem_accounts.secondPublicKey.toString('hex')).to.equal(signatureTransaction2.asset.signature.publicKey);
+								seqCb();
+								done();
+							});
+						});
+					});
+				});
+			});
+
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

Apply and undo (confirmed and unconfirmed) functions were updating both confirmed and unconfirmed state of the transaction. If applyUnconfirmed is called, then it should only update unconfirmed state, and if undo is called, it should only reset confirmed state and so on and so forth.

### How did I fix it?

Deleted account update parameters which were responsible for the issue.

### How to test it?

Run system tests for multisignature and second_signature transactions.### Review checklist

* The PR solves #1328
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated