### PR TITLE
Remove unneeded calls to GitHubCommitStatusSetter - Closes #1531

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,19 +138,6 @@ def reportCoverage(node) {
 }
 
 def report() {
-	step([
-		$class: 'GitHubCommitStatusSetter',
-		errorHandlers: [[$class: 'ShallowAnyErrorHandler']],
-		contextSource: [$class: 'ManuallyEnteredCommitContextSource', context: 'jenkins-ci/func-unit'],
-		statusResultSource: [
-			$class: 'ConditionalStatusResultSource',
-			results: [
-					[$class: 'BetterThanOrEqualBuildResult', result: 'SUCCESS', state: 'SUCCESS', message: 'This commit looks good :)'],
-					[$class: 'BetterThanOrEqualBuildResult', result: 'FAILURE', state: 'FAILURE', message: 'This commit failed testing :('],
-					[$class: 'AnyBuildResult', state: 'FAILURE', message: 'This build somehow escaped evaluation']
-			]
-		]
-	])
 	if (currentBuild.result == 'FAILURE') {
 		def prBranch = ''
 		if (env.CHANGE_BRANCH != null) {

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -12,19 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 def report() {
-	step([
-		$class: 'GitHubCommitStatusSetter',
-		errorHandlers: [[$class: 'ShallowAnyErrorHandler']],
-		contextSource: [$class: 'ManuallyEnteredCommitContextSource', context: 'jenkins-ci/integration'],
-		statusResultSource: [
-			$class: 'ConditionalStatusResultSource',
-			results: [
-					[$class: 'BetterThanOrEqualBuildResult', result: 'SUCCESS', state: 'SUCCESS', message: 'This commit looks good :)'],
-					[$class: 'BetterThanOrEqualBuildResult', result: 'FAILURE', state: 'FAILURE', message: 'This commit failed testing :('],
-					[$class: 'AnyBuildResult', state: 'FAILURE', message: 'This build somehow escaped evaluation']
-			]
-		]
-	])
 	if (currentBuild.result == 'FAILURE') {
 		def prBranch = ''
 		if (env.CHANGE_BRANCH != null) {


### PR DESCRIPTION
### What was the problem?

`GitHubCommitStatusSetter` was being called explicitely in `Jenkinsfile`s which is not necessary any more.

### How did I fix it?

The calls to `GitHubCommitStatusSetter` were removed.

### How to test it?

Build PR on Jenkins and look at GitHub: the checks "jenkins-ci/func-unit" and "jenkins-ci/integration" should not appear any more.

### Review checklist

* The PR solves #1351 
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
