### PR TITLE
Node gets stuck during forward tick - Closes #1357

### DIFF
--- a/logic/round.js
+++ b/logic/round.js
@@ -113,13 +113,11 @@ Round.prototype.updateVotes = function () {
 
 	return self.getVotes(self.scope.round).then(function (votes) {
 		var queries = votes.map(function (vote) {
-			return self.scope.library.db.rounds.updateVotes(self.scope.modules.accounts.generateAddressByPublicKey(vote.delegate), Math.floor(vote.amount));
+			return self.t.rounds.updateVotes(self.scope.modules.accounts.generateAddressByPublicKey(vote.delegate), Math.floor(vote.amount));
 		});
 
 		if (queries.length > 0) {
-			return self.t.tx(function (t) {
-				return t.batch(queries);
-			});
+			return self.t.batch(queries);
 		} else {
 			return self.t;
 		}

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -388,19 +388,24 @@ describe('rounds', function () {
 					delegate: '6a01c4b86f4519ec9fa5c3288ae20e2e7a58822ebe891fb81e839588b95b242a',
 					address: '16010222169256538112L'
 				};
-				getVotes_stub = sinon.stub(db.rounds, 'getVotes');
-				getVotes_stub.withArgs(scope.round).resolves([delegate, delegate]);
-
-				updateVotes_stub = sinon.stub(db.rounds, 'updateVotes');
-				updateVotes_stub.withArgs(delegate.address, delegate.amount).resolves('QUERY');
 
 				scope.library.db = db;
 				scope.modules.accounts.generateAddressByPublicKey = function () {
 					return delegate.address;
 				};
 
-				round = new Round(_.cloneDeep(scope), db);
-				res = round.updateVotes();
+				return db.task(function (t) {
+					// Init stubs
+					getVotes_stub = sinon.stub(t.rounds, 'getVotes');
+					getVotes_stub.withArgs(scope.round).resolves([delegate, delegate]);
+					updateVotes_stub = sinon.stub(t.rounds, 'updateVotes');
+					updateVotes_stub.withArgs(delegate.address, delegate.amount).resolves('QUERY');
+
+					round = new Round(_.cloneDeep(scope), t);
+					res = round.updateVotes();
+				});
+
+				//res = round.updateVotes();
 			});
 
 			after(function () {
@@ -442,19 +447,22 @@ describe('rounds', function () {
 					delegate: '6a01c4b86f4519ec9fa5c3288ae20e2e7a58822ebe891fb81e839588b95b242a',
 					address: '16010222169256538112L'
 				};
-				getVotes_stub = sinon.stub(db.rounds, 'getVotes');
-				getVotes_stub.withArgs(scope.round).resolves([]);
-
-				updateVotes_stub = sinon.stub(db.rounds, 'updateVotes');
-				updateVotes_stub.withArgs(delegate.address, delegate.amount).resolves('QUERY');
 
 				scope.library.db = db;
 				scope.modules.accounts.generateAddressByPublicKey = function () {
 					return delegate.address;
 				};
 
-				round = new Round(_.cloneDeep(scope), db);
-				res = round.updateVotes();
+				return db.task(function (t) {
+					// Init stubs
+					getVotes_stub = sinon.stub(t.rounds, 'getVotes');
+					getVotes_stub.withArgs(scope.round).resolves([]);
+					updateVotes_stub = sinon.stub(t.rounds, 'updateVotes');
+					updateVotes_stub.withArgs(delegate.address, delegate.amount).resolves('QUERY');
+
+					round = new Round(_.cloneDeep(scope), t);
+					res = round.updateVotes();
+				});
 			});
 
 			after(function () {
@@ -473,12 +481,6 @@ describe('rounds', function () {
 
 			it('updateVotes should be not called', function () {
 				expect(updateVotes_stub.called).to.be.false;
-			});
-
-			it('getVotes should return t object', function () {
-				return res.then(function (res) {
-					expect(res).to.deep.equal(db);
-				});
 			});
 		});
 	});
@@ -1533,12 +1535,17 @@ describe('rounds', function () {
 				address: '16010222169256538112L'
 			};
 
-			// Init stubs
-			none_stub = sinon.stub(db, 'none').resolves();
-			roundOutsiders_stub = sinon.stub(db.rounds, 'updateMissedBlocks').resolves();
-			getVotes_stub = sinon.stub(db.rounds, 'getVotes').resolves([delegate]);
-			updateVotes_stub = sinon.stub(db.rounds, 'updateVotes').resolves('QUERY');
-			flush_stub = sinon.stub(db.rounds, 'flush').resolves();
+			return db.task(function (t) {
+				// Init stubs
+				none_stub = sinon.stub(t, 'none').resolves();
+				roundOutsiders_stub = sinon.stub(t.rounds, 'updateMissedBlocks').resolves();
+				getVotes_stub = sinon.stub(t.rounds, 'getVotes').resolves([delegate]);
+				updateVotes_stub = sinon.stub(t.rounds, 'updateVotes').resolves('QUERY');
+				flush_stub = sinon.stub(t.rounds, 'flush').resolves();
+
+				round = new Round(_.cloneDeep(scope), t);
+				res = round.land();
+			});
 
 			round = new Round(_.cloneDeep(scope), db);
 			res = round.land();
@@ -1556,12 +1563,6 @@ describe('rounds', function () {
 
 		it('should return promise', function () {
 			expect(isPromise(res)).to.be.true;
-		});
-
-		it('should return t object', function () {
-			return res.then(function (res) {
-				expect(res).to.deep.equal(db);
-			});
 		});
 
 		it('query getVotes should be called twice', function () {
@@ -1613,17 +1614,19 @@ describe('rounds', function () {
 				address: '16010222169256538112L'
 			};
 
-			// Init stubs
-			none_stub = sinon.stub(db, 'none').resolves();
-			roundOutsiders_stub = sinon.stub(db.rounds, 'updateMissedBlocks').resolves();
-			getVotes_stub = sinon.stub(db.rounds, 'getVotes').resolves([delegate]);
-			updateVotes_stub = sinon.stub(db.rounds, 'updateVotes').resolves('QUERY');
-			flush_stub = sinon.stub(db.rounds, 'flush').resolves();
-			restoreRoundSnapshot_stub = sinon.stub(db.rounds, 'restoreRoundSnapshot').resolves();
-			restoreVotesSnapshot_stub = sinon.stub(db.rounds, 'restoreVotesSnapshot').resolves();
+			return db.task(function (t) {
+				// Init stubs
+				none_stub = sinon.stub(t, 'none').resolves();
+				roundOutsiders_stub = sinon.stub(t.rounds, 'updateMissedBlocks').resolves();
+				getVotes_stub = sinon.stub(t.rounds, 'getVotes').resolves([delegate]);
+				updateVotes_stub = sinon.stub(t.rounds, 'updateVotes').resolves('QUERY');
+				flush_stub = sinon.stub(t.rounds, 'flush').resolves();
+				restoreRoundSnapshot_stub = sinon.stub(t.rounds, 'restoreRoundSnapshot').resolves();
+				restoreVotesSnapshot_stub = sinon.stub(t.rounds, 'restoreVotesSnapshot').resolves();
 
-			round = new Round(_.cloneDeep(scope), db);
-			res = round.backwardLand();
+				round = new Round(_.cloneDeep(scope), t);
+				res = round.backwardLand();
+			});
 		});
 
 		after(function () {
@@ -1640,12 +1643,6 @@ describe('rounds', function () {
 
 		it('should return promise', function () {
 			expect(isPromise(res)).to.be.true;
-		});
-
-		it('should return t object', function () {
-			return res.then(function (res) {
-				expect(res).to.deep.equal(db);
-			});
 		});
 
 		it('query getVotes should be called twice', function () {

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -411,8 +411,6 @@ describe('rounds', function () {
 					round = new Round(_.cloneDeep(scope), t);
 					res = round.updateVotes();
 				});
-
-				//res = round.updateVotes();
 			});
 
 			after(function () {


### PR DESCRIPTION
### What was the problem?
Node get stuck during forward tick when finish a round.

### How did I fix it?
Replace `self.scope.library.db` with `self.t` in `Round.prototype.updateVotes`.

### How to test it?
Run node, run for example `functional/http/post/0.transfer tests`, wait for node to finish a round - it should pass.

### Notice
Depends on https://github.com/LiskHQ/lisk/issues/1187 (PR https://github.com/LiskHQ/lisk/pull/1346) which should go first.

### Review checklist

* The PR solves https://github.com/LiskHQ/lisk/issues/1357
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
