### PR TITLE
Bug in TransactionPool.transactionInPool - Closes #707

### DIFF
--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -89,10 +89,10 @@ TransactionPool.prototype.bind = function (accounts, transactions, loader) {
 };
 
 /**
- * Determines whether a transaction is in the pool based on transaction id,
- * checks in lists: unconfirmed, bundled, queued, multisignature.
+ * Determines whether a transaction is in the pool based on transaction id.
+ * Checks unconfirmed, bundled, queued and multisignature lists.
  * @param {string} id - Transaction id.
- * @return {boolean} true if transaction id exists in at least one lists of indexes.
+ * @return {boolean} true If transaction id exists in at least one of indexes.
  */
 TransactionPool.prototype.transactionInPool = function (id) {
 	return [

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -89,9 +89,10 @@ TransactionPool.prototype.bind = function (accounts, transactions, loader) {
 };
 
 /**
- * Determines whether a transaction is in the pool based on transaction id.
+ * Determines whether a transaction is in the pool based on transaction id,
+ * checks in lists: unconfirmed, bundled, queued, multisignature.
  * @param {string} id - Transaction id.
- * @return {boolean} True if transaction is found in any of the indexes.
+ * @return {boolean} true if transaction id exists in at least one lists of indexes.
  */
 TransactionPool.prototype.transactionInPool = function (id) {
 	return [
@@ -99,7 +100,9 @@ TransactionPool.prototype.transactionInPool = function (id) {
 		self.bundled.index[id],
 		self.queued.index[id],
 		self.multisignature.index[id]
-	].filter(Boolean).length > 0;
+	].some(function (index) {
+		return typeof(index) === 'number';
+	});
 };
 
 /**

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -613,7 +613,7 @@ describe('transactionPool', function () {
 					it('should return true', function () {
 						transactionPool.unconfirmed.index[tx] = 0;
 						expect(transactionPool.transactionInPool(tx)).to.equal(true);
-					})
+					});
 				});
 
 				describe('with other index', function () {
@@ -632,7 +632,7 @@ describe('transactionPool', function () {
 					it('should return true', function () {
 						transactionPool.bundled.index[tx] = 0;
 						expect(transactionPool.transactionInPool(tx)).to.equal(true);
-					})
+					});
 				});
 
 				describe('with other index', function () {
@@ -651,7 +651,7 @@ describe('transactionPool', function () {
 					it('should return true', function () {
 						transactionPool.queued.index[tx] = 0;
 						expect(transactionPool.transactionInPool(tx)).to.equal(true);
-					})
+					});
 				});
 
 				describe('with other index', function () {
@@ -670,7 +670,7 @@ describe('transactionPool', function () {
 					it('should return true', function () {
 						transactionPool.multisignature.index[tx] = 0;
 						expect(transactionPool.transactionInPool(tx)).to.equal(true);
-					})
+					});
 				});
 
 				describe('with other index', function () {

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -596,4 +596,98 @@ describe('transactionPool', function () {
 			});
 		});
 	});
+
+	describe('transactionInPool', function () {
+
+		afterEach(function () {
+			resetStates();
+		});
+
+		describe('when transaction is in pool', function () {
+			var tx = '123';
+
+			describe('unconfirmed list', function () {
+
+				describe('with index 0', function () {
+
+					it('should return true', function () {
+						transactionPool.unconfirmed.index[tx] = 0;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					})
+				});
+
+				describe('with other index', function () {
+
+					it('should return true', function () {
+						transactionPool.unconfirmed.index[tx] = 1;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+
+			describe('bundled list', function () {
+
+				describe('with index 0', function () {
+
+					it('should return true', function () {
+						transactionPool.bundled.index[tx] = 0;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					})
+				});
+
+				describe('with other index', function () {
+
+					it('should return true', function () {
+						transactionPool.bundled.index[tx] = 1;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+
+			describe('queued list', function () {
+
+				describe('with index 0', function () {
+
+					it('should return true', function () {
+						transactionPool.queued.index[tx] = 0;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					})
+				});
+
+				describe('with other index', function () {
+
+					it('should return true', function () {
+						transactionPool.queued.index[tx] = 1;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+
+			describe('multisignature list', function () {
+
+				describe('with index 0', function () {
+
+					it('should return true', function () {
+						transactionPool.multisignature.index[tx] = 0;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					})
+				});
+
+				describe('with other index', function () {
+
+					it('should return true', function () {
+						transactionPool.multisignature.index[tx] = 1;
+						expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+		});
+
+		describe('when transaction is not in pool', function () {
+
+			it('should return false', function () {
+				expect(transactionPool.transactionInPool('123')).to.equal(false);
+			});
+		});
+	});
 });

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -604,6 +604,7 @@ describe('transactionPool', function () {
 		});
 
 		describe('when transaction is in pool', function () {
+
 			var tx = '123';
 
 			describe('unconfirmed list', function () {


### PR DESCRIPTION
### What was the problem?
`TransactionPool.prototype.transactionInPool` returns `false` when transaction is in pool and have index `0` on list of indexes.

### How did I fix it?
Change condition.

### How to test it?
Run unit tests.

### Notice
Already fixed in `1.0.0`, but missing tests.

### Review checklist

* The PR solves https://github.com/LiskHQ/lisk/issues/707
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
