### PR TITLE
Logs are not verbose enough for apply unconfirmed transaction - Fixes #1331

### DIFF
--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -364,7 +364,7 @@ Chain.prototype.applyBlock = function (block, broadcast, saveBlock, cb) {
 					// DATABASE: write
 					modules.transactions.applyUnconfirmed(transaction, sender, function (err) {
 						if (err) {
-							err = ['Failed to apply transaction:', transaction.id, '-', err].join(' ');
+							err = ['Failed to apply unconfirmed transaction:', transaction.id, '-', err].join(' ');
 							library.logger.error(err);
 							library.logger.error('Transaction', transaction);
 							return setImmediate(eachSeriesCb, err);


### PR DESCRIPTION
### What was the problem?
The error log for applyUnconfirmed step during applyBlock function is not correct.
### How did I fix it?
Correct the log message.
### How to test it?
Look at the logs.
### Review checklist

* The PR solves #1331
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
