### PR TITLE
Round snapshot always fails - Closes #1409

### DIFF
--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -228,7 +228,7 @@ Rounds.prototype.tick = function (block, done) {
 			}
 		}).then(function () {
 			// Check if we are one block before last block of round, if yes - perform round snapshot
-			if ((block.height+1) % slots.delegates === 0) {
+			if ((block.height + 1) % slots.delegates === 0) {
 				library.logger.debug('Performing round snapshot...');
 
 				return t.batch([

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -17,7 +17,6 @@ var async = require('async');
 var constants = require('../helpers/constants.js');
 var Round = require('../logic/round.js');
 var slots = require('../helpers/slots.js');
-var Promise = require('bluebird');
 
 // Private fields
 var modules, library, self, __private = {}, shared = {};
@@ -241,7 +240,7 @@ Rounds.prototype.tick = function (block, done) {
 					library.logger.trace('Round snapshot done');
 				}).catch(function (err) {
 					library.logger.error('Round snapshot failed', err);
-					return Promise.reject(err);
+					throw err;
 				});
 			}
 		});

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -776,6 +776,7 @@ describe('rounds', function () {
 			describe('when (block.height+1) % slots.delegates === 0', function () {
 
 				describe('when there is no error form queries', function () {
+
 					var res;
 
 					before(function (done) {
@@ -826,6 +827,7 @@ describe('rounds', function () {
 				});
 
 				describe('when query clearRoundSnapshot fails', function () {
+
 					var res;
 
 					before(function (done) {
@@ -877,6 +879,7 @@ describe('rounds', function () {
 				});
 
 				describe('when query performRoundSnapshot fails', function () {
+
 					var res;
 
 					before(function (done) {
@@ -928,6 +931,7 @@ describe('rounds', function () {
 				});
 
 				describe('when query clearVotesSnapshot fails', function () {
+
 					var res;
 
 					before(function (done) {
@@ -979,6 +983,7 @@ describe('rounds', function () {
 				});
 
 				describe('when query performVotesSnapshot fails', function () {
+
 					var res;
 
 					before(function (done) {

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -775,7 +775,7 @@ describe('rounds', function () {
 
 			describe('when (block.height+1) % slots.delegates === 0', function () {
 
-				describe('when there is no error form queries', function () {
+				describe('when queries are successful', function () {
 
 					var res;
 
@@ -826,7 +826,7 @@ describe('rounds', function () {
 					});
 				});
 
-				describe('when query clearRoundSnapshot fails', function () {
+				describe('when clearRoundSnapshot query fails', function () {
 
 					var res;
 
@@ -878,7 +878,7 @@ describe('rounds', function () {
 					});
 				});
 
-				describe('when query performRoundSnapshot fails', function () {
+				describe('when performRoundSnapshot query fails', function () {
 
 					var res;
 
@@ -930,7 +930,7 @@ describe('rounds', function () {
 					});
 				});
 
-				describe('when query clearVotesSnapshot fails', function () {
+				describe('when clearVotesSnapshot query fails', function () {
 
 					var res;
 
@@ -982,7 +982,7 @@ describe('rounds', function () {
 					});
 				});
 
-				describe('when query performVotesSnapshot fails', function () {
+				describe('when performVotesSnapshot query fails', function () {
 
 					var res;
 

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -466,10 +466,6 @@ describe('rounds', function () {
 			truncateBlocks_stub.resetHistory();
 			sumRound_stub.resetHistory();
 			getOutsiders_stub.resetHistory();
-			clearRoundSnapshot_stub.resetHistory();
-			performRoundSnapshot_stub.resetHistory();
-			clearVotesSnapshot_stub.resetHistory();
-			performVotesSnapshot_stub.resetHistory();
 		};
 
 		before(function () {
@@ -485,18 +481,6 @@ describe('rounds', function () {
 			// Set more stubs
 			set('__private.sumRound', sumRound_stub);
 			set('__private.getOutsiders', getOutsiders_stub);
-			clearRoundSnapshot_stub = sinon.stub(db.rounds, 'clearRoundSnapshot').resolves();
-			performRoundSnapshot_stub = sinon.stub(db.rounds, 'performRoundSnapshot').resolves();
-			clearVotesSnapshot_stub = sinon.stub(db.rounds, 'clearVotesSnapshot').resolves();
-			performVotesSnapshot_stub = sinon.stub(db.rounds, 'performVotesSnapshot').resolves();
-		});
-
-		after(function () {
-			// Clear stubs
-			clearRoundSnapshot_stub.restore();
-			performRoundSnapshot_stub.restore();
-			clearVotesSnapshot_stub.restore();
-			performVotesSnapshot_stub.restore();
 		});
 
 		describe('testing branches', function () {
@@ -782,42 +766,267 @@ describe('rounds', function () {
 
 		describe('performing round snapshot (queries)', function () {
 
-			var bus;
-
-			before(function () {
-				bus = get('library.bus.message');
-				bus.reset();
-			});
+			function clearStubs () {
+				clearRoundSnapshot_stub.restore();
+				performRoundSnapshot_stub.restore();
+				clearVotesSnapshot_stub.restore();
+				performVotesSnapshot_stub.restore();
+			}
 
 			describe('when (block.height+1) % slots.delegates === 0', function () {
 
-				before(function (done) {
-					block = {height: 100};
-					rounds.tick(block, function (err) {
-						expect(err).to.not.exist;
-						done();
+				describe('when there is no error form queries', function () {
+					var res;
+
+					before(function (done) {
+						// Init fake round logic
+						function Round (__scope, __t) {
+							roundScope = __scope;
+
+							clearRoundSnapshot_stub = sinon.stub(__t.rounds, 'clearRoundSnapshot').resolves();
+							performRoundSnapshot_stub = sinon.stub(__t.rounds, 'performRoundSnapshot').resolves();
+							clearVotesSnapshot_stub = sinon.stub(__t.rounds, 'clearVotesSnapshot').resolves();
+							performVotesSnapshot_stub = sinon.stub(__t.rounds, 'performVotesSnapshot').resolves();
+						}
+						Round.prototype.mergeBlockGenerator = mergeBlockGenerator_stub;
+						Round.prototype.land = land_stub;
+						Round.prototype.truncateBlocks = truncateBlocks_stub;
+						Rounds.__set__('Round', Round);
+
+						block = {height: 100};
+						rounds.tick(block, function (err) {
+							res = err;
+							done();
+						});
+					});
+
+					after(function () {
+						clearStubs();
+					});
+
+					it('should result with no error', function () {
+						expect(res).to.not.exist;
+					});
+
+					it('clearRoundSnapshot query should be called once', function () {
+						expect(clearRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performRoundSnapshot query should be called once', function () {
+						expect(performRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('clearVotesSnapshot query should be called once', function () {
+						expect(clearVotesSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performVotesSnapshot query should be called once', function () {
+						expect(performVotesSnapshot_stub.calledOnce).to.be.true;
 					});
 				});
 
-				after(function () {
-					resetStubsHistory();
-					bus.reset();
+				describe('when query clearRoundSnapshot fails', function () {
+					var res;
+
+					before(function (done) {
+						// Init fake round logic
+						function Round (__scope, __t) {
+							roundScope = __scope;
+
+							clearRoundSnapshot_stub = sinon.stub(__t.rounds, 'clearRoundSnapshot').rejects('clearRoundSnapshot');
+							performRoundSnapshot_stub = sinon.stub(__t.rounds, 'performRoundSnapshot').resolves();
+							clearVotesSnapshot_stub = sinon.stub(__t.rounds, 'clearVotesSnapshot').resolves();
+							performVotesSnapshot_stub = sinon.stub(__t.rounds, 'performVotesSnapshot').resolves();
+						}
+						Round.prototype.mergeBlockGenerator = mergeBlockGenerator_stub;
+						Round.prototype.land = land_stub;
+						Round.prototype.truncateBlocks = truncateBlocks_stub;
+						Rounds.__set__('Round', Round);
+
+						block = {height: 100};
+						rounds.tick(block, function (err) {
+							res = err;
+							done();
+						});
+					});
+
+					after(function () {
+						clearStubs();
+					});
+
+					it('should result with BatchError and first error = fail', function () {
+						expect(res.name).to.equal('BatchError');
+						expect(res.first.name).to.equal('clearRoundSnapshot');
+					});
+
+					it('clearRoundSnapshot query should be called once', function () {
+						expect(clearRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performRoundSnapshot query should be called once', function () {
+						expect(performRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('clearVotesSnapshot query should be called once', function () {
+						expect(clearVotesSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performVotesSnapshot query should be called once', function () {
+						expect(performVotesSnapshot_stub.calledOnce).to.be.true;
+					});
 				});
 
-				it('clearRoundSnapshot query should be called once', function () {
-					expect(clearRoundSnapshot_stub.calledOnce).to.be.true;
+				describe('when query performRoundSnapshot fails', function () {
+					var res;
+
+					before(function (done) {
+						// Init fake round logic
+						function Round (__scope, __t) {
+							roundScope = __scope;
+
+							clearRoundSnapshot_stub = sinon.stub(__t.rounds, 'clearRoundSnapshot').resolves();
+							performRoundSnapshot_stub = sinon.stub(__t.rounds, 'performRoundSnapshot').rejects('performRoundSnapshot');
+							clearVotesSnapshot_stub = sinon.stub(__t.rounds, 'clearVotesSnapshot').resolves();
+							performVotesSnapshot_stub = sinon.stub(__t.rounds, 'performVotesSnapshot').resolves();
+						}
+						Round.prototype.mergeBlockGenerator = mergeBlockGenerator_stub;
+						Round.prototype.land = land_stub;
+						Round.prototype.truncateBlocks = truncateBlocks_stub;
+						Rounds.__set__('Round', Round);
+
+						block = {height: 100};
+						rounds.tick(block, function (err) {
+							res = err;
+							done();
+						});
+					});
+
+					after(function () {
+						clearStubs();
+					});
+
+					it('should result with BatchError and first error = fail', function () {
+						expect(res.name).to.equal('BatchError');
+						expect(res.first.name).to.equal('performRoundSnapshot');
+					});
+
+					it('clearRoundSnapshot query should be called once', function () {
+						expect(clearRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performRoundSnapshot query should be called once', function () {
+						expect(performRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('clearVotesSnapshot query should be called once', function () {
+						expect(clearVotesSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performVotesSnapshot query should be called once', function () {
+						expect(performVotesSnapshot_stub.calledOnce).to.be.true;
+					});
 				});
 
-				it('performRoundSnapshot query should be called once', function () {
-					expect(performRoundSnapshot_stub.calledOnce).to.be.true;
+				describe('when query clearVotesSnapshot fails', function () {
+					var res;
+
+					before(function (done) {
+						// Init fake round logic
+						function Round (__scope, __t) {
+							roundScope = __scope;
+
+							clearRoundSnapshot_stub = sinon.stub(__t.rounds, 'clearRoundSnapshot').resolves();
+							performRoundSnapshot_stub = sinon.stub(__t.rounds, 'performRoundSnapshot').resolves();
+							clearVotesSnapshot_stub = sinon.stub(__t.rounds, 'clearVotesSnapshot').rejects('clearVotesSnapshot');
+							performVotesSnapshot_stub = sinon.stub(__t.rounds, 'performVotesSnapshot').resolves();
+						}
+						Round.prototype.mergeBlockGenerator = mergeBlockGenerator_stub;
+						Round.prototype.land = land_stub;
+						Round.prototype.truncateBlocks = truncateBlocks_stub;
+						Rounds.__set__('Round', Round);
+
+						block = {height: 100};
+						rounds.tick(block, function (err) {
+							res = err;
+							done();
+						});
+					});
+
+					after(function () {
+						clearStubs();
+					});
+
+					it('should result with BatchError and first error = fail', function () {
+						expect(res.name).to.equal('BatchError');
+						expect(res.first.name).to.equal('clearVotesSnapshot');
+					});
+
+					it('clearRoundSnapshot query should be called once', function () {
+						expect(clearRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performRoundSnapshot query should be called once', function () {
+						expect(performRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('clearVotesSnapshot query should be called once', function () {
+						expect(clearVotesSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performVotesSnapshot query should be called once', function () {
+						expect(performVotesSnapshot_stub.calledOnce).to.be.true;
+					});
 				});
 
-				it('clearVotesSnapshot query should be called once', function () {
-					expect(clearVotesSnapshot_stub.calledOnce).to.be.true;
-				});
+				describe('when query performVotesSnapshot fails', function () {
+					var res;
 
-				it('performVotesSnapshot query should be called once', function () {
-					expect(performVotesSnapshot_stub.calledOnce).to.be.true;
+					before(function (done) {
+						// Init fake round logic
+						function Round (__scope, __t) {
+							roundScope = __scope;
+
+							clearRoundSnapshot_stub = sinon.stub(__t.rounds, 'clearRoundSnapshot').resolves();
+							performRoundSnapshot_stub = sinon.stub(__t.rounds, 'performRoundSnapshot').resolves();
+							clearVotesSnapshot_stub = sinon.stub(__t.rounds, 'clearVotesSnapshot').resolves();
+							performVotesSnapshot_stub = sinon.stub(__t.rounds, 'performVotesSnapshot').rejects('performVotesSnapshot');
+						}
+						Round.prototype.mergeBlockGenerator = mergeBlockGenerator_stub;
+						Round.prototype.land = land_stub;
+						Round.prototype.truncateBlocks = truncateBlocks_stub;
+						Rounds.__set__('Round', Round);
+
+						block = {height: 100};
+						rounds.tick(block, function (err) {
+							res = err;
+							done();
+						});
+					});
+
+					after(function () {
+						clearStubs();
+					});
+
+					it('should result with BatchError and first error = fail', function () {
+						expect(res.name).to.equal('BatchError');
+						expect(res.first.name).to.equal('performVotesSnapshot');
+					});
+
+					it('clearRoundSnapshot query should be called once', function () {
+						expect(clearRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performRoundSnapshot query should be called once', function () {
+						expect(performRoundSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('clearVotesSnapshot query should be called once', function () {
+						expect(clearVotesSnapshot_stub.calledOnce).to.be.true;
+					});
+
+					it('performVotesSnapshot query should be called once', function () {
+						expect(performVotesSnapshot_stub.calledOnce).to.be.true;
+					});
 				});
 			});
 
@@ -833,22 +1042,21 @@ describe('rounds', function () {
 
 				after(function () {
 					resetStubsHistory();
-					bus.reset();
 				});
 
-				it('clearRoundSnapshot query should be called once', function () {
+				it('clearRoundSnapshot query should be not called', function () {
 					expect(clearRoundSnapshot_stub.calledOnce).to.be.false;
 				});
 
-				it('performRoundSnapshot query should be called once', function () {
+				it('performRoundSnapshot query should be not called', function () {
 					expect(performRoundSnapshot_stub.calledOnce).to.be.false;
 				});
 
-				it('clearVotesSnapshot query should be called once', function () {
+				it('clearVotesSnapshot query should be not called', function () {
 					expect(clearVotesSnapshot_stub.calledOnce).to.be.false;
 				});
 
-				it('performVotesSnapshot query should be called once', function () {
+				it('performVotesSnapshot query should be not called', function () {
 					expect(performVotesSnapshot_stub.calledOnce).to.be.false;
 				});
 			});


### PR DESCRIPTION
### What was the problem?
Round snapshot always fails on second end every next round.

### How did I fix it?
Move snapshoting queries to `Tick` promises chain (inside same transaction).

### How to test it?
- Run node, wait for second round to be closed, there should be no error.
- Run rounds module unit tests.

### Review checklist

* The PR solves https://github.com/LiskHQ/lisk/issues/1409
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
