### PR TITLE
Change to Jenkinsfile to never fail when archive artifacts - Closes #1435

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ def archiveLogs() {
 	try {
 		archiveArtifacts artifacts: "logs_${NODE_NAME}_${JOB_BASE_NAME}_${BUILD_ID}/*", allowEmptyArchive: true
 	} catch (err) {
-		echo err
+		echo "Error: ${err}"
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,9 +91,13 @@ def cleanUpMaster() {
 
 def archiveLogs() {
 	sh '''
-	mv "${WORKSPACE%@*}/logs" "${WORKSPACE}/logs_${NODE_NAME}_${JOB_BASE_NAME}_${BUILD_ID}"
+	mv "${WORKSPACE%@*}/logs" "${WORKSPACE}/logs_${NODE_NAME}_${JOB_BASE_NAME}_${BUILD_ID}" || true
 	'''
-	archiveArtifacts "logs_${NODE_NAME}_${JOB_BASE_NAME}_${BUILD_ID}/*"
+	try {
+		archiveArtifacts artifacts: "logs_${NODE_NAME}_${JOB_BASE_NAME}_${BUILD_ID}/*", allowEmptyArchive: true
+	} catch (err) {
+		echo err
+	}
 }
 
 def runAction(action) {


### PR DESCRIPTION
### What was the problem?
When lisk core is running from a parallel workspace (has something like an @2 in its directory name), the mv fails because it's assuming that core is running out of the base workspace
### How did I fix it?
For now, I allow the build to continue even when archiveLogs fails
### How to test it?
Hard to test directly since this is an edge case that has only happened after 1.5 months of working correctly. I tested it by setting it temporarily to try to archive a non-existent directory and it still succeeded
### Review checklist

* The PR solves #1435 
* All new code is covered with unit tests
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
