### PR TITLE
Integration tests are failing when given configurations for 10 nodes with address "127.0.0.1" - Closes #1475

### DIFF
--- a/test/integration/setup/shell.js
+++ b/test/integration/setup/shell.js
@@ -63,6 +63,7 @@ module.exports = {
 		);
 
 		child.stdout.pipe(process.stdout);
+		child.stderr.pipe(process.stderr);
 
 		child.on('close', code => {
 			if (code === 0) {

--- a/test/integration/setup/shell.js
+++ b/test/integration/setup/shell.js
@@ -50,7 +50,13 @@ module.exports = {
 	runMochaTests: function(testsPaths, cb) {
 		var child = child_process.spawn(
 			'node_modules/.bin/_mocha',
-			['--timeout', (8 * 60 * 1000).toString(), '--exit'].concat(testsPaths),
+			[
+				'--timeout',
+				(8 * 60 * 1000).toString(),
+				'--exit',
+				'--require',
+				'./test/setup.js',
+			].concat(testsPaths),
 			{
 				cwd: `${__dirname}/../../..`,
 			}


### PR DESCRIPTION
### What was the problem?
Integration tests are failing against of 1.0.0 branch. Running functional tests inside of integration tests fails.
### How did I fix it?
The recent changes introduced to functional tests requiring setting up test environment by passing the extra parameter to `mocha` test runner: `--require ./test/setup.js`. The parameter was missing during starting functional tests inside of integration tests. 
### How to test it?
Execute integration tests (`npm test -- mocha:untagged:integration`)
### Review checklist

* The PR solves #1475
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
