### PR TITLE
Skip unstable and slow functional tests during integration tests - Closes #1475

### DIFF
--- a/test/integration/setup/shell.js
+++ b/test/integration/setup/shell.js
@@ -56,6 +56,9 @@ module.exports = {
 				'--exit',
 				'--require',
 				'./test/setup.js',
+				'--grep',
+				'@slow|@unstable',
+				'--invert',
 			].concat(testsPaths),
 			{
 				cwd: `${__dirname}/../../..`,


### PR DESCRIPTION
### What was the problem?
Integration tests are randomly failing against of 1.0.0 branch due to running all tests - including the `@unstable` ones.
### How did I fix it?
I've added the extra parameter for skipping `@unstable` and `@slow` tests during starting functional tests inside of integration tests. 
### How to test it?
Execute integration tests (`npm test -- mocha:untagged:integration`)
### Review checklist

* The PR solves #1475
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
