### PR TITLE
Missing error handler for updateMemAccounts - Closes #1446

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -572,8 +572,7 @@ __private.loadBlockChain = function() {
 				return t.batch(promises);
 			}
 
-			// TODO: Missing .catch handler, see #1446
-			library.db
+			return library.db
 				.task(updateMemAccounts)
 				.spread(function(
 					updateMemAccounts,


### PR DESCRIPTION
### What was the problem?
Missing error handler/propagation when executing `updateMemAccounts` task in `__private.loadBlockChain` (loader module).
### How did I fix it?
Simply returning a promise.

### How to test it?
Modify one of those queries to make it fail, then run app.
- `accounts.updateMemAccounts()`
- `accounts.getOrphanedMemAccounts()`
- `accounts.getDelegates()`

### Notice
I skipped unit tests because `__private.loadBlockChain` is currently unsuitable to be unit tested and refactoring it is not a part of this issue. Instead I tested manually.

### Review checklist

* The PR solves https://github.com/LiskHQ/lisk/issues/1446
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
