### PR TITLE
Fix done callback for promise defer - Closes #1492

### DIFF
--- a/test/unit/helpers/promise_defer.js
+++ b/test/unit/helpers/promise_defer.js
@@ -36,16 +36,26 @@ describe('PromiseDefer', () => {
 	describe('when it fails', () => {
 		it('should reject', done => {
 			expect(promiseDefer.promise.isRejected()).to.be.false;
-			promiseDefer.reject({ message: REJECTED, done: done() });
-			expect(promiseDefer.promise.isRejected()).to.be.true;
+			promiseDefer.reject({
+				message: REJECTED,
+				done: () => {
+					expect(promiseDefer.promise.isRejected()).to.be.true;
+					done();
+				},
+			});
 		});
 	});
 
 	describe('when it succeeds', () => {
 		it('should resolve', done => {
 			expect(promiseDefer.promise.isFulfilled()).to.be.false;
-			promiseDefer.resolve({ message: RESOLVED, done: done() });
-			expect(promiseDefer.promise.isFulfilled()).to.be.true;
+			promiseDefer.resolve({
+				message: RESOLVED,
+				done: () => {
+					expect(promiseDefer.promise.isFulfilled()).to.be.true;
+					done();
+				},
+			});
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?
Mocha unit test done was not called properly in promise defer.
### How did I fix it?
Added callback to promise to defer and called done for the unit test.
### How to test it?
`npm run test -- mocha:untagged:unit`
### Review checklist

* The PR solves #1492 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
