### PR TITLE
Unauthorized try of change account's virgin field from 0 to 1 - Closes #1504

### DIFF
--- a/db/repos/accounts.js
+++ b/db/repos/accounts.js
@@ -238,16 +238,13 @@ class AccountsRepository {
 			conditionObject[field] = data[field];
 		});
 
-		return this.db.tx('db:accounts:upsert', function(t) {
-			return t.accounts
-				.list(conditionObject, ['address'])
-				.then(function(result) {
-					if (result.length) {
-						return t.accounts.update(result[0].address, updateData);
-					} else {
-						return t.accounts.insert(data);
-					}
-				});
+		return this.db.tx('db:accounts:upsert', function*(t) {
+			const result = yield t.accounts.list(conditionObject, ['address']);
+			if (result.length) {
+				yield t.accounts.update(result[0].address, updateData);
+			} else {
+				yield t.accounts.insert(data);
+			}
 		});
 	}
 
@@ -560,7 +557,7 @@ class AccountsRepository {
 	/**
 	 * Convert an account to be non-virgin account
 	 * @param {string} address - Account address
-	 * @return {Promise}
+	 * @return {Promise<null>}
 	 */
 	convertToNonVirgin(address) {
 		return this.db.none(sql.convertToNonVirgin, { address: address });

--- a/db/repos/accounts.js
+++ b/db/repos/accounts.js
@@ -555,7 +555,8 @@ class AccountsRepository {
 	}
 
 	/**
-	 * Convert an account to be non-virgin account
+	 * Convert an account to be non-virgin account.
+	 *
 	 * @param {string} address - Account address
 	 * @return {Promise<null>}
 	 */

--- a/db/repos/accounts.js
+++ b/db/repos/accounts.js
@@ -68,12 +68,12 @@ const normalFields = [
 		init: () => 'encode("secondPublicKey", \'hex\')',
 		skip: ifNotExists,
 	},
-	{ name: 'virgin', cast: 'int::boolean', def: 1, skip: ifNotExists },
 ];
 
 // Only used in SELECT and INSERT queries
 const immutableFields = [
 	{ name: 'address', mod: ':raw', init: () => 'upper(address)' },
+	{ name: 'virgin', cast: 'int::boolean', def: 1, skip: ifNotExists },
 ];
 
 // Only used in SELECT queries
@@ -130,11 +130,11 @@ class AccountsRepository {
 				{ name: 'u_isDelegate', cast: 'int', def: 0, skip: ifNotExists },
 				{ name: 'secondSignature', cast: 'int', def: 0, skip: ifNotExists },
 				{ name: 'u_secondSignature', cast: 'int', def: 0, skip: ifNotExists },
-				{ name: 'virgin', cast: 'int', def: 1 },
 			]);
 
 			cs.insert = cs.update.merge([
 				{ name: 'address', mod: ':raw', init: c => `upper('${c.value}')` },
+				{ name: 'virgin', cast: 'int', def: 1, skip: ifNotExists },
 			]);
 		}
 	}
@@ -556,6 +556,15 @@ class AccountsRepository {
 				dependentTable
 			)
 		);
+	}
+
+	/**
+	 * Convert an account to be non-virgin account
+	 * @param {string} address - Account address
+	 * @return {Promise}
+	 */
+	convertToNonVirgin(address) {
+		return this.db.none(sql.convertToNonVirgin, { address: address });
 	}
 }
 

--- a/db/repos/accounts.js
+++ b/db/repos/accounts.js
@@ -275,6 +275,16 @@ class AccountsRepository {
 			); // eslint-disable-line prefer-promise-reject-errors
 		}
 
+		this.getImmutableFields().map(function(field) {
+			delete data[field];
+		});
+
+		// To avoid Error: Cannot generate an UPDATE without any columns.
+		// If there is nothing to update, return else pg-promise will fail
+		if (Object.keys(data).length === 0) {
+			return Promise.resolve();
+		}
+
 		return this.db.none(
 			this.pgp.helpers.update(data, this.cs.update) +
 				this.pgp.as.format(' WHERE $1:name=$2', ['address', address])

--- a/db/sql/accounts/convert_to_non_virgin.sql
+++ b/db/sql/accounts/convert_to_non_virgin.sql
@@ -22,5 +22,4 @@
 
 UPDATE mem_accounts
 SET virgin = 0
-WHERE
-	upper(address) = upper(${address})
+WHERE upper(address) = upper(${address})

--- a/db/sql/accounts/convert_to_non_virgin.sql
+++ b/db/sql/accounts/convert_to_non_virgin.sql
@@ -14,9 +14,10 @@
 
 
 /*
-  DESCRIPTION: ?
+  DESCRIPTION: Convert a virgin account to non-virgin state
 
-  PARAMETERS: ?
+  PARAMETERS:
+  	address - Address of the particular account
 */
 
 UPDATE mem_accounts

--- a/db/sql/accounts/convert_to_non_virgin.sql
+++ b/db/sql/accounts/convert_to_non_virgin.sql
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: ?
+
+  PARAMETERS: ?
+*/
+
+UPDATE mem_accounts
+SET virgin = 0
+WHERE
+	upper(address) = upper(${address})

--- a/db/sql/index.js
+++ b/db/sql/index.js
@@ -30,6 +30,7 @@ module.exports = {
 		columnMultisignatures: link('accounts/column_multisignatures.sql'),
 		columnUMultisignatures: link('accounts/column_u_multisignatures.sql'),
 		columnRank: link('accounts/column_rank.sql'),
+		convertToNonVirgin: link('accounts/convert_to_non_virgin.sql'),
 	},
 	blocks: {
 		aggregateBlocksReward: link('blocks/aggregate_blocks_reward.sql'),

--- a/logic/account.js
+++ b/logic/account.js
@@ -13,18 +13,18 @@
  */
 'use strict';
 
-var _ = require('lodash');
-var constants = require('../helpers/constants.js');
-var sortBy = require('../helpers/sort_by.js');
-var Bignum = require('../helpers/bignum.js');
-var BlockReward = require('./block_reward.js');
+const _ = require('lodash');
+const constants = require('../helpers/constants.js');
+const sortBy = require('../helpers/sort_by.js');
+const Bignum = require('../helpers/bignum.js');
+const BlockReward = require('./block_reward.js');
 
 // Private fields
-var self; // eslint-disable-line no-unused-vars
-var library;
-var modules;
+let self; // eslint-disable-line no-unused-vars
+let library;
+let modules;
 
-var __private = {};
+const __private = {};
 
 /**
  * Main account logic.
@@ -37,304 +37,800 @@ var __private = {};
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */
-function Account(db, schema, logger, cb) {
-	this.scope = {
-		db: db,
-		schema: schema,
-	};
+class Account {
+	constructor(db, schema, logger, cb) {
+		this.scope = {
+			db,
+			schema,
+		};
 
-	__private.blockReward = new BlockReward();
+		__private.blockReward = new BlockReward();
 
-	self = this;
-	library = {
-		logger: logger,
-	};
+		self = this;
+		library = {
+			logger,
+		};
 
-	this.table = 'mem_accounts';
-	/**
-	 * @typedef {Object} account
-	 * @property {string} username - Lowercase, between 1 and 20 chars.
-	 * @property {boolean} isDelegate
-	 * @property {boolean} u_isDelegate
-	 * @property {boolean} secondSignature
-	 * @property {boolean} u_secondSignature
-	 * @property {string} u_username
-	 * @property {address} address - Uppercase, between 1 and 22 chars.
-	 * @property {publicKey} publicKey
-	 * @property {publicKey} secondPublicKey
-	 * @property {number} balance - Between 0 and totalAmount from constants.
-	 * @property {number} u_balance - Between 0 and totalAmount from constants.
-	 * @property {number} vote
-	 * @property {number} rate
-	 * @property {String[]} delegates - From mem_account2delegates table, filtered by address.
-	 * @property {String[]} u_delegates - From mem_account2u_delegates table, filtered by address.
-	 * @property {String[]} multisignatures - From mem_account2multisignatures table, filtered by address.
-	 * @property {String[]} u_multisignatures - From mem_account2u_multisignatures table, filtered by address.
-	 * @property {number} multimin - Between 0 and 17.
-	 * @property {number} u_multimin - Between 0 and 17.
-	 * @property {number} multilifetime - Between 1 and 72.
-	 * @property {number} u_multilifetime - Between 1 and 72.
-	 * @property {string} blockId
-	 * @property {boolean} nameexist
-	 * @property {boolean} u_nameexist
-	 * @property {number} producedblocks
-	 * @property {number} missedblocks
-	 * @property {number} fees
-	 * @property {number} rewards
-	 * @property {boolean} virgin
-	 */
-	this.model = [
-		{
-			name: 'username',
-			type: 'String',
-			conv: String,
-			immutable: true,
-		},
-		{
-			name: 'isDelegate',
-			type: 'SmallInt',
-			conv: Boolean,
-		},
-		{
-			name: 'u_isDelegate',
-			type: 'SmallInt',
-			conv: Boolean,
-		},
-		{
-			name: 'secondSignature',
-			type: 'SmallInt',
-			conv: Boolean,
-		},
-		{
-			name: 'u_secondSignature',
-			type: 'SmallInt',
-			conv: Boolean,
-		},
-		{
-			name: 'u_username',
-			type: 'String',
-			conv: String,
-			immutable: true,
-		},
-		{
-			name: 'address',
-			type: 'String',
-			conv: String,
-			immutable: true,
-			expression: 'UPPER(a.address)',
-		},
-		{
-			name: 'publicKey',
-			type: 'Binary',
-			conv: String,
-			immutable: true,
-			expression: 'ENCODE("publicKey", \'hex\')',
-		},
-		{
-			name: 'secondPublicKey',
-			type: 'Binary',
-			conv: String,
-			immutable: true,
-			expression: 'ENCODE("secondPublicKey", \'hex\')',
-		},
-		{
-			name: 'balance',
-			type: 'BigInt',
-			conv: Number,
-			expression: '("balance")::bigint',
-		},
-		{
-			name: 'u_balance',
-			type: 'BigInt',
-			conv: Number,
-			expression: '("u_balance")::bigint',
-		},
-		{
-			name: 'rate',
-			type: 'BigInt',
-			conv: Number,
-			expression: '("rate")::bigint',
-		},
-		{
-			name: 'delegates',
-			type: 'Text',
-			conv: Array,
-			expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-				this.table
-			}2delegates WHERE "accountId" = a."address")`,
-		},
-		{
-			name: 'u_delegates',
-			type: 'Text',
-			conv: Array,
-			expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-				this.table
-			}2u_delegates WHERE "accountId" = a."address")`,
-		},
-		{
-			name: 'multisignatures',
-			type: 'Text',
-			conv: Array,
-			expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-				this.table
-			}2multisignatures WHERE "accountId" = a."address")`,
-		},
-		{
-			name: 'u_multisignatures',
-			type: 'Text',
-			conv: Array,
-			expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-				this.table
-			}2u_multisignatures WHERE "accountId" = a."address")`,
-		},
-		{
-			name: 'multimin',
-			type: 'SmallInt',
-			conv: Number,
-		},
-		{
-			name: 'u_multimin',
-			type: 'SmallInt',
-			conv: Number,
-		},
-		{
-			name: 'multilifetime',
-			type: 'SmallInt',
-			conv: Number,
-		},
-		{
-			name: 'u_multilifetime',
-			type: 'SmallInt',
-			conv: Number,
-		},
-		{
-			name: 'blockId',
-			type: 'String',
-			conv: String,
-		},
-		{
-			name: 'nameexist',
-			type: 'SmallInt',
-			conv: Boolean,
-		},
-		{
-			name: 'u_nameexist',
-			type: 'SmallInt',
-			conv: Boolean,
-		},
-		{
-			name: 'fees',
-			type: 'BigInt',
-			conv: Number,
-			expression: '(a."fees")::bigint',
-		},
-		{
-			name: 'rank',
-			type: 'BigInt',
-			conv: Number,
-			expression:
-				'(SELECT m.row_number FROM (SELECT row_number() OVER (ORDER BY r."vote" DESC, r."publicKey" ASC), address FROM (SELECT d."isDelegate", d.vote, d."publicKey", d.address FROM mem_accounts AS d WHERE d."isDelegate" = 1) AS r) m WHERE m."address" = a."address")::int',
-		},
-		{
-			name: 'rewards',
-			type: 'BigInt',
-			conv: Number,
-			expression: '(a."rewards")::bigint',
-		},
-		{
-			name: 'vote',
-			type: 'BigInt',
-			conv: Number,
-			expression: '(a."vote")::bigint',
-		},
-		{
-			name: 'producedBlocks',
-			type: 'BigInt',
-			conv: Number,
-			expression: '(a."producedblocks")::bigint',
-		},
-		{
-			name: 'missedBlocks',
-			type: 'BigInt',
-			conv: Number,
-			expression: '(a."missedblocks")::bigint',
-		},
-		{
-			name: 'virgin',
-			type: 'SmallInt',
-			conv: Boolean,
-			immutable: true,
-		},
-		{
-			name: 'approval',
-			type: 'integer',
-			dependentFields: ['vote'],
-			computedField: true,
-		},
-		{
-			name: 'productivity',
-			type: 'integer',
-			dependentFields: ['producedBlocks', 'missedBlocks', 'rank'],
-			computedField: true,
-		},
-	];
+		this.computedFields = this.model.filter(field => field.computedField);
 
-	this.computedFields = this.model.filter(function(field) {
-		return field.computedField;
-	});
+		// Obtains fields from model
+		this.fields = this.model.map(field => {
+			const _tmp = {};
 
-	// Obtains fields from model
-	this.fields = this.model.map(function(field) {
-		var _tmp = {};
-
-		if (field.expression) {
-			_tmp.expression = field.expression;
-		} else {
-			if (field.mod) {
-				_tmp.expression = field.mod;
+			if (field.expression) {
+				_tmp.expression = field.expression;
+			} else {
+				if (field.mod) {
+					_tmp.expression = field.mod;
+				}
+				_tmp.field = field.name;
 			}
-			_tmp.field = field.name;
-		}
-		if (_tmp.expression || field.alias) {
-			_tmp.alias = field.alias || field.name;
-		}
+			if (_tmp.expression || field.alias) {
+				_tmp.alias = field.alias || field.name;
+			}
 
-		_tmp.computedField = field.computedField || false;
+			_tmp.computedField = field.computedField || false;
 
-		return _tmp;
-	});
+			return _tmp;
+		});
 
-	// Obtains bynary fields from model
-	this.binary = [];
-	this.model.forEach(
-		function(field) {
+		// Obtains bynary fields from model
+		this.binary = [];
+		this.model.forEach(field => {
 			if (field.type === 'Binary') {
 				this.binary.push(field.name);
 			}
-		}.bind(this)
-	);
+		});
 
-	// Obtains conv from model
-	this.conv = {};
-	this.model.forEach(
-		function(field) {
+		// Obtains conv from model
+		this.conv = {};
+		this.model.forEach(field => {
 			this.conv[field.name] = field.conv;
-		}.bind(this)
-	);
+		});
 
-	// Obtains editable fields from model
-	this.editable = [];
-	this.model.forEach(
-		function(field) {
+		// Obtains editable fields from model
+		this.editable = [];
+		this.model.forEach(field => {
 			if (!field.immutable) {
 				this.editable.push(field.name);
 			}
-		}.bind(this)
-	);
+		});
 
-	return setImmediate(cb, null, this);
+		return setImmediate(cb, null, this);
+	}
+
+	// Public methods
+	/**
+	 * Binds input parameters to private variables modules.
+	 * @param {Blocks} blocks
+	 */
+	// eslint-disable-next-line class-methods-use-this
+	bind(blocks) {
+		modules = {
+			blocks,
+		};
+	}
+
+	/**
+	 * Deletes the contents of these tables:
+	 * - mem_round
+	 * - mem_accounts2delegates
+	 * - mem_accounts2u_delegates
+	 * - mem_accounts2multisignatures
+	 * - mem_accounts2u_multisignatures
+	 * @param {function} cb - Callback function.
+	 * @returns {setImmediateCallback} cb|error.
+	 */
+	resetMemTables(cb) {
+		this.scope.db.accounts
+			.resetMemTables()
+			.then(() => setImmediate(cb))
+			.catch(err => {
+				library.logger.error(err.stack);
+				return setImmediate(cb, 'Account#resetMemTables error');
+			});
+	}
+
+	/**
+	 * Validates account schema.
+	 * @param {account} account
+	 * @returns {err|account} Error message or input parameter account.
+	 * @throws {string} If schema.validate fails, throws 'Failed to validate account schema'.
+	 */
+	objectNormalize(account) {
+		const report = this.scope.schema.validate(
+			account,
+			Account.prototype.schema
+		);
+
+		if (!report) {
+			throw `Failed to validate account schema: ${this.scope.schema
+				.getLastErrors()
+				.map(err => {
+					const path = err.path.replace('#/', '').trim();
+					return [path, ': ', err.message, ' (', account[path], ')'].join('');
+				})
+				.join(', ')}`;
+		}
+
+		return account;
+	}
+
+	/**
+	 * Checks type, lenght and format from publicKey.
+	 * @param {publicKey} publicKey
+	 * @throws {string} throws one error for every check.
+	 */
+	verifyPublicKey(publicKey) {
+		if (publicKey !== undefined) {
+			// Check type
+			if (typeof publicKey !== 'string') {
+				throw 'Invalid public key, must be a string';
+			}
+			// Check length
+			if (publicKey.length !== 64) {
+				throw 'Invalid public key, must be 64 characters long';
+			}
+
+			if (!this.scope.schema.validate(publicKey, { format: 'hex' })) {
+				throw 'Invalid public key, must be a hex string';
+			}
+		}
+	}
+
+	/**
+	 * Normalizes address and creates binary buffers to insert.
+	 * @param {Object} raw - with address and public key.
+	 * @returns {Object} Normalized address.
+	 */
+	toDB(raw) {
+		this.binary.forEach(field => {
+			if (raw[field]) {
+				raw[field] = Buffer.from(raw[field], 'hex');
+			}
+		});
+
+		// Normalize address
+		raw.address = String(raw.address).toUpperCase();
+
+		return raw;
+	}
+
+	/**
+	 * Gets Multisignature account information for specified fields and filter criteria.
+	 * @param {Object} filter - Contains address.
+	 * @param {Object|function} fields - Table fields.
+	 * @param {function} cb - Callback function.
+	 * @param {Object} tx - Database Transaction/Task Object
+	 * @returns {setImmediateCallback} Returns null or Object with database data.
+	 */
+	getMultiSignature(filter, fields, cb, tx) {
+		if (typeof fields === 'function') {
+			tx = cb;
+			cb = fields;
+			fields = null;
+		}
+
+		filter.multisig = true;
+
+		this.get(filter, fields, cb, tx);
+	}
+
+	/**
+	 * Gets account information for specified fields and filter criteria.
+	 * @param {Object} filter - Contains address.
+	 * @param {Object|function} fields - Table fields.
+	 * @param {function} cb - Callback function.
+	 * @param {Object} tx - Database Transaction/Task Object
+	 * @returns {setImmediateCallback} Returns null or Object with database data.
+	 */
+	get(filter, fields, cb, tx) {
+		if (typeof fields === 'function') {
+			tx = cb;
+			cb = fields;
+			fields = null;
+		}
+
+		this.getAll(
+			filter,
+			fields,
+			(err, data) =>
+				setImmediate(cb, err, data && data.length ? data[0] : null),
+			tx
+		);
+	}
+
+	/**
+	 * Gets accounts information from mem_accounts.
+	 * @param {Object} filter - Contains address.
+	 * @param {Object|function} fields - Table fields.
+	 * @param {function} cb - Callback function.
+	 * @param {Object} tx - Database Transaction/Task Object
+	 * @returns {setImmediateCallback} data with rows | 'Account#getAll error'.
+	 */
+	getAll(filter, fields, cb, tx) {
+		if (typeof fields === 'function') {
+			cb = fields;
+			fields = null;
+		}
+
+		const computedFieldsMap = {};
+		this.computedFields.map(field => {
+			computedFieldsMap[field.name] = field.dependentFields;
+		});
+
+		// If fields are not provided append computed fields
+		if (!fields) {
+			fields = this.scope.db.accounts.getDBFields();
+			fields = fields.concat(Object.keys(computedFieldsMap));
+		}
+
+		let fieldsAddedForComputation = [];
+		const performComputationFor = [];
+
+		Object.keys(computedFieldsMap).forEach(computedField => {
+			if (fields.includes(computedField)) {
+				// Add computed field to list to process later
+				performComputationFor.push(computedField);
+
+				// Remove computed field from the db fields list
+				fields.splice(fields.indexOf(computedField), 1);
+
+				// Marks fields which are explicitly added due to computation
+				fieldsAddedForComputation = fieldsAddedForComputation.concat(
+					_.difference(computedFieldsMap[computedField], fields)
+				);
+
+				// Add computation dependant fields to db fields list
+				fields = fields.concat(computedFieldsMap[computedField]);
+			}
+		});
+
+		let limit = constants.activeDelegates;
+		let offset = 0;
+		let sort = { sortField: '', sortMethod: '' };
+
+		if (filter.offset > 0) {
+			offset = filter.offset;
+		}
+		delete filter.offset;
+
+		if (filter.limit > 0) {
+			limit = filter.limit;
+		}
+		delete filter.limit;
+
+		if (filter.sort) {
+			const allowedSortFields = [
+				'username',
+				'balance',
+				'rank',
+				'missedBlocks',
+				'vote',
+				'publicKey',
+			];
+			sort = sortBy.sortBy(filter.sort, {
+				sortFields: allowedSortFields,
+				quoteField: false,
+			});
+		}
+		delete filter.sort;
+
+		const self = this;
+
+		(tx || this.scope.db).accounts
+			.list(filter, fields, {
+				limit,
+				offset,
+				sortField: sort.sortField,
+				sortMethod: sort.sortMethod,
+			})
+			.then(rows => {
+				const lastBlock = modules.blocks.lastBlock.get();
+				// If the last block height is undefined, it means it's a genesis block with height = 1
+				// look for a constant for total supply
+				const totalSupply = lastBlock.height
+					? __private.blockReward.calcSupply(lastBlock.height)
+					: 0;
+
+				if (performComputationFor.includes('approval')) {
+					rows.forEach(accountRow => {
+						accountRow.approval = self.calculateApproval(
+							accountRow.vote,
+							totalSupply
+						);
+					});
+				}
+
+				if (performComputationFor.includes('productivity')) {
+					rows.forEach(accountRow => {
+						accountRow.productivity = self.calculateProductivity(
+							accountRow.producedBlocks,
+							accountRow.missedBlocks
+						);
+					});
+				}
+
+				if (fieldsAddedForComputation.length > 0) {
+					// Remove the fields which were only added for computation
+					rows.forEach(accountRow => {
+						fieldsAddedForComputation.forEach(field => {
+							delete accountRow[field];
+						});
+					});
+				}
+
+				return setImmediate(cb, null, rows);
+			})
+			.catch(err => {
+				library.logger.error(err.stack);
+				return setImmediate(cb, 'Account#getAll error');
+			});
+	}
+
+	/**
+	 * Calculates productivity of a delegate account.
+	 * @param {String} votersBalance
+	 * @param {String} totalSupply
+	 * @returns {Number}
+	 */
+	// eslint-disable-next-line class-methods-use-this
+	calculateApproval(votersBalance, totalSupply) {
+		// votersBalance and totalSupply are sent as strings, we convert them into bignum and send the response as number as well.
+		const votersBalanceBignum = new Bignum(votersBalance || 0);
+		const totalSupplyBignum = new Bignum(totalSupply);
+		const approvalBignum = votersBalanceBignum
+			.dividedBy(totalSupplyBignum)
+			.times(100)
+			.round(2);
+		return !approvalBignum.isNaN() ? approvalBignum.toNumber() : 0;
+	}
+
+	/**
+	 * Calculates productivity of a delegate account.
+	 * @param {String} producedBlocks
+	 * @param {String} missedBlocks
+	 * @returns {Number}
+	 */
+	// eslint-disable-next-line class-methods-use-this
+	calculateProductivity(producedBlocks, missedBlocks) {
+		const producedBlocksBignum = new Bignum(producedBlocks || 0);
+		const missedBlocksBignum = new Bignum(missedBlocks || 0);
+		const percent = producedBlocksBignum
+			.dividedBy(producedBlocksBignum.plus(missedBlocksBignum))
+			.times(100)
+			.round(2);
+		return !percent.isNaN() ? percent.toNumber() : 0;
+	}
+
+	/**
+	 * Sets fields for specific address in mem_accounts table.
+	 * @param {address} address
+	 * @param {Object} fields
+	 * @param {function} cb - Callback function.
+	 * @param {Object} tx - Database Transaction/Task Object
+	 * @returns {setImmediateCallback} cb | 'Account#set error'.
+	 */
+	set(address, fields, cb, tx) {
+		// Verify public key
+		this.verifyPublicKey(fields.publicKey);
+
+		// Normalize address
+		fields.address = address;
+
+		(tx || this.scope.db).accounts
+			.upsert(fields, ['address'])
+			.then(() => setImmediate(cb))
+			.catch(err => {
+				library.logger.error(err.stack);
+				return setImmediate(cb, 'Account#set error');
+			});
+	}
+
+	/**
+	 * Updates account from mem_account with diff data belonging to an editable field.
+	 * Inserts into mem_round "address", "amount", "delegate", "blockId", "round" based on balance or delegates fields.
+	 * @param {address} address
+	 * @param {Object} diff - Must contains only mem_account editable fields.
+	 * @param {function} cb - Callback function.
+	 * @param {Object} tx - Database Transaction/Task Object
+	 * @returns {setImmediateCallback|cb|done} Multiple returns: done() or error.
+	 */
+	merge(address, diff, cb, tx) {
+		// Verify public key
+		this.verifyPublicKey(diff.publicKey);
+
+		// Normalize address
+		address = String(address).toUpperCase();
+
+		const self = this;
+
+		// If merge was called without any diff object
+		if (Object.keys(diff).length === 0) {
+			return self.get({ address }, cb, tx);
+		}
+
+		// Loop through each of updated attribute
+		(tx || self.scope.db)
+			.tx('logic:account:merge', dbTx => {
+				const promises = [];
+
+				Object.keys(diff).forEach(updatedField => {
+					// Return if updated field is not editable
+					if (!self.editable.includes(updatedField)) {
+						return;
+					}
+
+					// Get field data type
+					const fieldType = self.conv[updatedField];
+					const updatedValue = diff[updatedField];
+
+					// Make execution selection based on field type
+					switch (fieldType) {
+						// blockId
+						case String:
+							promises.push(
+								dbTx.accounts.update(address, _.pick(diff, [updatedField]))
+							);
+							break;
+
+						// [u_]balance, [u_]multimin, [u_]multilifetime, rate, fees, rank, rewards, votes, producedBlocks, missedBlocks
+						case Number:
+							if (isNaN(updatedValue) || updatedValue === Infinity) {
+								throw `Encountered insane number: ${updatedValue}`;
+							}
+
+							// If updated value is positive number
+							if (
+								Math.abs(updatedValue) === updatedValue &&
+								updatedValue !== 0
+							) {
+								promises.push(
+									dbTx.accounts.increment(
+										address,
+										updatedField,
+										Math.floor(updatedValue)
+									)
+								);
+
+								// If updated value is negative number
+							} else if (updatedValue < 0) {
+								promises.push(
+									dbTx.accounts.decrement(
+										address,
+										updatedField,
+										Math.floor(Math.abs(updatedValue))
+									)
+								);
+
+								// If money is taken out from an account so its an active account now.
+								if (updatedField === 'u_balance') {
+									promises.push(dbTx.accounts.update(address, { virgin: 0 }));
+								}
+							}
+
+							if (updatedField === 'balance') {
+								promises.push(
+									dbTx.rounds.insertRoundInformationWithAmount(
+										address,
+										diff.blockId,
+										diff.round,
+										updatedValue
+									)
+								);
+							}
+							break;
+
+						// [u_]delegates, [u_]multisignatures
+						case Array:
+							// If we received update as array of strings
+							if (_.isString(updatedValue[0])) {
+								updatedValue.forEach(updatedValueItem => {
+									// Fetch first character
+									let mode = updatedValueItem[0];
+									let dependentId = '';
+
+									if (mode === '-' || mode === '+') {
+										dependentId = updatedValueItem.slice(1);
+									} else {
+										dependentId = updatedValueItem;
+										mode = '+';
+									}
+
+									if (mode === '-') {
+										promises.push(
+											dbTx.accounts.removeDependencies(
+												address,
+												dependentId,
+												updatedField
+											)
+										);
+									} else {
+										promises.push(
+											dbTx.accounts.insertDependencies(
+												address,
+												dependentId,
+												updatedField
+											)
+										);
+									}
+
+									if (updatedField === 'delegates') {
+										promises.push(
+											dbTx.rounds.insertRoundInformationWithDelegate(
+												address,
+												diff.blockId,
+												diff.round,
+												dependentId,
+												mode
+											)
+										);
+									}
+								});
+								// If we received update as array of objects
+							} else if (_.isObject(updatedValue[0])) {
+								// TODO: Need to look the usage of object based diff param
+							}
+							break;
+					}
+				});
+
+				// Run all db operations in a batch
+				return dbTx.batch(promises);
+			})
+			.then(() => self.get({ address }, cb, tx))
+			.catch(err => {
+				library.logger.error(err.stack);
+				return setImmediate(cb, _.isString(err) ? err : 'Account#merge error');
+			});
+	}
+
+	/**
+	 * Removes an account from mem_account table based on address.
+	 * @param {address} address
+	 * @param {function} cb - Callback function.
+	 * @returns {setImmediateCallback} Data with address | Account#remove error.
+	 */
+	remove(address, cb) {
+		this.scope.db.accounts
+			.remove(address)
+			.then(() => setImmediate(cb, null, address))
+			.catch(err => {
+				library.logger.error(err.stack);
+				return setImmediate(cb, 'Account#remove error');
+			});
+	}
 }
 
+/**
+ * @typedef {Object} account
+ * @property {string} username - Lowercase, between 1 and 20 chars.
+ * @property {boolean} isDelegate
+ * @property {boolean} u_isDelegate
+ * @property {boolean} secondSignature
+ * @property {boolean} u_secondSignature
+ * @property {string} u_username
+ * @property {address} address - Uppercase, between 1 and 22 chars.
+ * @property {publicKey} publicKey
+ * @property {publicKey} secondPublicKey
+ * @property {number} balance - Between 0 and totalAmount from constants.
+ * @property {number} u_balance - Between 0 and totalAmount from constants.
+ * @property {number} vote
+ * @property {number} rate
+ * @property {String[]} delegates - From mem_account2delegates table, filtered by address.
+ * @property {String[]} u_delegates - From mem_account2u_delegates table, filtered by address.
+ * @property {String[]} multisignatures - From mem_account2multisignatures table, filtered by address.
+ * @property {String[]} u_multisignatures - From mem_account2u_multisignatures table, filtered by address.
+ * @property {number} multimin - Between 0 and 17.
+ * @property {number} u_multimin - Between 0 and 17.
+ * @property {number} multilifetime - Between 1 and 72.
+ * @property {number} u_multilifetime - Between 1 and 72.
+ * @property {string} blockId
+ * @property {boolean} nameexist
+ * @property {boolean} u_nameexist
+ * @property {number} producedblocks
+ * @property {number} missedblocks
+ * @property {number} fees
+ * @property {number} rewards
+ * @property {boolean} virgin
+ */
+// TODO: TO maintain backward compatibility, have to user prototype otherwise these must be converted to static attributes
+Account.prototype.table = 'mem_accounts';
+Account.prototype.model = [
+	{
+		name: 'username',
+		type: 'String',
+		conv: String,
+		immutable: true,
+	},
+	{
+		name: 'isDelegate',
+		type: 'SmallInt',
+		conv: Boolean,
+	},
+	{
+		name: 'u_isDelegate',
+		type: 'SmallInt',
+		conv: Boolean,
+	},
+	{
+		name: 'secondSignature',
+		type: 'SmallInt',
+		conv: Boolean,
+	},
+	{
+		name: 'u_secondSignature',
+		type: 'SmallInt',
+		conv: Boolean,
+	},
+	{
+		name: 'u_username',
+		type: 'String',
+		conv: String,
+		immutable: true,
+	},
+	{
+		name: 'address',
+		type: 'String',
+		conv: String,
+		immutable: true,
+		expression: 'UPPER(a.address)',
+	},
+	{
+		name: 'publicKey',
+		type: 'Binary',
+		conv: String,
+		immutable: true,
+		expression: 'ENCODE("publicKey", \'hex\')',
+	},
+	{
+		name: 'secondPublicKey',
+		type: 'Binary',
+		conv: String,
+		immutable: true,
+		expression: 'ENCODE("secondPublicKey", \'hex\')',
+	},
+	{
+		name: 'balance',
+		type: 'BigInt',
+		conv: Number,
+		expression: '("balance")::bigint',
+	},
+	{
+		name: 'u_balance',
+		type: 'BigInt',
+		conv: Number,
+		expression: '("u_balance")::bigint',
+	},
+	{
+		name: 'rate',
+		type: 'BigInt',
+		conv: Number,
+		expression: '("rate")::bigint',
+	},
+	{
+		name: 'delegates',
+		type: 'Text',
+		conv: Array,
+		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
+			this.table
+		}2delegates WHERE "accountId" = a."address")`,
+	},
+	{
+		name: 'u_delegates',
+		type: 'Text',
+		conv: Array,
+		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
+			this.table
+		}2u_delegates WHERE "accountId" = a."address")`,
+	},
+	{
+		name: 'multisignatures',
+		type: 'Text',
+		conv: Array,
+		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
+			this.table
+		}2multisignatures WHERE "accountId" = a."address")`,
+	},
+	{
+		name: 'u_multisignatures',
+		type: 'Text',
+		conv: Array,
+		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
+			this.table
+		}2u_multisignatures WHERE "accountId" = a."address")`,
+	},
+	{
+		name: 'multimin',
+		type: 'SmallInt',
+		conv: Number,
+	},
+	{
+		name: 'u_multimin',
+		type: 'SmallInt',
+		conv: Number,
+	},
+	{
+		name: 'multilifetime',
+		type: 'SmallInt',
+		conv: Number,
+	},
+	{
+		name: 'u_multilifetime',
+		type: 'SmallInt',
+		conv: Number,
+	},
+	{
+		name: 'blockId',
+		type: 'String',
+		conv: String,
+	},
+	{
+		name: 'nameexist',
+		type: 'SmallInt',
+		conv: Boolean,
+	},
+	{
+		name: 'u_nameexist',
+		type: 'SmallInt',
+		conv: Boolean,
+	},
+	{
+		name: 'fees',
+		type: 'BigInt',
+		conv: Number,
+		expression: '(a."fees")::bigint',
+	},
+	{
+		name: 'rank',
+		type: 'BigInt',
+		conv: Number,
+		expression:
+			'(SELECT m.row_number FROM (SELECT row_number() OVER (ORDER BY r."vote" DESC, r."publicKey" ASC), address FROM (SELECT d."isDelegate", d.vote, d."publicKey", d.address FROM mem_accounts AS d WHERE d."isDelegate" = 1) AS r) m WHERE m."address" = a."address")::int',
+	},
+	{
+		name: 'rewards',
+		type: 'BigInt',
+		conv: Number,
+		expression: '(a."rewards")::bigint',
+	},
+	{
+		name: 'vote',
+		type: 'BigInt',
+		conv: Number,
+		expression: '(a."vote")::bigint',
+	},
+	{
+		name: 'producedBlocks',
+		type: 'BigInt',
+		conv: Number,
+		expression: '(a."producedblocks")::bigint',
+	},
+	{
+		name: 'missedBlocks',
+		type: 'BigInt',
+		conv: Number,
+		expression: '(a."missedblocks")::bigint',
+	},
+	{
+		name: 'virgin',
+		type: 'SmallInt',
+		conv: Boolean,
+		immutable: true,
+	},
+	{
+		name: 'approval',
+		type: 'integer',
+		dependentFields: ['vote'],
+		computedField: true,
+	},
+	{
+		name: 'productivity',
+		type: 'integer',
+		dependentFields: ['producedBlocks', 'missedBlocks', 'rank'],
+		computedField: true,
+	},
+];
 Account.prototype.schema = {
 	id: 'Account',
 	type: 'object',
@@ -516,507 +1012,6 @@ Account.prototype.schema = {
 		},
 	},
 	required: ['address', 'balance', 'u_balance'],
-};
-
-// Public methods
-/**
- * Binds input parameters to private variables modules.
- * @param {Blocks} blocks
- */
-Account.prototype.bind = function(blocks) {
-	modules = {
-		blocks: blocks,
-	};
-};
-
-/**
- * Deletes the contents of these tables:
- * - mem_round
- * - mem_accounts2delegates
- * - mem_accounts2u_delegates
- * - mem_accounts2multisignatures
- * - mem_accounts2u_multisignatures
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} cb|error.
- */
-Account.prototype.resetMemTables = function(cb) {
-	this.scope.db.accounts
-		.resetMemTables()
-		.then(function() {
-			return setImmediate(cb);
-		})
-		.catch(function(err) {
-			library.logger.error(err.stack);
-			return setImmediate(cb, 'Account#resetMemTables error');
-		});
-};
-
-/**
- * Validates account schema.
- * @param {account} account
- * @returns {err|account} Error message or input parameter account.
- * @throws {string} If schema.validate fails, throws 'Failed to validate account schema'.
- */
-Account.prototype.objectNormalize = function(account) {
-	var report = this.scope.schema.validate(account, Account.prototype.schema);
-
-	if (!report) {
-		throw `Failed to validate account schema: ${this.scope.schema
-			.getLastErrors()
-			.map(function(err) {
-				var path = err.path.replace('#/', '').trim();
-				return [path, ': ', err.message, ' (', account[path], ')'].join('');
-			})
-			.join(', ')}`;
-	}
-
-	return account;
-};
-
-/**
- * Checks type, lenght and format from publicKey.
- * @param {publicKey} publicKey
- * @throws {string} throws one error for every check.
- */
-Account.prototype.verifyPublicKey = function(publicKey) {
-	if (publicKey !== undefined) {
-		// Check type
-		if (typeof publicKey !== 'string') {
-			throw 'Invalid public key, must be a string';
-		}
-		// Check length
-		if (publicKey.length !== 64) {
-			throw 'Invalid public key, must be 64 characters long';
-		}
-
-		if (!this.scope.schema.validate(publicKey, { format: 'hex' })) {
-			throw 'Invalid public key, must be a hex string';
-		}
-	}
-};
-
-/**
- * Normalizes address and creates binary buffers to insert.
- * @param {Object} raw - with address and public key.
- * @returns {Object} Normalized address.
- */
-Account.prototype.toDB = function(raw) {
-	this.binary.forEach(function(field) {
-		if (raw[field]) {
-			raw[field] = Buffer.from(raw[field], 'hex');
-		}
-	});
-
-	// Normalize address
-	raw.address = String(raw.address).toUpperCase();
-
-	return raw;
-};
-
-/**
- * Gets Multisignature account information for specified fields and filter criteria.
- * @param {Object} filter - Contains address.
- * @param {Object|function} fields - Table fields.
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} Returns null or Object with database data.
- */
-Account.prototype.getMultiSignature = function(filter, fields, cb, tx) {
-	if (typeof fields === 'function') {
-		tx = cb;
-		cb = fields;
-		fields = null;
-	}
-
-	filter.multisig = true;
-
-	this.get(filter, fields, cb, tx);
-};
-
-/**
- * Gets account information for specified fields and filter criteria.
- * @param {Object} filter - Contains address.
- * @param {Object|function} fields - Table fields.
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} Returns null or Object with database data.
- */
-Account.prototype.get = function(filter, fields, cb, tx) {
-	if (typeof fields === 'function') {
-		tx = cb;
-		cb = fields;
-		fields = null;
-	}
-
-	this.getAll(
-		filter,
-		fields,
-		function(err, data) {
-			return setImmediate(cb, err, data && data.length ? data[0] : null);
-		},
-		tx
-	);
-};
-
-/**
- * Gets accounts information from mem_accounts.
- * @param {Object} filter - Contains address.
- * @param {Object|function} fields - Table fields.
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} data with rows | 'Account#getAll error'.
- */
-Account.prototype.getAll = function(filter, fields, cb, tx) {
-	if (typeof fields === 'function') {
-		cb = fields;
-		fields = null;
-	}
-
-	var computedFields = {
-		approval: ['vote'],
-		productivity: ['producedBlocks', 'missedBlocks', 'rank'],
-	};
-
-	// If fields are not provided append computed fields
-	if (!fields) {
-		fields = this.scope.db.accounts.getDBFields();
-		fields = fields.concat(Object.keys(computedFields));
-	}
-
-	var fieldsAddedForComputation = [];
-	var performComputationFor = [];
-
-	Object.keys(computedFields).forEach(function(computedField) {
-		if (fields.indexOf(computedField) !== -1) {
-			// Add computed field to list to process later
-			performComputationFor.push(computedField);
-
-			// Remove computed field from the db fields list
-			fields.splice(fields.indexOf(computedField), 1);
-
-			// Marks fields which are explicitly added due to computation
-			fieldsAddedForComputation = fieldsAddedForComputation.concat(
-				_.difference(computedFields[computedField], fields)
-			);
-
-			// Add computation dependant fields to db fields list
-			fields = fields.concat(computedFields[computedField]);
-		}
-	});
-
-	var DEFAULT_LIMIT = constants.activeDelegates;
-	var limit = DEFAULT_LIMIT;
-	var offset = 0;
-	var sort = { sortField: '', sortMethod: '' };
-
-	if (filter.offset > 0) {
-		offset = filter.offset;
-	}
-	delete filter.offset;
-
-	if (filter.limit > 0) {
-		limit = filter.limit;
-	}
-	delete filter.limit;
-
-	if (filter.sort) {
-		var allowedSortFields = [
-			'username',
-			'balance',
-			'rank',
-			'missedBlocks',
-			'vote',
-			'publicKey',
-		];
-		sort = sortBy.sortBy(filter.sort, {
-			sortFields: allowedSortFields,
-			quoteField: false,
-		});
-	}
-	delete filter.sort;
-
-	var self = this;
-
-	(tx || this.scope.db).accounts
-		.list(filter, fields, {
-			limit: limit,
-			offset: offset,
-			sortField: sort.sortField,
-			sortMethod: sort.sortMethod,
-		})
-		.then(function(rows) {
-			var lastBlock = modules.blocks.lastBlock.get();
-			// If the last block height is undefined, it means it's a genesis block with height = 1
-			// look for a constant for total supply
-			var totalSupply = lastBlock.height
-				? __private.blockReward.calcSupply(lastBlock.height)
-				: 0;
-
-			if (performComputationFor.indexOf('approval') !== -1) {
-				rows.forEach(function(accountRow) {
-					accountRow.approval = self.calculateApproval(
-						accountRow.vote,
-						totalSupply
-					);
-				});
-			}
-
-			if (performComputationFor.indexOf('productivity') !== -1) {
-				rows.forEach(function(accountRow) {
-					accountRow.productivity = self.calculateProductivity(
-						accountRow.producedBlocks,
-						accountRow.missedBlocks
-					);
-				});
-			}
-
-			if (fieldsAddedForComputation.length > 0) {
-				// Remove the fields which were only added for computation
-				rows.forEach(function(accountRow) {
-					fieldsAddedForComputation.forEach(function(field) {
-						delete accountRow[field];
-					});
-				});
-			}
-
-			return setImmediate(cb, null, rows);
-		})
-		.catch(function(err) {
-			library.logger.error(err.stack);
-			return setImmediate(cb, 'Account#getAll error');
-		});
-};
-
-/**
- * Calculates productivity of a delegate account.
- * @param {String} votersBalance
- * @param {String} totalSupply
- * @returns {Number}
- */
-Account.prototype.calculateApproval = function(votersBalance, totalSupply) {
-	// votersBalance and totalSupply are sent as strings, we convert them into bignum and send the response as number as well.
-	var votersBalanceBignum = new Bignum(votersBalance || 0);
-	var totalSupplyBignum = new Bignum(totalSupply);
-	var approvalBignum = votersBalanceBignum
-		.dividedBy(totalSupplyBignum)
-		.times(100)
-		.round(2);
-	return !approvalBignum.isNaN() ? approvalBignum.toNumber() : 0;
-};
-
-/**
- * Calculates productivity of a delegate account.
- * @param {String} producedBlocks
- * @param {String} missedBlocks
- * @returns {Number}
- */
-Account.prototype.calculateProductivity = function(
-	producedBlocks,
-	missedBlocks
-) {
-	var producedBlocksBignum = new Bignum(producedBlocks || 0);
-	var missedBlocksBignum = new Bignum(missedBlocks || 0);
-	var percent = producedBlocksBignum
-		.dividedBy(producedBlocksBignum.plus(missedBlocksBignum))
-		.times(100)
-		.round(2);
-	return !percent.isNaN() ? percent.toNumber() : 0;
-};
-
-/**
- * Sets fields for specific address in mem_accounts table.
- * @param {address} address
- * @param {Object} fields
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} cb | 'Account#set error'.
- */
-Account.prototype.set = function(address, fields, cb, tx) {
-	// Verify public key
-	this.verifyPublicKey(fields.publicKey);
-
-	// Normalize address
-	fields.address = address;
-
-	(tx || this.scope.db).accounts
-		.upsert(fields, ['address'])
-		.then(function() {
-			return setImmediate(cb);
-		})
-		.catch(function(err) {
-			library.logger.error(err.stack);
-			return setImmediate(cb, 'Account#set error');
-		});
-};
-
-/**
- * Updates account from mem_account with diff data belonging to an editable field.
- * Inserts into mem_round "address", "amount", "delegate", "blockId", "round" based on balance or delegates fields.
- * @param {address} address
- * @param {Object} diff - Must contains only mem_account editable fields.
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback|cb|done} Multiple returns: done() or error.
- */
-Account.prototype.merge = function(address, diff, cb, tx) {
-	// Verify public key
-	this.verifyPublicKey(diff.publicKey);
-
-	// Normalize address
-	address = String(address).toUpperCase();
-
-	var self = this;
-
-	// If merge was called without any diff object
-	if (Object.keys(diff).length === 0) {
-		return self.get({ address: address }, cb, tx);
-	}
-
-	// Loop through each of updated attribute
-	(tx || self.scope.db)
-		.tx('logic:account:merge', function(dbTx) {
-			var promises = [];
-
-			Object.keys(diff).forEach(function(updatedField) {
-				// Return if updated field is not editable
-				if (self.editable.indexOf(updatedField) === -1) {
-					return;
-				}
-
-				// Get field data type
-				var fieldType = self.conv[updatedField];
-				var updatedValue = diff[updatedField];
-
-				// Make execution selection based on field type
-				switch (fieldType) {
-					// blockId
-					case String:
-						promises.push(
-							dbTx.accounts.update(address, _.pick(diff, [updatedField]))
-						);
-						break;
-
-					// [u_]balance, [u_]multimin, [u_]multilifetime, rate, fees, rank, rewards, votes, producedBlocks, missedBlocks
-					case Number:
-						if (isNaN(updatedValue) || updatedValue === Infinity) {
-							throw `Encountered insane number: ${updatedValue}`;
-						}
-
-						// If updated value is positive number
-						if (Math.abs(updatedValue) === updatedValue && updatedValue !== 0) {
-							promises.push(
-								dbTx.accounts.increment(
-									address,
-									updatedField,
-									Math.floor(updatedValue)
-								)
-							);
-
-							// If updated value is negative number
-						} else if (updatedValue < 0) {
-							promises.push(
-								dbTx.accounts.decrement(
-									address,
-									updatedField,
-									Math.floor(Math.abs(updatedValue))
-								)
-							);
-
-							// If money is taken out from an account so its an active account now.
-							if (updatedField === 'u_balance') {
-								promises.push(dbTx.accounts.update(address, { virgin: 0 }));
-							}
-						}
-
-						if (updatedField === 'balance') {
-							promises.push(
-								dbTx.rounds.insertRoundInformationWithAmount(
-									address,
-									diff.blockId,
-									diff.round,
-									updatedValue
-								)
-							);
-						}
-						break;
-
-					// [u_]delegates, [u_]multisignatures
-					case Array:
-						// If we received update as array of strings
-						if (_.isString(updatedValue[0])) {
-							updatedValue.forEach(function(updatedValueItem) {
-								// Fetch first character
-								var mode = updatedValueItem[0];
-								var dependentId = '';
-
-								if (mode === '-' || mode === '+') {
-									dependentId = updatedValueItem.slice(1);
-								} else {
-									dependentId = updatedValueItem;
-									mode = '+';
-								}
-
-								if (mode === '-') {
-									promises.push(
-										dbTx.accounts.removeDependencies(
-											address,
-											dependentId,
-											updatedField
-										)
-									);
-								} else {
-									promises.push(
-										dbTx.accounts.insertDependencies(
-											address,
-											dependentId,
-											updatedField
-										)
-									);
-								}
-
-								if (updatedField === 'delegates') {
-									promises.push(
-										dbTx.rounds.insertRoundInformationWithDelegate(
-											address,
-											diff.blockId,
-											diff.round,
-											dependentId,
-											mode
-										)
-									);
-								}
-							});
-							// If we received update as array of objects
-						} else if (_.isObject(updatedValue[0])) {
-							// TODO: Need to look the usage of object based diff param
-						}
-						break;
-				}
-			});
-
-			// Run all db operations in a batch
-			return dbTx.batch(promises);
-		})
-		.then(function() {
-			return self.get({ address: address }, cb, tx);
-		})
-		.catch(function(err) {
-			library.logger.error(err.stack);
-			return setImmediate(cb, _.isString(err) ? err : 'Account#merge error');
-		});
-};
-
-/**
- * Removes an account from mem_account table based on address.
- * @param {address} address
- * @param {function} cb - Callback function.
- * @returns {setImmediateCallback} Data with address | Account#remove error.
- */
-Account.prototype.remove = function(address, cb) {
-	this.scope.db.accounts
-		.remove(address)
-		.then(function() {
-			return setImmediate(cb, null, address);
-		})
-		.catch(function(err) {
-			library.logger.error(err.stack);
-			return setImmediate(cb, 'Account#remove error');
-		});
 };
 
 // Export

--- a/logic/account.js
+++ b/logic/account.js
@@ -674,71 +674,53 @@ Account.prototype.model = [
 		type: 'String',
 		conv: String,
 		immutable: true,
-		expression: 'UPPER(a.address)',
 	},
 	{
 		name: 'publicKey',
 		type: 'Binary',
 		conv: String,
 		immutable: true,
-		expression: 'ENCODE("publicKey", \'hex\')',
 	},
 	{
 		name: 'secondPublicKey',
 		type: 'Binary',
 		conv: String,
 		immutable: true,
-		expression: 'ENCODE("secondPublicKey", \'hex\')',
 	},
 	{
 		name: 'balance',
 		type: 'BigInt',
 		conv: Number,
-		expression: '("balance")::bigint',
 	},
 	{
 		name: 'u_balance',
 		type: 'BigInt',
 		conv: Number,
-		expression: '("u_balance")::bigint',
 	},
 	{
 		name: 'rate',
 		type: 'BigInt',
 		conv: Number,
-		expression: '("rate")::bigint',
 	},
 	{
 		name: 'delegates',
 		type: 'Text',
 		conv: Array,
-		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-			this.table
-		}2delegates WHERE "accountId" = a."address")`,
 	},
 	{
 		name: 'u_delegates',
 		type: 'Text',
 		conv: Array,
-		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-			this.table
-		}2u_delegates WHERE "accountId" = a."address")`,
 	},
 	{
 		name: 'multisignatures',
 		type: 'Text',
 		conv: Array,
-		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-			this.table
-		}2multisignatures WHERE "accountId" = a."address")`,
 	},
 	{
 		name: 'u_multisignatures',
 		type: 'Text',
 		conv: Array,
-		expression: `(SELECT ARRAY_AGG("dependentId") FROM ${
-			this.table
-		}2u_multisignatures WHERE "accountId" = a."address")`,
 	},
 	{
 		name: 'multimin',
@@ -779,38 +761,31 @@ Account.prototype.model = [
 		name: 'fees',
 		type: 'BigInt',
 		conv: Number,
-		expression: '(a."fees")::bigint',
 	},
 	{
 		name: 'rank',
 		type: 'BigInt',
 		conv: Number,
-		expression:
-			'(SELECT m.row_number FROM (SELECT row_number() OVER (ORDER BY r."vote" DESC, r."publicKey" ASC), address FROM (SELECT d."isDelegate", d.vote, d."publicKey", d.address FROM mem_accounts AS d WHERE d."isDelegate" = 1) AS r) m WHERE m."address" = a."address")::int',
 	},
 	{
 		name: 'rewards',
 		type: 'BigInt',
 		conv: Number,
-		expression: '(a."rewards")::bigint',
 	},
 	{
 		name: 'vote',
 		type: 'BigInt',
 		conv: Number,
-		expression: '(a."vote")::bigint',
 	},
 	{
 		name: 'producedBlocks',
 		type: 'BigInt',
 		conv: Number,
-		expression: '(a."producedblocks")::bigint',
 	},
 	{
 		name: 'missedBlocks',
 		type: 'BigInt',
 		conv: Number,
-		expression: '(a."missedblocks")::bigint',
 	},
 	{
 		name: 'virgin',

--- a/logic/account.js
+++ b/logic/account.js
@@ -505,7 +505,7 @@ class Account {
 
 								// If money is taken out from an account so its an active account now.
 								if (updatedField === 'u_balance') {
-									promises.push(dbTx.accounts.update(address, { virgin: 0 }));
+									promises.push(dbTx.accounts.convertToNonVirgin(address));
 								}
 							}
 

--- a/logic/account.js
+++ b/logic/account.js
@@ -28,14 +28,15 @@ const __private = {};
 
 /**
  * Main account logic.
+ *
  * @memberof module:accounts
  * @class
  * @classdesc Main account logic.
  * @param {Database} db
  * @param {ZSchema} schema
  * @param {Object} logger
- * @param {function} cb - Callback function.
- * @return {setImmediateCallback} With `this` as data.
+ * @param {function} cb - Callback function
+ * @return {setImmediateCallback} error, this
  */
 class Account {
 	constructor(db, schema, logger, cb) {
@@ -74,7 +75,7 @@ class Account {
 			return _tmp;
 		});
 
-		// Obtains bynary fields from model
+		// Obtains binary fields from model
 		this.binary = [];
 		this.model.forEach(field => {
 			if (field.type === 'Binary') {
@@ -102,6 +103,7 @@ class Account {
 	// Public methods
 	/**
 	 * Binds input parameters to private variables modules.
+	 *
 	 * @param {Blocks} blocks
 	 */
 	// eslint-disable-next-line class-methods-use-this
@@ -118,8 +120,9 @@ class Account {
 	 * - mem_accounts2u_delegates
 	 * - mem_accounts2multisignatures
 	 * - mem_accounts2u_multisignatures
-	 * @param {function} cb - Callback function.
-	 * @returns {setImmediateCallback} cb|error.
+	 *
+	 * @param {function} cb - Callback function
+	 * @returns {setImmediateCallback} error
 	 */
 	resetMemTables(cb) {
 		this.scope.db.accounts
@@ -133,9 +136,10 @@ class Account {
 
 	/**
 	 * Validates account schema.
+	 *
 	 * @param {account} account
-	 * @returns {err|account} Error message or input parameter account.
-	 * @throws {string} If schema.validate fails, throws 'Failed to validate account schema'.
+	 * @returns {account} account
+	 * @throws {string} On schema.validate failure
 	 */
 	objectNormalize(account) {
 		const report = this.scope.schema.validate(
@@ -158,8 +162,9 @@ class Account {
 
 	/**
 	 * Checks type, lenght and format from publicKey.
+	 *
 	 * @param {publicKey} publicKey
-	 * @throws {string} throws one error for every check.
+	 * @throws {string} On check failure
 	 */
 	verifyPublicKey(publicKey) {
 		if (publicKey !== undefined) {
@@ -180,8 +185,9 @@ class Account {
 
 	/**
 	 * Normalizes address and creates binary buffers to insert.
-	 * @param {Object} raw - with address and public key.
-	 * @returns {Object} Normalized address.
+	 *
+	 * @param {Object} raw - With address and public key
+	 * @returns {Object} Normalized address
 	 */
 	toDB(raw) {
 		this.binary.forEach(field => {
@@ -197,12 +203,13 @@ class Account {
 	}
 
 	/**
-	 * Gets Multisignature account information for specified fields and filter criteria.
-	 * @param {Object} filter - Contains address.
-	 * @param {Object|function} fields - Table fields.
-	 * @param {function} cb - Callback function.
-	 * @param {Object} tx - Database Transaction/Task Object
-	 * @returns {setImmediateCallback} Returns null or Object with database data.
+	 * Gets multisignature account information for specified fields and filter criteria.
+	 *
+	 * @param {Object} filter - Contains address
+	 * @param {Object|function} fields - Table fields
+	 * @param {function} cb - Callback function
+	 * @param {Object} tx - Database transaction/task object
+	 * @returns {setImmediateCallback} error, object|null
 	 */
 	getMultiSignature(filter, fields, cb, tx) {
 		if (typeof fields === 'function') {
@@ -218,11 +225,12 @@ class Account {
 
 	/**
 	 * Gets account information for specified fields and filter criteria.
-	 * @param {Object} filter - Contains address.
-	 * @param {Object|function} fields - Table fields.
-	 * @param {function} cb - Callback function.
-	 * @param {Object} tx - Database Transaction/Task Object
-	 * @returns {setImmediateCallback} Returns null or Object with database data.
+	 *
+	 * @param {Object} filter - Contains address
+	 * @param {Object|function} fields - Table fields
+	 * @param {function} cb - Callback function
+	 * @param {Object} tx - Database transaction/task object
+	 * @returns {setImmediateCallback} error, account|null
 	 */
 	get(filter, fields, cb, tx) {
 		if (typeof fields === 'function') {
@@ -242,11 +250,12 @@ class Account {
 
 	/**
 	 * Gets accounts information from mem_accounts.
-	 * @param {Object} filter - Contains address.
-	 * @param {Object|function} fields - Table fields.
-	 * @param {function} cb - Callback function.
-	 * @param {Object} tx - Database Transaction/Task Object
-	 * @returns {setImmediateCallback} data with rows | 'Account#getAll error'.
+	 *
+	 * @param {Object} filter - Contains address
+	 * @param {Object|function} fields - Table fields
+	 * @param {function} cb - Callback function
+	 * @param {Object} tx - Database transaction/task object
+	 * @returns {setImmediateCallback} error, accounts
 	 */
 	getAll(filter, fields, cb, tx) {
 		if (typeof fields === 'function') {
@@ -370,13 +379,15 @@ class Account {
 
 	/**
 	 * Calculates productivity of a delegate account.
+	 *
 	 * @param {String} votersBalance
 	 * @param {String} totalSupply
 	 * @returns {Number}
 	 */
 	// eslint-disable-next-line class-methods-use-this
 	calculateApproval(votersBalance, totalSupply) {
-		// votersBalance and totalSupply are sent as strings, we convert them into bignum and send the response as number as well.
+		// votersBalance and totalSupply are sent as strings,
+		// we convert them into bignum and send the response as number as well
 		const votersBalanceBignum = new Bignum(votersBalance || 0);
 		const totalSupplyBignum = new Bignum(totalSupply);
 		const approvalBignum = votersBalanceBignum
@@ -388,6 +399,7 @@ class Account {
 
 	/**
 	 * Calculates productivity of a delegate account.
+	 *
 	 * @param {String} producedBlocks
 	 * @param {String} missedBlocks
 	 * @returns {Number}
@@ -405,11 +417,12 @@ class Account {
 
 	/**
 	 * Sets fields for specific address in mem_accounts table.
+	 *
 	 * @param {address} address
 	 * @param {Object} fields
-	 * @param {function} cb - Callback function.
-	 * @param {Object} tx - Database Transaction/Task Object
-	 * @returns {setImmediateCallback} cb | 'Account#set error'.
+	 * @param {function} cb - Callback function
+	 * @param {Object} tx - Database transaction/task object
+	 * @returns {setImmediateCallback} error
 	 */
 	set(address, fields, cb, tx) {
 		// Verify public key
@@ -430,11 +443,12 @@ class Account {
 	/**
 	 * Updates account from mem_account with diff data belonging to an editable field.
 	 * Inserts into mem_round "address", "amount", "delegate", "blockId", "round" based on balance or delegates fields.
+	 *
 	 * @param {address} address
-	 * @param {Object} diff - Must contains only mem_account editable fields.
-	 * @param {function} cb - Callback function.
-	 * @param {Object} tx - Database Transaction/Task Object
-	 * @returns {setImmediateCallback|cb|done} Multiple returns: done() or error.
+	 * @param {Object} diff - Must contains only mem_account editable fields
+	 * @param {function} cb - Callback function
+	 * @param {Object} tx - Database transaction/task object
+	 * @returns {setImmediateCallback} error
 	 */
 	merge(address, diff, cb, tx) {
 		// Verify public key
@@ -503,7 +517,7 @@ class Account {
 									)
 								);
 
-								// If money is taken out from an account so its an active account now.
+								// Withdrawal, therefore convert to non-virgin account
 								if (updatedField === 'u_balance') {
 									promises.push(dbTx.accounts.convertToNonVirgin(address));
 								}
@@ -569,7 +583,7 @@ class Account {
 								});
 								// If we received update as array of objects
 							} else if (_.isObject(updatedValue[0])) {
-								// TODO: Need to look the usage of object based diff param
+								// TODO: Need to look at usage of object based diff param
 							}
 							break;
 					}
@@ -587,9 +601,10 @@ class Account {
 
 	/**
 	 * Removes an account from mem_account table based on address.
+	 *
 	 * @param {address} address
-	 * @param {function} cb - Callback function.
-	 * @returns {setImmediateCallback} Data with address | Account#remove error.
+	 * @param {function} cb - Callback function
+	 * @returns {setImmediateCallback} error, address
 	 */
 	remove(address, cb) {
 		this.scope.db.accounts
@@ -604,27 +619,27 @@ class Account {
 
 /**
  * @typedef {Object} account
- * @property {string} username - Lowercase, between 1 and 20 chars.
+ * @property {string} username - Lowercase, between 1 and 20 chars
  * @property {boolean} isDelegate
  * @property {boolean} u_isDelegate
  * @property {boolean} secondSignature
  * @property {boolean} u_secondSignature
  * @property {string} u_username
- * @property {address} address - Uppercase, between 1 and 22 chars.
+ * @property {address} address - Uppercase, between 1 and 22 chars
  * @property {publicKey} publicKey
  * @property {publicKey} secondPublicKey
- * @property {number} balance - Between 0 and totalAmount from constants.
- * @property {number} u_balance - Between 0 and totalAmount from constants.
+ * @property {number} balance - Between 0 and totalAmount from constants
+ * @property {number} u_balance - Between 0 and totalAmount from constants
  * @property {number} vote
  * @property {number} rate
- * @property {String[]} delegates - From mem_account2delegates table, filtered by address.
- * @property {String[]} u_delegates - From mem_account2u_delegates table, filtered by address.
- * @property {String[]} multisignatures - From mem_account2multisignatures table, filtered by address.
- * @property {String[]} u_multisignatures - From mem_account2u_multisignatures table, filtered by address.
- * @property {number} multimin - Between 0 and 17.
- * @property {number} u_multimin - Between 0 and 17.
- * @property {number} multilifetime - Between 1 and 72.
- * @property {number} u_multilifetime - Between 1 and 72.
+ * @property {String[]} delegates - From mem_account2delegates table, filtered by address
+ * @property {String[]} u_delegates - From mem_account2u_delegates table, filtered by address
+ * @property {String[]} multisignatures - From mem_account2multisignatures table, filtered by address
+ * @property {String[]} u_multisignatures - From mem_account2u_multisignatures table, filtered by address
+ * @property {number} multimin - Between 0 and 17
+ * @property {number} u_multimin - Between 0 and 17
+ * @property {number} multilifetime - Between 1 and 72
+ * @property {number} u_multilifetime - Between 1 and 72
  * @property {string} blockId
  * @property {boolean} nameexist
  * @property {boolean} u_nameexist
@@ -636,6 +651,7 @@ class Account {
  */
 // TODO: TO maintain backward compatibility, have to user prototype otherwise these must be converted to static attributes
 Account.prototype.table = 'mem_accounts';
+
 Account.prototype.model = [
 	{
 		name: 'username',
@@ -806,6 +822,7 @@ Account.prototype.model = [
 		computedField: true,
 	},
 ];
+
 Account.prototype.schema = {
 	id: 'Account',
 	type: 'object',

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 		"browserify-bignum": "=1.3.0-2",
 		"chai": "=4.0.2",
 		"chai-bignumber": "=2.0.0",
+		"co-mocha": "=1.2.1",
 		"coveralls": "=2.13.1",
 		"csv": "=1.1.1",
 		"eslint": "=4.16.0",

--- a/test/setup.js
+++ b/test/setup.js
@@ -14,11 +14,15 @@
 'use strict';
 
 require('colors');
+var mocha = require('mocha');
+var coMocha = require('co-mocha');
 var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
 var supertest = require('supertest');
 var _ = require('lodash');
+
+coMocha(mocha);
 
 process.env.NODE_ENV = 'test';
 

--- a/test/unit/db/repos/accounts.js
+++ b/test/unit/db/repos/accounts.js
@@ -901,6 +901,24 @@ describe('db', () => {
 					});
 				});
 			});
+
+			describe('convertToNonVirgin', () => {
+				it('should convert a virgin account to non virgin', function*() {
+					const account = accountFixtures.Account();
+					let result = null;
+
+					yield db.accounts.insert(account);
+					result = yield db.accounts.list({ address: account.address });
+
+					expect(result[0].address).to.eql(account.address);
+					expect(result[0].virgin).to.eql(true);
+
+					yield db.accounts.convertToNonVirgin(account.address);
+					result = yield db.accounts.list({ address: account.address });
+					expect(result[0].address).to.eql(account.address);
+					expect(result[0].virgin).to.eql(false);
+				});
+			});
 		});
 	});
 });

--- a/test/unit/db/repos/accounts.js
+++ b/test/unit/db/repos/accounts.js
@@ -602,7 +602,7 @@ describe('db', () => {
 					var account = accountFixtures.Account();
 
 					return db.accounts.upsert(account, 'address').then(result => {
-						expect(result).to.be.null;
+						expect(result).to.be.undefined;
 					});
 				});
 


### PR DESCRIPTION
### What was the problem?
Whenever we try to update any account for any attribute it was including **virgin** in update SQL. We have a DB trigger that protects any change in **virgin** attribute once its set to 0. Due to that unwanted update for **virgin** attribute we were having log message from database. 

### How did I fix it?
I found the occurrence of the code where we actually convert an account to non-vrigin explicitly 

https://github.com/LiskHQ/lisk/blob/7da23971ae74a6f57ba274c215efbb6e06da5817/logic/account.js#L921-L923

And converted this call to a special method in db repo for account and removed virgin attribute from update column set. 

### How to test it?

Start the app, while applying genesis block, look for warning messages 
> WARNING:  Reverting change of virgin from 0 to 1

If you don't see this warning then the issue would be fixed 😄 

### Review checklist

* The PR solves #1504
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated