### PR TITLE
Enable eslint rules with zero errors - Closes #1515

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,6 @@
 		"lines-around-directive": "off",
 		"max-len": "off",
 		"new-cap": "off",
-		"newline-per-chained-call": "off",
 		"no-bitwise": "off",
 		"no-console": "off",
 		"no-else-return": "off",
@@ -44,7 +43,18 @@
 		"prefer-destructuring": "off",
 		"prefer-rest-params": "off",
 		"radix": "off",
-		"require-jsdoc": "off",
+		"require-jsdoc": [
+			"error",
+			{
+				"require": {
+					"FunctionDeclaration": false,
+					"MethodDefinition": false,
+					"ClassDeclaration": false,
+					"ArrowFunctionExpression": false,
+					"FunctionExpression": false
+				}
+			}
+		],
 		"strict": "off",
 		"space-before-function-paren": ["error", "never"],
 		"vars-on-top": "off",


### PR DESCRIPTION
### What was the problem?
Eslint rules with zero error were disabled.
### How did I fix it?
Enabled the rules with zero error and for `require-jsdoc` specifically turned off all the required flag for now, once @Tschakki fixes the #1333 issue we can enable appropriate flags. 
### How to test it?
`npm run lint` should not throw any errors or warnings.
### Review checklist

* The PR solves #1515 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
