### PR TITLE
Fixing SQL environment config + debug flag - Closes #1511

### DIFF
--- a/db/sql/README.md
+++ b/db/sql/README.md
@@ -44,8 +44,11 @@ Try to avoid needlessly repeating in the file name the name of the repository th
 ## Development Notes
 
 When editing an SQL file on the development machine, you do not need to restart the application in order
-to see the immediate change. The development environment is configured to detect any change, and reload
-the SQL file immediately. This feature is provided automatically by the [QueryFile] class (option `debug`).
+to see the immediate change. Class [QueryFile] automatically detects changes and reloads the SQL file
+immediately, if its option `debug` is set.
+
+Option `debug` defaults to `true` when your `NODE_ENV` is set to a name that contains `dev` in it,
+case-insensitive. Otherwise, SQL-auto-reload feature is disabled.
 
 [index variables]: https://github.com/vitaly-t/pg-promise#index-variables
 [named parameters]: https://github.com/vitaly-t/pg-promise#named-parameters

--- a/db/sql/config.js
+++ b/db/sql/config.js
@@ -16,13 +16,7 @@
 const QueryFile = require('pg-promise').QueryFile;
 const path = require('path');
 
-// Check if we are in development environment:
-const isDev = __dirname.endsWith('db/sql');
-
-// Full path to the SQL folder, depending on the packaging:
-// - production expects ./sql folder at its root;
-// - development expects sql in this very folder.
-const sqlRoot = isDev ? __dirname : path.join(__dirname, './sql');
+const sqlRoot = __dirname;
 
 /////////////////////////////////////////
 // Provides dynamic link to an SQL file:
@@ -31,7 +25,6 @@ function link(file) {
 
 	const options = {
 		minify: true, // Minifies the SQL
-		debug: isDev, // Debug SQL when in Dev environment
 	};
 
 	const qf = new QueryFile(fullPath, options);


### PR DESCRIPTION
Closes #1511

---

Since the app is no longer packaged, there is no more point in trying to detect what environment it is in, so we just use the default.

We also start relying on `NODE_ENV` containing `dev` in it, to auto-activate the `debug` functionality within `pg-promise`. 

The way that `pg-promise` itself detects the development environment: https://github.com/vitaly-t/pg-promise/blob/master/lib/utils/index.js#L41
