### PR TITLE
Set api limit to 101 as maximum - Closes #1500

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -517,8 +517,15 @@ paths:
         - $ref: '#/parameters/publicKey'
         - $ref: '#/parameters/secondPublicKey'
         - $ref: '#/parameters/username'
-        - $ref: '#/parameters/limit'
         - $ref: '#/parameters/offset'
+        - name: limit
+          in: query
+          description: Limit applied to results
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 101
+          default: 10
         - name: search
           in: query
           description: Fuzzy delegate username to query

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -46,12 +46,12 @@ describe('GET /delegates', () => {
 			var data = [];
 
 			return delegatesEndpoint
-				.makeRequest({ limit: 100 }, 200)
+				.makeRequest({ limit: 101 }, 200)
 				.then(res => {
 					data = res.body.data;
 
 					return delegatesEndpoint.makeRequest(
-						{ offset: 100, limit: 100 },
+						{ offset: 101, limit: 101 },
 						200
 					);
 				})
@@ -307,9 +307,9 @@ describe('GET /delegates', () => {
 
 			it('using higher limit should return 101 delegates', () => {
 				return delegatesEndpoint
-					.makeRequest({ search: 'genesis_', limit: 100 }, 200)
+					.makeRequest({ search: 'genesis_', limit: 101 }, 200)
 					.then(res => {
-						expect(res.body.data).to.have.length(100);
+						expect(res.body.data).to.have.length(101);
 						res.body.data.map(d => {
 							expect(/^genesis_.*/.test(d.username)).to.be.true;
 						});
@@ -461,13 +461,13 @@ describe('GET /delegates', () => {
 			});
 
 			it('using limit=101 should be ok', () => {
-				return delegatesEndpoint.makeRequest({ limit: 100 }, 200).then(res => {
-					expect(res.body.data).to.have.length(100);
+				return delegatesEndpoint.makeRequest({ limit: 101 }, 200).then(res => {
+					expect(res.body.data).to.have.length(101);
 				});
 			});
 
-			it('using limit > 100 should fail', () => {
-				return delegatesEndpoint.makeRequest({ limit: 101 }, 400).then(res => {
+			it('using limit > 101 should fail', () => {
+				return delegatesEndpoint.makeRequest({ limit: 102 }, 400).then(res => {
 					expectSwaggerParamError(res, 'limit');
 				});
 			});

--- a/test/functional/system/blocks/chain.delete_last_block.js
+++ b/test/functional/system/blocks/chain.delete_last_block.js
@@ -12,6 +12,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
 'use strict';
 
 var expect = require('chai').expect;


### PR DESCRIPTION
### How did I fix it?

Change Swagger specifications. It affects to the next endpoints: GET blocks, dapps, delegates and transactions.

### How to test it?

`npm test -- mocha:untagged:functional:get`

### Review checklist

* The PR solves #1500
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
