### PR TITLE
404 should respect Accept header - Closes #1110

### DIFF
--- a/config/swagger.js
+++ b/config/swagger.js
@@ -109,6 +109,19 @@ function bootstrapSwagger(app, config, logger, scope, cb) {
 		// To be used in test cases or getting configuration runtime
 		app.swaggerRunner = runner;
 
+		// Managing all the queries which were not caught by previous middlewares.
+		app.use((req, res, next) => {
+			// We need to check if the response is already handled by some other middlewares/fittings/controllers
+			// In case not, we consider it as 404 and send default response
+			// res.headersSent is a patch, and only works if above middlewares set some header no matter the status code
+			// Another possible workaround would be res.bodySize === 0
+			if (!res.headersSent) {
+				res.status(404);
+				res.json({ description: 'Page not found' });
+			}
+			next();
+		});
+
 		swaggerHelper
 			.getResolvedSwaggerSpec()
 			.then(resolvedSchema => {

--- a/test/common/helpers/api.js
+++ b/test/common/helpers/api.js
@@ -117,6 +117,13 @@ function httpResponseCallbackHelper(cb, err, res) {
 	cb(null, res);
 }
 
+function getNotFoundEndpoint(cb) {
+	http.get(
+		'/api/not_found_endpoint',
+		httpResponseCallbackHelper.bind(null, cb)
+	);
+}
+
 function getTransactionById(transactionId, cb) {
 	// Get transactionById uses the same /api/transactions endpoint, this is just a helper function
 	http.get(
@@ -382,6 +389,7 @@ var getForgedByAccountPromise = Promise.promisify(getForgedByAccount);
 var getForgersPromise = Promise.promisify(getForgers);
 var getAccountsPromise = Promise.promisify(getAccounts);
 var getBlocksPromise = Promise.promisify(getBlocks);
+var getNotFoundEndpointPromise = Promise.promisify(getNotFoundEndpoint);
 
 module.exports = {
 	getTransactionByIdPromise,
@@ -418,4 +426,5 @@ module.exports = {
 	expectSwaggerParamError,
 	createSignatureObject,
 	normalizeTransactionObject,
+	getNotFoundEndpointPromise,
 };

--- a/test/functional/http/get/cache.js
+++ b/test/functional/http/get/cache.js
@@ -53,7 +53,7 @@ describe('cached endpoints', () => {
 		cache.quit(done);
 	});
 
-	describe('GET /transactions', () => {
+	describe('GET /transactions @unstable', () => {
 		var transactionsEndpoint = new swaggerEndpoint('GET /transactions');
 
 		it('cache transactions by the url and parameters when response is a success', () => {

--- a/test/functional/http/get/error_404.js
+++ b/test/functional/http/get/error_404.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+require('../../functional.js');
+var apiHelpers = require('../../../common/helpers/api');
+
+describe('GET /unknown_endpoint', () => {
+	it('should fail with error 404', () => {
+		return apiHelpers.getNotFoundEndpointPromise().then(res => {
+			expect(res.error).is.not.empty;
+			expect(res.error.status).to.equal(404);
+			expect(res.body.description).to.equal('Page not found');
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

Swagger middleware silently ends the response. Therefore Express is not aware of an error in the middleware.

### How did I fix it?

Adding a check after middleware's execution, where we check if the response has been already handled. In case not, we consider it as 404 and send default response.

### How to test it?

`mocha test/functional/http/get/error_404.js`

### Review checklist

* The PR solves #1110
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
