### PR TITLE
Ignore non-constructibles when requiring all from db/repos - Closes #1541

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -30,7 +30,9 @@ let initOptions = {
 	// API: http://vitaly-t.github.io/pg-promise/global.html#event:extend
 	extend: object => {
 		Object.keys(repos).forEach(repoName => {
-			object[repoName] = new repos[repoName](object, pgp);
+			if (!!repos[repoName].prototype && !!repos[repoName].prototype.constructor.name) {
+				object[repoName] = new repos[repoName](object, pgp);
+			}
 		});
 	},
 };


### PR DESCRIPTION
### What was the problem?

Adding files to `db/repos` which are not valid database repository modules caused an unexpected error when starting the application.

### How did I fix it?

By ignoring non-constructibles when requiring all from db/repos.

### How to test it?

Add a non constructible module to `db/repos` and the start the application, e.g. an empty `index.js` file. The application should start without any fatal errors.

### Review checklist

* The PR solves #1541
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated