### PR TITLE
Add "round ticks" (forwards/backwards) to the same promise chain as Chain.prototype.saveBlock - Closes #1297

### DIFF
--- a/logic/account.js
+++ b/logic/account.js
@@ -495,10 +495,7 @@ class Account {
 						}
 
 						// If updated value is positive number
-						if (
-							Math.abs(updatedValue) === updatedValue &&
-							updatedValue !== 0
-						) {
+						if (Math.abs(updatedValue) === updatedValue && updatedValue !== 0) {
 							promises.push(
 								dbTx.accounts.increment(
 									address,

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -109,9 +109,10 @@ Accounts.prototype.getAccount = function(filter, fields, cb, tx) {
  * @param {Object} filter
  * @param {Object} fields
  * @param {function} cb - Callback function.
+ * @param {Object} tx - Database transaction/task object
  */
-Accounts.prototype.getAccounts = function(filter, fields, cb) {
-	library.logic.account.getAll(filter, fields, cb);
+Accounts.prototype.getAccounts = function(filter, fields, cb, tx) {
+	library.logic.account.getAll(filter, fields, cb, tx);
 };
 
 /**

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -479,7 +479,16 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 						library.bus.message('newBlock', block);
 
 						// DATABASE write. Update delegates accounts
-						modules.rounds.tick(block, resolve);
+						modules.rounds.tick(
+							block,
+							err => {
+								if (err) {
+									return reject(err);
+								}
+								return resolve();
+							},
+							tx
+						);
 					},
 					tx
 				);
@@ -487,7 +496,16 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 				library.bus.message('newBlock', block);
 
 				// DATABASE write. Update delegates accounts
-				modules.rounds.tick(block, resolve);
+				modules.rounds.tick(
+					block,
+					err => {
+						if (err) {
+							return reject(err);
+						}
+						return resolve();
+					},
+					tx
+				);
 			}
 		});
 	};

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -89,7 +89,7 @@ function Delegates(cb, scope) {
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback}
  */
-__private.getKeysSortByVote = function(cb) {
+__private.getKeysSortByVote = function(cb, tx) {
 	modules.accounts.getAccounts(
 		{
 			isDelegate: 1,
@@ -102,7 +102,8 @@ __private.getKeysSortByVote = function(cb) {
 				return setImmediate(cb, err);
 			}
 			return setImmediate(cb, null, rows.map(el => el.publicKey));
-		}
+		},
+		tx
 	);
 };
 
@@ -112,8 +113,8 @@ __private.getKeysSortByVote = function(cb) {
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback}
  */
-__private.getDelegatesFromPreviousRound = function(cb) {
-	library.db.rounds
+__private.getDelegatesFromPreviousRound = function(cb, tx) {
+	(tx || library.db).rounds
 		.getDelegatesSnapshot(slots.delegates)
 		.then(rows => {
 			var delegatesPublicKeys = [];
@@ -625,7 +626,7 @@ Delegates.prototype.toggleForgingStatus = function(publicKey, secretKey, cb) {
  * @param {function} cb - Callback function.
  * @returns {setImmediateCallback} err | truncated delegate list
  */
-Delegates.prototype.generateDelegateList = function(height, source, cb) {
+Delegates.prototype.generateDelegateList = function(height, source, cb, tx) {
 	// Set default function for getting delegates
 	source = source || __private.getKeysSortByVote;
 
@@ -654,7 +655,7 @@ Delegates.prototype.generateDelegateList = function(height, source, cb) {
 		}
 
 		return setImmediate(cb, null, truncDelegateList);
-	});
+	}, tx);
 };
 
 /**

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -87,6 +87,7 @@ function Delegates(cb, scope) {
  * Gets delegate public keys sorted by vote descending.
  * @private
  * @param {function} cb - Callback function.
+ * @param {Object} tx - Database transaction/task object
  * @returns {setImmediateCallback}
  */
 __private.getKeysSortByVote = function(cb, tx) {
@@ -111,6 +112,7 @@ __private.getKeysSortByVote = function(cb, tx) {
  * Gets delegate public keys from previous round, sorted by vote descending.
  * @private
  * @param {function} cb - Callback function.
+ * @param {Object} tx - Database transaction/task object
  * @returns {setImmediateCallback}
  */
 __private.getDelegatesFromPreviousRound = function(cb, tx) {
@@ -624,6 +626,7 @@ Delegates.prototype.toggleForgingStatus = function(publicKey, secretKey, cb) {
  * @param {number} height
  * @param {function} source - Source function for get delegates.
  * @param {function} cb - Callback function.
+ * @param {Object} tx - Database transaction/task object
  * @returns {setImmediateCallback} err | truncated delegate list
  */
 Delegates.prototype.generateDelegateList = function(height, source, cb, tx) {

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -399,8 +399,6 @@ __private.sumRound = function(scope, cb, tx) {
 	(tx || library.db).rounds
 		.summedRound(scope.round, constants.activeDelegates)
 		.then(rows => {
-			console.log('QUERY: ' + rows);
-			console.log('QUERY: ' + rows[0].delegates.length);
 			var rewards = [];
 
 			rows[0].rewards.forEach(reward => {

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -189,6 +189,7 @@ Rounds.prototype.setSnapshotRound = function(round) {
  * @implements {__private.getOutsiders}
  * @param {block} block - Current block.
  * @param {function} done - Callback function.
+ * @param {Object} tx - Database transaction/task object
  * @return {function} Calling done with error if any.
  */
 Rounds.prototype.tick = function(block, done, tx) {
@@ -349,6 +350,7 @@ Rounds.prototype.cleanup = function(cb) {
  * @implements {modules.accounts.generateAddressByPublicKey}
  * @param {scope} scope
  * @param {function} cb
+ * @param {Object} tx - Database transaction/task object
  * @return {setImmediateCallback}
  */
 __private.getOutsiders = function(scope, cb, tx) {
@@ -391,6 +393,7 @@ __private.getOutsiders = function(scope, cb, tx) {
  * @implements {library.db.query}
  * @param {number} round
  * @param {function} cb
+ * @param {Object} tx - Database transaction/task object
  * @return {setImmediateCallback}
  */
 __private.sumRound = function(scope, cb, tx) {

--- a/test/common/ws/server_process.js
+++ b/test/common/ws/server_process.js
@@ -93,7 +93,8 @@ WSServer.prototype.start = function() {
 					.callsArgWith(1, null, { success: true, common: null }),
 			});
 
-			self.socketClient.start()
+			self.socketClient
+				.start()
 				.then(resolve)
 				.catch(() => {
 					reject();

--- a/test/unit/modules/blocks/utils.js
+++ b/test/unit/modules/blocks/utils.js
@@ -295,7 +295,9 @@ describe('blocks/utils', () => {
 
 			blocksUtilsModule.loadBlocksPart({}, () => {
 				expect(blocksUtilsModule.readDbRows).to.have.been.calledOnce;
-				expect(blocksUtilsModule.readDbRows).to.have.been.calledWith(fullBlocksListRows);
+				expect(blocksUtilsModule.readDbRows).to.have.been.calledWith(
+					fullBlocksListRows
+				);
 				done();
 			});
 		});
@@ -493,9 +495,7 @@ describe('blocks/utils', () => {
 				expect(err).to.be.null;
 				expect(sequence).to.be.an('object');
 				expect(sequence.firstHeight).to.equal(1);
-				expect(sequence.ids).to.equal(
-					'9314232245035524467,1'
-				);
+				expect(sequence.ids).to.equal('9314232245035524467,1');
 				library.genesisblock = genesisblock;
 				done();
 			});
@@ -513,9 +513,7 @@ describe('blocks/utils', () => {
 				expect(err).to.be.null;
 				expect(sequence).to.be.an('object');
 				expect(sequence.firstHeight).to.equal(1);
-				expect(sequence.ids).to.equal(
-					'9314232245035524467,1'
-				);
+				expect(sequence.ids).to.equal('9314232245035524467,1');
 				library.genesisblock.block = block;
 				done();
 			});
@@ -548,9 +546,7 @@ describe('blocks/utils', () => {
 				expect(err).to.be.null;
 				expect(sequence).to.be.an('object');
 				expect(sequence.firstHeight).to.equal(1);
-				expect(sequence.ids).to.equal(
-					'6524861224470851795'
-				);
+				expect(sequence.ids).to.equal('6524861224470851795');
 				done();
 			});
 		});
@@ -624,15 +620,15 @@ describe('blocks/utils', () => {
 		});
 
 		it('should return one row when called with valid id', done => {
-			blocksUtilsModule.loadBlocksData({ id: '13068833527549895884' }, (
-				err,
-				blocks
-			) => {
-				expect(err).to.be.null;
-				expect(blocks).to.be.an('array');
-				expect(blocks[0].b_id).to.eql('13068833527549895884');
-				done();
-			});
+			blocksUtilsModule.loadBlocksData(
+				{ id: '13068833527549895884' },
+				(err, blocks) => {
+					expect(err).to.be.null;
+					expect(blocks).to.be.an('array');
+					expect(blocks[0].b_id).to.eql('13068833527549895884');
+					done();
+				}
+			);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
Round tick was called from outside of `Chain:applyBlock` SQL transaction.
### How did I fix it?
Pass `tx` handler all the way from `Chain:applyBlock`.

### How to test it?
Run app, wait for end of a round, check `lisk_db.log` file.

### Review checklist

* The PR solves https://github.com/LiskHQ/lisk/issues/1297
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
