### PR TITLE
Extend chai with assertions about promises - Closes #1553

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"bitcore-mnemonic": "=1.2.5",
 		"browserify-bignum": "=1.3.0-2",
 		"chai": "=4.0.2",
+		"chai-as-promised": "=7.1.1",
 		"chai-bignumber": "=2.0.0",
 		"co-mocha": "=1.2.1",
 		"coveralls": "=2.13.1",

--- a/test/setup.js
+++ b/test/setup.js
@@ -18,6 +18,7 @@ require('colors');
 var mocha = require('mocha');
 var coMocha = require('co-mocha');
 var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
 var supertest = require('supertest');
@@ -28,6 +29,7 @@ coMocha(mocha);
 process.env.NODE_ENV = 'test';
 
 chai.use(sinonChai);
+chai.use(chaiAsPromised);
 
 var testContext = {};
 


### PR DESCRIPTION
### What was the problem?
In order to reduce boilerplate for making assertions on promises.
### How did I fix it?
Introducing `chai-as-promised` middleware for making assertions on promises.
### How to test it?
When writing test against function which returns promise we can use
```
return doSomethingAsync().should.eventually.equal("foo");
```
or
```
doSomethingAsync().should.eventually.equal("foo").notify(done);
```
### Review checklist

* The PR solves #1553 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
