### PR TITLE
Change Jenkinsfile.migration to allow snake_case or camelCase - Closes #1474

### DIFF
--- a/Jenkinsfile.migration
+++ b/Jenkinsfile.migration
@@ -24,19 +24,26 @@ pipeline {
 					git url: "https://github.com/LiskHQ/lisk.git", branch: params.MIGRATE_TO
 				}
 				sh """
+				json_files_copy() {
+					case \$1 in
+						0*)
+							cp test/config.json .
+							cp test/genesisBlock.json .
+							;;
+						*)
+							cp test/data/config.json .
+							cp test/data/genesis_block.json .
+							;;
+					esac
+				}
+
 				dropdb lisk_test || true
 				createdb lisk_test
 				cd "${params.MIGRATE_FROM}"
-				cd test
-				find . -iname config.json -exec cp {} .. \;
-				find . -iname genesis\*lock.json -exec cp {} .. \;
-				cd ..
+				json_files_copy "${params.MIGRATE_FROM}"
 				npm install
 				cd "../${params.MIGRATE_TO}"
-				cd test
-				find . -iname config.json -exec cp {} .. \;
-				find . -iname genesis\*lock.json -exec cp {} .. \;
-				cd ..
+				json_files_copy "${params.MIGRATE_TO}"
 				npm install
 				sudo service postgresql restart
 				"""

--- a/Jenkinsfile.migration
+++ b/Jenkinsfile.migration
@@ -27,12 +27,16 @@ pipeline {
 				dropdb lisk_test || true
 				createdb lisk_test
 				cd "${params.MIGRATE_FROM}"
-				cp test/config.json .
-				cp test/genesis_block.json .
+				cd test
+				find . -iname config.json -exec cp {} .. \;
+				find . -iname genesis\*lock.json -exec cp {} .. \;
+				cd ..
 				npm install
 				cd "../${params.MIGRATE_TO}"
-				cp test/data/config.json .
-				cp test/data/genesis_block.json .
+				cd test
+				find . -iname config.json -exec cp {} .. \;
+				find . -iname genesis\*lock.json -exec cp {} .. \;
+				cd ..
 				npm install
 				sudo service postgresql restart
 				"""


### PR DESCRIPTION
### What was the problem?
Jenkinsfile.migration was looking for files named in snake_case, irrespective of branch version.

### How did I fix it?
Uses find and a wildcard. Instead of looking for genesis_block.json or genesisBlock.json, it looks for genesis*lock.json Similar deal for config.json - whether it lives in test/config.json or test/data/config.json. This should allow the copy to work for any two branches irrespective of version.

### How to test it?
I ran a replay job where I made this change

### Review checklist
* The PR solves #1474 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated