### PR TITLE
Jenkins runs produce excessive console output - Closes #1468

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,8 +122,8 @@ var config = {
  * @property {Object} - Logger instance.
  */
 var logger = new Logger({
-	echo: appConfig.consoleLogLevel,
-	errorLevel: appConfig.fileLogLevel,
+	echo: process.env.LOG_LEVEL || appConfig.consoleLogLevel,
+	errorLevel: process.env.FILE_LOG_LEVEL || appConfig.fileLogLevel,
 	filename: appConfig.logFileName,
 });
 
@@ -136,8 +136,8 @@ if (
 	dbLogger = logger;
 } else {
 	dbLogger = new Logger({
-		echo: appConfig.db.consoleLogLevel || appConfig.consoleLogLevel,
-		errorLevel: appConfig.db.fileLogLevel || appConfig.fileLogLevel,
+		echo: process.env.DB_LOG_LEVEL || appConfig.db.consoleLogLevel,
+		errorLevel: process.env.FILE_LOG_LEVEL || appConfig.db.fileLogLevel,
 		filename: appConfig.db.logFileName,
 	});
 }

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -4,9 +4,9 @@
 	"address": "0.0.0.0",
 	"version": "0.0.1",
 	"minVersion": ">=0.0.0",
-	"fileLogLevel": "debug",
+	"fileLogLevel": "error",
 	"logFileName": "logs/lisk.log",
-	"consoleLogLevel": "info",
+	"consoleLogLevel": "none",
 	"trustProxy": false,
 	"topAccounts": false,
 	"cacheEnabled": true,
@@ -21,14 +21,7 @@
 		"max": 9,
 		"poolIdleTimeout": 30000,
 		"reapIntervalMillis": 1000,
-		"logEvents": [
-			"connect",
-			"disconnect",
-			"query",
-			"task",
-			"transact",
-			"error"
-		],
+		"logEvents": ["error"],
 		"logFileName": "logs/lisk_db.log"
 	},
 	"redis": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --timeout 1200s
 --exit
+--reporter min
 --require ./test/setup.js

--- a/test/setup.js
+++ b/test/setup.js
@@ -41,6 +41,22 @@ if (process.env.SILENT === 'true') {
 	testContext.debug = console.info;
 }
 
+if (process.env.LOG_DB_EVENTS === 'true') {
+	testContext.config.db.logEvents = [
+		'connect',
+		'disconnect',
+		'query',
+		'task',
+		'transact',
+		'error',
+	];
+} else {
+	testContext.config.db.logEvents = ['error'];
+}
+
+testContext.consoleLogLevel =
+	process.env.LOG_LEVEL || testContext.consoleLogLevel;
+
 testContext.baseUrl = `http://${testContext.config.address}:${
 	testContext.config.httpPort
 }`;


### PR DESCRIPTION
### What was the problem?
Default log level for the test was set to `debug` and all the DB log events were enabled, which results in huge console logs on the local machine while running test and importantly at Jenkins producing lots of logs.

### How did I fix it?
First changing the console log level from `debug` to `none` and DB log events to `error` only.
for customized logs, we can enable the log level and DB log events by setting the environment variables as follows.

For console logs set env variable `export LOG_LEVEL=debug` or `export LOG_LEVEL=info` whichever preferred according to ones need.

For DB log events `export LOG_DB_EVENTS=true` or `export LOG_DB_EVENTS=false` 

For file logs `export FILE_LOG_LEVEL=debug` or `export FILE_LOG_LEVEL=info` 

### How to test it?
```
LOG_LEVEL=debug LOG_DB_EVENTS=true npm run test -- mocha:untagged:unit
```

### Review checklist
* The PR solves #1468 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
