### PR TITLE
Enable log level and log db events env variables in jenkins - Closes #1576

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,8 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 		parameters([
 			string(name: 'JENKINS_PROFILE', defaultValue: 'jenkins', description: 'To build cache dependencies and run slow tests, change this value to jenkins-extensive.', ),
 			string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
-			string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', )
+			string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', ),
+			string(name: 'SILENT', defaultValue: 'true', description: 'To turn off test debug logs.', )
 		 ])
 	])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,9 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 
 	properties([
 		parameters([
-			string(name: 'JENKINS_PROFILE', defaultValue: 'jenkins', description: 'To build cache dependencies and run slow tests, change this value to jenkins-extensive.', )
+			string(name: 'JENKINS_PROFILE', defaultValue: 'jenkins', description: 'To build cache dependencies and run slow tests, change this value to jenkins-extensive.', ),
+			string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
+			string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', )
 		 ])
 	])
 

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -39,7 +39,6 @@ node('node-06') {
 
 		properties([
 			parameters([
-				string(name: 'JENKINS_PROFILE', defaultValue: 'jenkins', description: 'To build cache dependencies and run slow tests, change this value to jenkins-extensive.', ),
 				string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
 				string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', )
 			 ])

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -36,6 +36,15 @@ def cleanUp() {
 
 node('node-06') {
 	lock(resource: "core-integration-tests", inversePrecedence: true) {
+
+		properties([
+			parameters([
+				string(name: 'JENKINS_PROFILE', defaultValue: 'jenkins', description: 'To build cache dependencies and run slow tests, change this value to jenkins-extensive.', ),
+				string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
+				string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', )
+			 ])
+		])
+
 		stage('Prepare workspace') {
 			try {
 				deleteDir()

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -40,7 +40,8 @@ node('node-06') {
 		properties([
 			parameters([
 				string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
-				string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', )
+				string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', ),
+				string(name: 'SILENT', defaultValue: 'true', description: 'To turn off test debug logs.', )
 			 ])
 		])
 


### PR DESCRIPTION
### What was the problem?
Jenkins runs with default LOG_LEVEL which is error and default LOG_DB_EVENTS which is false, if we want to run a build with specific log level it's not possible at the moment.
### How did I fix it?
`LOG_LEVEL` and `LOG_DB_EVENTS` are build parameter included as build parameter with default values.
### How to test it?
Once this PR is merged you can log into Jenkins and when you click on build with parameter, you should be able to see `LOG_LEVEL` and `LOG_DB_EVENTS` build parameters.
### Review checklist

* The PR solves #1576 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
