### PR TITLE
Update mocha reporter to default - Closes #1582

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --timeout 1200s
 --exit
---reporter min
 --require ./test/setup.js


### PR DESCRIPTION
### What was the problem?
The `min` reporter displays the summary only, this reporter clears the terminal in order to keep the test summary at the top, due to which observations becomes difficult.
### How did I fix it?
Removed the `min` reporter from mocha opts so that mocha uses default `spec` reporter.
### How to test it?
`npm run test -- mocha:untagged:unit`
### Review checklist

* The PR solves #1582 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
