### PR TITLE
Don't log 'Failed to load delegates' message when active delegate(s) are forging - Closes #1506

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -874,11 +874,10 @@ Delegates.prototype.onBlockchainReady = function() {
 	__private.loaded = true;
 
 	__private.loadDelegates(err => {
+		if (err) {
+			library.logger.error('Failed to load delegates', err);
+		}
 		function nextForge(cb) {
-			if (err) {
-				library.logger.error('Failed to load delegates', err);
-			}
-
 			async.series([__private.forge, modules.transactions.fillPool], () =>
 				setImmediate(cb)
 			);

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -203,7 +203,7 @@ __private.getBlockSlotData = function(slot, height, cb) {
 __private.forge = function(cb) {
 	if (!Object.keys(__private.keypairs).length) {
 		library.logger.debug('No delegates enabled');
-		return __private.loadDelegates(cb);
+		return setImmediate(cb);
 	}
 
 	// When client is not loaded, is syncing or round is ticking


### PR DESCRIPTION
### What was the problem?
1. the error of no delegates being loaded ('Failed to load delegates') was visible even when delegates were actually actively forging on Node. 
2. when __private.keypairs is empty during every second forge loop, reload the delegates from library.config immutable variable takes place.

### How did I fix it?
1. Error is being logged one time only
2. Forge process ends without reloading delegates attempt when there is an empty keypairs list.
### How to test it?
Run the node without secrets and see if "Failed to load delegates" is being logged only once.
### Review checklist

* The PR solves #1506
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
