### PR TITLE
Exporting pg-promise root object

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -21,10 +21,10 @@
 
 const Promise = require('bluebird');
 const monitor = require('pg-monitor');
-let pgp = require('pg-promise');
+const pgpLib = require('pg-promise');
 const repos = require('./repos');
 
-// TODO: Had to change it from 'const' into 'let' because of the nasty 'rewire' hacks inside DBSandbox.js.
+// TODO: Had to change below from 'const' into 'let' because of the nasty 'rewire' hacks inside DBSandbox.js.
 // eslint-disable-next-line prefer-const
 let initOptions = {
 	pgNative: true,
@@ -40,7 +40,7 @@ let initOptions = {
 	},
 };
 
-pgp = pgp(initOptions);
+const pgp = pgpLib(initOptions);
 
 /**
  * @module db
@@ -50,6 +50,13 @@ pgp = pgp(initOptions);
  * @requires db/repos/*
  * @see Parent: {@link db}
  */
+
+/**
+ * Initialized root of pg-promise library, to give access to its complete API.
+ *
+ * @property {Object} pgp
+ */
+module.exports.pgp = pgp;
 
 /**
  * Connects to the database.


### PR DESCRIPTION
...so that the rest of the library's API becomes accessible.

This is a quick update, following [this comment](https://github.com/LiskHQ/lisk/issues/538#issuecomment-366558427), so the `spex` sub-module becomes easily accessible:

```js
const spex = require('./db').pgp.spex;

// now can use spex.sequence or any other methods.
```
