### PR TITLE
Make mocha test output more readable - Closes #1585

### DIFF
--- a/test/common/parallel_tests.js
+++ b/test/common/parallel_tests.js
@@ -90,6 +90,8 @@ function parallelTests(tag, suite, section) {
 			'--dir',
 			'test/.coverage-unit',
 			'--include-pid',
+			'--print',
+			'none',
 			'node_modules/.bin/_mocha',
 			test,
 		];

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --timeout 1200s
 --exit
+--colors
 --require ./test/setup.js


### PR DESCRIPTION
### What was the problem?
The test report shows coverage output and the reports don't highlight the status of the tests and which makes it harder to read.
### How did I fix it?
Turn off the coverage report print output and enable colours option for the mocha report.
### How to test it?
Run `npm run test -- mocha:untagged:unit` to see only mocha report output with colors option.
### Review checklist

* The PR solves #1585 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
