### PR TITLE
Change blocks/signatures/transactions from RPC to broadcasts - Closes #1505

### DIFF
--- a/api/ws/transport.js
+++ b/api/ws/transport.js
@@ -36,6 +36,9 @@ function TransportWSApi(transportModule) {
 		getTransactions: transportModule.shared.getTransactions,
 		getSignatures: transportModule.shared.getSignatures,
 		status: transportModule.shared.status,
+	});
+
+	wsRPC.getServer().registerEventEndpoints({
 		postBlock: transportModule.shared.postBlock,
 		postSignatures: transportModule.shared.postSignatures,
 		postTransactions: transportModule.shared.postTransactions,

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -198,23 +198,14 @@ Broadcaster.prototype.broadcast = function(params, options, cb) {
 				if (params.limit === self.config.peerLimit) {
 					peers = peers.slice(0, self.config.broadcastLimit);
 				}
+
 				async.eachLimit(
 					peers,
 					self.config.parallelLimit,
-					(peer, eachLimitCb) => {
-						peer.rpc[options.api](options.data, err => {
-							if (err) {
-								library.logger.debug(
-									`Failed to broadcast to peer: ${peer.string}`,
-									err
-								);
-							}
-							return setImmediate(eachLimitCb);
-						});
-					},
-					err => {
+					peer => peer.rpc[options.api](options.data),
+					() => {
 						library.logger.debug('End broadcast');
-						return setImmediate(waterCb, err, peers);
+						return setImmediate(waterCb, null, peers);
 					}
 				);
 			},

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -549,9 +549,9 @@ Transport.prototype.shared = {
 	 * @todo Add @returns tag
 	 * @todo Add description of the function
 	 */
-	postBlock(query, cb) {
+	postBlock(query) {
 		query = query || {};
-		var block;
+		let block;
 		try {
 			if (query.block) {
 				query.block = bson.deserialize(Buffer.from(query.block));
@@ -566,13 +566,9 @@ Transport.prototype.shared = {
 			});
 
 			__private.removePeer({ peer: query.peer, code: 'EBLOCK' });
-
-			return setImmediate(cb, e.toString());
 		}
 
 		library.bus.message('receiveBlock', block);
-
-		return setImmediate(cb, null, { success: true, blockId: block.id });
 	},
 
 	/**

--- a/test/functional/ws/transport/blocks.js
+++ b/test/functional/ws/transport/blocks.js
@@ -17,33 +17,8 @@
 require('../../functional.js');
 var ws = require('../../../common/ws/communication');
 var genesisblock = require('../../../data/genesis_block.json');
-var verify = require('../../../../modules/blocks/verify');
-var bson = require('../../../../helpers/bson');
 
 describe('WS transport blocks', () => {
-	var testBlock = {
-		id: '2807833455815592401',
-		version: 0,
-		timestamp: 39997040,
-		height: 1258,
-		previousBlock: '3863141986505461614',
-		numberOfTransactions: 0,
-		transactions: [],
-		totalAmount: 0,
-		totalFee: 0,
-		reward: 0,
-		payloadLength: 0,
-		payloadHash:
-			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-		generatorPublicKey:
-			'bf9f5cfc548d29983cc0dfa5c4ec47c66c31df0f87aa669869678996902ab47f',
-		generatorId: '9950029393097476480L',
-		blockSignature:
-			'd54ac91d2f712f408e16ff5057f7ceaa2e3a1ad4bde759e1025b16ec48bdd8ea1d3adaf5e8b94ef205f9f365f6ebae0f178a3cb3f6354c28e74ba7a05fce600c',
-		confirmations: 2,
-		totalForged: '0',
-	};
-
 	describe('blocks', () => {
 		it('using valid headers should be ok', done => {
 			ws.call('blocks', null, (err, res) => {
@@ -257,60 +232,6 @@ describe('WS transport blocks', () => {
 					done();
 				}
 			);
-		});
-	});
-
-	describe('postBlock', () => {
-		it('using no block should fail', done => {
-			ws.call('postBlock', (err, res) => {
-				__testContext.debug(
-					'> Error / Response:'.grey,
-					JSON.stringify(err),
-					JSON.stringify(res)
-				);
-				expect(err).to.contain('Failed to validate block schema');
-				done();
-			});
-		});
-
-		it('using invalid block schema should fail', done => {
-			var blockSignature = genesisblock.blockSignature;
-			genesisblock.blockSignature = null;
-			genesisblock = verify.prototype.deleteBlockProperties(genesisblock);
-
-			ws.call(
-				'postBlock',
-				{ block: bson.serialize(genesisblock) },
-				(err, res) => {
-					__testContext.debug(
-						'> Error / Response:'.grey,
-						JSON.stringify(err),
-						JSON.stringify(res)
-					);
-					expect(err).to.contain('Failed to validate block schema');
-					genesisblock.blockSignature = blockSignature;
-					done();
-				}
-			);
-		});
-
-		it('using valid block schema should be ok', done => {
-			testBlock.transactions.forEach(transaction => {
-				if (transaction.asset && transaction.asset.delegate) {
-					transaction.asset.delegate.publicKey = transaction.senderPublicKey;
-				}
-			});
-			ws.call('postBlock', { block: bson.serialize(testBlock) }, (err, res) => {
-				__testContext.debug(
-					'> Error / Response:'.grey,
-					JSON.stringify(err),
-					JSON.stringify(res)
-				);
-				expect(res)
-					.to.have.property('blockId')
-					.to.equal('2807833455815592401');
-				done();
-			});
 		});
 	});
 });

--- a/test/functional/ws/transport/transactions.js
+++ b/test/functional/ws/transport/transactions.js
@@ -58,12 +58,14 @@ describe('Posting transaction (type 0)', () => {
 			postTransaction(transaction, () => {
 				done();
 			});
+			badTransactions.push(transaction);
 		});
 
 		it('when sender has funds should be ok', done => {
 			postTransaction(transaction, () => {
 				done();
 			});
+			goodTransactions.push(transaction);
 		});
 	});
 

--- a/test/functional/ws/transport/transactions.js
+++ b/test/functional/ws/transport/transactions.js
@@ -15,11 +15,11 @@
 'use strict';
 
 require('../../functional.js');
-var lisk = require('lisk-js');
-var phases = require('../../common/phases');
-var ws = require('../../../common/ws/communication');
-var randomUtil = require('../../../common/utils/random');
-var normalizeTransactionObject = require('../../../common/helpers/api')
+const lisk = require('lisk-js');
+const phases = require('../../common/phases');
+const ws = require('../../../common/ws/communication');
+const randomUtil = require('../../../common/utils/random');
+const normalizeTransactionObject = require('../../../common/helpers/api')
 	.normalizeTransactionObject;
 
 function postTransaction(transaction, cb) {
@@ -30,62 +30,40 @@ function postTransaction(transaction, cb) {
 		{
 			transactions: [transaction],
 		},
-		cb,
+		() => {},
 		true
 	);
+	cb();
 }
 
 describe('Posting transaction (type 0)', () => {
-	var account;
-	var transaction;
-	var error;
-	var response;
-	var goodTransactions = [];
-	var badTransactions = [];
+	let transaction;
+	const goodTransactions = [];
+	const badTransactions = [];
+	const account = randomUtil.account();
 
 	beforeEach(done => {
-		account = randomUtil.account();
 		transaction = randomUtil.transaction();
 		done();
 	});
 
-	describe('when sender has no funds for a transaction in batch', () => {
-		beforeEach(done => {
+	describe('transaction processing', () => {
+		it('when sender has no funds should fail', done => {
 			transaction = lisk.transaction.createTransaction(
 				'1L',
 				1,
 				account.password
 			);
-			postTransaction(transaction, (err, res) => {
-				error = err;
-				response = res;
+
+			postTransaction(transaction, () => {
 				done();
 			});
 		});
 
-		// For peer-to-peer communiation, the peer does not need to send back
-		// an error message if one of the transactions in the batch fails.
-		// Either the peer acknowledges the receipt of the batch or their don't.
-		it('operation should succeed', () => {
-			badTransactions.push(transaction);
-			expect(error).to.be.null;
-			return expect(response).to.have.property('success').to.be.ok;
-		});
-	});
-
-	describe('when sender has funds for a transaction in batch', () => {
-		beforeEach(done => {
-			postTransaction(transaction, (err, res) => {
-				error = err;
-				response = res;
+		it('when sender has funds should be ok', done => {
+			postTransaction(transaction, () => {
 				done();
 			});
-		});
-
-		it('operation should succeed', () => {
-			goodTransactions.push(transaction);
-			expect(error).to.be.null;
-			return expect(response).to.have.property('success').to.be.ok;
 		});
 	});
 

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -320,17 +320,13 @@ describe('transport', () => {
 		describe('receiveSignatures', () => {
 			describe('for every signature in signatures', () => {
 				describe('when __private.receiveSignature succeeds', () => {
-					var error;
-
 					beforeEach(done => {
 						__private.receiveSignature = sinonSandbox.stub().callsArg(1);
-						__private.receiveSignatures(
-							[SAMPLE_SIGNATURE_1, SAMPLE_SIGNATURE_2],
-							err => {
-								error = err;
-								done();
-							}
-						);
+						__private.receiveSignatures([
+							SAMPLE_SIGNATURE_1,
+							SAMPLE_SIGNATURE_2,
+						]);
+						done();
 					});
 
 					it('should call __private.receiveSignature with signature', () => {
@@ -341,14 +337,9 @@ describe('transport', () => {
 							__private.receiveSignature.calledWith(SAMPLE_SIGNATURE_2)
 						).to.be.true;
 					});
-
-					it('should call callback with error null', () => {
-						return expect(error).to.equal(null);
-					});
 				});
 
 				describe('when __private.receiveSignature fails', () => {
-					var error;
 					var receiveSignatureError;
 
 					beforeEach(done => {
@@ -356,13 +347,11 @@ describe('transport', () => {
 						__private.receiveSignature = sinonSandbox
 							.stub()
 							.callsArgWith(1, receiveSignatureError);
-						__private.receiveSignatures(
-							[SAMPLE_SIGNATURE_1, SAMPLE_SIGNATURE_2],
-							err => {
-								error = err;
-								done();
-							}
-						);
+						__private.receiveSignatures([
+							SAMPLE_SIGNATURE_1,
+							SAMPLE_SIGNATURE_2,
+						]);
+						done();
 					});
 
 					it('should call library.logger.debug with err and signature', () => {
@@ -381,10 +370,6 @@ describe('transport', () => {
 								SAMPLE_SIGNATURE_2
 							)
 						).to.be.true;
-					});
-
-					it('should call callback with error set to null', () => {
-						return expect(error).to.equal(null);
 					});
 				});
 			});

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -526,36 +526,27 @@ describe('transport', () => {
 
 			describe('for every transaction in transactions', () => {
 				describe('when transactions argument is undefined', () => {
-					var error;
-
 					beforeEach(done => {
-						__private.receiveTransactions(undefined, peerStub, '', err => {
-							error = err;
-							done();
-						});
+						__private.receiveTransactions(undefined, peerStub, '');
+						done();
 					});
 
 					// If a single transaction within the batch fails, it is not going to
 					// send back an error.
-					it('should call callback with null error', () => {
-						return expect(error).to.equal(null);
+					it('should should not call __private.receiveTransaction', () => {
+						return expect(__private.receiveTransaction.notCalled).to.be.true;
 					});
 				});
 
 				describe('when transaction is defined', () => {
 					describe('when call __private.receiveTransaction succeeds', () => {
-						var error;
-
 						beforeEach(done => {
 							__private.receiveTransactions(
 								transactions,
 								peerStub,
-								'This is a log message',
-								err => {
-									error = err;
-									done();
-								}
+								'This is a log message'
 							);
+							done();
 						});
 
 						it('should set transaction.bundled = true', () => {
@@ -573,14 +564,9 @@ describe('transport', () => {
 								)
 							).to.be.true;
 						});
-
-						it('should call callback with error = null', () => {
-							return expect(error).to.equal(null);
-						});
 					});
 
 					describe('when call __private.receiveTransaction fails', () => {
-						var error;
 						var receiveTransactionError;
 
 						beforeEach(done => {
@@ -592,12 +578,9 @@ describe('transport', () => {
 							__private.receiveTransactions(
 								transactions,
 								peerStub,
-								'This is a log message',
-								err => {
-									error = err;
-									done();
-								}
+								'This is a log message'
 							);
+							done();
 						});
 
 						it('should call library.logger.debug with error and transaction', () => {
@@ -607,12 +590,6 @@ describe('transport', () => {
 									transactions[0]
 								)
 							).to.be.true;
-						});
-
-						// If a single transaction within the batch fails, it is not going to
-						// send back an error.
-						it('should call callback with null error', () => {
-							return expect(error).to.equal(null);
 						});
 					});
 				});


### PR DESCRIPTION
### What was the problem?
Entries accepting data to the system should not return any response on P2P layer.

### How did I fix it?
- transactions
- blocks
- signatures

endpoints are implemented in publish (broadcast) style using `wamp-socket-cluster`.
### How to test it?
Integration test
### Review checklist

* The PR solves #1505
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
