### PR TITLE
Add JSDoc styleguide to contribution guidelines - Closes #1609

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ propose changes to this document in a pull request.
 1. [Styleguides](#styleguides)
    1. [Git Commit Messages](#git-commit-messages)
    1. [JavaScript Styleguide](#javascript-styleguide)
-   1. [Code documentation Styleguide](#code-documentation-styleguide)
+   1. [Code Documentation Styleguide](#code-documentation-styleguide)
 
 ## Code of Conduct
 
@@ -246,7 +246,7 @@ On Lisk we are using [Prettier](https://prettier.io/) and
 some opinions not covered by Prettier’s formatting concerns. You can get more
 details here: https://github.com/LiskHQ/eslint-config-lisk-base
 
-### Code documentation Styleguide
+### Code Documentation Styleguide
 
 For code documentation, we use [JSDoc](http://usejsdoc.org/).
 With JSDoc you can generate a static HTML documentation site.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ propose changes to this document in a pull request.
 1. [Styleguides](#styleguides)
    1. [Git Commit Messages](#git-commit-messages)
    1. [JavaScript Styleguide](#javascript-styleguide)
-   1. [JSDoc Styleguide](#jsdoc-styleguide)
+   1. [Code documentation Styleguide](#code-documentation-styleguide)
 
 ## Code of Conduct
 
@@ -246,22 +246,17 @@ On Lisk we are using [Prettier](https://prettier.io/) and
 some opinions not covered by Prettier’s formatting concerns. You can get more
 details here: https://github.com/LiskHQ/eslint-config-lisk-base
 
-These contribution guidelines were inspired by and are based on Atom’s
-contribution guidelines. They were modified for the purposes of this repository.
-https://github.com/atom/atom/blob/master/CONTRIBUTING.md - Copyright (c)
-2011-2017 GitHub Inc. (MIT)
-
-### JSDoc Styleguide
+### Code documentation Styleguide
 
 For code documentation, we use [JSDoc](http://usejsdoc.org/).
-You can generate a HTML documentation out of it.
-Navigate to the projects folder and run:
+With JSDoc you can generate a static HTML documentation site.
+To build the documentation site, run the following command:
 
 ```
 npm run docs:build
 ```
 
-To access the documentation via browser, use the following command:
+To host the documentation site (e.g. for easy access via a browser), use the following command:
 
 ```
 npm run docs:serve
@@ -274,24 +269,31 @@ If tags follow, leave a blank line between the description and the tags.
 
 **Tags to use:**
 
-| Tag          | When to use                                                             |
-| ------------ | ----------------------------------------------------------------------- |
-| `@class`     | Describes the constructor of a class.                                   |
-| `@event`     | Describes an event, that the app is listening to.                       |
-| `@example`   | If convenient, provide an example.                                      |
-| `@func`      | Only if JSDoc does not recognize the code as a function, but it is one. |
-| `@link`      | To add inline links.                                                    |
-| `@memberof`  | To describe child-parent hierarchies.                                   |
-| `@module`    | When a module is exported and it is not a `@class`.                     |
-| `@namespace` | To describe a parent folder or object.                                  |
-| `@param`     | Always when a function expects a param.                                 |
-| `@private`   | For private functions.                                                  |
-| `@property`  | Describes the property of an object.                                    |
-| `@requires`  | Describes the modules required by a class or module.                    |
-| `@returns`   | Always when a function returns something.                               |
-| `@see`       | To add additional information, e.g. about the parent.                   |
-| `@throws`    | When an error can be thrown.                                            |
-| `@todo`      | If there are open todos for the following code.                         |
-| `@typedef`   | To describe custom types.                                               |
+| Tag          | When to use                                                                             |
+| ------------ | --------------------------------------------------------------------------------------- |
+| `@class`     | Describes the constructor of a class.                                                   |
+| `@event`     | Describes an event, that the app is listening to.                                       |
+| `@example`   | If convenient, provide an example.                                                      |
+| `@func`      | Only if JSDoc does not recognize the code as a function, but it is one.                 |
+| `@link`      | Adds internal or external inline links.                                                 |
+| `@memberof`  | Describes child-parent hierarchies. Usable for code tagged as `@class` or `@namespace`. |
+| `@module`    | When a module is exported and it is not a `@class`.                                     |
+| `@namespace` | Describes a parent folder or object.                                                    |
+| `@param`     | **Required** for each parameter of a function.                                          |
+| `@private`   | For private functions.                                                                  |
+| `@property`  | Describes the property of an object.                                                    |
+| `@requires`  | Describes the modules required by a class or module.                                    |
+| `@returns`   | **Required** for all functions with an explicit return statement.                       |
+| `@see`       | Adds additional information, e.g. about the parent.                                     |
+| `@throws`    | When an error can be thrown.                                                            |
+| `@todo`      | If there are open todos for the following code.                                         |
+| `@typedef`   | For defining custom types to be used in other JSDoc blocks.                             |
 
-For examples please have a look in the code.
+For examples please have a look in the existing code.
+
+---
+
+These contribution guidelines were inspired by and are based on Atom’s
+contribution guidelines. They were modified for the purposes of this repository.
+https://github.com/atom/atom/blob/master/CONTRIBUTING.md - Copyright (c)
+2011-2017 GitHub Inc. (MIT)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,6 +22,7 @@ propose changes to this document in a pull request.
 1. [Styleguides](#styleguides)
    1. [Git Commit Messages](#git-commit-messages)
    1. [JavaScript Styleguide](#javascript-styleguide)
+   1. [JSDoc Styleguide](#jsdoc-styleguide)
 
 ## Code of Conduct
 
@@ -249,3 +250,48 @@ These contribution guidelines were inspired by and are based on Atom’s
 contribution guidelines. They were modified for the purposes of this repository.
 https://github.com/atom/atom/blob/master/CONTRIBUTING.md - Copyright (c)
 2011-2017 GitHub Inc. (MIT)
+
+### JSDoc Styleguide
+
+For code documentation, we use [JSDoc](http://usejsdoc.org/).
+You can generate a HTML documentation out of it.
+Navigate to the projects folder and run:
+
+```
+npm run docs:build
+```
+
+To access the documentation via browser, use the following command:
+
+```
+npm run docs:serve
+```
+
+If you add or change code, please always provide or update the corresponding code documentation.
+
+**Always mandatory:** A general description of what the code is doing.
+If tags follow, leave a blank line between the description and the tags.
+
+**Tags to use:**
+
+| Tag          | When to use                                                             |
+| ------------ | ----------------------------------------------------------------------- |
+| `@class`     | Describes the constructor of a class.                                   |
+| `@event`     | Describes an event, that the app is listening to.                       |
+| `@example`   | If convenient, provide an example.                                      |
+| `@func`      | Only if JSDoc does not recognize the code as a function, but it is one. |
+| `@link`      | To add inline links.                                                    |
+| `@memberof`  | To describe child-parent hierarchies.                                   |
+| `@module`    | When a module is exported and it is not a `@class`.                     |
+| `@namespace` | To describe a parent folder or object.                                  |
+| `@param`     | Always when a function expects a param.                                 |
+| `@private`   | For private functions.                                                  |
+| `@property`  | Describes the property of an object.                                    |
+| `@requires`  | Describes the modules required by a class or module.                    |
+| `@returns`   | Always when a function returns something.                               |
+| `@see`       | To add additional information, e.g. about the parent.                   |
+| `@throws`    | When an error can be thrown.                                            |
+| `@todo`      | If there are open todos for the following code.                         |
+| `@typedef`   | To describe custom types.                                               |
+
+For examples please have a look in the code.


### PR DESCRIPTION
### What was the problem?
A styleguide for code documentation was missing in the contribution guidelines.

### How did I fix it?
Add a styleguide.

### Review checklist

* The PR solves #1609 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
