### PR TITLE
Change blocks/signatures/transactions from RPC to broadcasts - Fixes #1505

### DIFF
--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -199,15 +199,11 @@ Broadcaster.prototype.broadcast = function(params, options, cb) {
 					peers = peers.slice(0, self.config.broadcastLimit);
 				}
 
-				async.eachLimit(
-					peers,
-					self.config.parallelLimit,
-					peer => peer.rpc[options.api](options.data),
-					() => {
-						library.logger.debug('End broadcast');
-						return setImmediate(waterCb, null, peers);
-					}
-				);
+				peers
+					.slice(0, self.config.peerLimit)
+					.map(peer => peer.rpc[options.api](options.data));
+				library.logger.debug('End broadcast');
+				return setImmediate(waterCb, null, peers);
 			},
 		],
 		(err, peers) => {


### PR DESCRIPTION
### What was the problem?
After merging https://github.com/LiskHQ/lisk/pull/1608, `Broadcaster.prototype.broadcast` was never resolved - `async. eachLimit` callback was never called. 
### How did I fix it?
As broadcasts are not relying on responses now the action can be done synchronously. I've replaced emits with `async. eachLimit` with its synchronous equivalent.
### How to test it?
Tests for broadcaster module are currently being created by @ManuGowda in https://github.com/LiskHQ/lisk/pull/1640.
### Review checklist

* The PR solves #1505
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
