### PR TITLE
Backport inconsistent log for apply unconfirmed transaction - Closes #1664

### DIFF
--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -348,7 +348,7 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 								err => {
 									if (err) {
 										err = [
-											'Failed to apply transaction:',
+											'Failed to apply unconfirmed transaction:',
 											transaction.id,
 											'-',
 											err,


### PR DESCRIPTION
### What was the problem?
The error log for applyUnconfirmed step during applyBlock function is not correct.

### How did I fix it?
Correct the log message.

### How to test it?
Look at the logs.

### Review checklist
- The PR solves #1664 
- All new code is covered with unit tests
- Linting passes
- Tests pass
- Commit messages follow the commit guidelines
- Documentation has been added/updated