### PR TITLE
Bump API version to 1.0.23 - Closes #1669

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -16,7 +16,7 @@ swagger: '2.0'
 info:
   description: Lisk API Documentation
   title: Lisk API Documentation
-  version: '1.0.22'
+  version: '1.0.23'
   contact:
     email: admin@lisk.io
   license:


### PR DESCRIPTION
### What was the problem?

Swagger API schema contains modifications but they are not published.

### How did I fix it?

Bumping from 1.0.22 to 1.0.23 and publishing them in Swagger Hub https://app.swaggerhub.com/apis/LiskHQ/Lisk/1.0.23

### Review checklist

* The PR solves #1669
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
