### PR TITLE
Backport tests for transactionInPool in transactionPool - Closes #1670

### DIFF
--- a/test/unit/logic/transaction_pool.js
+++ b/test/unit/logic/transaction_pool.js
@@ -644,4 +644,84 @@ describe('transactionPool', () => {
 			});
 		});
 	});
+
+	describe('transactionInPool', () => {
+		afterEach(() => {
+			return resetStates();
+		});
+
+		describe('when transaction is in pool', () => {
+			var tx = '123';
+
+			describe('unconfirmed list', () => {
+				describe('with index 0', () => {
+					it('should return true', () => {
+						transactionPool.unconfirmed.index[tx] = 0;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+
+				describe('with other index', () => {
+					it('should return true', () => {
+						transactionPool.unconfirmed.index[tx] = 1;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+
+			describe('bundled list', () => {
+				describe('with index 0', () => {
+					it('should return true', () => {
+						transactionPool.bundled.index[tx] = 0;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+
+				describe('with other index', () => {
+					it('should return true', () => {
+						transactionPool.bundled.index[tx] = 1;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+
+			describe('queued list', () => {
+				describe('with index 0', () => {
+					it('should return true', () => {
+						transactionPool.queued.index[tx] = 0;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+
+				describe('with other index', () => {
+					it('should return true', () => {
+						transactionPool.queued.index[tx] = 1;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+
+			describe('multisignature list', () => {
+				describe('with index 0', () => {
+					it('should return true', () => {
+						transactionPool.multisignature.index[tx] = 0;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+
+				describe('with other index', () => {
+					it('should return true', () => {
+						transactionPool.multisignature.index[tx] = 1;
+						return expect(transactionPool.transactionInPool(tx)).to.equal(true);
+					});
+				});
+			});
+		});
+
+		describe('when transaction is not in pool', () => {
+			it('should return false', () => {
+				return expect(transactionPool.transactionInPool('123')).to.equal(false);
+			});
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?
There was a bug in TransactionPool.transactionInPool. Which was fixed in commit 9f1ac7f. This PR adds relevant tests cases for it.
* The PR solves #1670
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
