### PR TITLE
Backport fix for corrupt unconfirmed state due to transaction queues - Closes #1661

### DIFF
--- a/logic/transaction_pool.js
+++ b/logic/transaction_pool.js
@@ -43,7 +43,7 @@ var __private = {};
  * @param {Transaction} transaction - Transaction logic instance
  * @param {bus} bus - Bus instance
  * @param {Object} logger - Logger instance
- * @param {Sequence} balancesSequence - Balances sequence.
+ * @param {Sequence} balancesSequence - Balances sequence
  */
 // Constructor
 function TransactionPool(
@@ -504,8 +504,7 @@ TransactionPool.prototype.processBundled = function(cb) {
 				__private.processVerifyTransaction(transaction, true, err => {
 					// Remove bundled transaction after asynchronous processVerifyTransaction to avoid race conditions
 					self.removeBundledTransaction(transaction.id);
-					// Delete bundled flag from transaction
-					// so it is qualified as "queued" in queueTransaction
+					// Delete bundled flag from transaction so it is qualified as "queued" in queueTransaction
 					delete transaction.bundled;
 
 					if (err) {
@@ -638,7 +637,7 @@ TransactionPool.prototype.undoUnconfirmedList = function(cb, tx) {
 							return setImmediate(eachSeriesCb);
 						}
 
-						// Transaction successfully undone from unconfirmed states, try move it to queued list
+						// Transaction successfully undone from unconfirmed states, try moving it to queued list
 						library.balancesSequence.add(balancesSequenceCb => {
 							self.processUnconfirmedTransaction(
 								transaction,
@@ -771,8 +770,9 @@ __private.getTransactionList = function(transactions, reverse, limit) {
 
 /**
  * Check if transaction exists in unconfirmed queue.
+ *
  * @private
- * @param {Object} transaction - Transaction object.
+ * @param {Object} transaction - Transaction object
  * @returns {Boolean}
  */
 __private.isTransactionInUnconfirmedQueue = function(transaction) {
@@ -793,8 +793,8 @@ __private.processVerifyTransaction = function(transaction, broadcast, cb, tx) {
 		return setImmediate(cb, 'Missing transaction');
 	}
 
-	// At this point, transaction should not be in unconfirmed state, but this is a final barrier to stop us from
-	// making unconfirmed state dirty.
+	// At this point, transaction should not be in unconfirmed state,
+	// but this is a final barrier to stop us from making unconfirmed state dirty.
 	if (__private.isTransactionInUnconfirmedQueue(transaction)) {
 		return setImmediate(cb, 'Transaction is already in unconfirmed state');
 	}

--- a/logic/transaction_pool.js
+++ b/logic/transaction_pool.js
@@ -629,23 +629,22 @@ TransactionPool.prototype.undoUnconfirmedList = function(cb, tx) {
 								`Failed to undo unconfirmed transaction: ${transaction.id}`,
 								err
 							);
-						} else {
-							// Transaction successfully undone from unconfirmed states, try move it to queued list
-							library.balancesSequence.add(balancesSequenceCb => {
-								self.processUnconfirmedTransaction(transaction, false, err => {
-									if (err) {
-										library.logger.debug(
-											`Failed to queue transaction back after successful undo unconfirmed: ${
-												transaction.id
-											}`,
-											err
-										);
-									}
-									return setImmediate(balancesSequenceCb);
-								});
-							}, eachSeriesCb);
+							return setImmediate(eachSeriesCb);
 						}
-						return setImmediate(eachSeriesCb);
+						// Transaction successfully undone from unconfirmed states, try move it to queued list
+						library.balancesSequence.add(balancesSequenceCb => {
+							self.processUnconfirmedTransaction(transaction, false, err => {
+								if (err) {
+									library.logger.debug(
+										`Failed to queue transaction back after successful undo unconfirmed: ${
+											transaction.id
+										}`,
+										err
+									);
+								}
+								return setImmediate(balancesSequenceCb);
+							});
+						}, eachSeriesCb);
 					},
 					tx
 				);

--- a/logic/transaction_pool.js
+++ b/logic/transaction_pool.js
@@ -43,6 +43,7 @@ var __private = {};
  * @param {Transaction} transaction - Transaction logic instance
  * @param {bus} bus - Bus instance
  * @param {Object} logger - Logger instance
+ * @param {Sequence} balancesSequence - Balances sequence.
  */
 // Constructor
 function TransactionPool(
@@ -50,7 +51,8 @@ function TransactionPool(
 	releaseLimit,
 	transaction,
 	bus,
-	logger
+	logger,
+	balancesSequence
 ) {
 	library = {
 		logger,
@@ -64,6 +66,7 @@ function TransactionPool(
 				releaseLimit,
 			},
 		},
+		balancesSequence,
 	};
 	self = this;
 
@@ -497,29 +500,34 @@ TransactionPool.prototype.processBundled = function(cb) {
 			if (!transaction) {
 				return setImmediate(eachSeriesCb);
 			}
+			library.balancesSequence.add(balancesSequenceCb => {
+				__private.processVerifyTransaction(transaction, true, err => {
+					// Remove bundled transaction after asynchronous processVerifyTransaction to avoid race conditions
+					self.removeBundledTransaction(transaction.id);
+					// Delete bundled flag from transaction
+					// so it is qualified as "queued" in queueTransaction
+					delete transaction.bundled;
 
-			self.removeBundledTransaction(transaction.id);
-			delete transaction.bundled;
-
-			__private.processVerifyTransaction(transaction, true, err => {
-				if (err) {
-					library.logger.debug(
-						`Failed to process / verify bundled transaction: ${transaction.id}`,
-						err
-					);
-					self.removeUnconfirmedTransaction(transaction);
-					return setImmediate(eachSeriesCb);
-				}
-				self.queueTransaction(transaction, err => {
 					if (err) {
 						library.logger.debug(
-							`Failed to queue bundled transaction: ${transaction.id}`,
+							`Failed to process / verify bundled transaction: ${
+								transaction.id
+							}`,
 							err
 						);
+						return setImmediate(balancesSequenceCb);
 					}
-					return setImmediate(eachSeriesCb);
+					self.queueTransaction(transaction, err => {
+						if (err) {
+							library.logger.debug(
+								`Failed to queue bundled transaction: ${transaction.id}`,
+								err
+							);
+						}
+						return setImmediate(balancesSequenceCb);
+					});
 				});
-			});
+			}, eachSeriesCb);
 		},
 		err => setImmediate(cb, err)
 	);
@@ -622,8 +630,20 @@ TransactionPool.prototype.undoUnconfirmedList = function(cb, tx) {
 								err
 							);
 						} else {
-							// Transaction successfully undone from unconfirmed states, move it to queued list
-							self.addQueuedTransaction(transaction);
+							// Transaction successfully undone from unconfirmed states, try move it to queued list
+							library.balancesSequence.add(balancesSequenceCb => {
+								self.processUnconfirmedTransaction(transaction, false, err => {
+									if (err) {
+										library.logger.debug(
+											`Failed to queue transaction back after successful undo unconfirmed: ${
+												transaction.id
+											}`,
+											err
+										);
+									}
+									return setImmediate(balancesSequenceCb);
+								});
+							}, eachSeriesCb);
 						}
 						return setImmediate(eachSeriesCb);
 					},
@@ -739,6 +759,16 @@ __private.getTransactionList = function(transactions, reverse, limit) {
 };
 
 /**
+ * Check if transaction exists in unconfirmed queue.
+ * @private
+ * @param {Object} transaction - Transaction object.
+ * @returns {Boolean}
+ */
+__private.isTransactionInUnconfirmedQueue = function(transaction) {
+	return typeof self.unconfirmed.index[transaction.id] === 'number';
+};
+
+/**
  * Processes and verifies a transaction.
  *
  * @private
@@ -750,6 +780,12 @@ __private.getTransactionList = function(transactions, reverse, limit) {
 __private.processVerifyTransaction = function(transaction, broadcast, cb, tx) {
 	if (!transaction) {
 		return setImmediate(cb, 'Missing transaction');
+	}
+
+	// At this point, transaction should not be in unconfirmed state, but this is a final barrier to stop us from
+	// making unconfirmed state dirty.
+	if (__private.isTransactionInUnconfirmedQueue(transaction)) {
+		return setImmediate(cb, 'Transaction is already in unconfirmed state');
 	}
 
 	async.waterfall(
@@ -846,41 +882,45 @@ __private.applyUnconfirmedList = function(transactions, cb, tx) {
 			if (!transaction) {
 				return setImmediate(eachSeriesCb);
 			}
-			__private.processVerifyTransaction(
-				transaction,
-				false,
-				(err, sender) => {
-					if (err) {
-						library.logger.error(
-							`Failed to process / verify unconfirmed transaction: ${
-								transaction.id
-							}`,
-							err
+			library.balancesSequence.add(balancesSequenceCb => {
+				__private.processVerifyTransaction(
+					transaction,
+					false,
+					(err, sender) => {
+						if (err) {
+							library.logger.error(
+								`Failed to process / verify unconfirmed transaction: ${
+									transaction.id
+								}`,
+								err
+							);
+							self.removeQueuedTransaction(transaction.id);
+							return setImmediate(balancesSequenceCb);
+						}
+						modules.transactions.applyUnconfirmed(
+							transaction,
+							sender,
+							err => {
+								if (err) {
+									library.logger.error(
+										`Failed to apply unconfirmed transaction: ${
+											transaction.id
+										}`,
+										err
+									);
+									self.removeQueuedTransaction(transaction.id);
+								} else {
+									// Transaction successfully applied to unconfirmed states, move it to unconfirmed list
+									self.addUnconfirmedTransaction(transaction);
+								}
+								return setImmediate(balancesSequenceCb);
+							},
+							tx
 						);
-						self.removeUnconfirmedTransaction(transaction.id);
-						return setImmediate(eachSeriesCb);
-					}
-					modules.transactions.applyUnconfirmed(
-						transaction,
-						sender,
-						err => {
-							if (err) {
-								library.logger.error(
-									`Failed to apply unconfirmed transaction: ${transaction.id}`,
-									err
-								);
-								self.removeUnconfirmedTransaction(transaction.id);
-							} else {
-								// Transaction successfully applied to unconfirmed states, move it to unconfirmed list
-								self.addUnconfirmedTransaction(transaction);
-							}
-							return setImmediate(eachSeriesCb);
-						},
-						tx
-					);
-				},
-				tx
-			);
+					},
+					tx
+				);
+			}, eachSeriesCb);
 		},
 		cb
 	);

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -72,7 +72,8 @@ function Transactions(cb, scope) {
 		scope.config.broadcasts.releaseLimit,
 		scope.logic.transaction,
 		scope.bus,
-		scope.logger
+		scope.logger,
+		scope.balancesSequence
 	);
 
 	__private.assetTypes[

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -219,34 +219,28 @@ __private.receiveTransaction = function(
 		return setImmediate(cb, `Invalid transaction body - ${e.toString()}`);
 	}
 
-	library.balancesSequence.add(cb => {
-		if (!peer) {
-			library.logger.debug(
-				`Received transaction ${transaction.id} from public client`
-			);
-		} else {
-			library.logger.debug(
-				`Received transaction ${
-					transaction.id
-				} from peer ${library.logic.peers.peersManager.getAddress(peer.nonce)}`
-			);
-		}
-		modules.transactions.processUnconfirmedTransaction(
-			transaction,
-			true,
-			err => {
-				if (err) {
-					library.logger.debug(['Transaction', id].join(' '), err.toString());
-					if (transaction) {
-						library.logger.debug('Transaction', transaction);
-					}
-
-					return setImmediate(cb, err.toString());
-				}
-				return setImmediate(cb, null, transaction.id);
-			}
+	if (!peer) {
+		library.logger.debug(
+			`Received transaction ${transaction.id} from public client`
 		);
-	}, cb);
+	} else {
+		library.logger.debug(
+			`Received transaction ${
+				transaction.id
+			} from peer ${library.logic.peers.peersManager.getAddress(peer.nonce)}`
+		);
+	}
+	modules.transactions.processUnconfirmedTransaction(transaction, true, err => {
+		if (err) {
+			library.logger.debug(['Transaction', id].join(' '), err.toString());
+			if (transaction) {
+				library.logger.debug('Transaction', transaction);
+			}
+
+			return setImmediate(cb, err.toString());
+		}
+		return setImmediate(cb, null, transaction.id);
+	});
 };
 
 // Public methods

--- a/test/functional/system/common.js
+++ b/test/functional/system/common.js
@@ -162,21 +162,19 @@ function addTransaction(library, transaction, cb) {
 function addTransactionToUnconfirmedQueue(library, transaction, cb) {
 	// Add transaction to transactions pool - we use shortcut here to bypass transport module, but logic is the same
 	// See: modules.transport.__private.receiveTransaction
-	library.balancesSequence.add(sequenceCb => {
-		library.modules.transactions.processUnconfirmedTransaction(
-			transaction,
-			true,
-			err => {
-				if (err) {
-					return setImmediate(sequenceCb, err.toString());
-				}
-				var transactionPool = library.rewiredModules.transactions.__get__(
-					'__private.transactionPool'
-				);
-				transactionPool.fillPool(sequenceCb);
+	library.modules.transactions.processUnconfirmedTransaction(
+		transaction,
+		true,
+		err => {
+			if (err) {
+				return setImmediate(cb, err.toString());
 			}
-		);
-	}, cb);
+			var transactionPool = library.rewiredModules.transactions.__get__(
+				'__private.transactionPool'
+			);
+			transactionPool.fillPool(cb);
+		}
+	);
 }
 
 function addTransactionsAndForge(library, transactions, cb) {

--- a/test/unit/logic/transaction_pool.js
+++ b/test/unit/logic/transaction_pool.js
@@ -90,7 +90,8 @@ describe('transactionPool', () => {
 			config.broadcasts.releaseLimit,
 			sinon.spy(), // transaction
 			sinon.spy(), // bus
-			logger // logger
+			logger, // logger
+			{ add: sinon.spy() }
 		);
 
 		// Bind fake modules

--- a/test/unit/logic/transaction_pool.js
+++ b/test/unit/logic/transaction_pool.js
@@ -85,7 +85,10 @@ describe('transactionPool', () => {
 	before(done => {
 		// Use fresh instance of jobsQueue inside transaction pool
 		TransactionPool.__set__('jobsQueue', jobsQueue);
+
+		// Init balance sequence
 		balancesSequence = new Sequence();
+
 		// Init test subject
 		transactionPool = new TransactionPool(
 			config.broadcasts.broadcastInterval,

--- a/test/unit/logic/transaction_pool.js
+++ b/test/unit/logic/transaction_pool.js
@@ -20,6 +20,7 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 // Load config file - global (one from test directory)
 var config = require('../../../config.json');
+var Sequence = require('../../../helpers/sequence.js');
 
 // Instantiate test subject
 var TransactionPool = rewire('../../../logic/transaction_pool.js');
@@ -33,6 +34,7 @@ describe('transactionPool', () => {
 	var dummyProcessVerifyTransaction;
 	var dummyApplyUnconfirmed;
 	var dummyUndoUnconfirmed;
+	var balancesSequence;
 	var freshListState = { transactions: [], index: {} };
 
 	// Init fake logger
@@ -83,7 +85,7 @@ describe('transactionPool', () => {
 	before(done => {
 		// Use fresh instance of jobsQueue inside transaction pool
 		TransactionPool.__set__('jobsQueue', jobsQueue);
-
+		balancesSequence = new Sequence();
 		// Init test subject
 		transactionPool = new TransactionPool(
 			config.broadcasts.broadcastInterval,
@@ -91,7 +93,7 @@ describe('transactionPool', () => {
 			sinon.spy(), // transaction
 			sinon.spy(), // bus
 			logger, // logger
-			{ add: sinon.spy() }
+			balancesSequence
 		);
 
 		// Bind fake modules
@@ -554,7 +556,7 @@ describe('transactionPool', () => {
 						after(resetStates);
 					});
 
-					describe('that results with error on modules.transactions.undoUnconfirme', () => {
+					describe('that results with error on modules.transactions.undoUnconfirmed', () => {
 						var badTransaction = { id: 'badTx' };
 						var transactions = [badTransaction];
 						var error = 'undo error';

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -718,8 +718,8 @@ describe('transport', () => {
 					).to.be.true;
 				});
 
-				it('should call library.balancesSequence.add', () => {
-					return expect(library.balancesSequence.add.called).to.be.true;
+				it('should not call library.balancesSequence.add', () => {
+					return expect(library.balancesSequence.add.called).to.be.false;
 				});
 
 				it('should call modules.transactions.processUnconfirmedTransaction with transaction and true as arguments', () => {


### PR DESCRIPTION
### What was the problem?
Backporting changes made in transactionPool. Thanks to the awesome work done by @MaciejBaj.

### How did I fix it?
Backported changes in two PR. Could not do it separately because the second PR was for fixing failing tests.

### Review checklist
* The PR solves #1661
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
