### PR TITLE
Enable jenkins file log level build parameter - Closes #1686

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,6 +157,7 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 		parameters([
 			string(name: 'JENKINS_PROFILE', defaultValue: 'jenkins', description: 'To build cache dependencies and run slow tests, change this value to jenkins-extensive.', ),
 			string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
+			string(name: 'FILE_LOG_LEVEL', defaultValue: 'error', description: 'To get desired file log output change the log level', ),
 			string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', ),
 			string(name: 'SILENT', defaultValue: 'true', description: 'To turn off test debug logs.', )
 		 ])

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -41,6 +41,7 @@ node('node-06') {
 			parameters([
 				string(name: 'LOG_LEVEL', defaultValue: 'error', description: 'To get desired build log output change the log level', ),
 				string(name: 'LOG_DB_EVENTS', defaultValue: 'false', description: 'To get detailed info on db events log.', ),
+				string(name: 'FILE_LOG_LEVEL', defaultValue: 'error', description: 'To get desired file log output change the log level', ),
 				string(name: 'SILENT', defaultValue: 'true', description: 'To turn off test debug logs.', )
 			 ])
 		])


### PR DESCRIPTION
### What was the problem?
Missing `FILE_LEVEL_LOG` build parameter
### How did I fix it?
Adding `FILE_LEVEL_LOG` to Jenkins build parameter.
### How to test it?
When building a PR you should be able to set `FILE_LEVEL_LOG` build parameter.
### Review checklist

* The PR solves #1686 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
