### PR TITLE
Update the test to skip the order checking of round numbers - Closes #1592

### DIFF
--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -102,7 +102,10 @@ describe('db', () => {
 				expect(result1).to.have.lengthOf(3);
 				expect(result2).to.have.lengthOf(2);
 				expect(result2[0]).to.have.all.keys('round');
-				return expect(result2.map(r => r.round)).to.be.eql(['1', '2']);
+				return expect(result2.map(r => r.round)).to.have.all.members([
+					'1',
+					'2',
+				]);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
The order of `round` in query `select round from mem_round group by round` was behaving differently on linux and mac machines. 

### How did I fix it?
Since the order in that method is not important, so skipped the order checking in tests. 

### How to test it?
```
npx mocha test/unit/db/repos/rounds.js
```

### Review checklist
* The PR solves #1592
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
