### PR TITLE
Update Jenkinsfile.migration to treat the master branch the same as 0.9.x branches - Closes #1699

### DIFF
--- a/Jenkinsfile.migration
+++ b/Jenkinsfile.migration
@@ -26,7 +26,7 @@ pipeline {
 				sh """
 				json_files_copy() {
 					case \$1 in
-						0*)
+						0* | master)
 							cp test/config.json .
 							cp test/genesisBlock.json .
 							;;


### PR DESCRIPTION
### What was the problem?
Jenkinsfile.migration looks in the wrong place when selecting the master branch to migrate from.

### How did I fix it?
I changed the case statement to check if the branch name is also master.

### How to test it?
I ran a replay job with this change in Jenkins.

### Review checklist
* The PR solves #1699
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
