### PR TITLE
Make node synchronization and broadcast configurable - Closes #1696

### DIFF
--- a/config.json
+++ b/config.json
@@ -97,7 +97,7 @@
 		}
 	},
 	"broadcasts": {
-		"on": true,
+		"active": true,
 		"broadcastInterval": 5000,
 		"broadcastLimit": 20,
 		"parallelLimit": 20,
@@ -115,7 +115,7 @@
 		}
 	},
 	"syncing": {
-		"on": true
+		"active": true
 	},
 	"loading": {
 		"verifyOnLoading": false,

--- a/config.json
+++ b/config.json
@@ -97,6 +97,7 @@
 		}
 	},
 	"broadcasts": {
+		"on": true,
 		"broadcastInterval": 5000,
 		"broadcastLimit": 20,
 		"parallelLimit": 20,
@@ -112,6 +113,9 @@
 		"access": {
 			"whiteList": ["127.0.0.1"]
 		}
+	},
+	"syncing": {
+		"on": true
 	},
 	"loading": {
 		"verifyOnLoading": false,

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -82,14 +82,16 @@ class Broadcaster {
 			},
 		];
 
-		if (broadcasts.on) {
+		if (broadcasts.active) {
 			jobsQueue.register(
 				'broadcasterNextRelease',
 				nextRelease,
 				self.config.broadcastInterval
 			);
 		} else {
-			library.logger.info('Broadcasting data disabled by user through config.json');
+			library.logger.info(
+				'Broadcasting data disabled by user through config.json'
+			);
 		}
 	}
 

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -82,11 +82,15 @@ class Broadcaster {
 			},
 		];
 
-		jobsQueue.register(
-			'broadcasterNextRelease',
-			nextRelease,
-			self.config.broadcastInterval
-		);
+		if (broadcasts.on) {
+			jobsQueue.register(
+				'broadcasterNextRelease',
+				nextRelease,
+				self.config.broadcastInterval
+			);
+		} else {
+			library.logger.info('Broadcasting data disabled by user through config.json');
+		}
 	}
 
 	/**

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -75,6 +75,9 @@ function Loader(cb, scope) {
 				verifyOnLoading: scope.config.loading.verifyOnLoading,
 				snapshot: scope.config.loading.snapshot,
 			},
+			syncing: {
+				on: scope.config.syncing.on,
+			},
 		},
 	};
 	self = this;
@@ -877,7 +880,9 @@ Loader.prototype.loaded = function() {
 Loader.prototype.onPeersReady = function() {
 	library.logger.trace('Peers ready', { module: 'loader' });
 	// Enforce sync early
-	__private.syncTimer();
+	if (library.config.syncing.on) {
+		__private.syncTimer();
+	}
 
 	setImmediate(() => {
 		async.series(

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -76,7 +76,7 @@ function Loader(cb, scope) {
 				snapshot: scope.config.loading.snapshot,
 			},
 			syncing: {
-				on: scope.config.syncing.on,
+				active: scope.config.syncing.active,
 			},
 		},
 	};
@@ -880,7 +880,7 @@ Loader.prototype.loaded = function() {
 Loader.prototype.onPeersReady = function() {
 	library.logger.trace('Peers ready', { module: 'loader' });
 	// Enforce sync early
-	if (library.config.syncing.on) {
+	if (library.config.syncing.active) {
 		__private.syncTimer();
 	}
 

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -71,6 +71,9 @@ function Transport(cb, scope) {
 			forging: {
 				force: scope.config.forging.force,
 			},
+			broadcasts: {
+				on: scope.config.broadcasts.on,
+			},
 		},
 	};
 	self = this;
@@ -525,6 +528,9 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postBlock(query) {
+		if (!library.config.broadcaster.on) {
+			return library.logger.debug('Receiving blocks disabled by user through config.json');
+		}
 		query = query || {};
 		library.schema.validate(query, definitions.WSBlocksBroadcast, err => {
 			if (err) {
@@ -617,6 +623,9 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postSignature(query, cb) {
+		if (!library.config.broadcaster.on) {
+			return library.logger.debug('Receiving signatures disabled by user through config.json');
+		}
 		__private.receiveSignature(query.signature, err => {
 			if (err) {
 				return setImmediate(cb, null, { success: false, message: err });
@@ -720,6 +729,9 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postTransactions(query) {
+		if (!library.config.broadcaster.on) {
+			return library.logger.debug('Receiving transactions disabled by user through config.json');
+		}
 		library.schema.validate(query, definitions.WSTransactionsRequest, err => {
 			if (err) {
 				return library.logger.debug('Invalid transactions body', err);

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -528,7 +528,7 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postBlock(query) {
-		if (!library.config.broadcaster.on) {
+		if (!library.config.broadcasts.on) {
 			return library.logger.debug('Receiving blocks disabled by user through config.json');
 		}
 		query = query || {};
@@ -623,7 +623,7 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postSignature(query, cb) {
-		if (!library.config.broadcaster.on) {
+		if (!library.config.broadcasts.on) {
 			return library.logger.debug('Receiving signatures disabled by user through config.json');
 		}
 		__private.receiveSignature(query.signature, err => {
@@ -729,7 +729,7 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postTransactions(query) {
-		if (!library.config.broadcaster.on) {
+		if (!library.config.broadcasts.on) {
 			return library.logger.debug('Receiving transactions disabled by user through config.json');
 		}
 		library.schema.validate(query, definitions.WSTransactionsRequest, err => {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -72,7 +72,7 @@ function Transport(cb, scope) {
 				force: scope.config.forging.force,
 			},
 			broadcasts: {
-				on: scope.config.broadcasts.on,
+				active: scope.config.broadcasts.active,
 			},
 		},
 	};
@@ -528,8 +528,10 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postBlock(query) {
-		if (!library.config.broadcasts.on) {
-			return library.logger.debug('Receiving blocks disabled by user through config.json');
+		if (!library.config.broadcasts.active) {
+			return library.logger.debug(
+				'Receiving blocks disabled by user through config.json'
+			);
 		}
 		query = query || {};
 		library.schema.validate(query, definitions.WSBlocksBroadcast, err => {
@@ -623,8 +625,10 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postSignature(query, cb) {
-		if (!library.config.broadcasts.on) {
-			return library.logger.debug('Receiving signatures disabled by user through config.json');
+		if (!library.config.broadcasts.active) {
+			return library.logger.debug(
+				'Receiving signatures disabled by user through config.json'
+			);
 		}
 		__private.receiveSignature(query.signature, err => {
 			if (err) {
@@ -729,8 +733,10 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postTransactions(query) {
-		if (!library.config.broadcasts.on) {
-			return library.logger.debug('Receiving transactions disabled by user through config.json');
+		if (!library.config.broadcasts.active) {
+			return library.logger.debug(
+				'Receiving transactions disabled by user through config.json'
+			);
 		}
 		library.schema.validate(query, definitions.WSTransactionsRequest, err => {
 			if (err) {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -625,11 +625,6 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postSignature(query, cb) {
-		if (!library.config.broadcasts.active) {
-			return library.logger.debug(
-				'Receiving signatures disabled by user through config.json'
-			);
-		}
 		__private.receiveSignature(query.signature, err => {
 			if (err) {
 				return setImmediate(cb, null, { success: false, message: err });
@@ -646,6 +641,11 @@ Transport.prototype.shared = {
 	 * @todo Add description of the function
 	 */
 	postSignatures(query) {
+		if (!library.config.broadcasts.active) {
+			return library.logger.debug(
+				'Receiving signatures disabled by user through config.json'
+			);
+		}
 		library.schema.validate(query, definitions.WSSignaturesList, err => {
 			if (err) {
 				return library.logger.debug('Invalid signatures body', err);

--- a/schema/config.js
+++ b/schema/config.js
@@ -218,6 +218,9 @@ module.exports = {
 			broadcasts: {
 				type: 'object',
 				properties: {
+					active: {
+						type: 'boolean',
+					},
 					broadcastInterval: {
 						type: 'integer',
 						minimum: 1000,

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -61,6 +61,7 @@
 		}
 	},
 	"broadcasts": {
+		"on": true,
 		"broadcastInterval": 5000,
 		"broadcastLimit": 20,
 		"parallelLimit": 20,
@@ -684,6 +685,9 @@
 		"access": {
 			"whiteList": ["127.0.0.1"]
 		}
+	},
+	"syncing": {
+		"on": true
 	},
 	"loading": {
 		"verifyOnLoading": false,

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -61,7 +61,7 @@
 		}
 	},
 	"broadcasts": {
-		"on": true,
+		"active": true,
 		"broadcastInterval": 5000,
 		"broadcastLimit": 20,
 		"parallelLimit": 20,
@@ -687,7 +687,7 @@
 		}
 	},
 	"syncing": {
-		"on": true
+		"active": true
 	},
 	"loading": {
 		"verifyOnLoading": false,

--- a/test/unit/logic/broadcaster.js
+++ b/test/unit/logic/broadcaster.js
@@ -42,6 +42,7 @@ describe('Broadcaster', () => {
 
 	beforeEach(done => {
 		broadcasts = {
+			on: true,
 			broadcastInterval: 10000,
 			releaseLimit: 10,
 			parallelLimit: 10,

--- a/test/unit/logic/broadcaster.js
+++ b/test/unit/logic/broadcaster.js
@@ -42,7 +42,7 @@ describe('Broadcaster', () => {
 
 	beforeEach(done => {
 		broadcasts = {
-			on: true,
+			active: true,
 			broadcastInterval: 10000,
 			releaseLimit: 10,
 			parallelLimit: 10,

--- a/test/unit/modules/transactions.js
+++ b/test/unit/modules/transactions.js
@@ -189,7 +189,7 @@ describe('transactions', () => {
 										snapshot: false,
 									},
 									syncing: {
-										on: true,
+										active: true,
 									},
 								},
 							},

--- a/test/unit/modules/transactions.js
+++ b/test/unit/modules/transactions.js
@@ -188,6 +188,9 @@ describe('transactions', () => {
 										verifyOnLoading: false,
 										snapshot: false,
 									},
+									syncing: {
+										on: true,
+									},
 								},
 							},
 							cb

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1019,6 +1019,9 @@ describe('transport', () => {
 						forging: {
 							force: false,
 						},
+						broadcasts: {
+							active: true,
+						},
 					},
 					network: {
 						io: {
@@ -1740,6 +1743,23 @@ describe('transport', () => {
 						message: sinonSandbox.stub(),
 					};
 					done();
+				});
+
+				describe('when library.config.broadcasts.active option is false', () => {
+					beforeEach(done => {
+						library.config.broadcasts.active = false;
+						transportInstance.shared.postBlock(query);
+						done();
+					});
+
+					it('should call library.logger.debug', () => {
+						expect(
+							library.logger.debug.calledWith(
+								'Receiving blocks disabled by user through config.json'
+							)
+						).to.be.true;
+						return expect(library.schema.validate.called).to.be.false;
+					});
 				});
 
 				describe('when query is specified', () => {

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1753,11 +1753,14 @@ describe('transport', () => {
 					});
 
 					it('should call library.logger.debug', () => {
-						expect(
+						return expect(
 							library.logger.debug.calledWith(
 								'Receiving blocks disabled by user through config.json'
 							)
 						).to.be.true;
+					});
+
+					it('should not call library.schema.validate; function should return before', () => {
 						return expect(library.schema.validate.called).to.be.false;
 					});
 				});
@@ -2098,6 +2101,27 @@ describe('transport', () => {
 					done();
 				});
 
+				describe('when library.config.broadcasts.active option is false', () => {
+					beforeEach(done => {
+						library.config.broadcasts.active = false;
+						library.schema.validate = sinonSandbox.stub().callsArg(2);
+						transportInstance.shared.postSignatures(query);
+						done();
+					});
+
+					it('should call library.logger.debug', () => {
+						return expect(
+							library.logger.debug.calledWith(
+								'Receiving signatures disabled by user through config.json'
+							)
+						).to.be.true;
+					});
+
+					it('should not call library.schema.validate; function should return before', () => {
+						return expect(library.schema.validate.called).to.be.false;
+					});
+				});
+
 				describe('when library.schema.validate succeeds', () => {
 					beforeEach(done => {
 						transportInstance.shared.postSignatures(query);
@@ -2322,6 +2346,27 @@ describe('transport', () => {
 			});
 
 			describe('postTransactions', () => {
+				describe('when library.config.broadcasts.active option is false', () => {
+					beforeEach(done => {
+						library.config.broadcasts.active = false;
+						library.schema.validate = sinonSandbox.stub().callsArg(2);
+						transportInstance.shared.postTransactions(query);
+						done();
+					});
+
+					it('should call library.logger.debug', () => {
+						return expect(
+							library.logger.debug.calledWith(
+								'Receiving transactions disabled by user through config.json'
+							)
+						).to.be.true;
+					});
+
+					it('should not call library.schema.validate; function should return before', () => {
+						return expect(library.schema.validate.called).to.be.false;
+					});
+				});
+
 				describe('when library.schema.validate succeeds', () => {
 					beforeEach(done => {
 						query = {

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -210,7 +210,7 @@ describe('transport', () => {
 				},
 				forging: {},
 				broadcasts: {
-					on: true,
+					active: true,
 					broadcastInterval: 10000,
 					releaseLimit: 10,
 				},

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -210,6 +210,7 @@ describe('transport', () => {
 				},
 				forging: {},
 				broadcasts: {
+					on: true,
 					broadcastInterval: 10000,
 					releaseLimit: 10,
 				},


### PR DESCRIPTION
### What was the problem?
Peer is syncing with the rest of the network by 2 overlapping processes -  synchronization and broadcast. It is hard to test them separately while they both are working.
### How did I fix it?
I've made node synchronization and broadcast configurable by new entries in devnet and mainnet config.json files: 
```
"broadcasts": {
	"on": true
...
"syncing": {
	"on": true
},
...
```
### How to test it?
Run node with new configurations turned on/off.
### Review checklist

* The PR solves #1696
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
