### PR TITLE
Improve apply block database transaction logic - Closes #1652

### DIFF
--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -338,15 +338,23 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 					modules.accounts.setAccountAndGet(
 						{ publicKey: transaction.senderPublicKey },
 						(accountErr, sender) => {
+							if (accountErr) {
+								const err = `Failed to get account for apply unconfirmed transaction: ${
+									transaction.id
+								} '-' ${accountErr}`;
+								library.logger.error(err);
+								library.logger.error('Transaction', transaction);
+								return setImmediate(reject, err);
+							}
 							// DATABASE: write
 							modules.transactions.applyUnconfirmed(
 								transaction,
 								sender,
 								err => {
-									if (err || accountErr) {
+									if (err) {
 										err = `Failed to apply unconfirmed transaction: ${
 											transaction.id
-										} '-' ${err || accountErr}`;
+										} '-' ${err}`;
 										library.logger.error(err);
 										library.logger.error('Transaction', transaction);
 										return setImmediate(reject, err);
@@ -380,6 +388,14 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 					modules.accounts.getAccount(
 						{ publicKey: transaction.senderPublicKey },
 						(accountErr, sender) => {
+							if (accountErr) {
+								const err = `Failed to get account for apply transaction: ${
+									transaction.id
+								} '-' ${accountErr}`;
+								library.logger.error(err);
+								library.logger.error('Transaction', transaction);
+								return setImmediate(reject, err);
+							}
 							// DATABASE: write
 							modules.transactions.apply(
 								transaction,
@@ -390,11 +406,11 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 										// Fatal error, memory tables will be inconsistent
 										err = `Failed to apply transaction: ${
 											transaction.id
-										} - ${err || accountErr}`;
+										} - ${err}`;
 										library.logger.error(err);
 										library.logger.error('Transaction', transaction);
 
-										reject(err);
+										return setImmediate(reject, err);
 									}
 									return setImmediate(resolve);
 								},
@@ -430,7 +446,7 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 							library.logger.error('Failed to save block...', err);
 							library.logger.error('Block', block);
 							var errObj = new Error('Failed to save block');
-							return reject(errObj);
+							return setImmediate(reject, errObj);
 						}
 
 						library.logger.debug(
@@ -445,9 +461,9 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 							block,
 							err => {
 								if (err) {
-									return reject(err);
+									return setImmediate(reject, err);
 								}
-								return resolve();
+								return setImmediate(resolve);
 							},
 							tx
 						);
@@ -462,9 +478,9 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 					block,
 					err => {
 						if (err) {
-							return reject(err);
+							return setImmediate(reject, err);
 						}
-						return resolve();
+						return setImmediate(resolve);
 					},
 					tx
 				);

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -396,10 +396,6 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 
 										reject(err);
 									}
-									// Transaction applied, removed from the unconfirmed list
-									modules.transactions.removeUnconfirmedTransaction(
-										transaction.id
-									);
 									return setImmediate(resolve);
 								},
 								tx
@@ -486,6 +482,10 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 					.then(() => saveBlockStep(tx));
 			})
 			.then(() => {
+				// Remove block transactions from transaction pool
+				block.transactions.forEach(transaction => {
+					modules.transactions.removeUnconfirmedTransaction(transaction.id);
+				});
 				modules.blocks.isActive.set(false);
 				block = null;
 				return setImmediate(cb, null);

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -336,7 +336,7 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 						{ publicKey: transaction.senderPublicKey },
 						(accountErr, sender) => {
 							if (accountErr) {
-								const err = `Failed to get account for apply unconfirmed transaction: ${
+								const err = `Failed to get account to apply unconfirmed transaction: ${
 									transaction.id
 								} '-' ${accountErr}`;
 								library.logger.error(err);
@@ -386,7 +386,7 @@ Chain.prototype.applyBlock = function(block, saveBlock, cb) {
 						{ publicKey: transaction.senderPublicKey },
 						(accountErr, sender) => {
 							if (accountErr) {
-								const err = `Failed to get account for apply transaction: ${
+								const err = `Failed to get account to apply transaction: ${
 									transaction.id
 								} '-' ${accountErr}`;
 								library.logger.error(err);

--- a/test/functional/system/blocks/chain/apply_block.js
+++ b/test/functional/system/blocks/chain/apply_block.js
@@ -1,0 +1,453 @@
+/* eslint-disable mocha/no-skipped-tests */
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const async = require('async');
+const expect = require('chai').expect;
+const lisk = require('lisk-js');
+const accountFixtures = require('../../../../fixtures/accounts');
+const randomUtil = require('../../../../common/utils/random');
+const localCommon = require('../../common');
+const genesisBlock = require('../../../../data/genesis_block.json');
+
+describe('system test (blocks) - chain/applyBlock', () => {
+	const transferAmount = 100000000 * 100;
+	let library;
+	let db;
+
+	localCommon.beforeBlock('system_blocks_chain_apply_block', lib => {
+		library = lib;
+		db = library.db;
+	});
+
+	afterEach(done => {
+		db
+			.task(t => {
+				return t.batch([
+					db.none('DELETE FROM blocks WHERE "height" > 1;'),
+					db.none('DELETE FROM forks_stat;'),
+				]);
+			})
+			.then(() => {
+				library.modules.blocks.lastBlock.set(genesisBlock);
+				done();
+			})
+			.catch(err => {
+				__testContext.debug(err.stack);
+				done();
+			});
+	});
+
+	let blockAccount1;
+	let blockAccount2;
+	let poolAccount3;
+	let poolAccount4;
+
+	beforeEach('send funds to accounts', done => {
+		blockAccount1 = randomUtil.account();
+		blockAccount2 = randomUtil.account();
+		poolAccount3 = randomUtil.account();
+		poolAccount4 = randomUtil.account();
+
+		const fundTrsForAccount1 = lisk.transaction.createTransaction(
+			blockAccount1.address,
+			transferAmount,
+			accountFixtures.genesis.password
+		);
+
+		const fundTrsForAccount2 = lisk.transaction.createTransaction(
+			blockAccount2.address,
+			transferAmount,
+			accountFixtures.genesis.password
+		);
+
+		const fundTrsForAccount3 = lisk.transaction.createTransaction(
+			poolAccount3.address,
+			transferAmount,
+			accountFixtures.genesis.password
+		);
+
+		const fundTrsForAccount4 = lisk.transaction.createTransaction(
+			poolAccount4.address,
+			transferAmount,
+			accountFixtures.genesis.password
+		);
+
+		localCommon.addTransactionsAndForge(
+			library,
+			[
+				fundTrsForAccount1,
+				fundTrsForAccount2,
+				fundTrsForAccount3,
+				fundTrsForAccount4,
+			],
+			err => {
+				expect(err).to.not.exist;
+				done();
+			}
+		);
+	});
+
+	describe('applyBlock', () => {
+		let block;
+		let blockTransaction1;
+		let blockTransaction2;
+
+		beforeEach('create block', done => {
+			blockTransaction1 = lisk.delegate.createDelegate(
+				blockAccount1.password,
+				blockAccount1.username
+			);
+			blockTransaction2 = lisk.delegate.createDelegate(
+				blockAccount2.password,
+				blockAccount2.username
+			);
+			blockTransaction1.senderId = blockAccount1.address;
+			blockTransaction2.senderId = blockAccount2.address;
+			localCommon.createValidBlock(
+				library,
+				[blockTransaction1, blockTransaction2],
+				(err, b) => {
+					block = b;
+					done(err);
+				}
+			);
+		});
+
+		describe('undoUnconfirmedList', () => {
+			let transaction3;
+			let transaction4;
+
+			beforeEach('with transactions in unconfirmed queue', done => {
+				transaction3 = lisk.signature.createSignature(
+					poolAccount3.password,
+					poolAccount3.secondPassword
+				);
+
+				transaction4 = lisk.signature.createSignature(
+					poolAccount4.password,
+					poolAccount4.secondPassword
+				);
+
+				transaction3.senderId = poolAccount3.address;
+				transaction4.senderId = poolAccount4.address;
+
+				async.map(
+					[transaction3, transaction4],
+					(transaction, eachCb) => {
+						localCommon.addTransaction(library, transaction, err => {
+							expect(err).to.not.exist;
+							eachCb();
+						});
+					},
+					err => {
+						expect(err).to.not.exist;
+						localCommon.fillPool(library, done);
+					}
+				);
+			});
+
+			it('should have transactions from pool in unconfirmed state', done => {
+				async.forEach(
+					[poolAccount3, poolAccount4],
+					(account, eachCb) => {
+						localCommon
+							.getAccountFromDb(library, account.address)
+							.then(accountRow => {
+								expect(1).to.equal(accountRow.mem_accounts.u_secondSignature);
+								eachCb();
+							});
+					},
+					done
+				);
+			});
+
+			describe('after applying a new block', () => {
+				beforeEach(done => {
+					library.modules.blocks.chain.applyBlock(block, true, done);
+				});
+
+				it('should undo unconfirmed transactions', done => {
+					async.forEach(
+						[poolAccount3, poolAccount4],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(0).to.equal(accountRow.mem_accounts.u_secondSignature);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+			});
+		});
+
+		describe('applyUnconfirmedStep', () => {
+			describe('after applying new block fails on applyUnconfirmedStep', () => {
+				beforeEach(done => {
+					// Making block invalid
+					block.transactions[0].asset.delegate.username =
+						block.transactions[1].asset.delegate.username;
+					library.modules.blocks.chain.applyBlock(block, true, () => done());
+				});
+
+				it('should have pooled transactions in queued state', done => {
+					async.forEach(
+						[poolAccount3, poolAccount4],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(0).to.equal(accountRow.mem_accounts.u_secondSignature);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+
+				it('should not applyUnconfirmedStep on block transactions', done => {
+					async.forEach(
+						[blockAccount1, blockAccount2],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(accountRow.mem_accounts.u_username).to.eql(null);
+									expect(accountRow.mem_accounts.u_isDelegate).to.equal(0);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+			});
+
+			describe('after applying new block passes', () => {
+				beforeEach(done => {
+					library.modules.blocks.chain.applyBlock(block, true, done);
+				});
+
+				it('should applyUnconfirmedStep for block transactions', done => {
+					async.forEach(
+						[blockAccount1, blockAccount2],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(accountRow.mem_accounts.u_username).to.equal(
+										account.username
+									);
+									expect(accountRow.mem_accounts.u_isDelegate).to.equal(1);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+			});
+		});
+
+		describe('applyConfirmedStep', () => {
+			const randomUsername = randomUtil.username();
+			describe('after applying new block fails', () => {
+				beforeEach(done => {
+					// Making mem_account invalid
+					library.logic.account.set(
+						blockAccount1.address,
+						{
+							isDelegate: 1,
+							username: randomUsername,
+							publicKey: blockTransaction1.senderPublicKey,
+						},
+						err => {
+							expect(err).to.not.exist;
+							library.modules.blocks.chain.applyBlock(block, true, () =>
+								done()
+							);
+						}
+					);
+				});
+
+				it('should have pooled transactions in queued state', done => {
+					async.forEach(
+						[poolAccount3, poolAccount4],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(0).to.equal(accountRow.mem_accounts.u_secondSignature);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+
+				// Should be unskipped once transaction
+				it.skip('should revert applyconfirmedStep on block transactions', done => {
+					async.forEach(
+						[blockAccount1, blockAccount2],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									// the transaction will fail, so we will have the username, isDelegate we initially set
+									if (account == blockAccount1) {
+										expect(accountRow.mem_accounts.username).to.equal(
+											randomUsername
+										);
+										expect(accountRow.mem_accounts.isDelegate).to.equal(1);
+									}
+
+									if (account == blockAccount2) {
+										expect(accountRow.mem_accounts.username).to.eql(null);
+										expect(accountRow.mem_accounts.isDelegate).to.equal(0);
+									}
+
+									expect(accountRow.mem_accounts.u_username).to.equal(null);
+									expect(accountRow.mem_accounts.u_isDelegate).to.equal(0);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+			});
+
+			describe('after applying a new block', () => {
+				beforeEach(done => {
+					library.modules.blocks.chain.applyBlock(block, true, done);
+				});
+
+				it('should applyConfirmedStep', done => {
+					async.forEach(
+						[blockAccount1, blockAccount2],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(accountRow.mem_accounts.username).to.equal(
+										account.username
+									);
+									expect(accountRow.mem_accounts.isDelegate).to.equal(1);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+			});
+		});
+
+		describe('saveBlockStep', () => {
+			describe('after applying new block fails', () => {
+				let blockId;
+				beforeEach(done => {
+					blockId = block.id;
+					// Make block invalid
+					block.id = null;
+					library.modules.blocks.chain.applyBlock(block, true, () => done());
+				});
+
+				it('should have pooled transactions in queued state', done => {
+					async.forEach(
+						[poolAccount3, poolAccount4],
+						(account, eachCb) => {
+							localCommon
+								.getAccountFromDb(library, account.address)
+								.then(accountRow => {
+									expect(0).to.equal(accountRow.mem_accounts.u_secondSignature);
+									eachCb();
+								});
+						},
+						done
+					);
+				});
+
+				it('should not save block in the blocks table', done => {
+					localCommon.getBlocks(library, (err, ids) => {
+						expect(ids).to.not.include(blockId);
+						return done();
+					});
+				});
+
+				it('should not save transactions in the trs table', done => {
+					async.forEach(
+						[blockTransaction1, blockTransaction2],
+						(transaction, eachCb) => {
+							const filter = {
+								id: transaction.id,
+							};
+							localCommon.getTransactionFromModule(
+								library,
+								filter,
+								(err, res) => {
+									expect(err).to.be.null;
+									expect(res)
+										.to.have.property('transactions')
+										.which.is.an('Array')
+										.to.have.length(0);
+									eachCb();
+								}
+							);
+						},
+						done
+					);
+				});
+			});
+
+			describe('after applying a new block', () => {
+				beforeEach(done => {
+					library.modules.blocks.chain.applyBlock(block, true, done);
+				});
+
+				it('should save block in the blocks table', done => {
+					localCommon.getBlocks(library, (err, ids) => {
+						expect(ids).to.include(block.id);
+						return done();
+					});
+				});
+
+				it('should save transactions in the trs table', done => {
+					async.forEach(
+						[blockTransaction1, blockTransaction2],
+						(transaction, eachCb) => {
+							const filter = {
+								id: transaction.id,
+							};
+							localCommon.getTransactionFromModule(
+								library,
+								filter,
+								(err, res) => {
+									expect(err).to.be.null;
+									expect(res)
+										.to.have.property('transactions')
+										.which.is.an('Array');
+									expect(res.transactions[0].id).to.equal(transaction.id);
+									eachCb();
+								}
+							);
+						},
+						done
+					);
+				});
+			});
+		});
+	});
+});

--- a/test/functional/system/blocks/chain/delete_last_block.js
+++ b/test/functional/system/blocks/chain/delete_last_block.js
@@ -17,13 +17,13 @@
 
 var expect = require('chai').expect;
 var lisk = require('lisk-js');
-var accountFixtures = require('../../../fixtures/accounts');
-var randomUtil = require('../../../common/utils/random');
-var localCommon = require('../common');
+var accountFixtures = require('../../../../fixtures/accounts');
+var randomUtil = require('../../../../common/utils/random');
+var localCommon = require('../../common');
 
 describe('system test (blocks) - chain/deleteLastBlock', () => {
 	var library;
-	localCommon.beforeBlock('system_blocks_chain_delete_last_block', lib => {
+	localCommon.beforeBlock('system_blocks_chain', lib => {
 		library = lib;
 	});
 

--- a/test/functional/system/blocks/process/process_tables_data.json
+++ b/test/functional/system/blocks/process/process_tables_data.json
@@ -237,7 +237,7 @@
 					"\\xc76a0e680e83f47cf07c0f46b410f3b97e424171057a0f8f0f420c613da2f7b5",
 				"secondPublicKey": null,
 				"balance": "34701000000",
-				"u_balance": "8000000",
+				"u_balance": "34701000000",
 				"vote": "0",
 				"rate": "0",
 				"delegates": null,

--- a/test/functional/system/common.js
+++ b/test/functional/system/common.js
@@ -26,7 +26,7 @@ function getDelegateForSlot(library, slot, cb) {
 	var lastBlock = library.modules.blocks.lastBlock.get();
 
 	library.modules.delegates.generateDelegateList(
-		lastBlock.height,
+		lastBlock.height + 1,
 		null,
 		(err, list) => {
 			var delegatePublicKey = list[slot % slots.delegates];
@@ -338,8 +338,8 @@ module.exports = {
 	fillPool,
 	addTransaction,
 	addTransactionToUnconfirmedQueue,
-	addTransactionsAndForge,
 	createValidBlock,
+	addTransactionsAndForge,
 	getBlocks,
 	getAccountFromDb,
 	getTransactionFromModule,


### PR DESCRIPTION
### What was the problem?
In applyUnconfirmed step, if there is an error, we are reverting the transactions, and resolving the promise in the chain. Which is redundant logic and erroneous, and can lead to an inconsistent state in mem_accounts.
### How did I fix it?

### How to test it?

### Review checklist

* The PR solves #1652
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
