### PR TITLE
Fix usage of balanceSequences and database transaction - Fixes #1702

### DIFF
--- a/modules/transport.js
+++ b/modules/transport.js
@@ -228,28 +228,34 @@ __private.receiveTransaction = function(
 		return setImmediate(cb, `Invalid transaction body - ${e.toString()}`);
 	}
 
-	if (!nonce) {
-		library.logger.debug(
-			`Received transaction ${transaction.id} from public client`
-		);
-	} else {
-		library.logger.debug(
-			`Received transaction ${
-				transaction.id
-			} from peer ${library.logic.peers.peersManager.getAddress(nonce)}`
-		);
-	}
-	modules.transactions.processUnconfirmedTransaction(transaction, true, err => {
-		if (err) {
-			library.logger.debug(['Transaction', id].join(' '), err.toString());
-			if (transaction) {
-				library.logger.debug('Transaction', transaction);
-			}
-
-			return setImmediate(cb, err.toString());
+	library.balancesSequence.add(balancesSequenceCb => {
+		if (!nonce) {
+			library.logger.debug(
+				`Received transaction ${transaction.id} from public client`
+			);
+		} else {
+			library.logger.debug(
+				`Received transaction ${
+					transaction.id
+				} from peer ${library.logic.peers.peersManager.getAddress(nonce)}`
+			);
 		}
-		return setImmediate(cb, null, transaction.id);
-	});
+		modules.transactions.processUnconfirmedTransaction(
+			transaction,
+			true,
+			err => {
+				if (err) {
+					library.logger.debug(['Transaction', id].join(' '), err.toString());
+					if (transaction) {
+						library.logger.debug('Transaction', transaction);
+					}
+
+					return setImmediate(balancesSequenceCb, err.toString());
+				}
+				return setImmediate(balancesSequenceCb, null, transaction.id);
+			}
+		);
+	}, cb);
 };
 
 // Public methods

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -243,14 +243,20 @@ __private.receiveTransaction = function(
 		modules.transactions.processUnconfirmedTransaction(
 			transaction,
 			true,
-			err => {
-				if (err) {
-					library.logger.debug(['Transaction', id].join(' '), err.toString());
+			processUnconfirmErr => {
+				if (processUnconfirmErr) {
+					library.logger.debug(
+						['Transaction', id].join(' '),
+						processUnconfirmErr.toString()
+					);
 					if (transaction) {
 						library.logger.debug('Transaction', transaction);
 					}
 
-					return setImmediate(balancesSequenceCb, err.toString());
+					return setImmediate(
+						balancesSequenceCb,
+						processUnconfirmErr.toString()
+					);
 				}
 				return setImmediate(balancesSequenceCb, null, transaction.id);
 			}

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -727,8 +727,8 @@ describe('transport', () => {
 					).to.be.true;
 				});
 
-				it('should not call library.balancesSequence.add', () => {
-					return expect(library.balancesSequence.add.called).to.be.false;
+				it('should call library.balancesSequence.add', () => {
+					return expect(library.balancesSequence.add.called).to.be.true;
 				});
 
 				it('should call modules.transactions.processUnconfirmedTransaction with transaction and true as arguments', () => {
@@ -839,9 +839,7 @@ describe('transport', () => {
 
 				it('should call library.logic.peers.peersManager.getAddress with peer.nonce', () => {
 					return expect(
-						library.logic.peers.peersManager.getAddress.calledWith(
-							validNonce
-						)
+						library.logic.peers.peersManager.getAddress.calledWith(validNonce)
 					).to.be.true;
 				});
 			});


### PR DESCRIPTION
### What was the problem?
The balanceSequences and database tx for applyBlock sometimes have a certain order which causes them to become codependent. This leads to balanceSequence callback waiting for the database tx to commit, and database tx is waiting for the (another) callback in balanceSequence to resolve.
### How did I fix it?
Wrapped undoUnconfirmedList, applyUnconfirmedList, undoUnconfrimStep (for applyBlock) inside a balanceSequence.
### How to test it?
Run integration tests/system tests
### Review checklist

* The PR solves #1702 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
