### PR TITLE
Unit tests are failing due to too many connections - Closes #1741

### DIFF
--- a/test/common/db_seed.js
+++ b/test/common/db_seed.js
@@ -152,14 +152,15 @@ class DatabaseSeed {
 			'trs',
 			'transfer',
 		];
-		const promises = [];
-
-		tables.forEach(table => {
-			promises.push(db.query(`TRUNCATE TABLE "${table}" CASCADE`));
-		});
 
 		return db
 			.task('db:seed:reset', t => {
+				const promises = [];
+
+				tables.forEach(table => {
+					promises.push(t.query(`TRUNCATE TABLE "${table}" CASCADE`));
+				});
+
 				return t.batch(promises);
 			})
 			.then(() => {

--- a/test/common/db_seed.js
+++ b/test/common/db_seed.js
@@ -158,7 +158,7 @@ class DatabaseSeed {
 				const promises = [];
 
 				tables.forEach(table => {
-					promises.push(t.query(`TRUNCATE TABLE "${table}" CASCADE`));
+					promises.push(t.query('TRUNCATE TABLE ${table:name} CASCADE', { table }));
 				});
 
 				return t.batch(promises);


### PR DESCRIPTION
### What was the problem?
Unit tests are failing due to too many connections.
### How did I fix it?
Execute reset tables in same database connection.
### How to test it?
Run `npm test mocha:untagged:unit`, check connection count on postgres server.
### Review checklist
N/A
* The PR solves #1741
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
