### PR TITLE
Remove minLength and maxLength schema restrictions for WSPeerHeaders - Closes #1744

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -2617,8 +2617,6 @@ definitions:
         type: string
         example: v0.8.0
         format: version
-        minLength: 5
-        maxLength: 12
       height:
         type: integer
         example: 123


### PR DESCRIPTION
### What was the problem?

It was causing a peer connection failure in alpha builds which had a long version numbers (e.g. 1.0.0-alpha123).

### How did I fix it?

Removed minLength and maxLength schema restrictions for WSPeerHeaders 

### How to test it?

By accessing the power of blockchain.

### Review checklist

* The PR solves #1744 
