### PR TITLE
Log peer WebSocket connection errors in debug mode - Closes #1745

### DIFF
--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -25,10 +25,11 @@ const disconnect = require('../api/ws/rpc/disconnect');
  * @see Parent: {@link helpers}
  * @todo Add description for the class
  */
-function PeersManager() {
+function PeersManager(logger) {
 	this.peers = {};
 	this.addressToNonceMap = {};
 	this.nonceToAddressMap = {};
+	this.logger = logger;
 }
 
 /**
@@ -58,7 +59,7 @@ PeersManager.prototype.add = function(peer) {
 		this.nonceToAddressMap[peer.nonce] = peer.string;
 	}
 	// Create client WS connection to peer
-	connect(peer, this.remove.bind(this, peer));
+	connect(peer, this.logger, this.remove.bind(this, peer));
 	return true;
 };
 
@@ -166,4 +167,4 @@ PeersManager.prototype.getAddress = function(nonce) {
 	return this.nonceToAddressMap[nonce];
 };
 
-module.exports = new PeersManager();
+module.exports = PeersManager;

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -18,7 +18,7 @@ const _ = require('lodash');
 const failureCodes = require('../api/ws/rpc/failure_codes.js');
 const Peer = require('../logic/peer.js');
 const System = require('../modules/system.js');
-const peersManager = require('../helpers/peers_manager.js');
+const PeersManager = require('../helpers/peers_manager.js');
 
 // Private fields
 const __private = {};
@@ -50,7 +50,7 @@ class Peers {
 		self = this;
 		__private.me = null;
 
-		this.peersManager = peersManager;
+		this.peersManager = new PeersManager(logger);
 
 		return setImmediate(cb, null, this);
 	}

--- a/test/common/ws/client.js
+++ b/test/common/ws/client.js
@@ -40,6 +40,7 @@ WSClient.prototype.start = function() {
 			ip: testConfig.address,
 			wsPort: testConfig.wsPort,
 		},
+		console,
 		this.stop.bind(this)
 	);
 	// Emit random message to initialize connection

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -29,7 +29,8 @@ describe('RPC Client', () => {
 	let socketClusterMock;
 
 	function reconnect(ip = validWSServerIp, wsPort = validWSServerPort) {
-		validClientRPCStub = connect({ ip, wsPort }).rpc;
+		validClientRPCStub = connect({ ip, wsPort }, { debug: sinonSandbox.stub() })
+			.rpc;
 	}
 
 	before(done => {

--- a/test/unit/api/ws/rpc/connect.js
+++ b/test/unit/api/ws/rpc/connect.js
@@ -64,7 +64,9 @@ describe('connect', () => {
 	describe('connect', () => {
 		describe('connectSteps order', () => {
 			beforeEach(done => {
-				connectResult = connectRewired(validPeer);
+				connectResult = connectRewired(validPeer, {
+					debug: sinonSandbox.stub(),
+				});
 				done();
 			});
 

--- a/test/unit/helpers/peers_manager.js
+++ b/test/unit/helpers/peers_manager.js
@@ -16,22 +16,31 @@
 
 var prefixedPeer = require('../../fixtures/peers').randomNormalizedPeer;
 var Peer = require('../../../logic/peer');
-var peersManager = require('../../../helpers/peers_manager');
+var PeersManager = require('../../../helpers/peers_manager');
+
+var peersManagerInstance;
 
 describe('PeersManager', () => {
+	beforeEach(done => {
+		peersManagerInstance = new PeersManager({
+			debug: sinonSandbox.stub(),
+		});
+		done();
+	});
+
 	describe('constructor', () => {
 		it('should have empty peers map after initialization', () => {
-			return expect(peersManager).to.have.property('peers').to.be.empty;
+			return expect(peersManagerInstance).to.have.property('peers').to.be.empty;
 		});
 
 		it('should have empty addressToNonceMap map after initialization', () => {
-			return expect(peersManager).to.have.property('addressToNonceMap').to.be
-				.empty;
+			return expect(peersManagerInstance).to.have.property('addressToNonceMap')
+				.to.be.empty;
 		});
 
 		it('should have empty nonceToConnectionIdMap map after initialization', () => {
-			return expect(peersManager).to.have.property('nonceToAddressMap').to.be
-				.empty;
+			return expect(peersManagerInstance).to.have.property('nonceToAddressMap')
+				.to.be.empty;
 		});
 	});
 
@@ -40,69 +49,73 @@ describe('PeersManager', () => {
 
 		beforeEach(done => {
 			validPeer = new Peer(prefixedPeer);
-			peersManager.peers = {};
-			peersManager.addressToNonceMap = {};
-			peersManager.nonceToAddressMap = {};
+			peersManagerInstance.peers = {};
+			peersManagerInstance.addressToNonceMap = {};
+			peersManagerInstance.nonceToAddressMap = {};
 			done();
 		});
 
 		describe('add', () => {
 			it('should return false when invoked without arguments', () => {
-				return expect(peersManager.add()).not.to.be.ok;
+				return expect(peersManagerInstance.add()).not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer equal null', () => {
-				return expect(peersManager.add(null)).not.to.be.ok;
+				return expect(peersManagerInstance.add(null)).not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer equal 0', () => {
-				return expect(peersManager.add(0)).not.to.be.ok;
+				return expect(peersManagerInstance.add(0)).not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer has no string field', () => {
-				return expect(peersManager.add({})).not.to.be.ok;
+				return expect(peersManagerInstance.add({})).not.to.be.ok;
 			});
 
 			it('should add entry to peers when invoked with valid arguments', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.peers)
+				peersManagerInstance.add(validPeer);
+				return expect(peersManagerInstance.peers)
 					.to.have.property(validPeer.string)
 					.eql(validPeer);
 			});
 
 			it('should add entry to addressToNonceMap when invoked with valid arguments', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.addressToNonceMap)
+				peersManagerInstance.add(validPeer);
+				return expect(peersManagerInstance.addressToNonceMap)
 					.to.have.property(validPeer.string)
 					.eql(validPeer.nonce);
 			});
 
 			it('should add entry to nonceToAddressMap when invoked with valid arguments', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.nonceToAddressMap)
+				peersManagerInstance.add(validPeer);
+				return expect(peersManagerInstance.nonceToAddressMap)
 					.to.have.property(validPeer.nonce)
 					.eql(validPeer.string);
 			});
 
 			it('should prevent from adding peer with the same nonce but different address', () => {
-				expect(peersManager.add(validPeer)).to.be.ok;
+				expect(peersManagerInstance.add(validPeer)).to.be.ok;
 				validPeer.string = 'DIFFERENT';
-				return expect(peersManager.add(validPeer)).not.to.be.ok;
+				return expect(peersManagerInstance.add(validPeer)).not.to.be.ok;
 			});
 
 			it('should update data on peers list', () => {
-				expect(peersManager.add(validPeer)).to.be.ok;
+				expect(peersManagerInstance.add(validPeer)).to.be.ok;
 				validPeer.height = 'DIFFERENT';
-				expect(peersManager.add(validPeer)).to.be.ok;
-				return expect(peersManager.peers[validPeer.string]).eql(validPeer);
+				expect(peersManagerInstance.add(validPeer)).to.be.ok;
+				return expect(peersManagerInstance.peers[validPeer.string]).eql(
+					validPeer
+				);
 			});
 
 			it('should remove old entry when nonce is different', () => {
-				expect(peersManager.add(validPeer)).to.be.ok;
+				expect(peersManagerInstance.add(validPeer)).to.be.ok;
 				validPeer.nonce = 'DIFFERENT';
-				expect(peersManager.add(validPeer)).to.be.ok;
-				expect(Object.keys(peersManager.peers).length).to.equal(1);
-				return expect(peersManager.peers[validPeer.string]).eql(validPeer);
+				expect(peersManagerInstance.add(validPeer)).to.be.ok;
+				expect(Object.keys(peersManagerInstance.peers).length).to.equal(1);
+				return expect(peersManagerInstance.peers[validPeer.string]).eql(
+					validPeer
+				);
 			});
 
 			describe('multiple valid entries', () => {
@@ -118,40 +131,40 @@ describe('PeersManager', () => {
 					validPeerB.string += 'B';
 					validPeerB.nonce += 'B';
 
-					expect(peersManager.add(validPeerA)).to.be.ok;
-					return expect(peersManager.add(validPeerB)).to.be.ok;
+					expect(peersManagerInstance.add(validPeerA)).to.be.ok;
+					return expect(peersManagerInstance.add(validPeerB)).to.be.ok;
 				});
 
 				it('should contain multiple entries in peers after multiple valid entries added', () => {
-					expect(Object.keys(peersManager.peers).length).to.equal(2);
-					expect(peersManager.peers)
+					expect(Object.keys(peersManagerInstance.peers).length).to.equal(2);
+					expect(peersManagerInstance.peers)
 						.to.have.property(validPeerA.string)
 						.eql(validPeerA);
-					return expect(peersManager.peers)
+					return expect(peersManagerInstance.peers)
 						.to.have.property(validPeerB.string)
 						.eql(validPeerB);
 				});
 
 				it('should contain multiple entries in addressToNonceMap after multiple valid entries added', () => {
-					expect(Object.keys(peersManager.addressToNonceMap).length).to.equal(
-						2
-					);
-					expect(peersManager.addressToNonceMap)
+					expect(
+						Object.keys(peersManagerInstance.addressToNonceMap).length
+					).to.equal(2);
+					expect(peersManagerInstance.addressToNonceMap)
 						.to.have.property(validPeerA.string)
 						.equal(validPeerA.nonce);
-					return expect(peersManager.addressToNonceMap)
+					return expect(peersManagerInstance.addressToNonceMap)
 						.to.have.property(validPeerB.string)
 						.equal(validPeerB.nonce);
 				});
 
 				it('should contain multiple entries in nonceToAddressMap after multiple valid entries added', () => {
-					expect(Object.keys(peersManager.addressToNonceMap).length).to.equal(
-						2
-					);
-					expect(peersManager.nonceToAddressMap)
+					expect(
+						Object.keys(peersManagerInstance.addressToNonceMap).length
+					).to.equal(2);
+					expect(peersManagerInstance.nonceToAddressMap)
 						.to.have.property(validPeerA.nonce)
 						.equal(validPeerA.string);
-					return expect(peersManager.nonceToAddressMap)
+					return expect(peersManagerInstance.nonceToAddressMap)
 						.to.have.property(validPeerB.nonce)
 						.equal(validPeerB.string);
 				});
@@ -160,58 +173,63 @@ describe('PeersManager', () => {
 
 		describe('remove', () => {
 			it('should return false when invoked without arguments', () => {
-				return expect(peersManager.remove()).not.to.be.ok;
+				return expect(peersManagerInstance.remove()).not.to.be.ok;
 			});
 
 			it('should return false when invoked with null', () => {
-				return expect(peersManager.remove(null)).not.to.be.ok;
+				return expect(peersManagerInstance.remove(null)).not.to.be.ok;
 			});
 
 			it('should return false when invoked with 0', () => {
-				return expect(peersManager.remove(0)).not.to.be.ok;
+				return expect(peersManagerInstance.remove(0)).not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer without string property', () => {
-				return expect(peersManager.remove({})).not.to.be.ok;
+				return expect(peersManagerInstance.remove({})).not.to.be.ok;
 			});
 
 			it('should return false when invoked with peer while attempt to remove not existing peer', () => {
-				return expect(peersManager.remove(validPeer)).not.to.be.ok;
+				return expect(peersManagerInstance.remove(validPeer)).not.to.be.ok;
 			});
 
 			it('should not change a state of connections table when removing not existing entry', () => {
-				peersManager.remove(validPeer);
-				expect(peersManager).to.have.property('peers').to.be.empty;
-				expect(peersManager).to.have.property('addressToNonceMap').to.be.empty;
-				return expect(peersManager).to.have.property('nonceToAddressMap').to.be
+				peersManagerInstance.remove(validPeer);
+				expect(peersManagerInstance).to.have.property('peers').to.be.empty;
+				expect(peersManagerInstance).to.have.property('addressToNonceMap').to.be
 					.empty;
+				return expect(peersManagerInstance).to.have.property(
+					'nonceToAddressMap'
+				).to.be.empty;
 			});
 
 			it('should remove previously added valid entry', () => {
-				peersManager.add(validPeer);
-				expect(peersManager.peers)
+				peersManagerInstance.add(validPeer);
+				expect(peersManagerInstance.peers)
 					.to.have.property(validPeer.string)
 					.eql(validPeer);
-				peersManager.remove(validPeer);
-				expect(peersManager).to.have.property('peers').to.be.empty;
-				expect(peersManager).to.have.property('addressToNonceMap').to.be.empty;
-				return expect(peersManager).to.have.property('nonceToAddressMap').to.be
+				peersManagerInstance.remove(validPeer);
+				expect(peersManagerInstance).to.have.property('peers').to.be.empty;
+				expect(peersManagerInstance).to.have.property('addressToNonceMap').to.be
 					.empty;
+				return expect(peersManagerInstance).to.have.property(
+					'nonceToAddressMap'
+				).to.be.empty;
 			});
 		});
 
 		describe('getNonce', () => {
 			it('should return undefined when invoked without arguments', () => {
-				return expect(peersManager.getNonce()).to.be.undefined;
+				return expect(peersManagerInstance.getNonce()).to.be.undefined;
 			});
 
 			it('should return undefined when asking of not existing entry', () => {
-				return expect(peersManager.getNonce(validPeer.string)).to.be.undefined;
+				return expect(peersManagerInstance.getNonce(validPeer.string)).to.be
+					.undefined;
 			});
 
 			it('should return nonce assigned to connection id when entry exists', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.getNonce(validPeer.string)).to.equal(
+				peersManagerInstance.add(validPeer);
+				return expect(peersManagerInstance.getNonce(validPeer.string)).to.equal(
 					validPeer.nonce
 				);
 			});
@@ -219,62 +237,68 @@ describe('PeersManager', () => {
 
 		describe('getAddress', () => {
 			it('should return undefined when invoked without arguments', () => {
-				return expect(peersManager.getAddress()).to.be.undefined;
+				return expect(peersManagerInstance.getAddress()).to.be.undefined;
 			});
 
 			it('should return undefined when asking of not existing entry', () => {
-				return expect(peersManager.getAddress(validPeer.nonce)).to.be.undefined;
+				return expect(peersManagerInstance.getAddress(validPeer.nonce)).to.be
+					.undefined;
 			});
 
 			it('should return nonce assigned to connection id when entry exists', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.getAddress(validPeer.nonce)).to.equal(
-					validPeer.string
-				);
+				peersManagerInstance.add(validPeer);
+				return expect(
+					peersManagerInstance.getAddress(validPeer.nonce)
+				).to.equal(validPeer.string);
 			});
 		});
 
 		describe('getAll', () => {
 			it('should return empty object if no peers were added before', () => {
-				return expect(peersManager.getAll()).to.be.empty;
+				return expect(peersManagerInstance.getAll()).to.be.empty;
 			});
 
 			it('should return map of added peers', () => {
-				peersManager.add(validPeer);
+				peersManagerInstance.add(validPeer);
 				var validResult = {};
 				validResult[validPeer.string] = validPeer;
-				return expect(peersManager.getAll(validPeer.nonce)).eql(validResult);
+				return expect(peersManagerInstance.getAll(validPeer.nonce)).eql(
+					validResult
+				);
 			});
 		});
 
 		describe('getByNonce', () => {
 			it('should return undefined when invoked without arguments', () => {
-				return expect(peersManager.getByNonce()).to.be.undefined;
+				return expect(peersManagerInstance.getByNonce()).to.be.undefined;
 			});
 
 			it('should return undefined when asking of not existing entry', () => {
-				return expect(peersManager.getByNonce(validPeer.nonce)).to.be.undefined;
+				return expect(peersManagerInstance.getByNonce(validPeer.nonce)).to.be
+					.undefined;
 			});
 
 			it('should return previously added peer when asking with valid nonce', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.getByNonce(validPeer.nonce)).eql(validPeer);
+				peersManagerInstance.add(validPeer);
+				return expect(peersManagerInstance.getByNonce(validPeer.nonce)).eql(
+					validPeer
+				);
 			});
 		});
 
 		describe('getByAddress', () => {
 			it('should return undefined when invoked without arguments', () => {
-				return expect(peersManager.getByAddress()).to.be.undefined;
+				return expect(peersManagerInstance.getByAddress()).to.be.undefined;
 			});
 
 			it('should return undefined when asking of not existing entry', () => {
-				return expect(peersManager.getByAddress(validPeer.string)).to.be
+				return expect(peersManagerInstance.getByAddress(validPeer.string)).to.be
 					.undefined;
 			});
 
 			it('should return previously added peer when asking with valid nonce', () => {
-				peersManager.add(validPeer);
-				return expect(peersManager.getByAddress(validPeer.string)).eql(
+				peersManagerInstance.add(validPeer);
+				return expect(peersManagerInstance.getByAddress(validPeer.string)).eql(
 					validPeer
 				);
 			});
@@ -283,27 +307,37 @@ describe('PeersManager', () => {
 
 	describe('multiple instances', () => {
 		describe('when required 2 times', () => {
-			const peersManagerA = require('../../../helpers/peers_manager');
-			const peersManagerB = require('../../../helpers/peers_manager');
-			describe('when [peersManagerA] adds data', () => {
+			var peersManagerInstanceA;
+			var peersManagerInstanceB;
+
+			beforeEach(done => {
+				peersManagerInstanceA = new PeersManager({
+					debug: sinonSandbox.stub(),
+				});
+				peersManagerInstanceB = new PeersManager({
+					debug: sinonSandbox.stub(),
+				});
+				done();
+			});
+			describe('when [peersManagerInstanceA] adds data', () => {
 				let validPeer;
 
 				beforeEach(done => {
 					validPeer = new Peer(prefixedPeer);
-					peersManagerA.add(validPeer);
+					peersManagerInstanceA.add(validPeer);
 					done();
 				});
 
-				it('should be reflected in [peersManagerA]', () => {
-					return expect(peersManagerA.getByAddress(validPeer.string)).eql(
-						validPeer
-					);
+				it('should be reflected in [peersManagerInstanceA]', () => {
+					return expect(
+						peersManagerInstanceA.getByAddress(validPeer.string)
+					).eql(validPeer);
 				});
 
-				it('should be reflected in [peersManagerB]', () => {
-					return expect(peersManagerB.getByAddress(validPeer.string)).eql(
-						validPeer
-					);
+				it('should not be reflected in [peersManagerInstanceB]', () => {
+					return expect(
+						peersManagerInstanceB.getByAddress(validPeer.string)
+					).not.eql(validPeer);
 				});
 			});
 		});


### PR DESCRIPTION
### What was the problem?

Low-level WebSocket connection errors were not logged - This made it harder to debug issues during QA testing.

### How did I fix it?

Added logger to log the result of 'close' events on the socket.

### How to test it?

`npm run mocha test/unit/api/ws/rpc/connect.js`

### Review checklist

* The PR solves #1745
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
