### PR TITLE
Improve logging of WebSocket messages and events - Closes #1762

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -130,6 +130,13 @@ const connectSteps = {
 			peer.socket.disconnect();
 		});
 
+		// The 'message' event can be used to log all low-level WebSocket messages.
+		peer.socket.on('message', message => {
+			logger.trace(
+				`[Outbound socket] Received message: ${message}`
+			);
+		});
+
 		// When WS connection ends - remove peer
 		peer.socket.on('close', (code, reason) => {
 			logger.debug(

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -133,7 +133,7 @@ const connectSteps = {
 		// When WS connection ends - remove peer
 		peer.socket.on('close', (code, reason) => {
 			logger.debug(
-				`Peer WebSocket connection failed with code ${code} and reason: "${reason}"`
+				`[Outbound socket] Peer WebSocket connection failed with code ${code} and reason: "${reason}"`
 			);
 			onDisconnectCb();
 		});

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -29,8 +29,14 @@ describe('RPC Client', () => {
 	let socketClusterMock;
 
 	function reconnect(ip = validWSServerIp, wsPort = validWSServerPort) {
-		validClientRPCStub = connect({ ip, wsPort }, { debug: sinonSandbox.stub() })
-			.rpc;
+		const loggerMock = {
+			error: sinonSandbox.stub(),
+			warn: sinonSandbox.stub(),
+			log: sinonSandbox.stub(),
+			debug: sinonSandbox.stub(),
+			trace: sinonSandbox.stub(),
+		};
+		validClientRPCStub = connect({ ip, wsPort }, loggerMock).rpc;
 	}
 
 	before(done => {

--- a/test/unit/api/ws/rpc/connect.js
+++ b/test/unit/api/ws/rpc/connect.js
@@ -30,6 +30,7 @@ describe('connect', () => {
 	let upgradeSocketSpy;
 	let registerRPCSpy;
 	let registerSocketListenersSpy;
+	let loggerMock;
 
 	before('spy on connectSteps', done => {
 		const connectionSteps = connectRewired.__get__('connectSteps');
@@ -58,19 +59,20 @@ describe('connect', () => {
 
 	beforeEach('provide non-mutated peer each time', done => {
 		validPeer = Object.assign({}, prefixedPeer);
+		loggerMock = {
+			error: sinonSandbox.stub(),
+			warn: sinonSandbox.stub(),
+			log: sinonSandbox.stub(),
+			debug: sinonSandbox.stub(),
+			trace: sinonSandbox.stub(),
+		};
 		done();
 	});
 
 	describe('connect', () => {
 		describe('connectSteps order', () => {
 			beforeEach(done => {
-				connectResult = connectRewired(validPeer, {
-					error: sinonSandbox.stub(),
-					warn: sinonSandbox.stub(),
-					log: sinonSandbox.stub(),
-					debug: sinonSandbox.stub(),
-					trace: sinonSandbox.stub(),
-				});
+				connectResult = connectRewired(validPeer, loggerMock);
 				done();
 			});
 
@@ -441,7 +443,7 @@ describe('connect', () => {
 					'connectSteps.registerSocketListeners'
 				);
 				validPeer.socket = validSocket;
-				peerAsResult = registerSocketListeners(validPeer);
+				peerAsResult = registerSocketListeners(validPeer, loggerMock);
 				done();
 			});
 

--- a/test/unit/api/ws/rpc/connect.js
+++ b/test/unit/api/ws/rpc/connect.js
@@ -65,7 +65,11 @@ describe('connect', () => {
 		describe('connectSteps order', () => {
 			beforeEach(done => {
 				connectResult = connectRewired(validPeer, {
+					error: sinonSandbox.stub(),
+					warn: sinonSandbox.stub(),
+					log: sinonSandbox.stub(),
 					debug: sinonSandbox.stub(),
+					trace: sinonSandbox.stub(),
 				});
 				done();
 			});

--- a/test/unit/api/ws/rpc/connect.js
+++ b/test/unit/api/ws/rpc/connect.js
@@ -459,8 +459,8 @@ describe('connect', () => {
 				return expect(peerAsResult.socket.on).to.be.calledWith('close');
 			});
 
-			it('should register 3 event listeners', () => {
-				return expect(peerAsResult.socket.on).to.be.calledThrice;
+			it('should register 5 event listeners', () => {
+				return expect(peerAsResult.socket.on).to.be.callCount(5);
 			});
 		});
 	});

--- a/test/unit/helpers/peers_manager.js
+++ b/test/unit/helpers/peers_manager.js
@@ -23,7 +23,11 @@ var peersManagerInstance;
 describe('PeersManager', () => {
 	beforeEach(done => {
 		peersManagerInstance = new PeersManager({
+			error: sinonSandbox.stub(),
+			warn: sinonSandbox.stub(),
+			log: sinonSandbox.stub(),
 			debug: sinonSandbox.stub(),
+			trace: sinonSandbox.stub(),
 		});
 		done();
 	});

--- a/workers_controller.js
+++ b/workers_controller.js
@@ -122,15 +122,24 @@ SCWorker.create({
 				scServer.addMiddleware(scServer.MIDDLEWARE_EMIT, emitMiddleware);
 
 				scServer.on('handshake', socket => {
+					socket.on('message', message => {
+						scope.logger.trace(`[Inbound socket] Received message: ${message}`);
+					});
 					// We can access the HTTP request (which instantiated the WebSocket connection) using socket.request
 					// so we can access our custom socket.request.failedQueryValidation property here.
 					// If the property exists then we disconnect the connection.
 					if (socket.request.failedHeadersValidationError) {
+						var handshakeFailedCode = socket.request.failedHeadersValidationError.code;
+						var handshakeFailedDesc = socket.request.failedHeadersValidationError.description;
+						scope.logger.debug(`[Inbound socket] WebSocket handshake from socket ${socket.id} failed with code ${handshakeFailedCode}: ${handshakeFailedDesc}`);
 						return socket.disconnect(
-							socket.request.failedHeadersValidationError.code,
-							socket.request.failedHeadersValidationError.description
+							handshakeFailedCode,
+							handshakeFailedDesc
 						);
 					}
+
+					scope.logger.trace(`[Inbound socket] WebSocket handshake from socket ${socket.id} succeeded`);
+
 					updatePeerConnection(
 						Rules.UPDATES.INSERT,
 						socket,


### PR DESCRIPTION
### What was the problem?

The current node doesn't have sufficient low-level WebSocket logging to aid in QA debugging.

### How did I fix it?

Added logging (debug/trace) for all major WebSocket events and all WebSocket messages for both inbound and outbound sockets.

### How to test it?

- In `config.json` set the `consoleLogLevel` to `trace`.
- Run the node.

There should now be additional `[trc]` and `[dbg]` log messages which look like this:
- `[Inbound socket] WebSocket handshake from socket MqHahyi-hAfHYXU3AAAD failed with code 4101: Expected nonce to be not equal to: FvPC4PCawdOUm31G`
- `[Outbound socket] Peer message received: {"event":"...","data":...}`

`[Inbound socket]` means that the connection which triggered the issue was created/initiated by a peer. `[Outbound socket]` means that the connection which triggered the issue was created/initiated by the current node.

Also, you can run the test:
`npm run mocha test/functional/ws/transport/client.js`

### Review checklist

* The PR solves #1762
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
