### PR TITLE
Fix issue with loading genesisBlock twice - Fixes #1766

### DIFF
--- a/db/sql/accounts/reset_memory_tables.sql
+++ b/db/sql/accounts/reset_memory_tables.sql
@@ -19,6 +19,7 @@
   PARAMETERS: None
 */
 
+DELETE FROM mem_accounts;
 DELETE FROM mem_round;
 DELETE FROM mem_accounts2delegates;
 DELETE FROM mem_accounts2u_delegates;

--- a/test/unit/logic/account.js
+++ b/test/unit/logic/account.js
@@ -113,16 +113,6 @@ describe('account', () => {
 		});
 	});
 
-	describe('resetMemTables', () => {
-		it('should remove the tables', done => {
-			account.resetMemTables((err, res) => {
-				expect(err).to.not.exist;
-				expect(res).to.be.undefined;
-				done();
-			});
-		});
-	});
-
 	describe('objectNormalize', () => {
 		it('should validate account schema', () => {
 			return expect(account.objectNormalize(validAccount)).to.be.an('object');
@@ -540,6 +530,16 @@ describe('account', () => {
 					expect(res).to.eql(_.sortBy(res, 'username').reverse());
 					done();
 				});
+			});
+		});
+	});
+
+	describe('resetMemTables', () => {
+		it('should remove the tables', done => {
+			account.resetMemTables((err, res) => {
+				expect(err).to.not.exist;
+				expect(res).to.be.undefined;
+				done();
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?
Node was trying to load genesisBlock again if the blocksCount = 1 (Which will always be true)
### How did I fix it?
Load genesisBlock when blocksCount = 0 as opposed to when it's 1.
### How to test it?
Run application
### Review checklist

* The PR solves #1766
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
