### PR TITLE
Nonce is not propagated correctly in PeersManager mappings - Closes #1752

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -122,7 +122,9 @@ const connectSteps = {
 
 		peer.socket.on('connect', () => {
 			logger.trace(
-				`[Outbound socket] Peer connection established with socket id ${peer.socket.id}`
+				`[Outbound socket] Peer connection established with socket id ${
+					peer.socket.id
+				}`
 			);
 		});
 
@@ -150,9 +152,7 @@ const connectSteps = {
 
 		// The 'message' event can be used to log all low-level WebSocket messages.
 		peer.socket.on('message', message => {
-			logger.trace(
-				`[Outbound socket] Peer message received: ${message}`
-			);
+			logger.trace(`[Outbound socket] Peer message received: ${message}`);
 		});
 		return peer;
 	},

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -50,9 +50,6 @@ PeersManager.prototype.add = function(peer) {
 	) {
 		return false;
 	}
-	if (this.peers[peer.string]) {
-		return this.update(peer);
-	}
 	this.peers[peer.string] = peer;
 	this.addressToNonceMap[peer.string] = peer.nonce;
 	if (peer.nonce) {
@@ -84,31 +81,6 @@ PeersManager.prototype.remove = function(peer) {
 	delete this.peers[peer.string];
 
 	disconnect(peer);
-	return true;
-};
-
-/**
- * Description of the function.
- *
- * @param {Object} peer
- * @todo Add description for the params
- * @todo Add @returns tag
- */
-PeersManager.prototype.update = function(peer) {
-	var oldNonce = this.addressToNonceMap[peer.string];
-	var oldAddress = this.nonceToAddressMap[oldNonce];
-	if (oldNonce) {
-		this.nonceToAddressMap[oldNonce] = null;
-		delete this.nonceToAddressMap[oldNonce];
-	}
-	if (oldAddress) {
-		this.addressToNonceMap[oldAddress] = null;
-		delete this.addressToNonceMap[oldAddress];
-
-		this.peers[oldAddress] = null;
-		delete this.peers[oldAddress];
-	}
-	this.add(peer);
 	return true;
 };
 

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -51,12 +51,14 @@ PeersManager.prototype.add = function(peer) {
 		return false;
 	}
 	this.peers[peer.string] = peer;
+	if (!this.addressToNonceMap[peer.string]) {
+		// Create client WS connection to peer
+		connect(peer, this.logger, this.remove.bind(this, peer));
+	}
 	this.addressToNonceMap[peer.string] = peer.nonce;
 	if (peer.nonce) {
 		this.nonceToAddressMap[peer.nonce] = peer.string;
 	}
-	// Create client WS connection to peer
-	connect(peer, this.logger, this.remove.bind(this, peer));
 	return true;
 };
 

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -128,18 +128,25 @@ Peers.prototype.upsert = function(peer, insertOnly) {
 	// Update existing peer
 	const update = function(peer) {
 		peer.updated = Date.now();
-
 		const diff = {};
-		_.each(peer, (value, key) => {
+
+		const recentPeer = self.peersManager.getByAddress(peer.string);
+		// Make a copy for logging difference purposes only
+		const recentPeerBeforeUpdate = Object.assign({}, recentPeer);
+
+		recentPeer.update(peer);
+		self.peersManager.add(recentPeer);
+
+		// Create a log after peer update to summarize updated fields
+		_.each(recentPeer, (value, key) => {
 			if (
 				key !== 'updated' &&
-				self.peersManager.getByAddress(peer.string)[key] !== value
+				peer.properties.indexOf(key) !== -1 &&
+				recentPeerBeforeUpdate[key] !== value
 			) {
 				diff[key] = value;
 			}
 		});
-
-		self.peersManager.getByAddress(peer.string).update(peer);
 
 		if (Object.keys(diff).length) {
 			library.logger.debug(`Updated peer ${peer.string}`, diff);

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -238,7 +238,10 @@ __private.updatePeerStatus = function(err, status, peer) {
 			// If the node tries to connect to itself as a peer, the
 			// nonce will be incompatible. Here we put the peer in a BANNED
 			// state so that the node doesn't keep trying to reconnect to itself.
-			peer.applyHeaders({ state: Peer.STATE.BANNED });
+			peer.applyHeaders({
+				state: Peer.STATE.BANNED,
+				nonce: self.me().nonce,
+			});
 		} else {
 			library.logic.peers.remove(peer);
 		}

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -392,10 +392,6 @@ Transport.prototype.onBroadcastBlock = function(block, broadcast) {
 						peer.rpc.updateMyself(library.logic.peers.me(), err => {
 							if (err) {
 								library.logger.debug('Failed to notify peer about self', err);
-								__private.removePeer({
-									nonce: peer.nonce,
-									code: 'ECOMMUNICATION',
-								});
 							} else {
 								library.logger.debug(
 									'Successfully notified peer about self',

--- a/test/unit/helpers/peers_manager.js
+++ b/test/unit/helpers/peers_manager.js
@@ -173,6 +173,46 @@ describe('PeersManager', () => {
 						.equal(validPeerB.string);
 				});
 			});
+
+			describe('when peer gets added nonce = undefined', () => {
+				beforeEach(done => {
+					validPeer.nonce = undefined;
+					peersManagerInstance.add(validPeer);
+					done();
+				});
+
+				it('should add an entry [validPeer.string] = undefined in addressToNonce map', () => {
+					return expect(
+						peersManagerInstance.addressToNonceMap
+					).to.have.property(validPeer.string).to.be.undefined;
+				});
+
+				it('should not create any entry in nonceToAddress map', () => {
+					return expect(
+						peersManagerInstance.nonceToAddressMap
+					).not.to.have.property(validPeer.nonce);
+				});
+
+				describe('when peer is updated with defined nonce = "validNonce"', () => {
+					beforeEach(done => {
+						validPeer.nonce = 'validNonce';
+						peersManagerInstance.add(validPeer);
+						done();
+					});
+
+					it('should update an entry [validPeer.string] = "validNonce" in addressToNonce map', () => {
+						return expect(peersManagerInstance.addressToNonceMap)
+							.to.have.property(validPeer.string)
+							.to.equal('validNonce');
+					});
+
+					it('should add an entry "validNonce" = [peer.string] in nonceToAddress map', () => {
+						return expect(peersManagerInstance.nonceToAddressMap)
+							.to.have.property('validNonce')
+							.equal(validPeer.string);
+					});
+				});
+			});
 		});
 
 		describe('remove', () => {

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1483,15 +1483,6 @@ describe('transport', () => {
 								transportInstance.onBroadcastBlock(block, true);
 								done();
 							});
-
-							it('should call __private.removePeer with {peer: peer, code: "ECOMMUNICATION"}', () => {
-								return expect(
-									__private.removePeer.calledWith({
-										nonce: peerMock.nonce,
-										code: 'ECOMMUNICATION',
-									})
-								).to.be.true;
-							});
 						});
 
 						describe('when peer.rpc.updateMyself succeeds', () => {

--- a/workers_controller.js
+++ b/workers_controller.js
@@ -129,16 +129,23 @@ SCWorker.create({
 					// so we can access our custom socket.request.failedQueryValidation property here.
 					// If the property exists then we disconnect the connection.
 					if (socket.request.failedHeadersValidationError) {
-						var handshakeFailedCode = socket.request.failedHeadersValidationError.code;
-						var handshakeFailedDesc = socket.request.failedHeadersValidationError.description;
-						scope.logger.debug(`[Inbound socket] WebSocket handshake from socket ${socket.id} failed with code ${handshakeFailedCode}: ${handshakeFailedDesc}`);
-						return socket.disconnect(
-							handshakeFailedCode,
-							handshakeFailedDesc
+						var handshakeFailedCode =
+							socket.request.failedHeadersValidationError.code;
+						var handshakeFailedDesc =
+							socket.request.failedHeadersValidationError.description;
+						scope.logger.debug(
+							`[Inbound socket] WebSocket handshake from socket ${
+								socket.id
+							} failed with code ${handshakeFailedCode}: ${handshakeFailedDesc}`
 						);
+						return socket.disconnect(handshakeFailedCode, handshakeFailedDesc);
 					}
 
-					scope.logger.trace(`[Inbound socket] WebSocket handshake from socket ${socket.id} succeeded`);
+					scope.logger.trace(
+						`[Inbound socket] WebSocket handshake from socket ${
+							socket.id
+						} succeeded`
+					);
 
 					updatePeerConnection(
 						Rules.UPDATES.INSERT,
@@ -190,7 +197,9 @@ SCWorker.create({
 										onUpdateError.code
 									}, message: ${
 										failureCodes.errorMessages[onUpdateError.code]
-									}, description: ${onUpdateError.description}`
+									}, description: ${onUpdateError.description} on peer ${
+										peer.ip
+									}:${peer.wsPort}`
 								);
 							} else {
 								scope.logger.info(


### PR DESCRIPTION
### What was the problem?
Peer's nonce was not updated correctly in periodically `rpc.updateMyself` actions when Peer was being inserted from seed peers before.
### How did I fix it?
Peer update action is now corrected.
Peer is not being removed from the Peers List when `rpc.updateMyself` action fails - peer can not necessarily contain themselves mutually on peers lists.
Peer's nonce update scenario is added to Peers Manager unit tests.
### How to test it?
Run integration tests. Verify that `Upsert invalid peer rejected` trace log is not appearing anymore.  
### Review checklist

* The PR solves #1752
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
