### PR TITLE
Failed to find common block with: xxx - Closes #1789

### DIFF
--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -294,6 +294,14 @@ Process.prototype.getCommonBlock = function(peer, height, cb) {
 				});
 			},
 			function(common, waterCb) {
+				// Check if we received genesis block - before response validation, as genesis block have previousBlock = null
+				if (common && common.height === 1) {
+					comparisionFailed = true;
+					return setImmediate(
+						waterCb,
+						'Comparison failed - received genesis as common block'
+					);
+				}
 				// Validate remote peer response via schema
 				library.schema.validate(common, definitions.CommonBlock, err => {
 					if (err) {

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -259,7 +259,7 @@ __private.receiveForkFive = function(block, lastBlock, cb) {
  * @returns {Object} cb.res - Result object
  */
 Process.prototype.getCommonBlock = function(peer, height, cb) {
-	let comparisionFailed = false;
+	let comparisonFailed = false;
 
 	async.waterfall(
 		[
@@ -279,7 +279,7 @@ Process.prototype.getCommonBlock = function(peer, height, cb) {
 						return setImmediate(waterCb, err);
 					} else if (!res.common) {
 						// FIXME: Need better checking here, is base on 'common' property enough?
-						comparisionFailed = true;
+						comparisonFailed = true;
 						return setImmediate(
 							waterCb,
 							[
@@ -296,7 +296,7 @@ Process.prototype.getCommonBlock = function(peer, height, cb) {
 			function(common, waterCb) {
 				// Check if we received genesis block - before response validation, as genesis block have previousBlock = null
 				if (common && common.height === 1) {
-					comparisionFailed = true;
+					comparisonFailed = true;
 					return setImmediate(
 						waterCb,
 						'Comparison failed - received genesis as common block'
@@ -321,7 +321,7 @@ Process.prototype.getCommonBlock = function(peer, height, cb) {
 					.then(rows => {
 						if (!rows.length || !rows[0].count) {
 							// Block doesn't exists - comparison failed
-							comparisionFailed = true;
+							comparisonFailed = true;
 							return setImmediate(
 								waterCb,
 								[
@@ -344,7 +344,7 @@ Process.prototype.getCommonBlock = function(peer, height, cb) {
 		],
 		(err, res) => {
 			// If comparison failed and current consensus is low - perform chain recovery
-			if (comparisionFailed && modules.transport.poorConsensus()) {
+			if (comparisonFailed && modules.transport.poorConsensus()) {
 				return modules.blocks.chain.recoverChain(cb);
 			}
 			return setImmediate(cb, err, res);

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -29,7 +29,6 @@ describe('blocks/process', () => {
 	var loggerStub;
 	var dummyBlock;
 	var dummyCommonBlock;
-	var dummyCommonBlockGenesis;
 	var blockStub;
 	var transactionStub;
 	var peersStub;
@@ -64,8 +63,15 @@ describe('blocks/process', () => {
 			string: 'ip:wsPort',
 		};
 
+		genesisblockStub = {
+			block: {
+				id: '6524861224470851795',
+				height: 1,
+				previousBlock: null,
+			},
+		};
+
 		dummyCommonBlock = { id: '3', previousBlock: '2', height: '3' };
-		dummyCommonBlockGenesis = { id: '3', previousBlock: '2', height: '1' };
 
 		peerStub.rpc.blocksCommon
 			.withArgs(sinonSandbox.match({ ids: 'ERR' }))
@@ -73,7 +79,7 @@ describe('blocks/process', () => {
 			.withArgs(sinonSandbox.match({ ids: 'rpc.blocksCommon-Empty' }))
 			.callsArgWith(1, null, { common: undefined })
 			.withArgs(sinonSandbox.match({ ids: 'rpc.blocksCommon-Genesis' }))
-			.callsArgWith(1, null, { common: dummyCommonBlockGenesis })
+			.callsArgWith(1, null, { common: genesisblockStub.block })
 			.withArgs(sinonSandbox.match({ ids: 'OK' }))
 			.callsArgWith(1, null, {
 				common: dummyCommonBlock,
@@ -122,13 +128,6 @@ describe('blocks/process', () => {
 
 		sequenceStub = {
 			add: sinonSandbox.stub(),
-		};
-
-		genesisblockStub = {
-			block: {
-				id: '6524861224470851795',
-				height: 1,
-			},
 		};
 
 		blocksProcessModule = new BlocksProcess(


### PR DESCRIPTION
### What was the problem?
Common block check failed on schema validation when received genesis block as a response (because of `previousBlock` that is `null` for genesis block).
### How did I fix it?
Mark comparison as failed and return error when receiving genesis block as response, so node can properly trigger `recoverChain` if have poor consensus.
### How to test it?
Manually. ;)
- run fresh `node1` with `forging.force = true`, allow forge some blocks
- stop `node1`
- run fresh `node2` with `forging.force = true`, allow forge some blocks
- start `node1` again with `forging.force = false`
- now nodes have different blocks in round `1`, so common block check is triggered
- `node1` should rollback properly now
### Review checklist
* The PR solves https://github.com/LiskHQ/lisk/issues/1789
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
