### PR TITLE
Version column in peers table expects shorter length value - Closes #1786

### DIFF
--- a/db/sql/migrations/updates/20180327170000_support_long_peer_version_numbers.sql
+++ b/db/sql/migrations/updates/20180327170000_support_long_peer_version_numbers.sql
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: Change the version column in the peers table so that it can accept longer version strings like x.x.x-alpha.x
+  PARAMETERS: None
+*/
+
+ALTER TABLE "peers"
+  ALTER COLUMN "version" TYPE VARCHAR(64);


### PR DESCRIPTION
### What was the problem?

Peers that had long version numbers (e.g. `x.x.x-alpha.x`) would cause a database error when the node was shut down because the peers table's version column only supported varchar(11).

### How did I fix it?

Changed version column type to varchar(64).

### How to test it?

1. Start the node - This should run the new migration.
2. In `psql` run ` \d+ peers;` - The `version` column should now be `character varying(64)`.

### Review checklist

* The PR solves #1786 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
