### PR TITLE
Improve jsdoc by replacing type {hash} with valid JavaScript type - Closes #1798

### DIFF
--- a/helpers/ed.js
+++ b/helpers/ed.js
@@ -29,7 +29,7 @@ var ed = {};
  * Creates a keypar based on a hash.
  *
  * @func makeKeypair
- * @param {hash} hash
+ * @param {Buffer} hash
  * @returns {Buffer}
  * @todo Add description for the params and the return value
  */
@@ -46,7 +46,7 @@ ed.makeKeypair = function(hash) {
  * Creates a signature based on a hash and a keypair.
  *
  * @func sign
- * @param {hash} hash
+ * @param {Buffer} hash
  * @param {Buffer} privateKey
  * @returns {Buffer}
  * @todo Add description for the params and the return value
@@ -59,7 +59,7 @@ ed.sign = function(hash, privateKey) {
  * Verifies a signature based on a hash and a publicKey.
  *
  * @func verify
- * @param {hash} hash
+ * @param {Buffer} hash
  * @param {Buffer} signature
  * @param {Buffer} publicKey
  * @returns {boolean} True if verified

--- a/logic/block.js
+++ b/logic/block.js
@@ -167,7 +167,7 @@ class Block {
 	 * Creates hash based on block bytes.
 	 *
 	 * @param {block} block
-	 * @returns {hash} SHA256 hash
+	 * @returns {Buffer} SHA256 hash
 	 * @todo Add description for the params
 	 */
 	getHash(block) {
@@ -287,7 +287,7 @@ __private.getAddressByPublicKey = function(publicKey) {
  * @property {signature} blockSignature
  * @property {publicKey} generatorPublicKey
  * @property {number} numberOfTransactions
- * @property {hash} payloadHash
+ * @property {string} payloadHash
  * @property {number} payloadLength
  * @property {string} previousBlock - Between 1 and 20 chars
  * @property {number} timestamp

--- a/logic/peer.js
+++ b/logic/peer.js
@@ -154,7 +154,7 @@ class Peer {
  * @property {number} state - Between 0 and 2. (banned = 0, unbanned = 1, active = 2)
  * @property {string} os - Between 1 and 64 chars
  * @property {string} version - Between 5 and 12 chars
- * @property {hash} broadhash
+ * @property {string} broadhash
  * @property {number} height - Minimum 1
  * @property {Date} clock
  * @property {Date} updated

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -131,7 +131,7 @@ class Transaction {
 	 * Creates hash based on transaction bytes.
 	 *
 	 * @param {transaction} transaction
-	 * @returns {hash} SHA256 hash
+	 * @returns {Buffer} SHA256 hash
 	 * @todo Add description for the params
 	 */
 	getHash(transaction) {


### PR DESCRIPTION
`hash` is not a type in Javascript and a hash can be encoded in multiple ways. This change makes clear, which type is used to pass around the hash.

Having a custom type {hash} seems to be dangerous without strict type checking in place. The actual data was sometimes a Buffer, sometimes a hex string.

### Review checklist

* The PR solves #1798
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
