### PR TITLE
Fix chain recovery by changing getCommonBlock - Closes #1795

### DIFF
--- a/db/repos/blocks.js
+++ b/db/repos/blocks.js
@@ -274,16 +274,15 @@ class BlocksRepository {
 	}
 
 	/**
-	 * Get multiple blocks to be transported to peers.
+	 * Get block to be transported to peers.
 	 *
-	 * @param {string} ids - Comma separated string of ids
+	 * @param {string} id - id of the block
 	 * @returns {Promise}
 	 * @todo Add description for the return value
 	 *
 	 */
-	getBlocksForTransport(ids) {
-		// TODO: Must use a result-specific method, not .query
-		return this.db.query(sql.getBlocksForTransport, [ids]);
+	getBlockForTransport(id) {
+		return this.db.oneOrNone(sql.getBlockForTransport, [id]);
 	}
 
 	/**

--- a/db/sql/blocks/get_block_for_transport.sql
+++ b/db/sql/blocks/get_block_for_transport.sql
@@ -19,8 +19,6 @@
   PARAMETERS: ?
 */
 
-SELECT max(height) AS height, id, "previousBlock", "timestamp"
+SELECT height, id, "previousBlock", "timestamp"
 FROM blocks
-WHERE id IN ($1:csv)
-GROUP BY id
-ORDER BY height DESC
+WHERE id = $1

--- a/db/sql/index.js
+++ b/db/sql/index.js
@@ -57,7 +57,7 @@ module.exports = {
 		loadLastNBlockIds: link('blocks/load_last_n_block_ids.sql'),
 		blockExists: link('blocks/block_exists.sql'),
 		deleteAfterBlock: link('blocks/delete_after_block.sql'),
-		getBlocksForTransport: link('blocks/get_blocks_for_transport.sql'),
+		getBlockForTransport: link('blocks/get_block_for_transport.sql'),
 		getHeightByLastId: link('blocks/get_height_by_last_id.sql'),
 		getCommonBlock: link('blocks/get_common_block.sql'),
 	},

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -501,10 +501,8 @@ Transport.prototype.shared = {
 				}
 
 				library.db.blocks
-					.getBlocksForTransport(escapedIds)
-					.then(rows =>
-						setImmediate(cb, null, { success: true, common: rows[0] || null })
-					)
+					.getBlockForTransport(escapedIds[0])
+					.then(row => setImmediate(cb, null, { success: true, common: row }))
 					.catch(err => {
 						library.logger.error(err.stack);
 						return setImmediate(cb, 'Failed to get common block');

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1046,7 +1046,7 @@ describe('transport', () => {
 					},
 					db: {
 						blocks: {
-							getBlocksForTransport: sinonSandbox.stub().resolves(blocksList),
+							getBlockForTransport: sinonSandbox.stub().resolves(blocksList),
 						},
 					},
 				};


### PR DESCRIPTION
### What was the problem?
We weren't deleting block when our last block did not exist for peer
### How did I fix it?
Updated getCommonBlock to return null if last block doesn't exist.
### How to test it?
Run unit tests and create a devnet of forked nodes.
### Review checklist

* The PR solves #1795 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
