### PR TITLE
Migrations takes too long after rebuild from snapshot - Closes #1799

### DIFF
--- a/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
+++ b/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
@@ -29,7 +29,8 @@ DROP TRIGGER  IF EXISTS rounds_fees_insert ON "blocks";
 DROP FUNCTION IF EXISTS round_fees_insert();
 
 -- Create table 'rounds_rewards' for storing rewards
-CREATE TABLE IF NOT EXISTS "rounds_rewards"(
+DROP TABLE IF EXISTS "rounds_rewards";
+CREATE TABLE "rounds_rewards"(
 	"timestamp" INT    NOT NULL,
 	"fees"      BIGINT NOT NULL,
 	"reward"    BIGINT NOT NULL,
@@ -49,12 +50,13 @@ DO $$
 				ceil(height / 101::float)::int AS round
 			FROM blocks
 			-- Perform only for rounds that are completed and not present in 'rounds_rewards'
-			WHERE height % 101 = 0 AND height NOT IN (SELECT height FROM rounds_rewards)
+			WHERE height % 101 = 0
 			-- Group by round
 			GROUP BY ceil(height / 101::float)::int
 			-- Order by round
 			ORDER BY ceil(height / 101::float)::int ASC
 		LOOP
+			RAISE NOTICE 'Calculating rewards for round %', row.round;
 			WITH
 				-- Selecting all blocks of round
 				round AS (
@@ -62,28 +64,31 @@ DO $$
 						b.timestamp, b.height, b."generatorPublicKey" AS "publicKey", b."totalFee" AS fees,
 						b.reward AS reward
 					FROM blocks b
-					WHERE ceil(b.height / 101::float)::int = row.round AND b.height > 1
+					WHERE ceil(b.height / 101::float)::int = row.round
+				),
+				filtered_round AS (
+					SELECT * FROM round WHERE height > 1
 				),
 				-- Calculating total fees of round
-				fees AS (SELECT sum(fees) AS total, floor(sum(fees) / 101) AS single FROM round),
+				fees AS (SELECT sum(fees) AS total, floor(sum(fees) / 101) AS single FROM filtered_round),
 				-- Get last delegate and timestamp of round's last block
-				last AS (SELECT "publicKey", timestamp FROM round ORDER BY height DESC LIMIT 1)
+				last AS (SELECT "publicKey", timestamp FROM filtered_round ORDER BY height DESC LIMIT 1)
 			INSERT INTO rounds_rewards
 				SELECT
 					-- Timestamp of last round's block
 					last.timestamp,
 					-- Calculating real fee reward for delegate:
 					-- Rounded fee per delegate + remaining fees if block is last one of round
-					(fees.single + (CASE WHEN last."publicKey" = round."publicKey" AND last.timestamp = round.timestamp THEN (fees.total - fees.single * 101) ELSE 0 END)) AS fees,
+					(fees.single + (CASE WHEN last."publicKey" = filtered_round."publicKey" AND last.timestamp = filtered_round.timestamp THEN (fees.total - fees.single * 101) ELSE 0 END)) AS fees,
 					-- Block reward
-					round.reward,
+					filtered_round.reward,
 					-- Round
-					ceil(round.height / 101::float)::int,
+					ceil(filtered_round.height / 101::float)::int,
 					-- Delegate public key
-					round."publicKey"
-				FROM last, fees, round
+					filtered_round."publicKey"
+				FROM last, fees, filtered_round
 				-- Sort fees by block height
-				ORDER BY round.height ASC;
+				ORDER BY filtered_round.height ASC;
 		END LOOP;
 	RETURN;
 END $$;


### PR DESCRIPTION
### What was the problem?

When executing migrations just after rebuilding node from snapshot - migrations take forever.

### How did I fix it?

Add a DB Vacuum before running the migrations if there is any pending. 

### How to test it?
Load the DB snapshot and run the migrations by starting application. 

### Review checklist

* The PR solves #1799
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
