### PR TITLE
Database migrations must run in series but mutually exclusive to each other - Close #1806

### DIFF
--- a/db/repos/migrations.js
+++ b/db/repos/migrations.js
@@ -133,7 +133,7 @@ class MigrationsRepository {
 	 * @returns {Promise} Promise object that resolves with `undefined`.
 	 */
 	applyAll() {
-		return this.db.tx('migrations:applyAll', t1 =>
+		return this.db.task('migrations:applyAll', t1 =>
 			t1.migrations
 				.hasMigrations()
 				.then(hasMigrations => (hasMigrations ? t1.migrations.getLastId() : 0))

--- a/test/unit/db/repos/migrations.js
+++ b/test/unit/db/repos/migrations.js
@@ -295,7 +295,7 @@ describe('db', () => {
 					});
 			});
 
-			it('should apply all pending migrations in a transaction', () => {
+			it('should apply all pending migrations in independent transactions', () => {
 				const t2 = {
 					none: sinonSandbox.stub().resolves(true),
 				};
@@ -318,13 +318,13 @@ describe('db', () => {
 				 * there is no way in sinon to resolve to the value returned by a callback.
 				 */
 				sinonSandbox
-					.stub(db, 'tx')
+					.stub(db, 'task')
 					.callsArgWith(1, t1)
 					.resolves(Promise.delay(2000));
 
 				return db.migrations.applyAll().then(() => {
-					expect(db.tx).to.be.calledOnce;
-					expect(db.tx.firstCall.args[0]).to.be.eql('migrations:applyAll');
+					expect(db.task).to.be.calledOnce;
+					expect(db.task.firstCall.args[0]).to.be.eql('migrations:applyAll');
 
 					expect(t1.migrations.hasMigrations).to.be.calledOnce;
 					expect(t1.tx).to.have.callCount(updates.length);


### PR DESCRIPTION
### What was the problem?

Each migration was running in one main transaction. Which was causing every migration to rollback if one failed. 

### How did I fix it?

Converted top level transaction to task, so sub level save points automatically converted to individual transactions. 

### How to test it?

Drop the db and start the app. 

### Review checklist

* The PR solves #1806
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
