### PR TITLE
Fix logs for peers listing attempt parameter - Closes #1809

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -648,7 +648,7 @@ Peers.prototype.list = function(options, cb) {
 				const picked = peersList.length;
 				const accepted = peers.concat(peersList);
 				library.logger.debug('Listing peers', {
-					attempt: attemptsDescriptions[options.attempt],
+					attempt: attemptsDescriptions[attempt],
 					found,
 					matched,
 					picked,


### PR DESCRIPTION
### What was the problem?
attempt type parameter was not logged in peers listing
### How did I fix it?
Fixed wrong parameters used.
### How to test it?
Check the logs
### Review checklist

* The PR solves #1809 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
