### PR TITLE
Sort delegates for nextForgers endpoint - Closes #1811

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -799,12 +799,13 @@ Delegates.prototype.getForgers = function(query, cb) {
 			library.db.delegates
 				.getDelegatesByPublicKeys(forgerKeys)
 				.then(rows => {
-					rows.map(forger => {
+					rows.forEach(forger => {
 						forger.nextSlot =
 							activeDelegates.indexOf(forger.publicKey) + currentSlot + 1;
 
 						return forger;
 					});
+					rows = _.sortBy(rows, 'nextSlot');
 					return setImmediate(cb, null, rows);
 				})
 				.catch(error => setImmediate(cb, error));


### PR DESCRIPTION
### What was the problem?
Next forgers were not sorted by their slot number.
### How did I fix it?
Sorted the delegates before sending the response.
### How to test it?
Call `/api/delegates/forgers` endpoint
### Review checklist

* The PR solves #1811
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
