### PR TITLE
Sort delegates for nextForgers endpoint - Closes #1811

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -801,9 +801,7 @@ Delegates.prototype.getForgers = function(query, cb) {
 				.then(rows => {
 					rows.forEach(forger => {
 						forger.nextSlot =
-							activeDelegates.indexOf(forger.publicKey) + currentSlot + 1;
-
-						return forger;
+							forgerKeys.indexOf(forger.publicKey) + currentSlot + 1;
 					});
 					rows = _.sortBy(rows, 'nextSlot');
 					return setImmediate(cb, null, rows);


### PR DESCRIPTION
### What was the problem?
Using incorrect object (activeDelegates) for delegate forgers lookup when calculating nextForgersList
### How did I fix it?
Used correct object (forgerKeys) for delegate forgers lookup when calculating nextForgersList
### How to test it?
Enable/disable forging on next forgers and check if node forges a block in it's slot.
### Review checklist

* The PR solves #1812 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
