### PR TITLE
Map of peer connections in worker process can go out of sync with map of peers in master process - Closes #1823

### DIFF
--- a/app.js
+++ b/app.js
@@ -368,6 +368,14 @@ d.run(() => {
 						scope.logger.info('Socket Cluster ready for incoming connections');
 						cb();
 					});
+
+					scope.socketCluster.on('workerExit', workerInfo => {
+						var exitMessage = `Worker with pid ${workerInfo.pid} exited`;
+						if (workerInfo.signal) {
+							exitMessage += ` due to signal: '${workerInfo.signal}'`;
+						}
+						scope.logger.error(exitMessage);
+					});
 				},
 			],
 

--- a/workers_controller.js
+++ b/workers_controller.js
@@ -214,6 +214,8 @@ SCWorker.create({
 						}
 					);
 				}
+
+				scope.logger.debug(`Worker pid ${process.pid} started`);
 			}
 		);
 	},


### PR DESCRIPTION
### What was the problem?

There were two sources of truth when dealing with peer removal; sometimes peer removal was initiated by the master process, other times it was triggered by a command from the worker. This caused the peer nonce/address/connectionId mappings on the worker and master processes to be in inconsistent states which prevented peers from being added back to the peer list at a later time.

### How did I fix it?

Don't let the master process decide when to remove a peer; always wait for the instruction from the worker process. If the master process notices a failed connection on an outbound socket, it will just put the peer in a disconnected state and wait for instruction from the worker process.

### How to test it?

1. You need to prepare two nodes: A and B.
2. The config.json file of node B should contain node A as a seed node in `peers.list` *but not the other way round*; let node A be discovered by node B.
3. Launch both nodes and wait for them to discover each other.
4. Use the HTTP GET `/api/peers` endpoint to get the list of peer nodes of node A - Node B should be visible.
5. Kill the worker process of node B and wait a bit.
6. According to the `/api/peers` endpoint on node A, node B should still show up in the peers list (after the node B worker has respawned).
7. Shut down the entire node B (master process).
8. According to the `/api/peers` endpoint on node A, the peers list should now be empty.

Note that it's important that node B is not listed as a seed peer in node A's config file or else node B will never be removed from the list (there will be an error thrown because you cannot remove a 'frozen peer').

### Review checklist

* The PR solves #1823
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
