### PR TITLE
Remove obsolete typedef `hash` - Closes #1826

### DIFF
--- a/docs/typedef/crypto.js
+++ b/docs/typedef/crypto.js
@@ -24,10 +24,6 @@
  * @typedef {string} address
  */
 /**
- * Crypto hash hex
- * @typedef {string} hash
- */
-/**
  * publicKey, privateKey
  * @typedef {Object} keypair
  */


### PR DESCRIPTION
The typedef `hash` was obsoleted by https://github.com/LiskHQ/lisk/pull/1796

### What was the problem?

See #1826

### How did I fix it?

See diff

### How to test it?

Build documentation. Unfortunately, I cannot build the documentation myself because I don't have node 6.12.3 (see also https://github.com/LiskHQ/lisk/issues/1824)

### Review checklist

* The PR solves #1826
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
