### PR TITLE
Sockets are not being cleaned up properly and are disconnecting too often - Closes #1836

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -147,13 +147,11 @@ const connectSteps = {
 		});
 
 		socket.on('disconnect', () => {
-			logger.error(
+			logger.trace(
 				`[Outbound socket :: disconnect] Peer connection to ${
 					peer.ip
 				} disconnected`
 			);
-
-			logger.error(socket.clientId);
 		});
 
 		// When handshake process will fail - disconnect

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -180,6 +180,7 @@ const connectSteps = {
 					peer.ip
 				} failed with code ${code} and reason - ${reason}`
 			);
+			socket.destroy();
 			onDisconnectCb();
 		});
 

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -56,6 +56,13 @@ const connectSteps = {
 	},
 
 	addSocket: peer => {
+		if (peer.socket) {
+			// if a socket connect exisits
+			// before issuing a new connection
+			// destroy the exisiting connection
+			// to avoid too many socket connections
+			peer.socket.destroy();
+		}
 		peer.socket = scClient.connect(peer.connectionOptions);
 		return peer;
 	},
@@ -124,37 +131,48 @@ const connectSteps = {
 
 	registerSocketListeners: (peer, logger, onDisconnectCb = () => {}) => {
 		// Unregister all the events just in case
-		peer.socket.off('connect');
-		peer.socket.off('connectAbort');
-		peer.socket.off('error');
-		peer.socket.off('close');
-		peer.socket.off('message');
+		const socket = peer.socket;
+		socket.off('connect');
+		socket.off('connectAbort');
+		socket.off('error');
+		socket.off('close');
+		socket.off('message');
 
-		peer.socket.on('connect', () => {
+		socket.on('connect', () => {
 			logger.trace(
 				`[Outbound socket :: connect] Peer connection to ${peer.ip} established`
 			);
 		});
 
+		socket.on('disconnect', () => {
+			logger.error(
+				`[Outbound socket :: disconnect] Peer connection to ${
+					peer.ip
+				} disconnected`
+			);
+
+			logger.error(socket.clientId);
+		});
+
 		// When handshake process will fail - disconnect
 		// ToDo: Use parameters code and description returned while handshake fails
-		peer.socket.on('connectAbort', () => {
-			peer.socket.disconnect(
+		socket.on('connectAbort', () => {
+			socket.disconnect(
 				failureCodes.HANDSHAKE_ERROR,
 				failureCodes.errorMessages[failureCodes.HANDSHAKE_ERROR]
 			);
 		});
 
 		// When error on transport layer occurs - disconnect
-		peer.socket.on('error', err => {
+		socket.on('error', err => {
 			logger.debug(
 				`[Outbound socket :: error] Peer error from ${peer.ip} - ${err.message}`
 			);
-			peer.socket.disconnect();
+			socket.disconnect();
 		});
 
 		// When WS connection ends - remove peer
-		peer.socket.on('close', (code, reason) => {
+		socket.on('close', (code, reason) => {
 			logger.debug(
 				`[Outbound socket :: close] Peer connection to ${
 					peer.ip
@@ -164,7 +182,7 @@ const connectSteps = {
 		});
 
 		// The 'message' event can be used to log all low-level WebSocket messages.
-		peer.socket.on('message', message => {
+		socket.on('message', message => {
 			logger.trace(
 				`[Outbound socket :: message] Peer message from ${
 					peer.ip

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -57,10 +57,10 @@ const connectSteps = {
 
 	addSocket: peer => {
 		if (peer.socket) {
-			// if a socket connect exisits
+			// If a socket connection exists,
 			// before issuing a new connection
 			// destroy the exisiting connection
-			// to avoid too many socket connections
+			// to avoid too many socket connections.
 			peer.socket.destroy();
 			delete peer.socket;
 			peer.socket = null;

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -62,6 +62,8 @@ const connectSteps = {
 			// destroy the exisiting connection
 			// to avoid too many socket connections
 			peer.socket.destroy();
+			delete peer.socket;
+			peer.socket = null;
 		}
 		peer.socket = scClient.connect(peer.connectionOptions);
 		return peer;

--- a/test/unit/api/ws/rpc/connect.js
+++ b/test/unit/api/ws/rpc/connect.js
@@ -459,8 +459,8 @@ describe('connect', () => {
 				return expect(peerAsResult.socket.on).to.be.calledWith('close');
 			});
 
-			it('should register 5 event listeners', () => {
-				return expect(peerAsResult.socket.on).to.be.callCount(5);
+			it('should register 6 event listeners', () => {
+				return expect(peerAsResult.socket.on).to.be.callCount(6);
 			});
 		});
 	});

--- a/workers_controller.js
+++ b/workers_controller.js
@@ -169,9 +169,6 @@ SCWorker.create({
 				scServer.on('connection', socket => {
 					scope.slaveWAMPServer.upgradeToWAMP(socket);
 					socket.on('disconnect', removePeerConnection.bind(null, socket));
-					socket.on('error', err => {
-						socket.disconnect(err.code, err.message);
-					});
 				});
 
 				function removePeerConnection(socket, code) {


### PR DESCRIPTION
### What was the problem?

- Memory leak related to outbound peer sockets.
- Sockets disconnecting too easily.

### How did we fix it?

- Destroy the old sockets when they become disconnected.
- Destroy the old socket when an old peer socket is replaced with a new one.
- Removed handler which force-disconnected a socket on error (regardless of the type of error).

### How to test it?

To test the memory leak fix, run the node with `node-inspector` or just:

```sh
node --inspect app.js
```

Take memory heap snapshots and check that the number of `SCSocket` objects doesn't grow over time.

To test the reduced rate of disconnection, we may not know for sure until we roll out to the beta network.

### Review checklist

* The PR solves #1836, #1831
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
