### PR TITLE
Add json schema validation for transaction.signatures property - Closes #1845

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1289,6 +1289,14 @@ Transaction.prototype.schema = {
 			type: 'string',
 			format: 'signature',
 		},
+		signatures: {
+			type: 'array',
+			items: {
+				type: 'string',
+				format: 'signature',
+			},
+			uniqueItems: true,
+		},
 		asset: {
 			type: 'object',
 		},

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1175,7 +1175,7 @@ definitions:
         type: string
         format: signature
         example: 2821d93a742c4edf5fd960efad41a4def7bf0fd0f7c09869aed524f6f52bf9c97a617095e2c712bd28b4279078a29509b339ac55187854006591aa759784c205
-      multisignatures:
+      signatures:
         type: array
         items:
           type: string

--- a/test/functional/http/post/4.multisignature.advanced.js
+++ b/test/functional/http/post/4.multisignature.advanced.js
@@ -1,0 +1,310 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+require('../../functional.js');
+var phases = require('../../common/phases');
+var Scenarios = require('../../common/scenarios');
+var waitFor = require('../../../common/utils/wait_for');
+var randomUtil = require('../../../common/utils/random');
+var apiHelpers = require('../../../common/helpers/api');
+var errorCodes = require('../../../../helpers/api_codes');
+
+var sendTransactionPromise = apiHelpers.sendTransactionPromise;
+
+describe('POST /api/transactions (type 4) register multisignature', () => {
+    var scenarios = {
+        incorrectly_offline_signed: new Scenarios.Multisig(),
+        offline_signed_empty_signatures: new Scenarios.Multisig(),
+        offline_signed_without_ready: new Scenarios.Multisig(),
+        offline_signed_with_ready_false: new Scenarios.Multisig(),
+        offline_signed_with_ready_true: new Scenarios.Multisig(),
+        duplicated_signature: new Scenarios.Multisig(),
+        extra_signature: new Scenarios.Multisig(),
+        unknown_signature: new Scenarios.Multisig(),
+    };
+
+    var transactionsToWaitFor = [];
+    var badTransactions = [];
+    var goodTransactions = [];
+    var pendingMultisignatures = [];
+
+    before(() => {
+        var transactions = [];
+
+        Object.keys(scenarios).map(type => {
+            if (type !== 'no_funds') {
+                transactions.push(scenarios[type].creditTransaction);
+            }
+        });
+
+        return apiHelpers.sendTransactionsPromise(transactions).then(responses => {
+            responses.map(res => {
+                expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
+            });
+            transactionsToWaitFor = transactionsToWaitFor.concat(
+                _.map(transactions, 'id')
+            );
+
+            return waitFor.confirmations(transactionsToWaitFor);
+        });
+    });
+
+    describe('transactions processing', () => {
+        describe('signatures property', () => {
+            describe('correctly offline signed transaction', () => {
+                it('using ready should be ok but never confirmed', () => {
+                    var scenario = scenarios.offline_signed_without_ready;
+
+                    scenario.multiSigTransaction.signatures = _.map(scenario.members, member => {
+                        var signatureObject = apiHelpers.createSignatureObject(
+                            scenario.multiSigTransaction,
+                            member
+                        );
+                        return signatureObject.signature;
+                    });
+
+                    return sendTransactionPromise(scenario.multiSigTransaction).then(res => {
+                        expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
+                        badTransactions.push(scenario.multiSigTransaction);
+                        pendingMultisignatures.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using ready false should be ok but never confirmed', () => {
+                    var scenario = scenarios.offline_signed_with_ready_false;
+
+                    scenario.multiSigTransaction.signatures = _.map(scenario.members, member => {
+                        var signatureObject = apiHelpers.createSignatureObject(
+                            scenario.multiSigTransaction,
+                            member
+                        );
+                        return signatureObject.signature;
+                    });
+
+                    scenario.multiSigTransaction.ready = false;
+
+                    return sendTransactionPromise(scenario.multiSigTransaction).then(res => {
+                        expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
+                        badTransactions.push(scenario.multiSigTransaction);
+                        pendingMultisignatures.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using ready true should be ok', () => {
+                    var scenario = scenarios.offline_signed_with_ready_true;
+
+                    scenario.multiSigTransaction.signatures = _.map(scenario.members, member => {
+                        var signatureObject = apiHelpers.createSignatureObject(
+                            scenario.multiSigTransaction,
+                            member
+                        );
+                        return signatureObject.signature;
+                    });
+
+                    scenario.multiSigTransaction.ready = true;
+
+                    return sendTransactionPromise(scenario.multiSigTransaction).then(res => {
+                        expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
+                        goodTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+            });
+
+            describe('incorrectly offline signed transaction', () => {
+                it('using null inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = [null];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.BAD_REQUEST
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Validation errors');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using undefined inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = [undefined];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.BAD_REQUEST
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Validation errors');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using integer inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = [1];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.BAD_REQUEST
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Validation errors');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using empty object inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = [{}];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.BAD_REQUEST
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Validation errors');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using non empty object inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = [new Buffer.from('Duppa')];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.BAD_REQUEST
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Validation errors');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using empty string inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = [''];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.PROCESSING_ERROR
+                    ).then(res => {
+                        expect(res.body.message).to.be.equal('Failed to verify multisignature');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using invalid signature inside array should fail', () => {
+                    var scenario = scenarios.incorrectly_offline_signed;
+                    scenario.multiSigTransaction.signatures = ['x'];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.BAD_REQUEST
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Validation errors');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using empty array should be ok but not confirmed', () => {
+                    var scenario = scenarios.offline_signed_empty_signatures;
+                    scenario.multiSigTransaction.signatures = [];
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction
+                    ).then(res => {
+                        expect(res.body.data.message).to.be.equal('Transaction(s) accepted');
+                        badTransactions.push(scenario.multiSigTransaction);
+                        pendingMultisignatures.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using unknown signature should fail', () => {
+                    var scenario = scenarios.unknown_signature;
+
+                    var signatureObject = apiHelpers.createSignatureObject(
+                        scenario.multiSigTransaction,
+                        scenario.members[0]
+                    );
+
+                    var signatureFromunknown = apiHelpers.createSignatureObject(
+                        scenario.multiSigTransaction,
+                        randomUtil.account()
+                    );
+
+                    scenario.multiSigTransaction.signatures = [];
+                    scenario.multiSigTransaction.signatures.push(signatureObject.signature, signatureFromunknown.signature);
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.PROCESSING_ERROR
+                    ).then(res => {
+                        expect(res.body.message).to.equal('Failed to verify multisignature');
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using duplicate signature should fail', () => {
+                    var scenario = scenarios.duplicated_signature;
+
+                    var signatureObject = apiHelpers.createSignatureObject(
+                        scenario.multiSigTransaction,
+                        scenario.members[0]
+                    );
+                    scenario.multiSigTransaction.signatures = [];
+                    scenario.multiSigTransaction.signatures.push(signatureObject.signature, signatureObject.signature);
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.PROCESSING_ERROR
+                    ).then(res => {
+                        expect(res.body.message).to.match(/^Invalid transaction body - Failed to validate transaction schema: Array items are not unique \(indexes/);
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+
+                it('using extra signature should fail', () => {
+                    var scenario = scenarios.extra_signature;
+
+                    var signatureObject0 = apiHelpers.createSignatureObject(
+                        scenario.multiSigTransaction,
+                        randomUtil.account()
+                    );
+
+                    var signatureObject1 = apiHelpers.createSignatureObject(
+                        scenario.multiSigTransaction,
+                        scenario.members[1]
+                    );
+
+                    scenario.multiSigTransaction.signatures = [];
+                    scenario.multiSigTransaction.signatures.push(signatureObject0.signature, signatureObject1.signature, signatureObject0.signature);
+
+                    return sendTransactionPromise(
+                        scenario.multiSigTransaction,
+                        errorCodes.PROCESSING_ERROR
+                    ).then(res => {
+                        expect(res.body.message).to.match(/^Invalid transaction body - Failed to validate transaction schema: Array items are not unique \(indexes/);
+                        badTransactions.push(scenario.multiSigTransaction);
+                    });
+                });
+            });
+        });
+    });
+
+    describe('confirmation', () => {
+        phases.confirmation(
+            goodTransactions,
+            badTransactions,
+            pendingMultisignatures
+        );
+    });
+});


### PR DESCRIPTION
### What was the problem?
We have no json schema for `transactions.signatures` array. This can be used by an user who wants to sign offline a multisig transaction and broadcast it with some or all the signatures.

### How did I fix it?
Adding json schema validation for `transaction.signatures` property.

### How to test it?
`test/functional/http/post/4.multisignature.advanced.js`

### Review checklist

* The PR solves #1845 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
