### PR TITLE
Add git commit feature for compile builds - Closes #1834

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,10 @@ module.exports = function(grunt) {
 				command: `cd ${__dirname}/ && echo "v${today}" > build`,
 			},
 
+			revision: {
+				command: `cd ${__dirname}/ && git rev-parse HEAD > REVISION`,
+			},
+
 			pack: {
 				command: 'npm pack',
 			},
@@ -74,6 +78,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-exec');
 	grunt.registerTask('release', [
 		'exec:build',
+		'exec:revision',
 		'exec:pack',
 		'exec:folder',
 		'exec:copy',

--- a/helpers/git.js
+++ b/helpers/git.js
@@ -15,6 +15,7 @@
 'use strict';
 
 var childProcess = require('child_process');
+var fs = require('fs');
 
 /**
  * Helper module for parsing git commit information.
@@ -34,10 +35,19 @@ function getLastCommit() {
 	var spawn = childProcess.spawnSync('git', ['rev-parse', 'HEAD']);
 	var err = spawn.stderr.toString().trim();
 
-	if (err) {
-		throw new Error(err);
-	} else {
+	// If there is git tool available and current directory is a git owned directory
+	if (!err) {
 		return spawn.stdout.toString().trim();
+	}
+
+	// Try looking for a file REVISION for a compiled build
+	try {
+		return fs
+			.readFileSync('REVISION')
+			.toString()
+			.trim();
+	} catch (error) {
+		throw error;
 	}
 }
 


### PR DESCRIPTION
### What was the problem?
Git commit was missing for compile builds 

### How did I fix it?
Add static REVISION file during build process and then use it as fail safe level.

### How to test it?

Call this API on a compile build running instance. 

```
GET /api/node/constants 
```
### Review checklist

* The PR solves #1834
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
