### PR TITLE
Reject transaction with requesterPublicKey - Closes #1847 

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -426,6 +426,11 @@ class Transaction {
 			return setImmediate(cb, `Unknown transaction type ${transaction.type}`);
 		}
 
+		// Reject if transaction has requester public key
+		if (transaction.requesterPublicKey) {
+			return setImmediate(cb, 'Multisig request is not allowed');
+		}
+
 		// Check for missing sender second signature
 		if (
 			!transaction.requesterPublicKey &&
@@ -524,11 +529,6 @@ class Transaction {
 					multisignatures.push(key.slice(1));
 				}
 			}
-		}
-
-		// Reject if transaction has requester public key
-		if (transaction.requesterPublicKey) {
-			return setImmediate(cb, 'Multisig request is not allowed');
 		}
 
 		// Verify signature

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -526,19 +526,9 @@ class Transaction {
 			}
 		}
 
-		// Check requester public key
+		// Reject if transaction has requester public key
 		if (transaction.requesterPublicKey) {
-			multisignatures.push(transaction.senderPublicKey);
-
-			if (
-				!Array.isArray(sender.multisignatures) ||
-				sender.multisignatures.indexOf(transaction.requesterPublicKey) < 0
-			) {
-				return setImmediate(
-					cb,
-					'Account does not belong to multisignature group'
-				);
-			}
+			return setImmediate(cb, 'Multisig request is not allowed');
 		}
 
 		// Verify signature

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -233,6 +233,10 @@ __private.receiveTransaction = function(
 		return setImmediate(cb, `Invalid transaction body - ${e.toString()}`);
 	}
 
+	if (transaction.requesterPublicKey) {
+		return setImmediate(cb, 'Multisig request is not allowed');
+	}
+
 	library.balancesSequence.add(balancesSequenceCb => {
 		if (!nonce) {
 			library.logger.debug(

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -528,7 +528,7 @@ describe('transaction', () => {
 				'839eba0f811554b9f935e39a68b3078f90bea22c5424d3ad16630f027a48362f78349ddc3948360045d6460404f5bc8e25b662d4fd09e60c89453776962df40d';
 
 			transactionLogic.verify(transaction, sender, dummyRequester, err => {
-				expect(err).to.include('Missing requester second signature');
+				expect(err).to.include('Multisig request is not allowed');
 				done();
 			});
 		});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -579,7 +579,7 @@ describe('transaction', () => {
 			});
 		});
 
-		it('should return error when Account does not belong to multisignature group', done => {
+		it('should return error when transaction has requester', done => {
 			var transaction = _.cloneDeep(validTransaction);
 			var vs = _.cloneDeep(sender);
 			// Different publicKey for multisignature account
@@ -589,7 +589,7 @@ describe('transaction', () => {
 			transaction.signature = transactionLogic.sign(validKeypair, transaction);
 
 			transactionLogic.verify(transaction, vs, {}, err => {
-				expect(err).to.equal('Account does not belong to multisignature group');
+				expect(err).to.equal('Multisig request is not allowed');
 				done();
 			});
 		});
@@ -616,24 +616,6 @@ describe('transaction', () => {
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transactionLogic.verify(transaction, vs, {}, err => {
 				expect(err).to.equal('Encountered duplicate signature in transaction');
-				done();
-			});
-		});
-
-		it('should return error when failed to verify multisignature', done => {
-			var transaction = _.cloneDeep(validTransaction);
-			var vs = _.cloneDeep(sender);
-			vs.multisignatures = [validKeypair.publicKey.toString('hex')];
-			transaction.requesterPublicKey = validKeypair.publicKey.toString('hex');
-			delete transaction.signature;
-			// using validKeypair as opposed to senderKeypair
-			transaction.signatures = [
-				transactionLogic.sign(validKeypair, transaction),
-			];
-			transaction.signature = transactionLogic.sign(validKeypair, transaction);
-
-			transactionLogic.verify(transaction, vs, {}, err => {
-				expect(err).to.equal('Failed to verify multisignature');
 				done();
 			});
 		});


### PR DESCRIPTION
## What was the problem?
Application aims to offer the ability to request transactions related to a multisig account from any member of the group not only from the author/owner. Unfortunately, the application behaves wrongly around this topic in many ways. 

### How did I fix it?
The decision is to disable the feature following the next workaround:
- Posted transactions with `requesterPublicKey` will be rejected either through HTTP or WS 

The fix does not imply a hardfork because the application was never able to apply a transaction with `requesterPublicKey` property. We have confirmed it on two ways:
- scouting testnet and mainnet databases encountering `requesterPublicKey` column from every row on `trs` table set to `null`
- checking several cases where the transaction was accepted by the node, inserted in pending multisig queue but remained stuck with no chance to sign and make it advance. These cases cannot be reproduced anymore after this PR.

The application will enforce all transactions from a multisig group to be initiated by the author/owner of the multisig account.

### How to test it?
` test/functional/http/post/4.multisignature.advanced.js `

### Review checklist

* The PR solves #1847 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
