### PR TITLE
Internal SocketCluster errors are not being logged - Closes #1853

### DIFF
--- a/app.js
+++ b/app.js
@@ -369,6 +369,11 @@ d.run(() => {
 						cb();
 					});
 
+					// The 'fail' event aggregates errors from all SocketCluster processes.
+					scope.socketCluster.on('fail', err => {
+						scope.logger.error(err);
+					});
+
 					scope.socketCluster.on('workerExit', workerInfo => {
 						var exitMessage = `Worker with pid ${workerInfo.pid} exited`;
 						if (workerInfo.signal) {


### PR DESCRIPTION
### What was the problem?

A lot of errors from SocketCluster processes were not being logged.

### How did I fix it?

Capture all errors from SC and pass to our logger (this includes errors aggregated from child processes).

### How to test it?

Run the node, throw an error inside workers_controller.js.

### Review checklist

* The PR solves #1853
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
