### PR TITLE
Remove variable shadowing in transaction apply, applyUnconfirmed, undo, undoUnconfirmed - Closes #1726

### DIFF
--- a/logic/delegate.js
+++ b/logic/delegate.js
@@ -258,7 +258,14 @@ Delegate.prototype.checkUnconfirmed = function(transaction, cb, tx) {
 		transaction,
 		'u_username',
 		'u_isDelegate',
-		err => setImmediate(cb, err, transaction),
+		err => {
+			if (err && exceptions.delegates.indexOf(transaction.id) > -1) {
+				library.logger.debug(err);
+				library.logger.debug(JSON.stringify(transaction));
+				err = null;
+			}
+			return setImmediate(cb, err, transaction);
+		},
 		tx
 	);
 };

--- a/logic/in_transfer.js
+++ b/logic/in_transfer.js
@@ -163,9 +163,9 @@ InTransfer.prototype.getBytes = function(transaction) {
 InTransfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 	shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
-		(err, res) => {
-			if (err) {
-				return setImmediate(cb, err);
+		(getGenesisErr, res) => {
+			if (getGenesisErr) {
+				return setImmediate(cb, getGenesisErr);
 			}
 			modules.accounts.mergeAccountAndGet(
 				{
@@ -175,7 +175,7 @@ InTransfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 					blockId: block.id,
 					round: slots.calcRound(block.height),
 				},
-				err => setImmediate(cb, err),
+				mergeAccountAndGetErr => setImmediate(cb, mergeAccountAndGetErr),
 				tx
 			);
 		},
@@ -198,9 +198,9 @@ InTransfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 InTransfer.prototype.undo = function(transaction, block, sender, cb, tx) {
 	shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
-		(err, res) => {
-			if (err) {
-				return setImmediate(cb, err);
+		(getGenesisErr, res) => {
+			if (getGenesisErr) {
+				return setImmediate(cb, getGenesisErr);
 			}
 			modules.accounts.mergeAccountAndGet(
 				{
@@ -210,7 +210,7 @@ InTransfer.prototype.undo = function(transaction, block, sender, cb, tx) {
 					blockId: block.id,
 					round: slots.calcRound(block.height),
 				},
-				err => setImmediate(cb, err),
+				mergeAccountAndGetErr => setImmediate(cb, mergeAccountAndGetErr),
 				tx
 			);
 		},

--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -348,9 +348,9 @@ Multisignature.prototype.apply = function(transaction, block, sender, cb, tx) {
 			blockId: block.id,
 			round: slots.calcRound(block.height),
 		},
-		err => {
-			if (err) {
-				return setImmediate(cb, err);
+		mergeErr => {
+			if (mergeErr) {
+				return setImmediate(cb, mergeErr);
 			}
 
 			// Get public keys
@@ -366,7 +366,7 @@ Multisignature.prototype.apply = function(transaction, block, sender, cb, tx) {
 							address,
 							publicKey: key,
 						},
-						err => setImmediate(cb, err),
+						setAccountAndGetErr => setImmediate(cb, setAccountAndGetErr),
 						tx
 					);
 				},
@@ -402,7 +402,7 @@ Multisignature.prototype.undo = function(transaction, block, sender, cb, tx) {
 			blockId: block.id,
 			round: slots.calcRound(block.height),
 		},
-		err => setImmediate(cb, err),
+		mergeErr => setImmediate(cb, mergeErr),
 		tx
 	);
 };
@@ -439,7 +439,7 @@ Multisignature.prototype.applyUnconfirmed = function(
 			u_multimin: transaction.asset.multisignature.min,
 			u_multilifetime: transaction.asset.multisignature.lifetime,
 		},
-		err => setImmediate(cb, err),
+		mergeErr => setImmediate(cb, mergeErr),
 		tx
 	);
 };

--- a/logic/out_transfer.js
+++ b/logic/out_transfer.js
@@ -203,9 +203,9 @@ OutTransfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 
 	modules.accounts.setAccountAndGet(
 		{ address: transaction.recipientId },
-		err => {
-			if (err) {
-				return setImmediate(cb, err);
+		setAccountAndGetErr => {
+			if (setAccountAndGetErr) {
+				return setImmediate(cb, setAccountAndGetErr);
 			}
 
 			modules.accounts.mergeAccountAndGet(
@@ -216,7 +216,7 @@ OutTransfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 					blockId: block.id,
 					round: slots.calcRound(block.height),
 				},
-				err => setImmediate(cb, err),
+				mergeAccountAndGetErr => setImmediate(cb, mergeAccountAndGetErr),
 				tx
 			);
 		},
@@ -243,9 +243,9 @@ OutTransfer.prototype.undo = function(transaction, block, sender, cb, tx) {
 
 	modules.accounts.setAccountAndGet(
 		{ address: transaction.recipientId },
-		err => {
-			if (err) {
-				return setImmediate(cb, err);
+		setAccountAndGetErr => {
+			if (setAccountAndGetErr) {
+				return setImmediate(cb, setAccountAndGetErr);
 			}
 			modules.accounts.mergeAccountAndGet(
 				{
@@ -255,7 +255,7 @@ OutTransfer.prototype.undo = function(transaction, block, sender, cb, tx) {
 					blockId: block.id,
 					round: slots.calcRound(block.height),
 				},
-				err => setImmediate(cb, err),
+				mergeAccountAndGetErr => setImmediate(cb, mergeAccountAndGetErr),
 				tx
 			);
 		},

--- a/logic/transfer.js
+++ b/logic/transfer.js
@@ -140,9 +140,9 @@ Transfer.prototype.getBytes = function(transaction) {
 Transfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 	modules.accounts.setAccountAndGet(
 		{ address: transaction.recipientId },
-		err => {
-			if (err) {
-				return setImmediate(cb, err);
+		setAccountAndGetErr => {
+			if (setAccountAndGetErr) {
+				return setImmediate(cb, setAccountAndGetErr);
 			}
 
 			modules.accounts.mergeAccountAndGet(
@@ -153,7 +153,7 @@ Transfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 					blockId: block.id,
 					round: slots.calcRound(block.height),
 				},
-				err => setImmediate(cb, err),
+				mergeAccountAndGetErr => setImmediate(cb, mergeAccountAndGetErr),
 				tx
 			);
 		},
@@ -175,9 +175,9 @@ Transfer.prototype.apply = function(transaction, block, sender, cb, tx) {
 Transfer.prototype.undo = function(transaction, block, sender, cb, tx) {
 	modules.accounts.setAccountAndGet(
 		{ address: transaction.recipientId },
-		err => {
-			if (err) {
-				return setImmediate(cb, err);
+		setAccountAndGetErr => {
+			if (setAccountAndGetErr) {
+				return setImmediate(cb, setAccountAndGetErr);
 			}
 
 			modules.accounts.mergeAccountAndGet(
@@ -188,7 +188,7 @@ Transfer.prototype.undo = function(transaction, block, sender, cb, tx) {
 					blockId: block.id,
 					round: slots.calcRound(block.height),
 				},
-				err => setImmediate(cb, err),
+				mergeAccountAndGetErr => setImmediate(cb, mergeAccountAndGetErr),
 				tx
 			);
 		},

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -77,7 +77,7 @@ class Vote {
 				blockId: block.id,
 				round: slots.calcRound(block.height),
 			},
-			err => setImmediate(cb, err),
+			mergeErr => setImmediate(cb, mergeErr),
 			tx
 		);
 	}
@@ -102,7 +102,7 @@ class Vote {
 		this.scope.account.merge(
 			sender.address,
 			{ u_delegates: votesInvert },
-			err => setImmediate(cb, err),
+			mergeErr => setImmediate(cb, mergeErr),
 			tx
 		);
 	}
@@ -346,7 +346,7 @@ Vote.prototype.apply = function(transaction, block, sender, cb, tx) {
 						blockId: block.id,
 						round: slots.calcRound(block.height),
 					},
-					err => setImmediate(cb, err),
+					mergeErr => setImmediate(cb, mergeErr),
 					tx
 				);
 			},
@@ -379,7 +379,7 @@ Vote.prototype.applyUnconfirmed = function(transaction, sender, cb, tx) {
 					{
 						u_delegates: transaction.asset.votes,
 					},
-					err => setImmediate(seriesCb, err),
+					mergeErr => setImmediate(seriesCb, mergeErr),
 					tx
 				);
 			},


### PR DESCRIPTION
### What was the problem?
In some cases, we are creating same variable names for assigning error objects. This causes variable shadowing, which can lead to unexpected results.

### How did I fix it?

Updated the code blocks involving error shadowing

### How to test it?

Run normal tests

### Review checklist

* The PR solves #1726
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
