### PR TITLE
Log current socket number while connecting Peer - Closes #1859

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -24,10 +24,11 @@ const wsRPC = require('../../../api/ws/rpc/ws_rpc').wsRPC;
 
 const TIMEOUT = 2000;
 const wampClient = new WAMPClient(TIMEOUT); // Timeout failed requests after 1 second
+const socketConnections = {};
 
 const connect = (peer, logger, onDisconnectCb) => {
 	connectSteps.addConnectionOptions(peer);
-	connectSteps.addSocket(peer);
+	connectSteps.addSocket(peer, logger);
 
 	async.parallel([
 		() => {
@@ -55,17 +56,40 @@ const connectSteps = {
 		return peer;
 	},
 
-	addSocket: peer => {
+	addSocket: (peer, logger) => {
 		if (peer.socket) {
 			// If a socket connection exists,
 			// before issuing a new connection
 			// destroy the exisiting connection
-			// to avoid too many socket connections.
+			// to avoid too many socket connections
 			peer.socket.destroy();
 			delete peer.socket;
 			peer.socket = null;
 		}
 		peer.socket = scClient.connect(peer.connectionOptions);
+
+		const hostname = peer.socket.options.hostname;
+		if (!socketConnections[hostname]) {
+			socketConnections[hostname] = { closed: 0, open: 0, disconnect: 0 };
+		}
+
+		if (peer.socket.state === 'closed') {
+			socketConnections[hostname].closed += 1;
+		} else if (peer.socket.state === 'open') {
+			socketConnections[hostname].open += 1;
+		} else if (peer.socket.state === 'disconnect') {
+			socketConnections[hostname].disconnect += 1;
+		}
+
+		logger.trace(
+			`${socketConnections[hostname].closed}:closed, ${
+				socketConnections[hostname].open
+			}:open and ${
+				socketConnections[hostname].disconnect
+			}:disconnect websocket connection to peer ${
+				peer.socket.options.hostname
+			}.`
+		);
 		return peer;
 	},
 

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -68,28 +68,31 @@ const connectSteps = {
 		}
 		peer.socket = scClient.connect(peer.connectionOptions);
 
-		const hostname = peer.socket.options.hostname;
-		if (!socketConnections[hostname]) {
-			socketConnections[hostname] = { closed: 0, open: 0, disconnect: 0 };
+		if (peer.socket) {
+			const hostname = peer.socket.options.hostname;
+			if (!socketConnections[hostname]) {
+				socketConnections[hostname] = { closed: 0, open: 0, disconnect: 0 };
+			}
+
+			if (peer.socket.state === 'closed') {
+				socketConnections[hostname].closed += 1;
+			} else if (peer.socket.state === 'open') {
+				socketConnections[hostname].open += 1;
+			} else if (peer.socket.state === 'disconnect') {
+				socketConnections[hostname].disconnect += 1;
+			}
+
+			logger.trace(
+				`${socketConnections[hostname].closed}:closed, ${
+					socketConnections[hostname].open
+				}:open and ${
+					socketConnections[hostname].disconnect
+				}:disconnect websocket connection to peer ${
+					peer.socket.options.hostname
+				}.`
+			);
 		}
 
-		if (peer.socket.state === 'closed') {
-			socketConnections[hostname].closed += 1;
-		} else if (peer.socket.state === 'open') {
-			socketConnections[hostname].open += 1;
-		} else if (peer.socket.state === 'disconnect') {
-			socketConnections[hostname].disconnect += 1;
-		}
-
-		logger.trace(
-			`${socketConnections[hostname].closed}:closed, ${
-				socketConnections[hostname].open
-			}:open and ${
-				socketConnections[hostname].disconnect
-			}:disconnect websocket connection to peer ${
-				peer.socket.options.hostname
-			}.`
-		);
 		return peer;
 	},
 

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -68,7 +68,7 @@ const connectSteps = {
 		}
 		peer.socket = scClient.connect(peer.connectionOptions);
 
-		if (peer.socket) {
+		if (peer.socket && Object.keys(socketConnections).length < 1000) {
 			const hostname = peer.socket.options.hostname;
 			if (!socketConnections[hostname]) {
 				socketConnections[hostname] = { closed: 0, open: 0, disconnect: 0 };

--- a/test/unit/helpers/peers_manager.js
+++ b/test/unit/helpers/peers_manager.js
@@ -357,9 +357,11 @@ describe('PeersManager', () => {
 			beforeEach(done => {
 				peersManagerInstanceA = new PeersManager({
 					debug: sinonSandbox.stub(),
+					trace: sinonSandbox.stub(),
 				});
 				peersManagerInstanceB = new PeersManager({
 					debug: sinonSandbox.stub(),
+					trace: sinonSandbox.stub(),
 				});
 				done();
 			});


### PR DESCRIPTION
### What was the problem?
No info about the number of the socket connections counts to a specific peer.
### How did I fix it?
Every time when Peer is being connected, it's current client socket number should be logged.
### How to test it?
Run node with log enabled to trace
### Review checklist

* The PR solves #1859 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
