### PR TITLE
Node keeps on deleting blocks - Closes #1878

### DIFF
--- a/db/sql/rounds/restore_round_snapshot.sql
+++ b/db/sql/rounds/restore_round_snapshot.sql
@@ -19,5 +19,6 @@
   PARAMETERS: ?
 */
 
-INSERT INTO mem_round
-SELECT * FROM mem_round_snapshot
+INSERT INTO mem_round SELECT * FROM mem_round_snapshot;
+
+DROP TABLE IF EXISTS mem_round_snapshot;

--- a/db/sql/rounds/restore_votes_snapshot.sql
+++ b/db/sql/rounds/restore_votes_snapshot.sql
@@ -22,4 +22,6 @@
 UPDATE mem_accounts m
 SET vote = b.vote
 FROM mem_votes_snapshot b
-WHERE m.address = b.address
+WHERE m.address = b.address;
+
+DROP TABLE IF EXISTS mem_votes_snapshot;

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -714,9 +714,7 @@ __private.popLastBlock = function(oldLastBlock, cb) {
 				.then(() => __private.deleteBlockStep(oldLastBlock, tx))
 		)
 		.then(() => setImmediate(cb, null, secondLastBlock))
-		.catch(err => {
-			return setImmediate(cb, err);
-		});
+		.catch(err => setImmediate(cb, err));
 };
 
 /**

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -715,7 +715,6 @@ __private.popLastBlock = function(oldLastBlock, cb) {
 		)
 		.then(() => setImmediate(cb, null, secondLastBlock))
 		.catch(err => {
-			process.exit(1);
 			return setImmediate(cb, err);
 		});
 };

--- a/test/functional/system/blocks/chain/delete_last_block_db_trs.js
+++ b/test/functional/system/blocks/chain/delete_last_block_db_trs.js
@@ -74,18 +74,6 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 	});
 
 	describe('popLastBlock', () => {
-		let processExit;
-
-		beforeEach(done => {
-			processExit = sinonSandbox.stub(process, 'exit');
-			return done();
-		});
-
-		afterEach(done => {
-			processExit.restore();
-			done();
-		});
-
 		describe('when popLastBlock fails', () => {
 			describe('when loadBlockSecondLastBlockStep fails', () => {
 				beforeEach(done => {
@@ -94,11 +82,10 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 					return done();
 				});
 
-				it('it should call process.exit(1)', done => {
+				it('should fail with proper error', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
-						expect(process.exit.calledWith(1)).to.equal(true);
+						expect(err).to.eql('previousBlock is null');
 						done();
 					});
 				});
@@ -123,20 +110,17 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 					library.modules.accounts.setAccountAndGet = setAccountAndGet;
 					done();
 				});
-				// ToDo: Unskip when #1726 done
-				it.skip('it should call process.exit(1)', done => {
+				it('should fail with proper error', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
-						expect(process.exit.calledWith(1)).to.equal(true);
+						expect(err).to.eql('err');
 						done();
 					});
 				});
-				// ToDo: Unskip when #1726 done
-				it.skip('should not have perform undoStep on transactions of block', done => {
+				it('should not have perform undoStep on transactions of block', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -170,11 +154,10 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 					done();
 				});
 
-				it('it should call process.exit(1)', done => {
+				it('should fail with proper error', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
-						expect(process.exit.calledWith(1)).to.equal(true);
+						expect(err).to.eql('err');
 						done();
 					});
 				});
@@ -182,6 +165,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not change balance in mem_accounts table', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -196,7 +180,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not change u_balance in mem_accounts table', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -228,11 +212,10 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 					done();
 				});
 
-				it('it should call process.exit(1)', done => {
+				it('should fail with proper error message', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
-						expect(process.exit.calledWith(1)).to.equal(true);
+						expect(err).to.eql('err');
 						done();
 					});
 				});
@@ -240,7 +223,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('modules.rounds.backwardTick stub should be called once', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						expect(library.modules.rounds.backwardTick.calledOnce).to.equal(
 							true
 						);
@@ -251,7 +234,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not change balance in mem_accounts table', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -266,7 +249,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not change u_balance in mem_accounts table', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -298,11 +281,10 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 					done();
 				});
 
-				it('it should call process.exit(1)', done => {
+				it('should fail with proper error message', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
-						expect(process.exit.calledWith(1)).to.equal(true);
+						expect(err).to.eql('err');
 						done();
 					});
 				});
@@ -310,6 +292,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('modules.blocks.chain.deleteBlock should be called once', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
+						expect(err).to.eql('err');
 						expect(
 							library.modules.blocks.chain.deleteBlock.calledOnce
 						).to.equal(true);
@@ -320,7 +303,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not change balance in mem_accounts table', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -335,7 +318,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not change u_balance in mem_accounts table', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(library, fundTrsForAccount1.recipientId)
 							.then(account => {
@@ -350,7 +333,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 				it('should not perform backwardTick', done => {
 					library.modules.blocks.chain.deleteLastBlock(err => {
 						expect(err).to.exist;
-						expect(process.exit.calledOnce).to.equal(true);
+						expect(err).to.eql('err');
 						localCommon
 							.getAccountFromDb(
 								library,
@@ -368,10 +351,9 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 		});
 
 		describe('when deleteLastBlock succeeds', () => {
-			it('should not call process.exit', done => {
+			it('should not return an error', done => {
 				library.modules.blocks.chain.deleteLastBlock(err => {
 					expect(err).to.not.exist;
-					expect(process.exit.calledOnce).to.equal(false);
 					done();
 				});
 			});

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1145,7 +1145,9 @@ describe('rounds', () => {
 		});
 
 		it('should fail when try to delete one more block (last block of round 1)', () => {
-			return expect(deleteLastBlockPromise()).to.eventually.be.rejectedWith('relation "mem_round_snapshot" does not exist');
+			return expect(deleteLastBlockPromise()).to.eventually.be.rejectedWith(
+				'relation "mem_round_snapshot" does not exist'
+			);
 		});
 
 		it('last block height should be still at height 101', () => {

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1130,53 +1130,12 @@ describe('rounds', () => {
 		});
 	});
 
-	describe('round 3', () => {
-		describe('should forge 101 blocks with 1 TRANSFER transaction each to random account', () => {
-			const blocksToForge = 101;
-			let blocksProcessed = 0;
-			const transactionsPerBlock = 1;
 
-			before(done => {
-				const transactionPool = library.rewiredModules.transactions.__get__(
-					'__private.transactionPool'
-				);
-				transactionPool.queued.transactions = [];
-
-				done();
 			});
 
-			async.doUntil(
-				untilCb => {
-					++blocksProcessed;
-					const transactions = [];
-					for (let t = transactionsPerBlock - 1; t >= 0; t--) {
-						const transaction = elements.transaction.transfer({
-							recipientId: randomUtil.account().address,
-							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountsFixtures.genesis.password,
-						});
-						transactions.push(transaction);
-					}
 
-					__testContext.debug(
-						`	Processing block ${blocksProcessed} of ${blocksToForge} with ${
-							transactions.length
-							} transactions`
-					);
-					tickAndValidate(transactions);
-					untilCb();
-				},
-				err => {
-					return err || blocksProcessed >= blocksToForge;
-				}
-			);
 		});
 
-		describe('after finish round', () => {
-			it('last block height should be at height 303', () => {
-				const lastBlock = library.modules.blocks.lastBlock.get();
-				return expect(lastBlock.height).to.equal(303);
-			});
 		});
 	});
 });

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1130,12 +1130,27 @@ describe('rounds', () => {
 		});
 	});
 
+	describe('rollback more than 1 round of blocks', () => {
+		let lastBlock;
 
+		before(() => {
+			return Promise.mapSeries([...Array(101)], () => {
+				return deleteLastBlockPromise();
 			});
-
-
 		});
 
+		it('last block height should be at height 101', () => {
+			lastBlock = library.modules.blocks.lastBlock.get();
+			return expect(lastBlock.height).to.equal(101);
+		});
+
+		it('should fail when try to delete one more block (last block of round 1)', () => {
+			return expect(deleteLastBlockPromise()).to.eventually.be.rejectedWith('relation "mem_round_snapshot" does not exist');
+		});
+
+		it('last block height should be still at height 101', () => {
+			lastBlock = library.modules.blocks.lastBlock.get();
+			return expect(lastBlock.height).to.equal(101);
 		});
 	});
 });

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -30,6 +30,7 @@ describe('rounds', () => {
 	let Queries;
 	let generateDelegateListPromise;
 	let addTransactionsAndForgePromise;
+	let deleteLastBlockPromise;
 
 	// Set rewards start at 150-th block
 	constants.rewards.offset = 150;
@@ -44,6 +45,10 @@ describe('rounds', () => {
 
 		addTransactionsAndForgePromise = Promise.promisify(
 			localCommon.addTransactionsAndForge
+		);
+
+		deleteLastBlockPromise = Promise.promisify(
+			library.modules.blocks.chain.deleteLastBlock
 		);
 	});
 
@@ -487,7 +492,6 @@ describe('rounds', () => {
 	}
 
 	describe('round 1', () => {
-		let deleteLastBlockPromise;
 		const round = {
 			current: 1,
 			outsiderPublicKey:
@@ -496,10 +500,6 @@ describe('rounds', () => {
 
 		before(() => {
 			const lastBlock = library.modules.blocks.lastBlock.get();
-
-			deleteLastBlockPromise = Promise.promisify(
-				library.modules.blocks.chain.deleteLastBlock
-			);
 
 			// Copy initial states for later comparison
 			return Promise.join(

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -1489,8 +1489,6 @@ describe('blocks/chain', () => {
 			it('should call process.exit with 1', done => {
 				__private.popLastBlock(blockWithTransactions, err => {
 					expect(err.name).to.eql('db-tx_ERR');
-					expect(process.exit.calledOnce).to.equal(true);
-					expect(process.exit.calledWith(1)).to.equal(true);
 					done();
 				});
 			});

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -553,7 +553,7 @@ describe('blocks/chain', () => {
 						);
 					});
 
-					it('should call process.exit with 0', done => {
+					it('should call a callback with proper error message', done => {
 						blocksChainModule.applyGenesisBlock(
 							blockWithTransactions,
 							result => {
@@ -1486,7 +1486,7 @@ describe('blocks/chain', () => {
 				done();
 			});
 
-			it('should call process.exit with 1', done => {
+			it('should call a callback with proper error message', done => {
 				__private.popLastBlock(blockWithTransactions, err => {
 					expect(err.name).to.eql('db-tx_ERR');
 					done();


### PR DESCRIPTION
### What was the problem?
Node keep deleting blocks when unable to recreate round state.
### How did I fix it?
Don't allow node to keep deleting blocks when round/votes snapshot is not available by fail entire SQL transaction.
### How to test it?
Run functional system rounds test.
### Review checklist

* The PR solves #1878
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
