### PR TITLE
Cannot debug worker processes for memory leaks - Closes #1887

### DIFF
--- a/helpers/config.js
+++ b/helpers/config.js
@@ -45,6 +45,8 @@ function Config(packageJson) {
 		.option('-x, --peers [peers...]', 'peers list')
 		.option('-l, --log <level>', 'log level')
 		.option('-s, --snapshot <round>', 'verify snapshot')
+		.option('--inspect-workers', 'inspect worker processes')
+		.option('--inspect-brokers', 'inspect broker processes')
 		.parse(process.argv);
 
 	var configPath = program.config;


### PR DESCRIPTION
### What was the problem?

Could not attach Chrome debugger to worker processes.

### How did I fix it?

Made it so that commander module would allow the necessary CLI flags.

### How to test it?

run `NODE_ENV=test node app.js --inspect-workers` and copy the debug URL from the console into the Chrome browser address bar.

### Review checklist

* The PR solves #1887
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
