### PR TITLE
Make webSocket task dependent on database - Closes # 1839

### DIFF
--- a/app.js
+++ b/app.js
@@ -305,85 +305,6 @@ d.run(() => {
 				},
 			],
 
-			webSocket: [
-				'config',
-				'connect',
-				'logger',
-				'network',
-				/**
-				 * Description of the function.
-				 *
-				 * @func webSocket[4]
-				 * @memberof! app
-				 * @param {Object} scope
-				 * @param {function} cb - Callback function
-				 * @todo Add description for the function and its params
-				 */
-				function(scope, cb) {
-					var webSocketConfig = {
-						workers: scope.config.wsWorkers,
-						port: scope.config.wsPort,
-						wsEngine: 'uws',
-						appName: 'lisk',
-						workerController: workersControllerPath,
-						perMessageDeflate: false,
-						secretKey: 'liskSecretKey',
-						pingInterval: 5000,
-						// How many milliseconds to wait without receiving a ping
-						// before closing the socket
-						pingTimeout: 60000,
-						// Maximum amount of milliseconds to wait before force-killing
-						// a process after it was passed a 'SIGTERM' or 'SIGUSR2' signal
-						processTermTimeout: 10000,
-						logLevel: 0,
-					};
-
-					if (scope.config.ssl.enabled) {
-						extend(webSocketConfig, {
-							protocol: 'https',
-							protocolOptions: {
-								key: fs.readFileSync(scope.config.ssl.options.key),
-								cert: fs.readFileSync(scope.config.ssl.options.cert),
-								ciphers:
-									'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA',
-							},
-						});
-					}
-
-					var childProcessOptions = {
-						version: scope.config.version,
-						minVersion: scope.config.minVersion,
-						nethash: scope.config.nethash,
-						port: scope.config.wsPort,
-						nonce: scope.config.nonce,
-					};
-
-					scope.socketCluster = new SocketCluster(webSocketConfig);
-					var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
-					scope.network.app.rpc = wsRPC.setServer(
-						new MasterWAMPServer(scope.socketCluster, childProcessOptions)
-					);
-
-					scope.socketCluster.on('ready', () => {
-						scope.logger.info('Socket Cluster ready for incoming connections');
-						cb();
-					});
-
-					// The 'fail' event aggregates errors from all SocketCluster processes.
-					scope.socketCluster.on('fail', err => {
-						scope.logger.error(err);
-					});
-
-					scope.socketCluster.on('workerExit', workerInfo => {
-						var exitMessage = `Worker with pid ${workerInfo.pid} exited`;
-						if (workerInfo.signal) {
-							exitMessage += ` due to signal: '${workerInfo.signal}'`;
-						}
-						scope.logger.error(exitMessage);
-					});
-				},
-			],
-
 			sequence: [
 				'logger',
 				/**
@@ -641,6 +562,86 @@ d.run(() => {
 				);
 				cache.connect(config.cacheEnabled, config.cache, logger, cb);
 			},
+
+			webSocket: [
+				'config',
+				'connect',
+				'logger',
+				'network',
+				'db',
+				/**
+				 * Description of the function.
+				 *
+				 * @func webSocket[4]
+				 * @memberof! app
+				 * @param {Object} scope
+				 * @param {function} cb - Callback function
+				 * @todo Add description for the function and its params
+				 */
+				function(scope, cb) {
+					var webSocketConfig = {
+						workers: scope.config.wsWorkers,
+						port: scope.config.wsPort,
+						wsEngine: 'uws',
+						appName: 'lisk',
+						workerController: workersControllerPath,
+						perMessageDeflate: false,
+						secretKey: 'liskSecretKey',
+						pingInterval: 5000,
+						// How many milliseconds to wait without receiving a ping
+						// before closing the socket
+						pingTimeout: 60000,
+						// Maximum amount of milliseconds to wait before force-killing
+						// a process after it was passed a 'SIGTERM' or 'SIGUSR2' signal
+						processTermTimeout: 10000,
+						logLevel: 0,
+					};
+
+					if (scope.config.ssl.enabled) {
+						extend(webSocketConfig, {
+							protocol: 'https',
+							protocolOptions: {
+								key: fs.readFileSync(scope.config.ssl.options.key),
+								cert: fs.readFileSync(scope.config.ssl.options.cert),
+								ciphers:
+									'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA',
+							},
+						});
+					}
+
+					var childProcessOptions = {
+						version: scope.config.version,
+						minVersion: scope.config.minVersion,
+						nethash: scope.config.nethash,
+						port: scope.config.wsPort,
+						nonce: scope.config.nonce,
+					};
+
+					scope.socketCluster = new SocketCluster(webSocketConfig);
+					var MasterWAMPServer = require('wamp-socket-cluster/MasterWAMPServer');
+					scope.network.app.rpc = wsRPC.setServer(
+						new MasterWAMPServer(scope.socketCluster, childProcessOptions)
+					);
+
+					scope.socketCluster.on('ready', () => {
+						scope.logger.info('Socket Cluster ready for incoming connections');
+						cb();
+					});
+
+					// The 'fail' event aggregates errors from all SocketCluster processes.
+					scope.socketCluster.on('fail', err => {
+						scope.logger.error(err);
+					});
+
+					scope.socketCluster.on('workerExit', workerInfo => {
+						var exitMessage = `Worker with pid ${workerInfo.pid} exited`;
+						if (workerInfo.signal) {
+							exitMessage += ` due to signal: '${workerInfo.signal}'`;
+						}
+						scope.logger.error(exitMessage);
+					});
+				},
+			],
 
 			logic: [
 				'db',


### PR DESCRIPTION
### What was the problem?
Even when unable to connect to db, we initialize socket cluster and make connections with peers.
### How did I fix it?
If node is unable to connect to database on startup, it will not load websockets, and cleanly exit.
### How to test it?
Kill postgres server, and start the application.
### Review checklist

* The PR solves #1839
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
