### PR TITLE
Use better socket timeouts - Closes #1898

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -191,7 +191,7 @@ const connectSteps = {
 			logger.debug(
 				`[Outbound socket :: error] Peer error from ${peer.ip} - ${err.message}`
 			);
-			socket.disconnect();
+			socket.disconnect(1000, 'Intentionally disconnected from peer because of error');
 		});
 
 		// When WS connection ends - remove peer
@@ -199,7 +199,7 @@ const connectSteps = {
 			logger.debug(
 				`[Outbound socket :: close] Peer connection to ${
 					peer.ip
-				} failed with code ${code} and reason - ${reason}`
+				} closed with code ${code} and reason - ${reason}`
 			);
 			socket.destroy();
 			onDisconnectCb();

--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -23,6 +23,8 @@ const System = require('../../../modules/system');
 const wsRPC = require('../../../api/ws/rpc/ws_rpc').wsRPC;
 
 const TIMEOUT = 2000;
+const INITIAL_PING_TIMEOUT = 8000;
+
 const wampClient = new WAMPClient(TIMEOUT); // Timeout failed requests after 1 second
 const socketConnections = {};
 
@@ -47,7 +49,7 @@ const connectSteps = {
 			autoReconnect: false,
 			connectTimeout: TIMEOUT,
 			ackTimeout: TIMEOUT,
-			pingTimeout: TIMEOUT,
+			pingTimeout: INITIAL_PING_TIMEOUT,
 			connectAttempts: 1,
 			port: peer.wsPort,
 			hostname: peer.ip,

--- a/api/ws/rpc/disconnect.js
+++ b/api/ws/rpc/disconnect.js
@@ -16,6 +16,7 @@
 
 const disconnect = peer => {
 	if (peer.socket) {
+		peer.socket.disconnect(1000, 'Intentionally disconnected from peer because of disconnect call');
 		peer.socket.destroy();
 	}
 	return peer;

--- a/test/unit/api/ws/rpc/disconnect.js
+++ b/test/unit/api/ws/rpc/disconnect.js
@@ -33,6 +33,7 @@ describe('disconnect', () => {
 	describe('when peer contains socket with destroy function', () => {
 		beforeEach(done => {
 			validPeer.socket = {
+				disconnect: sinon.spy(),
 				destroy: sinon.spy(),
 			};
 			done();

--- a/workers_controller.js
+++ b/workers_controller.js
@@ -183,6 +183,12 @@ SCWorker.create({
 				});
 
 				function removePeerConnection(socket, code) {
+					scope.logger.trace(
+						`[Inbound socket :: disconnect] Peer socket from ${
+							socket.request.remoteAddress
+						} disconnected`
+					);
+
 					if (failureCodes.errorMessages[code]) {
 						return;
 					}


### PR DESCRIPTION
### What was the problem?

Timeouts were not ideal and could cause unnecessary disconnects.

### How did I fix it?

Use better socket timeout values that are closer to our main RPC timeout value (2 seconds).

### How to test it?

On the beta net.

### Review checklist

* The PR solves #1898
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
