### PR TITLE
Truncate rounds_rewards table prior to start snapshotting - Closes #1900

### DIFF
--- a/db/sql/accounts/reset_memory_tables.sql
+++ b/db/sql/accounts/reset_memory_tables.sql
@@ -25,3 +25,4 @@ DELETE FROM mem_accounts2delegates;
 DELETE FROM mem_accounts2u_delegates;
 DELETE FROM mem_accounts2multisignatures;
 DELETE FROM mem_accounts2u_multisignatures;
+DELETE FROM rounds_rewards;

--- a/logic/account.js
+++ b/logic/account.js
@@ -129,6 +129,7 @@ class Account {
 	 * - mem_accounts2u_delegates
 	 * - mem_accounts2multisignatures
 	 * - mem_accounts2u_multisignatures
+	 * - rounds_rewards
 	 *
 	 * @param {function} cb - Callback function
 	 * @returns {setImmediate} error


### PR DESCRIPTION
### What was the problem?
`round_rewards` table should be cleared prior to start snapshotting, also when performing `load/reload`.
### How did I fix it?
Clear table as part of `reset_memory_tables` SQL query.
### How to test it?
N/A
### Review checklist

* The PR solves #1900
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
