### PR TITLE
Reviving destroyed sockets memory leak - Closes #1907

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const _ = require('lodash');
-const async = require('async');
 const scClient = require('socketcluster-client');
 const WAMPClient = require('wamp-socket-cluster/WAMPClient');
 const failureCodes = require('../../../api/ws/rpc/failure_codes');
@@ -24,8 +23,7 @@ const wsRPC = require('../../../api/ws/rpc/ws_rpc').wsRPC;
 const Peer = require('../../../logic/peer');
 
 const TIMEOUT = 2000;
-const INITIAL_PING_TIMEOUT = 8000;
-const SOCKET_DESTROY_CLOSE_COUNT = 20;
+const SOCKET_DESTROY_TIMEOUT = 10000; // Allow sockets to be reused in case of frequent reconnect
 
 const wampClient = new WAMPClient(TIMEOUT); // Timeout failed requests after 1 second
 const socketConnections = {};
@@ -34,13 +32,11 @@ const connect = (peer, logger) => {
 	connectSteps.addConnectionOptions(peer);
 	connectSteps.addSocket(peer, logger);
 
-	async.parallel([
-		() => {
-			connectSteps.upgradeSocket(peer);
-			connectSteps.registerRPC(peer, logger);
-		},
-		() => connectSteps.registerSocketListeners(peer, logger),
-	]);
+	connectSteps.upgradeSocket(peer);
+	connectSteps.registerRPC(peer, logger);
+
+	connectSteps.registerSocketListeners(peer, logger);
+
 	return peer;
 };
 
@@ -62,7 +58,6 @@ const connectSteps = {
 
 	addSocket: (peer, logger) => {
 		peer.socket = scClient.connect(peer.connectionOptions);
-		peer.socket.closeCount = 0;
 
 		if (peer.socket && Object.keys(socketConnections).length < 1000) {
 			const hostname = peer.socket.options.hostname;
@@ -164,6 +159,7 @@ const connectSteps = {
 		const socket = peer.socket;
 
 		socket.on('connect', () => {
+			clearTimeout(socket.destroyTimeout);
 			logger.trace(
 				`[Outbound socket :: connect] Peer connection to ${peer.ip} established`
 			);
@@ -208,10 +204,18 @@ const connectSteps = {
 			if (peer.socket && peer.socket.state === peer.socket.CLOSED) {
 				peer.state = Peer.STATE.DISCONNECTED;
 			}
-			if (++socket.closeCount >= SOCKET_DESTROY_CLOSE_COUNT) {
-				socket.destroy();
-				socket.closeCount = 0;
-			}
+			clearTimeout(socket.destroyTimeout);
+			socket.destroyTimeout = setTimeout(() => {
+				if (socket.state === socket.CLOSED || peer.socket !== socket) {
+					// If the socket is still closed after SOCKET_DESTROY_TIMEOUT
+					// (I.e. it hasn't been reopened since), then we will destroy
+					// it completely.
+					socket.destroy();
+					if (socket === peer.socket) {
+						delete peer.socket;
+					}
+				}
+			}, SOCKET_DESTROY_TIMEOUT);
 		});
 
 		// The 'message' event can be used to log all low-level WebSocket messages.

--- a/api/ws/rpc/disconnect.js
+++ b/api/ws/rpc/disconnect.js
@@ -20,8 +20,6 @@ const disconnect = peer => {
 			1000,
 			'Intentionally disconnected from peer because of disconnect call'
 		);
-		peer.socket.destroy();
-		delete peer.socket;
 	}
 	return peer;
 };

--- a/api/ws/rpc/disconnect.js
+++ b/api/ws/rpc/disconnect.js
@@ -21,6 +21,7 @@ const disconnect = peer => {
 			'Intentionally disconnected from peer because of disconnect call'
 		);
 		peer.socket.destroy();
+		delete peer.socket;
 	}
 	return peer;
 };

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -50,18 +50,23 @@ PeersManager.prototype.add = function(peer) {
 	) {
 		return false;
 	}
+
 	this.peers[peer.string] = peer;
-	if (!this.addressToNonceMap[peer.string] && !peer.socket) {
-		// Create client WS connection to peer
-		connect(peer, this.logger);
-	} else {
+
+	if (peer.socket) {
 		// Reconnect existing socket
 		peer.socket.connect();
+	} else {
+		// Create client WS connection to peer
+		connect(peer, this.logger);
 	}
 	if (peer.nonce) {
 		this.addressToNonceMap[peer.string] = peer.nonce;
 		this.nonceToAddressMap[peer.nonce] = peer.string;
+	} else if (this.addressToNonceMap[peer.string]) {
+		delete this.addressToNonceMap[peer.string];
 	}
+
 	return true;
 };
 

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -16,7 +16,6 @@
 
 const connect = require('../api/ws/rpc/connect');
 const disconnect = require('../api/ws/rpc/disconnect');
-const Peer = require('../logic/peer');
 
 /**
  * Description of the class.
@@ -52,22 +51,15 @@ PeersManager.prototype.add = function(peer) {
 		return false;
 	}
 	this.peers[peer.string] = peer;
-	if (!this.addressToNonceMap[peer.string]) {
+	if (!this.addressToNonceMap[peer.string] && !peer.socket) {
 		// Create client WS connection to peer
-		connect(peer, this.logger, () => {
-			// Upon disconnection, if the peer is still in the list,
-			// set the peer state to disconnected.
-			// The peer will only be removed when the master process receives the
-			// command to do so from the worker process; the worker process decides
-			// when the master process should remove a peer.
-			var lostPeer = this.peers[peer.string];
-			if (lostPeer) {
-				lostPeer.state = Peer.STATE.DISCONNECTED;
-			}
-		});
+		connect(peer, this.logger);
+	} else {
+		// Reconnect existing socket
+		peer.socket.connect();
 	}
-	this.addressToNonceMap[peer.string] = peer.nonce;
 	if (peer.nonce) {
+		this.addressToNonceMap[peer.string] = peer.nonce;
 		this.nonceToAddressMap[peer.nonce] = peer.string;
 	}
 	return true;

--- a/test/unit/api/ws/rpc/connect.js
+++ b/test/unit/api/ws/rpc/connect.js
@@ -161,39 +161,42 @@ describe('connect', () => {
 		});
 
 		describe('addSocket', () => {
-			let scClientConnectSpy;
+			let scClientConnectStub;
 			let validConnectionOptions;
 			before(done => {
 				validConnectionOptions = {
 					validProperty: 'validString',
 				};
-				scClientConnectSpy = sinon.stub(
+				scClientConnectStub = sinon.stub(
 					connectRewired.__get__('scClient'),
 					'connect'
 				);
 				done();
 			});
 			beforeEach(done => {
+				scClientConnectStub.callsFake(() => {
+					return { options: {} };
+				});
 				const addSocket = connectRewired.__get__('connectSteps.addSocket');
 				validPeer.connectionOptions = validConnectionOptions;
-				peerAsResult = addSocket(validPeer);
+				peerAsResult = addSocket(validPeer, loggerMock);
 				done();
 			});
 			afterEach(done => {
-				scClientConnectSpy.reset();
+				scClientConnectStub.reset();
 				done();
 			});
 			after(done => {
-				scClientConnectSpy.restore();
+				scClientConnectStub.restore();
 				done();
 			});
 
 			it('should call scClient.connect', () => {
-				return expect(scClientConnectSpy).to.be.calledOnce;
+				return expect(scClientConnectStub).to.be.calledOnce;
 			});
 
 			it('should call scClient.connect with [peer.connectionOptions]', () => {
-				return expect(scClientConnectSpy).to.be.calledWithExactly(
+				return expect(scClientConnectStub).to.be.calledWithExactly(
 					validPeer.connectionOptions
 				);
 			});

--- a/test/unit/api/ws/rpc/disconnect.js
+++ b/test/unit/api/ws/rpc/disconnect.js
@@ -31,7 +31,7 @@ describe('disconnect', () => {
 		return expect(disconnect(validPeer)).equal(validPeer);
 	});
 
-	describe('when peer contains socket with destroy function', () => {
+	describe('when peer contains socket with disconnect function', () => {
 		beforeEach(done => {
 			socket = {
 				disconnect: sinon.spy(),
@@ -45,7 +45,7 @@ describe('disconnect', () => {
 			disconnect(validPeer);
 			// The socket should be deleted.
 			expect(validPeer.socket, undefined);
-			return expect(socket.destroy).calledOnce;
+			return expect(socket.disconnect).calledOnce;
 		});
 	});
 });

--- a/test/unit/api/ws/rpc/disconnect.js
+++ b/test/unit/api/ws/rpc/disconnect.js
@@ -20,6 +20,7 @@ const prefixedPeer = require('../../../../fixtures/peers').randomNormalizedPeer;
 
 describe('disconnect', () => {
 	let validPeer;
+	let socket;
 
 	beforeEach('provide non-mutated peer each time', done => {
 		validPeer = Object.assign({}, prefixedPeer);
@@ -32,16 +33,19 @@ describe('disconnect', () => {
 
 	describe('when peer contains socket with destroy function', () => {
 		beforeEach(done => {
-			validPeer.socket = {
+			socket = {
 				disconnect: sinon.spy(),
 				destroy: sinon.spy(),
 			};
+			validPeer.socket = socket;
 			done();
 		});
 
 		it('should call peer.socket.disconnect', () => {
 			disconnect(validPeer);
-			return expect(validPeer.socket.destroy).calledOnce;
+			// The socket should be deleted.
+			expect(validPeer.socket, undefined);
+			return expect(socket.destroy).calledOnce;
 		});
 	});
 });

--- a/test/unit/helpers/peers_manager.js
+++ b/test/unit/helpers/peers_manager.js
@@ -181,10 +181,10 @@ describe('PeersManager', () => {
 					done();
 				});
 
-				it('should add an entry [validPeer.string] = undefined in addressToNonce map', () => {
+				it('should not create any entry in addressToNonce map', () => {
 					return expect(
 						peersManagerInstance.addressToNonceMap
-					).to.have.property(validPeer.string).to.be.undefined;
+					).not.to.have.property(validPeer.string);
 				});
 
 				it('should not create any entry in nonceToAddress map', () => {


### PR DESCRIPTION
### What was the problem?

Some sockets were being revived after they were destroyed.
A better strategy is needed for handling socket disconnections so that it doesn't leak.

### How did I fix it?

Use SocketCluster's multiplexing feature so that sockets are reused instead of creating a new one each time we re-add a peer (which causes a memory leak).
This patch was tested on beta net and it appears to fix the issue of leaking socket handles.

### How to test it?

Test on beta net.

### Review checklist

* The PR solves #1907
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
