### PR TITLE
Upgrade socketcluster-client version - Closes #1908

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"semver": "=5.3.0",
 		"socket.io": "=2.0.3",
 		"socketcluster": "=10.0.1",
-		"socketcluster-client": "=10.1.1",
+		"socketcluster-client": "=11.1.0",
 		"sodium": "LiskHQ/node-sodium#895ac4482a56a34eba81205e43e0c859490fb99d",
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",


### PR DESCRIPTION
### What was the problem?

The socketcluster-client module was out of date and also `ws` client for 2 major versions behind.

### How did I fix it?

Bumped up the version number in package.json

### How to test it?

Run on beta net.

### Review checklist

* The PR solves #1908 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
