### PR TITLE
Fix logging of database events received from pgMonitor - Closes #1885

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,9 +167,10 @@ if (
 ) {
 	dbLogger = logger;
 } else {
+	// since log levels for database monitor are different than node app, i.e. "query", "info", "error" etc, which is decided using "logEvents" property
 	dbLogger = new Logger({
-		echo: process.env.DB_LOG_LEVEL || appConfig.db.consoleLogLevel,
-		errorLevel: process.env.FILE_LOG_LEVEL || appConfig.db.fileLogLevel,
+		echo: process.env.DB_LOG_LEVEL || 'log',
+		errorLevel: process.env.FILE_LOG_LEVEL || 'log',
 		filename: appConfig.db.logFileName,
 	});
 }
@@ -543,9 +544,9 @@ d.run(() => {
 			db(cb) {
 				var db = require('./db');
 				db
-					.connect(config.db, dbLogger)
+					.connect(config.db, dbLogger, logger)
 					.then(db => cb(null, db))
-					.catch(err => cb(err));
+					.catch(cb);
 			},
 
 			/**

--- a/db/index.js
+++ b/db/index.js
@@ -75,11 +75,12 @@ module.exports.pgp = pgp;
  *
  * @function connect
  * @param {Object} config
- * @param {function} logger
+ * @param {Object} dbLogger - logger for database log file
+ * @param {Object} logger - logger for application
  * @returns {Promise}
  * @todo Add description for the params and the return value
  */
-module.exports.connect = (config, logger) => {
+module.exports.connect = (config, dbLogger, logger) => {
 	if (monitor.isAttached()) {
 		monitor.detach();
 	}
@@ -88,7 +89,7 @@ module.exports.connect = (config, logger) => {
 	monitor.setTheme('matrix');
 
 	monitor.log = (msg, info) => {
-		logger.log(info.event, info.text);
+		dbLogger.log(info.event, info.text);
 		info.display = false;
 	};
 


### PR DESCRIPTION
### What was the problem?
The application uses database logger with configuration based on application events (debug, trace, info) which have no one-to-one mapping with dblog events.
### How did I fix it?
Log all events on log level based on logEvents property.
### How to test it?
Check the logs
### Review checklist

* The PR solves #1885 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
