### PR TITLE
Provide API endpoint for transactions of an account - Closes #1892 

### DIFF
--- a/api/controllers/transactions.js
+++ b/api/controllers/transactions.js
@@ -54,7 +54,7 @@ TransactionsController.getTransactions = function(context, next) {
 	var params = context.request.swagger.params;
 
 	var filters = {
-		address: params.address.value,
+		senderIdOrRecipientId: params.senderIdOrRecipientId.value,
 		id: params.id.value,
 		blockId: params.blockId.value,
 		recipientId: params.recipientId.value,

--- a/api/controllers/transactions.js
+++ b/api/controllers/transactions.js
@@ -54,6 +54,7 @@ TransactionsController.getTransactions = function(context, next) {
 	var params = context.request.swagger.params;
 
 	var filters = {
+		address: params.address.value,
 		id: params.id.value,
 		blockId: params.blockId.value,
 		recipientId: params.recipientId.value,

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -103,7 +103,7 @@ __private.list = function(filter, cb) {
 	const where = [];
 	const allowedFieldsMap = {
 		senderIdOrRecipientId:
-			'"t_senderId" IN ${senderIdOrRecipientId} OR "t_recipientId" IN ${senderIdOrRecipientId}',
+			'"t_senderId" IN (${senderIdOrRecipientId}) OR "t_recipientId" IN (${senderIdOrRecipientId})',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -103,7 +103,7 @@ __private.list = function(filter, cb) {
 	const where = [];
 	const allowedFieldsMap = {
 		senderIdOrRecipientId:
-			'"t_senderId" IN (${senderIdOrRecipientId}) OR "t_recipientId" IN (${senderIdOrRecipientId})',
+			'"t_senderId" = ${senderIdOrRecipientId} OR "t_recipientId" = ${senderIdOrRecipientId}',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -103,7 +103,7 @@ __private.list = function(filter, cb) {
 	const where = [];
 	const allowedFieldsMap = {
 		senderIdOrRecipientId:
-			'"t_senderId" IN (${senderIdOrRecipientId:csv}) OR "t_recipientId" IN (${senderIdOrRecipientId:csv})',
+			'"t_senderId" IN ${senderIdOrRecipientId} OR "t_recipientId" IN ${senderIdOrRecipientId}',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -102,6 +102,8 @@ __private.list = function(filter, cb) {
 	const params = {};
 	const where = [];
 	const allowedFieldsMap = {
+		address:
+			't_senderId" IN (${senderId:csv}) OR t_recipientId" IN (${recipientId:csv})',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -103,7 +103,7 @@ __private.list = function(filter, cb) {
 	const where = [];
 	const allowedFieldsMap = {
 		senderIdOrRecipientId:
-			'"t_senderId" IN (${senderId:csv}) OR "t_recipientId" IN (${recipientId:csv})',
+			'"t_senderId" IN (${senderIdOrRecipientId:csv}) OR "t_recipientId" IN (${senderIdOrRecipientId:csv})',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -103,7 +103,7 @@ __private.list = function(filter, cb) {
 	const where = [];
 	const allowedFieldsMap = {
 		senderIdOrRecipientId:
-			't_senderId" IN (${senderId:csv}) OR t_recipientId" IN (${recipientId:csv})',
+			'"t_senderId" IN (${senderId:csv}) OR "t_recipientId" IN (${recipientId:csv})',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -102,7 +102,7 @@ __private.list = function(filter, cb) {
 	const params = {};
 	const where = [];
 	const allowedFieldsMap = {
-		address:
+		senderIdOrRecipientId:
 			't_senderId" IN (${senderId:csv}) OR t_recipientId" IN (${recipientId:csv})',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1088,13 +1088,13 @@ parameters:
     format: publicKey
     minLength: 1
   senderIdOrRecipientId:
-  	name: senderIdOrRecipientId
-  	in: query
-  	description: Sender or Recipient address to query
-  	type: string
-  	format: address
-  	minLength: 1
-  	maxLength: 22
+    name: senderIdOrRecipientId
+    in: query
+    description: Public key to query
+    type: string
+    format: address
+    minLength: 1
+    maxLength: 22
   transactionType:
     name: type
     in: query

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1176,6 +1176,10 @@ definitions:
         type: string
         format: address
         example: 12668885769632475474L
+      senderIdOrRecipientId:
+        type: string
+        format: address
+        example: 12668885769632475474L
       signature:
         type: string
         format: signature
@@ -1572,7 +1576,6 @@ definitions:
       - fee
       - senderPublicKey
       - recipientId
-      - senderIdOrRecipientId
       - timestamp
       - asset
       - signature

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1176,10 +1176,6 @@ definitions:
         type: string
         format: address
         example: 12668885769632475474L
-      senderIdOrRecipientId:
-        type: string
-        format: address
-        example: 12668885769632475474L
       signature:
         type: string
         format: signature
@@ -1628,10 +1624,6 @@ definitions:
         type: string
         format: publicKey
         example: 2ca9a7143fc721fdc540fef893b27e8d648d2288efa61e56264edf01a2c23079
-      senderIdOrRecipientId:
-        type: string
-      	format: address
-      	example: 12668885769632475474L
       signature:
         type: string
         format: signature

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1090,7 +1090,7 @@ parameters:
   senderIdOrRecipientId:
     name: senderIdOrRecipientId
     in: query
-    description: Public key to query
+    description: Sender Id or Recipient Id to query
     type: string
     format: address
     minLength: 1

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -859,6 +859,7 @@ paths:
         - $ref: '#/parameters/recipientPublicKey'
         - $ref: '#/parameters/senderId'
         - $ref: '#/parameters/senderPublicKey'
+        - $ref: '#/parameters/senderIdOrRecipientId'
         - $ref: '#/parameters/transactionType'
         - $ref: '#/parameters/height'
         - $ref: '#/parameters/minAmount'
@@ -1086,6 +1087,14 @@ parameters:
     type: string
     format: publicKey
     minLength: 1
+  senderIdOrRecipientId:
+  	name: senderIdOrRecipientId
+  	in: query
+  	description: Sender or Recipient address to query
+  	type: string
+  	format: address
+  	minLength: 1
+  	maxLength: 22
   transactionType:
     name: type
     in: query
@@ -1563,6 +1572,7 @@ definitions:
       - fee
       - senderPublicKey
       - recipientId
+      - senderIdOrRecipientId
       - timestamp
       - asset
       - signature
@@ -1615,6 +1625,10 @@ definitions:
         type: string
         format: publicKey
         example: 2ca9a7143fc721fdc540fef893b27e8d648d2288efa61e56264edf01a2c23079
+      senderIdOrRecipientId:
+        type: string
+      	format: address
+      	example: 12668885769632475474L
       signature:
         type: string
         format: signature

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -399,47 +399,31 @@ describe('GET /api/transactions', () => {
 		});
 
 		describe('senderIdOrRecipientId', () => {
-			it('using invalid senderIdOrRecipientId should fail', () => {
+			it('using empty senderIdOrRecipientId should fail', () => {
 				return transactionsEndpoint
 					.makeRequest({ senderIdOrRecipientId: '' }, 400)
 					.then(res => {
 						expectSwaggerParamError(res, 'senderIdOrRecipientId');
 					});
 			});
-
-			it('using one senderIdOrRecipientId should return incoming and outgoing transaction of an account', () => {
-				var sender = [];
-				var recipient = [];
+			it('using invalid senderIdOrRecipientId should fail', () => {
+				return transactionsEndpoint
+					.makeRequest(
+						{ senderIdOrRecipientId: '1234567890123456789012L' },
+						400
+					)
+					.then(res => {
+						expectSwaggerParamError(res, 'senderIdOrRecipientId');
+					});
+			});
+			it('using senderIdOrRecipientId should return incoming and outgoing transactions of an account', () => {
 				var accountId = account.address;
 				return transactionsEndpoint
 					.makeRequest({ senderIdOrRecipientId: accountId }, 200)
 					.then(res => {
 						expect(res.body.data).to.not.empty;
-						res.body.data.map(transaction => {
-							if (accountId === transaction.recipientId) {
-								recipient.push(transaction);
-							} else if (accountId === transaction.senderId) {
-								sender.push(transaction);
-							}
-						});
-						expect(sender).to.have.length(1);
-						expect(recipient).to.have.length(1);
-					});
-			});
-
-			it('using multiple senderIdOrRecipientId should fail', () => {
-				return transactionsEndpoint
-					.makeRequest(
-						{
-							senderIdOrRecipientId: [
-								accountFixtures.genesis.address,
-								accountFixtures.existingDelegate.address,
-							],
-						},
-						400
-					)
-					.then(res => {
-						expectSwaggerParamError(res, 'senderIdOrRecipientId');
+						expect(res.body.data[0].senderId).to.be.eql(accountId);
+						expect(res.body.data[1].recipientId).to.be.eql(accountId);
 					});
 			});
 		});


### PR DESCRIPTION
### What was the problem?
The new API had no endpoint to collect all the transactions of a specific address at once.

### How did I fix it?
Create new filter `senderIdOrRecipientId` for transactions.

### How to test it?
Make API call: `/api/transactions?senderIdOrRecipientId=<address>`

### Review checklist

* The PR solves #1892 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
