### PR TITLE
Lint only relevant files prepush - Closes #1902

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 		"docs:serve": "./node_modules/.bin/http-server docs/jsdoc/",
 		"precommit": "lint-staged",
 		"check:dependencies": "./node_modules/.bin/snyk protect",
-		"prepush": "npm run lint && npm run check:dependencies",
+		"prepush":
+			"./node_modules/.bin/eslint $(git ls-files '*.js') && npm run check:dependencies",
 		"prepublishOnly": "npm run check:dependencies"
 	},
 	"dependencies": {


### PR DESCRIPTION
### What was the problem?

`prepush` hook was linting untracked files, preventing pushes even when lint failures were irrelevant.

### How did I fix it?

Changed lint target to tracked js files.

### How to test it?

`npm run prepush` with untracked files with lint errors in.

### Review checklist

* The PR solves #1902 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
