### PR TITLE
Node syncing with Peers below minVersion - Closes #1922

### DIFF
--- a/logic/peers.js
+++ b/logic/peers.js
@@ -193,7 +193,7 @@ Peers.prototype.upsert = function(peer, insertOnly) {
 	let cnt_empty_height = 0;
 	let cnt_empty_broadhash = 0;
 
-	_.each(__private.peers, peer => {
+	_.each(self.peersManager.peers, peer => {
 		++cnt_total;
 		if (peer.state === Peer.STATE.CONNECTED) {
 			++cnt_active;

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -21,7 +21,6 @@ const System = require('../modules/system.js');
 const PeersManager = require('../helpers/peers_manager.js');
 
 // Private fields
-const __private = {};
 let self;
 let library;
 let modules;
@@ -48,7 +47,6 @@ class Peers {
 			logger,
 		};
 		self = this;
-		__private.me = null;
 
 		this.peersManager = new PeersManager(logger);
 

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -275,6 +275,9 @@ __private.updatePeerStatus = function(err, status, peer) {
 		} else {
 			library.logic.peers.remove(peer);
 		}
+	} else if (!modules.system.versionCompatible(status.version)) {
+		library.logger.debug(`Peers->updatePeerStatus Incompatible version, rejecting peer: ${peer.string}, version: ${status.version}`);
+		library.logic.peers.remove(peer);
 	} else {
 		peer.applyHeaders({
 			broadhash: status.broadhash,

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -276,7 +276,11 @@ __private.updatePeerStatus = function(err, status, peer) {
 			library.logic.peers.remove(peer);
 		}
 	} else if (!modules.system.versionCompatible(status.version)) {
-		library.logger.debug(`Peers->updatePeerStatus Incompatible version, rejecting peer: ${peer.string}, version: ${status.version}`);
+		library.logger.debug(
+			`Peers->updatePeerStatus Incompatible version, rejecting peer: ${
+				peer.string
+			}, version: ${status.version}`
+		);
 		library.logic.peers.remove(peer);
 	} else {
 		peer.applyHeaders({


### PR DESCRIPTION
### What was the problem?
Node establish connections with peers that have `version` lower than our own `minVersion`.
### How did I fix it?
Add check and disconnect peer in that case.
### How to test it?
Manually.
### Review checklist

* The PR solves #1922
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
