### PR TITLE
Bump socketcluster-client version - Closes #1937

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"semver": "=5.3.0",
 		"socket.io": "=2.0.3",
 		"socketcluster": "=10.0.1",
-		"socketcluster-client": "=11.1.0",
+		"socketcluster-client": "=11.2.0",
 		"sodium": "LiskHQ/node-sodium#895ac4482a56a34eba81205e43e0c859490fb99d",
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",


### PR DESCRIPTION
### What was the problem?

Our current socketcluster-client version number is missing some optimizations which allow old sockets to be garbage collected more quickly and also adds an option to disable pings (which should help lower CPU utilization).

### How did I fix it?

Bumped version number to 11.2.0 in package.json.

### How to test it?

Do npm install, and check that the socketcluster-client version is 11.2.0.

### Review checklist

* The PR solves #1937
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
