### PR TITLE
Rename "key" -> "password" for passphrase encryption - Closes #1923

### DIFF
--- a/api/controllers/node.js
+++ b/api/controllers/node.js
@@ -154,11 +154,11 @@ NodeController.updateForgingStatus = function(context, next) {
 	}
 
 	var publicKey = context.request.swagger.params.data.value.publicKey;
-	var decryptionKey = context.request.swagger.params.data.value.decryptionKey;
+	var password = context.request.swagger.params.data.value.password;
 
 	modules.node.internal.toggleForgingStatus(
 		publicKey,
-		decryptionKey,
+		password,
 		(err, data) => {
 			if (err) {
 				context.statusCode = apiCodes.NOT_FOUND;

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -676,12 +676,12 @@ __private.loadDelegates = function(cb) {
  * Updates the forging status of an account, valid actions are enable and disable.
  *
  * @param {publicKey} publicKey - Public key of delegate
- * @param {string} secretKey - Key used to decrypt encrypted passphrase
+ * @param {string} password - Password used to decrypt encrypted passphrase
  * @param {function} cb - Callback function
  * @returns {setImmediateCallback} cb
  * @todo Add description for the return value
  */
-Delegates.prototype.toggleForgingStatus = function(publicKey, secretKey, cb) {
+Delegates.prototype.toggleForgingStatus = function(publicKey, password, cb) {
 	const encryptedList = library.config.forging.secret;
 	const encryptedItem = _.find(
 		encryptedList,
@@ -697,7 +697,7 @@ Delegates.prototype.toggleForgingStatus = function(publicKey, secretKey, cb) {
 		try {
 			decryptedSecret = __private.decryptSecret(
 				encryptedItem.encryptedSecret,
-				secretKey
+				password
 			);
 		} catch (e) {
 			return setImmediate(cb, 'Invalid password and public key combination');

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -76,7 +76,7 @@ class Delegates {
 				forging: {
 					secret: scope.config.forging.secret,
 					force: scope.config.forging.force,
-					defaultKey: scope.config.forging.defaultKey,
+					defaultPassword: scope.config.forging.defaultPassword,
 					access: {
 						whiteList: scope.config.forging.access.whiteList,
 					},
@@ -582,7 +582,7 @@ __private.loadDelegates = function(cb) {
 		!secretsList ||
 		!secretsList.length ||
 		!library.config.forging.force ||
-		!library.config.forging.defaultKey
+		!library.config.forging.defaultPassword
 	) {
 		return setImmediate(cb);
 	}
@@ -601,7 +601,7 @@ __private.loadDelegates = function(cb) {
 			try {
 				secret = __private.decryptSecret(
 					encryptedItem.encryptedSecret,
-					library.config.forging.defaultKey
+					library.config.forging.defaultPassword
 				);
 			} catch (error) {
 				return setImmediate(

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -700,7 +700,7 @@ Delegates.prototype.toggleForgingStatus = function(publicKey, secretKey, cb) {
 				secretKey
 			);
 		} catch (e) {
-			return setImmediate(cb, 'Invalid key and public key combination');
+			return setImmediate(cb, 'Invalid password and public key combination');
 		}
 
 		keypair = library.ed.makeKeypair(
@@ -717,7 +717,7 @@ Delegates.prototype.toggleForgingStatus = function(publicKey, secretKey, cb) {
 	}
 
 	if (keypair.publicKey.toString('hex') !== publicKey) {
-		return setImmediate(cb, 'Invalid key and public key combination');
+		return setImmediate(cb, 'Invalid password and public key combination');
 	}
 
 	if (__private.keypairs[keypair.publicKey.toString('hex')]) {

--- a/modules/node.js
+++ b/modules/node.js
@@ -97,15 +97,15 @@ Node.prototype.internal = {
 	 * Toggle the forging status of a delegate.
 	 *
 	 * @param {string} publicKey - Public key of a delegate
-	 * @param {string} decryptionKey - Key used to decrypt encrypted passphrase
+	 * @param {string} password - Password used to decrypt encrypted passphrase
 	 * @param {function} cb - Callback function
 	 * @returns {setImmediateCallback} cb
 	 * @todo Add description for the return value
 	 */
-	toggleForgingStatus(publicKey, decryptionKey, cb) {
+	toggleForgingStatus(publicKey, password, cb) {
 		modules.delegates.toggleForgingStatus(
 			publicKey,
-			decryptionKey,
+			password,
 			(err, result) => {
 				if (err) {
 					return setImmediate(cb, err);

--- a/schema/config.js
+++ b/schema/config.js
@@ -268,7 +268,7 @@ module.exports = {
 					force: {
 						type: 'boolean',
 					},
-					defaultKey: {
+					defaultPassword: {
 						type: 'string',
 					},
 					secret: {

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -16,7 +16,7 @@ swagger: '2.0'
 info:
   description: Lisk API Documentation
   title: Lisk API Documentation
-  version: '1.0.25'
+  version: '1.0.26'
   contact:
     email: admin@lisk.io
   license:

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -385,7 +385,7 @@ paths:
       summary: Toggles the forging status of a delegate
       operationId: updateForgingStatus
       description:
-        Upon passing the correct key and publicKey, forging will be enabled or disabled
+        Upon passing the correct password and publicKey, forging will be enabled or disabled
       produces:
         - application/json
       consumes:
@@ -393,7 +393,7 @@ paths:
       parameters:
         - in: body
           name: data
-          description: Secret key for the delegate account
+          description: Password for decrypting passphrase of delegate with corresponding public key
           required: true
           schema:
             type: object

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -398,10 +398,10 @@ paths:
           schema:
             type: object
             required:
-              - decryptionKey
+              - password
               - publicKey
             properties:
-              decryptionKey:
+              password:
                 type: string
                 example: "happy tree friends"
                 minLength: 5

--- a/test/common/helpers/api.js
+++ b/test/common/helpers/api.js
@@ -218,7 +218,7 @@ function sendSignature(signature, transaction, cb) {
 function creditAccount(address, amount, cb) {
 	var transaction = lisk.transaction.transfer({
 		amount,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: address,
 	});
 	sendTransactionPromise(transaction).then(cb);

--- a/test/common/helpers/api.js
+++ b/test/common/helpers/api.js
@@ -218,7 +218,7 @@ function sendSignature(signature, transaction, cb) {
 function creditAccount(address, amount, cb) {
 	var transaction = lisk.transaction.transfer({
 		amount,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: address,
 	});
 	sendTransactionPromise(transaction).then(cb);

--- a/test/common/utils/random.js
+++ b/test/common/utils/random.js
@@ -117,7 +117,7 @@ random.account = function() {
 random.transaction = function(offset) {
 	return lisk.transaction.transfer({
 		amount: 1,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: random.account().address,
 		timeOffset: offset,
 	});

--- a/test/common/utils/random.js
+++ b/test/common/utils/random.js
@@ -117,7 +117,7 @@ random.account = function() {
 random.transaction = function(offset) {
 	return lisk.transaction.transfer({
 		amount: 1,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: random.account().address,
 		timeOffset: offset,
 	});

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -73,7 +73,7 @@
 	},
 	"forging": {
 		"force": true,
-		"defaultKey": "elephant tree paris dragon chair galaxy",
+		"defaultPassword": "elephant tree paris dragon chair galaxy",
 		"secret": [
 			{
 				"encryptedSecret":

--- a/test/data/genesis_delegates.json
+++ b/test/data/genesis_delegates.json
@@ -16,7 +16,7 @@
 			"publicKey":
 				"9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f",
 			"username": "genesis_1",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=8c79d754416acccb567a42cf62b2e3bb&cipherText=73f5827fcd8eeab475abff71476cbce3b1ecacdeac55a738bb2f0a676d8e543bb92c91e1c1e3ddb6cef07a503f034dc7718e39657218d5a955859c5524be06de5954a5875b4c7b1cd11835e3477f1d04&iv=aac6a3b77c0594552bd9c932&tag=86231fb20e7b263264ca68b3585967ca&version=1"
 		},
@@ -27,7 +27,7 @@
 			"publicKey":
 				"141b16ac8d5bd150f16b1caa08f689057ca4c4434445e56661831f4e671b7c0a",
 			"username": "genesis_2",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5c709afdae35d43d4090e9ef31d14d85&cipherText=c205189b91f797c3914f5d82ccc7cccfb3c620cef512c3bf8f50cd280bd5ff1450e8b9be997179582e62bec0cb655ca2eb8ff6833892f9e350dc5182b61bd648cd02f7f95468c7ec51aa3b43&iv=bfae7a255077c6de61a1ec59&tag=59cfd0a55d39a765a84725f4be464179&version=1"
 		},
@@ -38,7 +38,7 @@
 			"publicKey":
 				"3ff32442bb6da7d60c1b7752b24e6467813c9b698e0f278d48c43580da972135",
 			"username": "genesis_3",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=588600600cd7660cf2346cd390093900&cipherText=6469aca1fe386e709c89c9a1d644abd969e64326f0f27f7be25248727892ec860e1e2dae54d283e65b1d21657a74047fb46ba732d1c83b93c8e2c0c96e98c2a9c4d87d0ac23db6dec9e3728426e3&iv=357d723a607f5baaf1fb218a&tag=f42bc3722b2964806d83a8ca3da2f94d&version=1"
 		},
@@ -49,7 +49,7 @@
 			"publicKey":
 				"5d28e992b80172f38d3a2f9592cad740fd18d3c2e187745cd5f7badf285ed819",
 			"username": "genesis_4",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=95c144db05bb4d6a6f7abbba54624e30&cipherText=65397bb076a5424c99cedc7da59306007a712e2d2a555cbcad7f4389204f09ce49951f7a2acf84daa960a75cd1322942a0eb9476fcaa33ce19840351c2773634a74f8c86e34a368b2d&iv=c1c5cef55ca8687f499a7a79&tag=fa034de61a84452ee4bade5df8f836b4&version=1"
 		},
@@ -60,7 +60,7 @@
 			"publicKey":
 				"4fe5cd087a319956ddc05725651e56486961b7d5733ecd23e26e463bf9253bb5",
 			"username": "genesis_5",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=d589edb8464c2214c63021f0f91b2697&cipherText=138e98c5b5d050c41e06f73c84ee28144c0b45bbbbdab214c700152e59475c7651bfaea17f81f5df0fa2b01cbf3759e6715a0981579d6ecb6a51ae9cf241c42ea719f48e4f41089914&iv=4541e4782e6532d7c912c25d&tag=7bfe0a6a67dc6fff554efddbf9ade356&version=1"
 		},
@@ -71,7 +71,7 @@
 			"publicKey":
 				"a796e9c0516a40ccd0eee7a32fdc2dc297fee40a9c76fef9c1bb0cf41ae69750",
 			"username": "genesis_6",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=1902beabb6e3950cc8414c45add0cdb0&cipherText=dbb6cac1887f8be5e4fb0a7e262764687db5fdd800a79b82ed0826159b0e254e016fab6014a1409dcde3b601af2b2ec9e5d7b94695437cc9475c0ab68e7d47bbcff07b3e74413b8feb8a51bb93&iv=95e23e81ae83341dbfef4f06&tag=621846f829f6e151c67609728e357b28&version=1"
 		},
@@ -82,7 +82,7 @@
 			"publicKey":
 				"67651d29dc8d94bcb1174d5bd602762850a89850503b01a5ffde3b726b43d3d2",
 			"username": "genesis_7",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=3c7c970b5cc1abb12e5f14f70ab091a8&cipherText=7bd14430b2a745cb061ddae3ff74f65fe5ad1b3e3df2b754023deb33fb037e97d62b009e01497cd887fb130b0d6321180e79a860891c97f7b13d4b465513f23ee9c4128c86c303f1d39afa&iv=767fcb34d02b90e0f966bff3&tag=ee415dff9f68e3482dfdc9f4b6e3d34a&version=1"
 		},
@@ -93,7 +93,7 @@
 			"publicKey":
 				"c3d1bc76dea367512df3832c437c7b2c95508e140f655425a733090da86fb82d",
 			"username": "genesis_8",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=2b2e1587f22bb2cb70923f61f4677a96&cipherText=79d6574eb971910bdf07babdd9fdb75cd3a161eadb50c8a1e99e5be6543135a32be26feb8627b819b8d69f468c9387de18bb9f2b8c3d91cef4fc042bb3d39396b2065991be31f6f4daf5edf3c525&iv=b3fe8faeefdd4d0f7d286a18&tag=d4220e0e89c04dad36c1e1595a3aebae&version=1"
 		},
@@ -104,7 +104,7 @@
 			"publicKey":
 				"640dfec4541daed209a455577d7ba519ad92b18692edd9ae71d1a02958f47b1b",
 			"username": "genesis_9",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=6011c15cad8976e7bb32fc3ea3b5c912&cipherText=ca52b9f33404fb25b4adc9e20739bbfba2fa538b00d4ebdac94a6acfd5e04f42c9a7c138254ca8692da15077f5c2786ddc863234cf9ee3a2ffc34167677808eccc6fdb6a1fceaf0eef9efa89&iv=1f2699d32c1fce108c5d6234&tag=d7cdf995d6b1780121cb48232181be29&version=1"
 		},
@@ -115,7 +115,7 @@
 			"publicKey":
 				"3ea481498521e9fb1201b2295d0e9afa826ac6a3ef51de2f00365f915ac7ac06",
 			"username": "genesis_10",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=e831237bcae5ee132fd486cc2c273a4a&cipherText=eb630d6192c600a25b59857e9710f8ac212db654d21d7348aef8dc1d2bd6d00bd88e0a75e6dac1d2c7d129ab5af00a54f25584c4f8cd7fcf381cfe6464bdc06daad25f44c92dc87d2cc31390&iv=e918d03e153191e67f01b37c&tag=1551d61ca4414d77df67c0364c787cc1&version=1"
 		},
@@ -126,7 +126,7 @@
 			"publicKey":
 				"5c4af5cb0c1c92df2ed4feeb9751e54e951f9d3f77196511f13e636cf6064e74",
 			"username": "genesis_11",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=c2d0d37e735c091627933b279446ebd1&cipherText=4c02f3ee282c02d4b9c2b8e8dbe5d90c8d4ace29388667c72525aac5f47a80a3cc58ec23fd958c3ea23aa4377fe7cd5e300f3c5b300ab9a3f0aa8b4a09062b2f1b127d49976edd5fc14429&iv=1bf6fa8567725829729c4635&tag=16e783480281031da844a30f1ce371ed&version=1"
 		},
@@ -137,7 +137,7 @@
 			"publicKey":
 				"399a7d14610c4da8800ed929fc6a05133deb8fbac8403dec93226e96fa7590ee",
 			"username": "genesis_12",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=e79c61da5c665ee03fc5706b1ddbf6e0&cipherText=75129f98408341d4426e1772815354ac3fd35c7cfadef215c37f26ac77c0485dd11407a0d7cbbc5e28ae5362eea96e063f12f5bab6429d52a30e331b29205a67d7447362da02&iv=5e2b5cfb36336de499729245&tag=255fa9bcf668a7fe24fd92a72eca4349&version=1"
 		},
@@ -148,7 +148,7 @@
 			"publicKey":
 				"6e904b2f678eb3b6c3042acb188a607d903d441d61508d047fe36b3c982995c8",
 			"username": "genesis_13",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=c9b0b237bd22a50150ace3f08faab0df&cipherText=9b8c9e1b9e30400ab39eb0433770ecc815d5576c031d4d62677bf4df669349be402f8fb87c15c3d97d09965d0924ab3ff4731457fe9eaa2c17a62b10c349e40a7421f3f24bb45027&iv=675e9c4bae2acbd6d2090145&tag=d295a00e8b6ef6ae796e0bb8d91cb17d&version=1"
 		},
@@ -159,7 +159,7 @@
 			"publicKey":
 				"1af35b29ca515ff5b805a5e3a0ab8c518915b780d5988e76b0672a71b5a3be02",
 			"username": "genesis_14",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=9341eb935ba6fc160bf236128aaef9be&cipherText=fd3a6aa0a6da1b1e2dfa134a99945a5a7e191c7317f41674239c5124f38d01b5047f5a7d3c2044f76b2e80b43c9167fd6c6920cefaddf8bdd32589b7fb607473ced8fdde9a769835f2b961e186e1b29193fcd8d09e&iv=c6356c565189ae4c9f49d1c8&tag=c8a70fa0f64cf3810f4b70ac304b8417&version=1"
 		},
@@ -170,7 +170,7 @@
 			"publicKey":
 				"d8daea40fd098d4d546aa76b8e006ce4368c052ffe2c26b6eb843e925d54a408",
 			"username": "genesis_15",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f92d1472c6b23b84e8df5a0611af9a44&cipherText=57d9dd24f9d777f35fedaa2a7df9f6b6f604e44993dbb65b700deffd58843d4b730c1a87def2fcaf2bb45cc4a071d3486c7bb02c071f9eba3a7eb2fc0f98dbea9baa5f1c9370&iv=72fc7ef7d7089dc67742906c&tag=5a7bbc441b62a7ae8e25b1f240875887&version=1"
 		},
@@ -181,7 +181,7 @@
 			"publicKey":
 				"386217d98eee87268a54d2d76ce9e801ac86271284d793154989e37cb31bcd0e",
 			"username": "genesis_16",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=41cecfe964e5759c7c891ff8893e7f5b&cipherText=3a3f9f790fcfcb0be8a8f2f0d003feefcb7889d6a142725be1242bd3ccd0ac04e3b1d81f3459fb0af7b0fe714b3a6e21055c668835d6abfe56ea9b6c2ef05a57f8343fdae677015cba5266193fd3&iv=b1a00485d4f114888b3132e5&tag=cde6171f8a8a1a7b26e0ca1f32d734ff&version=1"
 		},
@@ -192,7 +192,7 @@
 			"publicKey":
 				"86499879448d1b0215d59cbf078836e3d7d9d2782d56a2274a568761bff36f19",
 			"username": "genesis_17",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=d5b4a1f31bb922606c2972d56ff343e0&cipherText=3f104765a3c2e231fe8d51b9361fe35617fcf51464c696c1dcc4c1604b73a4ac440eaed30a3f4a8ea23d240e00624957f31591d472cf6287d06bf7e65e01a9d2682aec9f8108e59b7533&iv=bb1e58c67e0af5cb8166f85f&tag=ac54c32393c85637ba834f42955c1f7c&version=1"
 		},
@@ -203,7 +203,7 @@
 			"publicKey":
 				"948b8b509579306694c00833ec1c0f81e964487db2206ddb1517bfeca2b0dc1b",
 			"username": "genesis_18",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=730cb31d66e1444e87e18e930b30b895&cipherText=37c694acc9ef4574e9050983db09fdcb6c01b185591101ec30bf1e85ff216a2979bcd8194ca99cea5ebf4d09877a56a55973655e96aa2b8fadbebf9795d38ed698c75424093cff2db40c80b4fa107341fa040918aa8e14&iv=09940ff6976efe0aeaf33cca&tag=f10128b46bca30ddd3f93585f4b7753f&version=1"
 		},
@@ -214,7 +214,7 @@
 			"publicKey":
 				"b00269bd169f0f89bd2f278788616521dd1539868ced5a63b652208a04ee1556",
 			"username": "genesis_19",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=e872337f5fcc1d6f5d909e1878e98b19&cipherText=c22a10e09e20f7ff69b6fdf2197f314a197a687ce8f04eefe69b1e78ebde67c966104445df8cb045ab99492ddd088129421ad8a910bcc3ec0e296260f527b2640e5869dfa4&iv=f2061c401d6607be18246445&tag=abc3b18d70cdf3f25b5d7989d27a036c&version=1"
 		},
@@ -225,7 +225,7 @@
 			"publicKey":
 				"e13a0267444e026fe755ec128858bf3c519864631e0e4c474ba33f2470a18b83",
 			"username": "genesis_20",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=150225d2050f96c09e1356da18d3b6bf&cipherText=42c9c6b18bfaa1b065c26436a224b31e0294dd69f96999a78a390081b99ea07e6634fbf6948abd85f53c540bd84db66c0c6d445a66d0af3a8b9b9f8bbf9caed5448b2ddb4c4c4df249d8&iv=a386dec5655b9f494867abf4&tag=03d2cac8fe72a317fdcd146510f32153&version=1"
 		},
@@ -236,7 +236,7 @@
 			"publicKey":
 				"1cc68fa0b12521158e09779fd5978ccc0ac26bf99320e00a9549b542dd9ada16",
 			"username": "genesis_21",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=1c0481df8e14fa21be07723053ffb995&cipherText=6a555765da080c06005f76f2455b80893f0af97276678aa4669fa551fead6423f77c31d72c336ee6eb12f7aceecd9766abb03f4b70637d08598457b9254fdb75da9791bf38784033fafa2e35f356097f54&iv=37ffdb2202d632de177807b0&tag=9be904e135b2fa5dfaab4a7875390a0a&version=1"
 		},
@@ -247,7 +247,7 @@
 			"publicKey":
 				"a10f963752b3a44702dfa48b429ac742bea94d97849b1180a36750df3a783621",
 			"username": "genesis_22",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=d280d156b06e21bffaacdb149331de83&cipherText=2a98ba9cc32fbd358fcd635d841ae096d315dbd7c7592e81c1b9039d0f1471583ecb38fd9b4b5e5e073ce9a71f782013a0eeeac7dd730e98bed0b996800a8463c72316175856499725ec76f34a&iv=8f6596496b4155708b1564bf&tag=ee025dc8ec3a0673ef6bd5383ce37ee8&version=1"
 		},
@@ -258,7 +258,7 @@
 			"publicKey":
 				"f33f93aa1f3ddcfd4e42d3206ddaab966f7f1b6672e5096d6da6adefd38edc67",
 			"username": "genesis_23",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=999dd3534ac82633a8657e9a27337694&cipherText=714762e79a6d551ea65fdde443bdaf76ca679dcb742cc34a097755f0580e0d14b1912e5f3fb46b57e2d275581480151f0f83f8ed7b0478176ec2793fc9e2e2627d9b2cfbaf26bd10&iv=e9e49b7c5168b0aafc5e0dcf&tag=4625461f6b20057c225c55f7163f70a7&version=1"
 		},
@@ -269,7 +269,7 @@
 			"publicKey":
 				"b5341e839b25c4cc2aaf421704c0fb6ba987d537678e23e45d3ca32454a2908c",
 			"username": "genesis_24",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=8716d67dfafe306dfbfb6ab42fb4e52a&cipherText=b434459b80d4fdaa298ebc478d8ae14be087799881259ab457200144ad7aeae9238b5884bde5fb4f83ce9e9f9ee286bed165d09c37f198187acc1acb04f3f2b9882be875266bbf9da45f08&iv=0aee8ca29f6ce2b44cb7fb5c&tag=687c3e103bece9d46d55d68ec5265a3d&version=1"
 		},
@@ -280,7 +280,7 @@
 			"publicKey":
 				"da673805f349faf9ca1db167cb941b27f4517a36d23b3c21da4159cff0045fbe",
 			"username": "genesis_25",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=68788ccb5a02960c7b181bd8e8c5ec18&cipherText=07d9d54ac764487a0a3e667e0b8ec3e86a10c7637b3312fedc2e21c0297db36a7900f97e888b94de20ae7d3e0bcc818f8d5b6558848854edddf0bf7314bcfc34821a28c99a75ff4102ecf57905&iv=32deae6059934e931f1027f6&tag=3b9328c8578fe34a867dae59061cebda&version=1"
 		},
@@ -291,7 +291,7 @@
 			"publicKey":
 				"55405aed8c3a1eabe678be3ad4d36043d6ef8e637d213b84ee703d87f6b250ed",
 			"username": "genesis_26",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=d383e34ff385eb3115c29ecbdf325b1d&cipherText=ff70851b845b62aeeae52e7d5fe4e4780c6df1115969b87014adead1a9cecd3ad245d3c9389af2a85ef2ac17013e2542a01ed5181b8a8d530990792c184c4f5bdb907a50&iv=4edf9401754305e32a7f1172&tag=fefcd0e045687bc843ff5e80cc593654&version=1"
 		},
@@ -302,7 +302,7 @@
 			"publicKey":
 				"19ffdf99dee16e4be2db4b0e000b56ab3a4e10bee9f457d8988f75ff7a79fc00",
 			"username": "genesis_27",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=e8950fa7a1eb91c0c478745d00561b18&cipherText=06eace2e12dd86babe2863a4455782c9630e252896e1e2d409e43cad7cde5fe068e14b0eb4aa9dd3760a7ae90168c43bae0ba0edd7a8c427b28b5a5f3fd8d180a08deb0cd634b5b04a609e33306ae4&iv=c9f6c66a4435cde319f7e0c9&tag=5b213bfe0ac4d356cee39e52495507db&version=1"
 		},
@@ -313,7 +313,7 @@
 			"publicKey":
 				"85b07e51ffe528f272b7eb734d0496158f2b0f890155ebe59ba2989a8ccc9a49",
 			"username": "genesis_28",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=edfc83c5d7997f5b98b634233eb236cc&cipherText=02b9d94b46aa2b5309e8cc022e3554ea2bda098c996ff178d67361cc4b676794854e07c9f17bc70c9c44eb653dbde7dc7305f55eca4727c5264d7a57bc38a670a7b7bb7ac0891a12ae84abb56ec9c455&iv=138edd79d859ffcabfbeb752&tag=d6195066802996032013bb47941b73f8&version=1"
 		},
@@ -324,7 +324,7 @@
 			"publicKey":
 				"8a0bcba8e909036b7a0fdb244f049d847b117d871d203ef7cc4c3917c94fd5fd",
 			"username": "genesis_29",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=dbfa6af5a55a56b78ebb8a41fd9f5fa5&cipherText=dd42eac4ca6c63cb4ba3f912aacdc6e315d500504ccc2035f477fa1643c0180485490e52db7419bad8a8b0f3cc3d14a05541361e88907b17045b05423583547f04f7d1f0cd86af371037&iv=17c5d98ccdaad7bebc8f880f&tag=409e89070a955f8a19cebcd07b7c2e62&version=1"
 		},
@@ -335,7 +335,7 @@
 			"publicKey":
 				"95ea7eb026e250741be85e3593166ef0c4cb3a6eb9114dba8f0974987f10403f",
 			"username": "genesis_30",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5a2adfb388204bee6e565186967bb451&cipherText=99d36f23bfbbd5a880616cda81e563eb383537ace21ca8f643f0d1f610d0c71ec430ce5816feba592b2aa3db374f104861da0d3cf5fc65ea82b36d794680f5993902b221d20aa839ded426de6aa0b8fb978e&iv=499b9d9833d96eb47e1d046f&tag=bc47585f13a07309555c78c4e64706b2&version=1"
 		},
@@ -346,7 +346,7 @@
 			"publicKey":
 				"cf8a3bf23d1936a34facc4ff63d86d21cc2e1ac17e0010035dc3ef7ae85010dc",
 			"username": "genesis_31",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f828448176ac65052f91e4e12a39e474&cipherText=cf9c979a573458d9e800f12355e43f63f719f730b202c1ccc6b6532ce367cde20d5e17a70356129c244da4ce3ee2eb06cae1896680beb3f37791c974c3862b29245b77fa81ff18e1f76bbe&iv=ad4abf84491a465c5882c2a3&tag=04d8fd2765151f155d2073364329adc3&version=1"
 		},
@@ -357,7 +357,7 @@
 			"publicKey":
 				"82174ee408161186e650427032f4cfb2496f429b4157da78888cbcea39c387fc",
 			"username": "genesis_32",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=25fc3f25ecf2b1488d2884b646d32648&cipherText=052af13cbd2a60a930b4290a5e0c3ede3fa3f3aefd10e4a1bb39126c9be98e118975384a7c9824a24e4c060c403ffffcd0d0628a7ec862837e33873e92b2e3288677466019a9b96eb8&iv=9463e4f505f3d025858637e4&tag=ca3b2d244eba62d3b92ff51d2aaedd1d&version=1"
 		},
@@ -368,7 +368,7 @@
 			"publicKey":
 				"4bde949c19a0803631768148019473929b5f8661e9e48efb8d895efa9dd24aef",
 			"username": "genesis_33",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=68aa036b7e636e0cf7b65a416932df64&cipherText=663830a1bba0e0fa4e215c50488dca84097095e0099e5fe6c8242224b8efedd0e783ae7e373a917350b3cee86d627108bf16d6d2029d1c97825e58264d3a3b8a89477d&iv=5fe1730a7592dc1264b444bb&tag=51ff76e0177b6771093c6bf834bd2764&version=1"
 		},
@@ -379,7 +379,7 @@
 			"publicKey":
 				"2f9b9a43b915bb8dcea45ea3b8552ebec202eb196a7889c2495d948e15f4a724",
 			"username": "genesis_34",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=71f3a9daed9a44d45f7e24734dd95360&cipherText=924dc57495aaa74000e2a72a241856c5fbae9726e21b7891d9bba133a1c517796e1421d3a99527dbe35db213671c4abdd8786a96708eec37f4b5c1a43ae2fdd5d72e1cd663117041794115&iv=288183d31ec44cdc82103645&tag=1688afeb6df1469e343d1ee118cbee33&version=1"
 		},
@@ -390,7 +390,7 @@
 			"publicKey":
 				"9503d36c0810f9ac1a9d7d45bf778387a2baab151a45d77ac1289fbe29abb18f",
 			"username": "genesis_35",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=695fa51a337f109c9a8330a01c4bfed1&cipherText=838b21ad0f6655627edaf3df9136077b35b651766f05f9c338618b3ad10d1fb1ce9f7fbb596f4eb2b6f5aa3e7cc8e46196528562f9edb3e44bda1488a85444770d4e47e368da8c8ea09428a3d6fb9cf16fa407a8&iv=9c3cfce44f557601a5c362f1&tag=c9b4653745c4f32ba6608a44d0f98b95&version=1"
 		},
@@ -401,7 +401,7 @@
 			"publicKey":
 				"a50a55d4476bb118ba5121a07b51c185a8fe0a92b65840143b006b9820124df4",
 			"username": "genesis_36",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=84b976ea49969356c30d576156516b75&cipherText=d115fd0f1fd4a83c2f0142f71eb5187481e653170ecf880951e7f12f0fd099a2c80d97f0d92fa757fbfea71e989a37905832efc3c550aaf979fc535d82e43573cd84e93d0de4f98267&iv=54e31dd9c82c374c9ded8c46&tag=392a6e751343f70784ffd5170ff6643c&version=1"
 		},
@@ -412,7 +412,7 @@
 			"publicKey":
 				"fc8672466cc16688b5e239a784cd0e4c0acf214af039d9b2bf7a006da4043883",
 			"username": "genesis_37",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5203ee36da9bb5ade94f50b81731d7a5&cipherText=836c1ea90811368060a117a175ce268095c1448d5484d958e1229987fec631774915fb7f5be25a4f488cf22e88c9971204f517f647648296dcb7be059df9a6afe705b193ef9841fd29718688282f&iv=8af5f7b6e97c1e3be66c1467&tag=db9b20da191c7ee941b703ce212c54c2&version=1"
 		},
@@ -423,7 +423,7 @@
 			"publicKey":
 				"db821a4f828db977c6a8d186cc4a44280a6ef6f54ac18ec9eb32f78735f38683",
 			"username": "genesis_38",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=7696bbd0fb5d9bbe7d14c24cae641f31&cipherText=a49d1d57011a9215272b01dee847302e480218ec34f2d079708232dbf9c470ec0f5a702a8807bfaa15835c807f8cbfbf954a093d9897374b8e6d8a2a9c8e2b158607bfc46695088ff1130c7dd6&iv=3b2ca39285881d7d16a511df&tag=a0fe103340230ef98201ff225f9ff0cd&version=1"
 		},
@@ -434,7 +434,7 @@
 			"publicKey":
 				"ba7acc3bcbd47dbf13d744e57f696341c260ce2ea8f332919f18cb543b1f3fc7",
 			"username": "genesis_39",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=b1f8f869086b8591ac79ad9902145bef&cipherText=113ea9826d988c8ef92a24fbb7fed7aeb7a7a3f0b98cbd2524e3b77b5ab3e823d858647bb8005bbddcba5a7eedc42fe49b86305a894ede27e43cb5a7174d4e5f6155f6fb43c6f4&iv=2e7770e91f1f66b1fc3a66e0&tag=d2696f5255ba5fd94bd0e54d3a957780&version=1"
 		},
@@ -445,7 +445,7 @@
 			"publicKey":
 				"47c8b3d6a9e418f0920ef58383260bcd04799db150612d4ff6eb399bcd07f216",
 			"username": "genesis_40",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=85146e385ba7ec1e7649d4b61440edf6&cipherText=719e61ef42b180c851f4de0951940dbd87549c1d418b293f3790d533c9089a2dc9779978313e95e3b239300e07bdd4a461f008df8e3e535b7b10fe6fcd158f478c703f06e830be5f50a42db231&iv=651869e2991fd3caff8083fd&tag=43c0dda58e26134d1111da89e68016a3&version=1"
 		},
@@ -456,7 +456,7 @@
 			"publicKey":
 				"d1c3a2cb254554971db289b917a665b5c547617d6fd20c2d6051bc5dfc805b34",
 			"username": "genesis_41",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=73d6fb6f4ea80b0c31e31779764a5c29&cipherText=149e9b0f891fe893fbba8549f2ac890f64337ffe38d313d6b034d22228105f9fa0dc24bb687e5b9d992200279c68a674c6ed35140bcb2445666cea5a0b69937ee8e9cefdc0b932113bfc2d111211da86&iv=9adab204c63d65957ea30597&tag=56a69197bede28f00bb339e1abe9b10b&version=1"
 		},
@@ -467,7 +467,7 @@
 			"publicKey":
 				"47b9b07df72d38c19867c6a8c12429e6b8e4d2be48b27cd407da590c7a2af0dc",
 			"username": "genesis_42",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=438fa855da510b33c96251e096ae58cf&cipherText=5e0610542a3142fd06b6db74b766ccbc464511bd0550aa477f7e195c1c51767ce07608bcc6eeb3c71176d2b85a7d8b19db35b2c14ace35df5c0d99e9e8b6cb6b2022a93a3668f979225a8d96&iv=20bd19d74924a628b002dc70&tag=0af9604e04ead32b4b6279379cda8d45&version=1"
 		},
@@ -478,7 +478,7 @@
 			"publicKey":
 				"9a7452495138cf7cf5a1564c3ef16b186dd8ab4f96423f160e22a3aec6eb614f",
 			"username": "genesis_43",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=0b3a43fa73a916b26f1871113e54bb56&cipherText=db8014d8484a7ad84e82ec91a5bda758d22f8fe49490532d37759b0f75861684139713148022b0ca33b1d48932a128bdc6388fa0114e4d00e3285c33d60391e402359debdfa76e4bdfe46f5e10e0&iv=327a535d8528c18fbc6ab542&tag=e2ddfd74941841d7dfb28f00d99e8d28&version=1"
 		},
@@ -489,7 +489,7 @@
 			"publicKey":
 				"c4dfedeb4f639f749e498a2307f1545ddd6bda62e5503ac1832b122c4a5aedf9",
 			"username": "genesis_44",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=857d986d59b66a52db56a47b7071ee7a&cipherText=94eea5cdf2c784a54748434c6691e0b1901e44fdf93613cb9c39d81f8720ba57bae420862f13ea20713852cd4e28621cf62ff1b084062e53db9be7eaa80d4d725f12db5605ce08c387404f&iv=69bc4183a2ad739725f93c38&tag=8f2f372e5942c340948dc2641d83306b&version=1"
 		},
@@ -500,7 +500,7 @@
 			"publicKey":
 				"96c16a6251e1b9a8c918d5821a5aa8dfb9385607258338297221c5a226eca5c6",
 			"username": "genesis_45",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=375ada9764def07d23f749d2a90b4ae4&cipherText=fd6e9185ffec1757452de3af634b9ce07b5bd4872f19166eb0ff0b8f300cd91ffb0b7a659a41a0d16fd36be510bd12b26d31fbc05f897b27fb21da5edc4a8cb38fd2f5edc925105026&iv=711e78179fb0c72bf593e0df&tag=edae3a25d4048944e4bf9851ec512e48&version=1"
 		},
@@ -511,7 +511,7 @@
 			"publicKey":
 				"910da2a8e20f25ccbcb029fdcafd369b43d75e5bc4dc6d92352c29404acc350f",
 			"username": "genesis_46",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f614d35343a1b3288e04dc383d6cf99a&cipherText=a66247c20bd6c1deb8fc7a5d4c7da9554d24242af29e1ce75dfe67a119188279f14eb7f52ccea168a29d999d504e69207df5280c223c162d0844c6e67179586862b815b8384d49e5a0e0f3d04d6af1fe41177c004e1d3490358a&iv=ac4153268b5e38adff895a83&tag=ef1dcebcf502d56c0b2e598c3d19f8e4&version=1"
 		},
@@ -522,7 +522,7 @@
 			"publicKey":
 				"eabfe7093ef2394deb1b84287f2ceb1b55fe638edc3358a28fc74f64b3498094",
 			"username": "genesis_47",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=cf5bf30b17da11ddb4f6698297747549&cipherText=aa38b8d14bd91975391dbfafd51663c308d2e73f94250162d9dd89721ced75e20086cede1806307a758a932cf5065da7fb44f41b86a74ea90aecdd34bac23ad909b423ab616e24e77800c222f726f4dcf81ce8&iv=f166067fe95b1470b39b412e&tag=0e083eee04a95fae1ce451fbddc053ec&version=1"
 		},
@@ -533,7 +533,7 @@
 			"publicKey":
 				"94b163c5a5ad346db1c84edaff51604164476cf78b8834b6b610dd03bd6b65d9",
 			"username": "genesis_48",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=6d53a42450f3149c538fcedd310477a1&cipherText=5a43de0d2c100eb67851fdde0a929197ec5c61e5f37c2211c84d295df9f73a25b01bd3d120d9f7961c1356f722a3cd93d92b2848a471d5aeeb7f6f6a06ea4a23663feba8118f5ceb7cd232b7dcd49bb6&iv=c937a0bee0d8b9cfb95b8609&tag=66c7d11852786f753b4460c9d0d247ac&version=1"
 		},
@@ -544,7 +544,7 @@
 			"publicKey":
 				"6164b0cc68f8de44cde90c78e838b9ee1d6041fa61cf0cfbd834d76bb369a10e",
 			"username": "genesis_49",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=3d9acaf2b484353afb4ca8c5e4f0495e&cipherText=07cb5db5ea636156725fca90a1167293bdc09855c416613acf669b2a469ce4d520918f6a6f4a61599b950c6cc280d34e2313b8f937c625c5854243cb2f7c94fb1db251188e109f6482a6a42648bb50cd21f885ca43&iv=6cbf0aa036a818bdf27e57af&tag=237b813bb08ffd91b9214dc12c0472e4&version=1"
 		},
@@ -555,7 +555,7 @@
 			"publicKey":
 				"3476bba16437ee0e04a29daa34d753139fbcfc14152372d7be5b7c75d51bac6c",
 			"username": "genesis_50",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=1147e3bc4c2dadf4552ffdf9544ab058&cipherText=29f2edcbd90160915d4a63d916054e4cbbc9709df6cfa3c09ff7205cbd72b8b64f999c9bf07d62e6d920c4b1ce567aacf01483077024078d17b268bad619b04779188e1647442bd301a4062b&iv=70045573360b49bbbc537b13&tag=cfe41d70c726a71a71e5b01e838dc7a5&version=1"
 		},
@@ -566,7 +566,7 @@
 			"publicKey":
 				"01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398db746",
 			"username": "genesis_51",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=18a56b84a96d83eeeb1a4871036ca804&cipherText=55843198777fa7318659d596857998b0bdc5eeacdaa0abfd8e452ddc3c97fa6e279bda60a579076a02f4f996ed72a07927728ebe6dc3e215c628605a2602079b201c83830047edda4c6d427f25a3&iv=b3a5c51a6d5f3380d6de48e4&tag=b6029ee2bb52b52dbcfb17897d4e7453&version=1"
 		},
@@ -577,7 +577,7 @@
 			"publicKey":
 				"aa33af13b440746b4f24312cba5fa910eb077ce6b16b84ebb482cb7720b5c686",
 			"username": "genesis_52",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=59e590ab68e70248b5c21854ab7ed4ba&cipherText=0bdb25592d4e50899f69868cd38fd3c030322163e8871df3a20f06bcac7a1e5bdf0b29138a2f3681811d163c9bf908b81fd4c78590627083e8b35d006cc663c9be0e52fcd479492c7c3b&iv=fae6cc4b4195f01d2ed28895&tag=471aa454fd6eb546ee9fa9c5900fb046&version=1"
 		},
@@ -588,7 +588,7 @@
 			"publicKey":
 				"6f04988de7e63537c8f14e84b0eb51e0ea9c5da8b4b9256243b3e40b1aeccb76",
 			"username": "genesis_53",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f985fde8c1d2d69fb0a28a49237c123a&cipherText=b0d4c242403433d24b4a6ff47984c67b726eb9a2dc05c22e8aa8c34eebf0dc6e90a6792cb0a6a887979fc36576392bbeb05c2a097b42837f27aa7c1501ac65dfea5505a00b332d8ab602c7a4636298&iv=7d7cf3f9962bf8ae774967c1&tag=727dcb9adad81751befd3cb6f720e936&version=1"
 		},
@@ -599,7 +599,7 @@
 			"publicKey":
 				"07935c642c7409c365258c8488760e96a851cee618aec72eeeb135c9c827f0f9",
 			"username": "genesis_54",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=a180583962aa5e842c88b365f92e3372&cipherText=dc20f8b3f5bbf861cc4833999eb69ebb51ff5e9de6326240ba0463230f5c720473a8d3f944b88e7ad4732e87ff6e44848bc0a3be495b1288b939f60c63dfbc918f75e0a447889fddd8a9fceac4&iv=2ab48c138e779dbc491c0674&tag=e138537bdcc1a0b897418cad56be2b37&version=1"
 		},
@@ -610,7 +610,7 @@
 			"publicKey":
 				"526931663cbee883ff22369172cba091a5dd5fa1200284fa790d7aeca53d37af",
 			"username": "genesis_55",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=68f0b4f0cb3f3cea0484b9c154612379&cipherText=e536d0f0256bdd649779b9cc14f677a5e658088fe2a13a8acbcf5902977637b225c380dd35a058eb6e75406cf3d2b7123a46c37944c390fbf6a92bab800f08557c6d2b7ead899de837d719b669366d&iv=52544fedd20ccbb7975d491c&tag=e41aa56ab1246069c0a58c1e2afdec0f&version=1"
 		},
@@ -621,7 +621,7 @@
 			"publicKey":
 				"f7b9751d59dd6be6029aa36a81a3f6436e2970cf4348845ab6254678fb946c18",
 			"username": "genesis_56",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=84da147e37488857e64401cf6b272314&cipherText=bcf362aac768853a215cb8580dff4f40a3730d8279459da3ce87f6c13ba656be18d52257774a109f9d6eacb71bf6f30faaf1c31cbb2966993150343c407e8a66a61fadbc183f06bb15e513&iv=8c10429a902d0d5fa40ddc01&tag=f3ddcff84d21553aa1cb9579fbc4c3c0&version=1"
 		},
@@ -632,7 +632,7 @@
 			"publicKey":
 				"5f6cc5a8aac752d37c676b0d46a798f7625e37dfa1e96091983274e04ab7ffe2",
 			"username": "genesis_57",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=e707db66a1d3d3e55d27b31e29451ff8&cipherText=4c25802e93578d3973e1b479babe468065b0a30ef75e54e785e66dfe20b8c4e261b0f963cb7a6b5406a55184a3a46a5ce82fdb2c66c72b335904703595212216b21d77c5a8fd9d&iv=9729c4fed81c656c5af36737&tag=6334f288fedf3663c5e140e7aaa63d10&version=1"
 		},
@@ -643,7 +643,7 @@
 			"publicKey":
 				"9c16751dbe57f4dff7b3fb8911a62c0cb2bdee6240e3f3fefe76832788cb14c6",
 			"username": "genesis_58",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=caf2f01de12a0ea329ee824b8191c530&cipherText=27256d18bb5e43dc51dc059973cbc0bc0356fa656aaf478555a313801c9146b6ac8c5f54b29e25a2c257d66002993a5da4fb65d3745a544eaa1e3d37e10370417c0ee02f9e086a2c9a7efb59b52f8204faae&iv=5ace676c94ebab17dde4ffb0&tag=22b51a1c2d6685175610b7a6e65f61d5&version=1"
 		},
@@ -654,7 +654,7 @@
 			"publicKey":
 				"ba2ea5e324eeb42fa6f4d1132a1d79911721e8507033bb0abd49715f531877b4",
 			"username": "genesis_59",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=e5ec123c9d4f0c5bee87566576c4d8d4&cipherText=da17c8444fe416c0c1edd88bedf21f94242a1b33a6ca0ed5dbe2321ff7c97252b9cf787de2926f6b568482c86cf5af8430d3e4a1929bafc98958cc81c450785aadaaa8e77c690e00fa85eb&iv=317e99b972a694df868e7305&tag=c84d2052ac12118eff5074dba637d7e2&version=1"
 		},
@@ -665,7 +665,7 @@
 			"publicKey":
 				"0186d6cbee0c9b1a9783e7202f57fc234b1d98197ada1cc29cfbdf697a636ef1",
 			"username": "genesis_60",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=3dc39fa7a33af88801a4bd6977c8be57&cipherText=9d236904f279f2c0db17931d4fc2e213e07e2ffb3a508f89af8ce2b24ad034ed5d9914ea14491f31b65df8a70c393a606a2af5a571e0a607a4e310834a51719044d4606ccaec971b7e4e0065dce8&iv=53ee05f204a63dd53c07d03a&tag=ccf6ee44d284537f6d18190cc5939e6e&version=1"
 		},
@@ -676,7 +676,7 @@
 			"publicKey":
 				"edbb9828fbe62da2a59afbc8623e8ebc5ed2f9b7f77a0cd1cdcf55edea30521c",
 			"username": "genesis_61",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=163a60405fb9b26848a9f2f9052712f8&cipherText=af1f5ac23ef69ea477ab2a1b5acd9785e5fb7d8292c01353866999c2bcd9adf1947bd276feb8178600e2375a544ab2276fe2fe8527b702378482d39e2dd7eff7f601e8b4c0e8ed&iv=097009905154c531bb59d89f&tag=758dfb65b4ce5c42f95b344ad1a03b60&version=1"
 		},
@@ -687,7 +687,7 @@
 			"publicKey":
 				"b6ac700bf890b887e218dbd55b8f6b091dfc5a684d0fd7a6f69db7dc0313b51b",
 			"username": "genesis_62",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=b504425df6ab8f66abdb703f4b105f9a&cipherText=ad0e7af9530aa7ec77693ecf771e476a243e2a0044b60aecf4df5ddd4797b826ef10cd0b800a093f968a8fbbc5e352d85844884b13d60c57b782b4be3960cb441e981c8f8f&iv=ac606f2085277f2d59240ecf&tag=051824e706791299b0c1726badf53ed6&version=1"
 		},
@@ -698,7 +698,7 @@
 			"publicKey":
 				"62bbb3c41e43df73de2c3f87e6577d095b84cf6deb1b2d6e87612a9156b980f8",
 			"username": "genesis_63",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f96f7c5816da54c9defcf613c4b2903b&cipherText=47c6dec93dad771034c56861d703068768187f8dc8d11f8668f0425b95092a4cff91f94071bdfc309d0b6d37aa1912c8f7b5c4df1fa1d5f341f1bc61ba027d692aa43abf7580cf379fe3f0e8abe2&iv=61dd9b8d7908827ddaf1e7e4&tag=8fe41e5c0b714dfaa04dd1cc2e486ea3&version=1"
 		},
@@ -709,7 +709,7 @@
 			"publicKey":
 				"6fb2e0882cd9d895e1e441b9f9be7f98e877aa0a16ae230ee5caceb7a1b896ae",
 			"username": "genesis_64",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=48fdebf627fb88bfc4b18458f5db2ed8&cipherText=20c5bcf879cfabf4188c1f553904fbc7a3f60753f61290f515f7a35a00cdc9d0a4a3199e15b3f50493b3b99b5f7fe94aa7990db6a5daadf1e6cabd741f81d5621a67beb6a9ec0241accf5a6337&iv=ea9c9deeb3220ae2b2695c16&tag=83d07f8c5ee8a66199ccc86c4d2ae0e1&version=1"
 		},
@@ -720,7 +720,7 @@
 			"publicKey":
 				"9a0f19e60581003b70291cf4a874e8217b04871e676b2c53c85a18ab95c2683b",
 			"username": "genesis_65",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=bd17e355b779f66658878e63d57da208&cipherText=2902ad2ea2ec4f40ab6e5239a593f7010f3acd1df574082e05a2bd5edea5750479e865c82bf999dea668f89dbc34efd22be36e6ffd011217bcf11607b053ee2cc0ac0c1901d8b37c7441&iv=ceff97c973d6abb338267fdc&tag=65958db68e57a5e6afdc60e5516e1d18&version=1"
 		},
@@ -731,7 +731,7 @@
 			"publicKey":
 				"1e6ce18addd973ad432f05f16a4c86372eaca054cbdbcaf1169ad6df033f6b85",
 			"username": "genesis_66",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=8f8a5fe220f8ae279beda3c84b0c8f40&cipherText=daa06dd1b3299b74c9fa77dc37417d2c7f2749cba03f701c08d251be1b2cf4a0295cbb310d997ae2364b2e02d2d0c3d90cd5068290a74e5c97839f612bb848ec979370aaac8e5ac877753ed0&iv=b05626ec4a6083f6b0190452&tag=b2bb75bf7e7824a22473435b6bea364c&version=1"
 		},
@@ -742,7 +742,7 @@
 			"publicKey":
 				"27f43391cca75cbc82d1750307649508d1d318cd015f1f172b97318f17ab954e",
 			"username": "genesis_67",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=ca4ee07df3099e7e869ca013b81586df&cipherText=d58ae3b350fbafac0f5b654b25f8ef2b8d2610f4e63f3f83a200795317f0cbf2bd0e3d68b34725509b57998a4238d6b3eeb9c05a077bb1e4d2532e8ab38996cd858b19d10bbf559fd8e82c56019f9a&iv=071d059a2518e399829ba600&tag=d1e284f2874de74ce4a5acb5c1a96066&version=1"
 		},
@@ -753,7 +753,7 @@
 			"publicKey":
 				"644a971f2c0d0d4b657d050fca27e5f9265e3dfa02a71f7fbf834cc2f2a6a4c8",
 			"username": "genesis_68",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=1b2fd47a0c93e67d71bfeec8fff82ac2&cipherText=5de370af8159a9d38530ffe5af1da0bc6f1dd0bd496e303af9e39079f32cc45da615485b73610b4e92bfc00c5e018a07dab6852146f312192427e058b325f52fe83af56fa29cec11b700c69c86ced3&iv=620e5f227e3211c0e503aa58&tag=fa19b83d073381bf959310db2f0a99dd&version=1"
 		},
@@ -764,7 +764,7 @@
 			"publicKey":
 				"cdd68a321ea737e82bce23d2208040f79471d36f2e6f84c74ea36ab26245e522",
 			"username": "genesis_69",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5c9553d8284e843fc01854e2dd8788a5&cipherText=0e1218601280cbadbb3f60eda58ff49636b3d62c6d70b4aa0da0a6e8f554d1534fc15935a18ef3ac1370d307e99fcbebcbb9f4b802d0d41b3b19951c65b0a0d7dabec8a8688767&iv=cd9cf08fbdc31b6878c2efe8&tag=321a9fc3c76a2ba9818b038a1c70ee74&version=1"
 		},
@@ -775,7 +775,7 @@
 			"publicKey":
 				"f9f6ff873c10c24eba834be28a56415a49c9c67b7c0ee9f106da827847168986",
 			"username": "genesis_70",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=eca8144bc6e83637478c792aa26031e3&cipherText=8e317693ce392fc35160ebe1c0538db8353d25b27c112ee523a5e3db478a0e8fc7bbf0f83d574a5ab4fa7990b6230a9231f0a22fdb96970d9c7c1e69b1604ffba6e349e0b334aee05a1f46f1fe&iv=8fafb245a360fe1642d236e5&tag=18ee70586a9a9cf1da7f0819593a3043&version=1"
 		},
@@ -786,7 +786,7 @@
 			"publicKey":
 				"fab7b58be4c1e9542c342023b52e9d359ea89a3af34440bdb97318273e8555f0",
 			"username": "genesis_71",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=7cb0b7d5350f7cedef4d09e67b518fa6&cipherText=59cb9075e037abcedf683c18b415cd40106d847980fb58f2584a5db0ed312e81f1ffc87533521709d6c3565776361743251ccb65c043040a5e24b29dab5773660c1d5a2030f9d16dbd19060ab7&iv=bd2655b572df29cdcad5e28e&tag=0423687ce59d8bc13a1267531f3a89b5&version=1"
 		},
@@ -797,7 +797,7 @@
 			"publicKey":
 				"1b5a93c7622c666b0228236a70ee1a31407828b71bfb6daaa29a1509e87d4d3c",
 			"username": "genesis_72",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=cca97c901afe4d3c72b2cba41286de59&cipherText=b97b739bdd115ee3fd0844e7c6a498803801fdc103b240829376b4bf545bc18b4876e2e4114c56677460c370e8d3cde04b6dd265d01196d22dec13e5132bc7e6740d37aee61dd2701441f77ed38d3c9081&iv=32ca4b44b6eba770b0d54851&tag=a97c942133c94ae291c30670586d766d&version=1"
 		},
@@ -808,7 +808,7 @@
 			"publicKey":
 				"74583aba9c0b92e4f08c8c75e6df341c255ca007971195ff64d6f909dc4b7177",
 			"username": "genesis_73",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=710924d72e8ce6f35e6af3891dd770a4&cipherText=5ac5574da1015a10debca2fee404f023a6b466423d794300afac5a4481c7746fcf30aa4c975ec2e32b6643f55b80f5c3e2894d66877c61cb4b65652f4419a593d98cfd42ca48dc47ac1cfb7d112d4f2876&iv=06515f5ce23f58da52414590&tag=7f13e9e006b76e36a3296c18701867d0&version=1"
 		},
@@ -819,7 +819,7 @@
 			"publicKey":
 				"2b6f49383af36fd9f1a72d5d2708c8c354add89aaea7edc702c420e2d5fdf22e",
 			"username": "genesis_74",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=582e6ba6edc4ecd9fdfb5c166f6882c1&cipherText=12305fa4a82f4f0c1769bc12fa483dc93a38b2ad712c48c9854c485b5ea1f66f79f5eeb6e22b534b1a399fdc2f849910efe977a64671a2c3577cf2b38aa07a044aa7c56933153ebff9b0076dfab8e80334a1&iv=d1ea8206f81024b54beb986a&tag=3afc654926dd44346f775172a2e4cdad&version=1"
 		},
@@ -830,7 +830,7 @@
 			"publicKey":
 				"a10ed9c59dac2c4b8264dc34f2d318719fb5f20ecdd8d6be2d7abfe32294f20d",
 			"username": "genesis_75",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=815403d5ea1b92044efe44a00a556904&cipherText=f0a69d55a9c0c21c5e93163fcb1d567809eb926de1661a6beb5cf284fc9a3e1f67a253b9adfa4cd07144d6f10ca7c3e4e3a2114c3330edd51eec9dc200ce78be9d9d596bf26ef623&iv=33ee076b433d0f1a6db8aa3c&tag=aafab8432b39b00561e2d1e535ce1368&version=1"
 		},
@@ -841,7 +841,7 @@
 			"publicKey":
 				"c61d0822bbdbfe2a0b5503daff0ce8441c623115c94c0cfcf047a51f8b7160d3",
 			"username": "genesis_76",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=6e2befc08cae7c206b3a674e1d7fcbc5&cipherText=310da499f7a7e2b63214dc9fb17d1993487aa7cffe05c6b70e5b8ef1432f39da2a36c83870a139847d4572eec7527aa95a86e4e806b5b4ab58132e3eb2c41aab93abaa8cfae1907acc5e93&iv=021f16b54775d37f1836cbce&tag=5504cfe43ad5b9b4f38dfba3d8f9b03b&version=1"
 		},
@@ -852,7 +852,7 @@
 			"publicKey":
 				"031e27beab583e2c94cb3167d128fc1a356c1ae88adfcfaa2334abffa3ae0b4c",
 			"username": "genesis_77",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5093469063accfe03a82bbf922709c70&cipherText=e38b05bd469435079e687f01d96e65f423fdd35df4d97ef2cf95073098b2da6d875768c9f081faa8f4cdd3bf88432c48cdeca22abeee89f1353e6406a8280a01f39face84f96843f0e&iv=b4b38e1f3fcb15371001a85c&tag=4c14eda4e362840344ca803290099740&version=1"
 		},
@@ -863,7 +863,7 @@
 			"publicKey":
 				"9986cedd4b5a28e4c81d9b4bff0461dddaa25099df00b8632fe99e88df28ce73",
 			"username": "genesis_78",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=b054ca5087dce93cef24290e2dcb8067&cipherText=63d6291e1e55ca3f3f47ca8c8ee997820673885e69add9b4047c816a8ec4f969811464b84e27aa51ae1be65d5d11a7be7707a3689130a3622af7425325c9ade60a77a6076718f58b4f8ce26a25ad9b&iv=b92cd108ebeb7eb7f4413811&tag=d3509129b7c65a224007f2c1bd47df89&version=1"
 		},
@@ -874,7 +874,7 @@
 			"publicKey":
 				"03e811dda4f51323ac712cd12299410830d655ddffb104f2c9974d90bf8c583a",
 			"username": "genesis_79",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=04e3e452113b2a351e9dd002a8e1b5dc&cipherText=434a8a8662b491d8eb1a049c77d766a20ee5c2da25c5470888e401a010f4bb98bfe7ca45e5436e1a8ec730bc10b0e8da9f173f083514515e980c80cccebed05e8e533f3e157af80c0d499a7f55&iv=d8a6ca8fe59251abf76c4bce&tag=dcd193ec54617a64a95a4748ff9b9f18&version=1"
 		},
@@ -885,7 +885,7 @@
 			"publicKey":
 				"64db2bce729e302f6021047dfd39b6c53caf83b42da4b5b881cb153a3fb31613",
 			"username": "genesis_80",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=b75d523c4215efcfe1491580b61dee33&cipherText=e5dc1a96240a18cd4a781a0f30f3d9e863502ec2160053d3f6c6fec975cbef3cfa75c267c73733570385854dcfcbc3b6335b1872e10c5a1adbdd84d5bd02b7c9ed278c737cfa4c6f94&iv=86e6ed36f4dd5647a5dba898&tag=04f57b58d8c47fcd911bdf997c908fa9&version=1"
 		},
@@ -896,7 +896,7 @@
 			"publicKey":
 				"f827f60366fae9f9ed65384979de780f4a18c6dbfbefb1c7d100957dde51a06d",
 			"username": "genesis_81",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f12f0e7a89a1ac096a64256130f0efaf&cipherText=d98465b0125e1ff1327ac7812ce99634a85c4f67f8259f565d1e0927ad33346bf4faaf100b42b7217e142febaf91ec3223f6a292eec29b38469c64655174e71b7fa6144e42e5343c92614e0f3b74b6c0&iv=e055915ca0e3ceaf7c9a6829&tag=578a1a0f43fd747e10f84669b25f2870&version=1"
 		},
@@ -907,7 +907,7 @@
 			"publicKey":
 				"68680ca0bcd4676489976837edeac305c34f652e970386013ef26e67589a2516",
 			"username": "genesis_82",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=ac19b9fdaa887ef96159d619de936b16&cipherText=c70e551caf6b35f6f3c2cadf7df84a6bc63adfc7f17c0064e56bf50b899b19b0cda4ed80b4f4b23be1d8cf4f6087428ccfc8cf70e3479e4a83403ba650f8dc71c314959ef528f5f02a88&iv=585dfb9def62efb2d8df513b&tag=52b1c2204a61479988f96c70820ed837&version=1"
 		},
@@ -918,7 +918,7 @@
 			"publicKey":
 				"f25af3c59ac7f5155c7a9f36762bd941b9dc9c5c051a1bc2d4e34ed773dd04a3",
 			"username": "genesis_83",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f7b88f901f1fc194d430039f8e2bdf15&cipherText=ce613664130c61db7f22141ca1464a8ca52e2f057884760b9fcd20caeab8603e9f55a87f42e132e516bf118c75cc796c6f2cfc5e661d58d9c5ba28e06bfb79d6e84ccea37ed54b4b89346d&iv=6d2692d0e523729164f82073&tag=9b2589bfd16caeaf915f2e52672d4993&version=1"
 		},
@@ -929,7 +929,7 @@
 			"publicKey":
 				"d3e3c8348bca51461eabfc382f8a01e8e284db54104ad37ec0695d48ae5531ac",
 			"username": "genesis_84",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=fdbf66337ec33cfa03944cf12734f3d7&cipherText=98a221f46b95f3d2f089fbceb8a2ba441077d88ca35fd8bfa15ecc3ab7e4c78a091a7aa1f7e25d0ec278b8ae6a38dd757e45401181d328cdff68271d8fd4e4b34cd4fd22ae4662396b3d1155&iv=ee8552ef696fdefc0a3c98d8&tag=28dfee11d9203a88e1cb14191589826c&version=1"
 		},
@@ -940,7 +940,7 @@
 			"publicKey":
 				"3be2eb47134d5158e5f7d52076b624b76744b3fba8aa50791b46ba21408524c9",
 			"username": "genesis_85",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=8d2919c95eeeefff9b5ca2bdaf63f02c&cipherText=69a09134f6249221010718674cd6b2a89af805d7c68ac9fa18c556defec46a93c7d003bb80c31b681f6780cd56d7b78e8ff432e1e33b8ad658d29ea01c64cfbe0a315457bae5d5c10d00ee97b29cc0&iv=a5ab0c756204a42740ed0dc6&tag=9eeef218d5a7a4c243181c47384e2fed&version=1"
 		},
@@ -951,7 +951,7 @@
 			"publicKey":
 				"9f2fcc688518324273da230afff9756312bf23592174896fab669c2d78b1533c",
 			"username": "genesis_86",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=160ad6b0c2c8fb78b9aaa52e15c6ee72&cipherText=49c6797603fc841ef9916d9c78affcfb27fe21599fee5ccce8002b1ed66816131de53e7c88822cf4fd8eebc7024b366d97f281b90020aedd168926b2789daadf713c22617af04219ca6d4b5af321f29bdeefc5&iv=774cbc477bc9ebf4e68cd40d&tag=adca688bc49ddf901af53481519069e8&version=1"
 		},
@@ -962,7 +962,7 @@
 			"publicKey":
 				"e818ac2e8e9ffacd2d49f0f2f6739e16711644194d10bb1a8e9e434603125fa1",
 			"username": "genesis_87",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=33cd7225d7de744964fc5aa9cdc02bb3&cipherText=2cb62ed09039f843d80a8e50f5f2ce52e2bffa53c27b81637cca1bc14754b8d44a6bcb1ff0b089df7f0851af9ea505db0a1b0f74a61acc9d4357079e13044ee78030ad080069025ea4&iv=1ed1bf0bbb68debf545b8cbc&tag=2352de652018cb6c96ed545e9b81bb40&version=1"
 		},
@@ -973,7 +973,7 @@
 			"publicKey":
 				"19d55c023d85d6061d1e196fa440a50907878e2d425bcd893366fa04bc23b4de",
 			"username": "genesis_88",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=779015fea9268465dc5ae6820278cf19&cipherText=85a477d91334b3251231bac71e22807360bb1797ae211133b8bda8cafbb0c737afcc7574ad8da7c02be977668d2a5dc42c9d90805cc4368ae28d8680a3eacdb3aaa2f61a8fc6daf11c419c8647b2&iv=60689c3d5b296bbf6f02bae4&tag=7ffd84e7269bcfa8935398561117b928&version=1"
 		},
@@ -984,7 +984,7 @@
 			"publicKey":
 				"6d462852d410e84ca199a34d7ccad443784471f22cf3de37c531ce3b87ebbc41",
 			"username": "genesis_89",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=9a13374d8856b6abd2f79c114a774948&cipherText=d30b2db6ddd10a1519054764b5fc79b0803d48301494fd8648dba1114b04964a7b460f3d334d789e947d1a65e0f4242d09af29e31744a3ba9e28f18dfb36c1d11938c135176fd27e0a7a034c5834&iv=fb3a652a169450ae600024cf&tag=6fe8a5b17e3c19fc2955703bcb3e9f41&version=1"
 		},
@@ -995,7 +995,7 @@
 			"publicKey":
 				"e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 			"username": "genesis_90",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5644563a298a0c2c3f1544306a31c4d5&cipherText=c4572e6a3186304c798176c1284b66fcf6c76f3e414a197a3bf513d7a84bf359c21a03e60c5694167b9b45f5c03739270ff04d6d768037b23cf310cc598f7cdccccc7f653f2b14445dda1f72&iv=0646068b227bb9003c84f5be&tag=65e4c1c1a0ca701cc372cce219b839b1&version=1"
 		},
@@ -1006,7 +1006,7 @@
 			"publicKey":
 				"0779ca873bbda77f2850965c8a3a3d40a6ee4ec56af55f0a3f16c7c34c0f298b",
 			"username": "genesis_91",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=5e2ac512841444502686892a3924383c&cipherText=486dec2ddd2aeb625a403531ef3ad170ef587789fc74cb4df63342915edce906bc2090f0b646db6e26d2face83316bfe2d0f7b1875d7b96b1bdac581776393abfbd8985055&iv=e01774493327bb6d6a7144fe&tag=fc9809349421ca8aa3f558b1f3ff1196&version=1"
 		},
@@ -1017,7 +1017,7 @@
 			"publicKey":
 				"73fec19d4bfe361c0680a7cfd24b3f744a1c1b29d932c4d89ce6157679f8af7d",
 			"username": "genesis_92",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=82bba6eaad8db23186af34bedee24d7c&cipherText=d6fa91de76f6886b757de0d3000681abc1ab087726833785e7910101ca1182a092f26c27baa745182a07b1681d53809bb15d64c8be347dd6762023182699a3418959e7db4a7a0c&iv=dbf69c4a966ad7b8b9c46b33&tag=0bbd9bcefa48804737242f2fccf1a85f&version=1"
 		},
@@ -1028,7 +1028,7 @@
 			"publicKey":
 				"1e82c7db09da2010e7f5fef24d83bc46238a20ef7ecdf12d9f32e4318a818777",
 			"username": "genesis_93",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=eaf7eeb5fa1149bad7ab28e7f2b61736&cipherText=4b834815318e7705b7ae2fb0b28a8ff3ffbff846677374b75636b38202c162dbe30e20fc8e6cadf260e91e64c6b7a07a498c549bcb9da9028c45908a72e45e8061804ee565cbb70d7cd27216cf87f1aba6d324fd&iv=b9800849adec3a22fcd2dd8f&tag=1a1d1fc83bbd77e67b08ff79aa1f389f&version=1"
 		},
@@ -1039,7 +1039,7 @@
 			"publicKey":
 				"e42bfabc4a61f02131760af5f2fa0311007932a819a508da25f2ce6af2468156",
 			"username": "genesis_94",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=a5e87ee4cf497012c19612059ac4395c&cipherText=e3988eb316fb09148e53d6cb28725e71b3d37c9dd34d807cddb15b915321cf8e3a7d787e2f68f9a7ff16a15de9ea691e645ce3542dd15dff14a3c658964fca28d0c08fdf4f707cc93c&iv=1c84c6f8991c3028c95239f7&tag=0838c6f6fef4d878128cbc0b074f2918&version=1"
 		},
@@ -1050,7 +1050,7 @@
 			"publicKey":
 				"bf9f5cfc548d29983cc0dfa5c4ec47c66c31df0f87aa669869678996902ab47f",
 			"username": "genesis_95",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=f23193fa0bb4132ed16edc879498b5ea&cipherText=f92b767be499943425e99d13d0b9490556340f1931189d800d60ee2f7b7ec34ccf506dd561c54f7de60ab1892bee6d97b5e90c99dcea8c8187db82786101068e60e9704d3b8c404d48b74694&iv=3ed05e17b38918737e60800c&tag=79ab02f68e7628b3fb7dbd0f6a42adf2&version=1"
 		},
@@ -1061,7 +1061,7 @@
 			"publicKey":
 				"b137de324fcc79dd1a21ae39a2ee8eed05e76b86d8e89d378f8bb766afb8719f",
 			"username": "genesis_96",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=96fb0395b2b2379e68e51f449113edb7&cipherText=52f722cdef945d6eb9524bb82d24f5aea27739263c93886125cad3281358046f0429efc7d147e1191360809303f4c07dc5f70653d2adc66ca36764ce04310be0b6f116952f3c196282&iv=de60a2c3b0a182fc9d32748b&tag=c3a3a64aa201b770b766f6fc1a8009eb&version=1"
 		},
@@ -1072,7 +1072,7 @@
 			"publicKey":
 				"31402977c7eaf9e38d18d0689a45d719d615de941f7e80f6db388453b46f4df5",
 			"username": "genesis_97",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=3a34ad5ed0c53f7419472be9c10aa774&cipherText=3a4ba8b2333ff529627d298c4278250591064c6c61ba9fff60615f22890b11ceca5bb2795d163f911ce1b2f148eb208c3da2e8d37389451ead13d268e83008daae5cf8d72428f1046f7eeef940&iv=c23d8468f09e277526d7f81d&tag=187d4276ad5e58819719f67b39e375b2&version=1"
 		},
@@ -1083,7 +1083,7 @@
 			"publicKey":
 				"f62062b7590d46f382fb8c37a26ab0a1bd512951777aedcaa96822230727d3a1",
 			"username": "genesis_98",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=7fcea0274f48200c6fc4bd7902a2a5d0&cipherText=3d56429d8495bb08328d8a47f2d02d71522fea42bb9cf4f941bb0a8e36c75489147783c406485cd1dc543e12a023d588942b466ef9f46dc5d2de6073f10fd53df19daa58512e3ceb66124b&iv=ac777e7901c656e51aab573c&tag=0f758e78aad769943bf1b4cb3b365c33&version=1"
 		},
@@ -1094,7 +1094,7 @@
 			"publicKey":
 				"76c9494237e608d43fd6fb0114106a7517f5503cf79d7482db58a02304339b6c",
 			"username": "genesis_99",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=bbd116e5f9470d12e909e6bad03d014c&cipherText=f3d2fc911f61792beb4a62752edc4f19f2308f5c1a85a818f257190163548195e19129a0595f69cc1a4dedaf636f2b1714374af6f9806a59860adc45026e1f25a863742d6fe47ad0aa042e216520f052&iv=ee03fb460c2df1b57122ede7&tag=2555203a8fdfcaae758f626390f06071&version=1"
 		},
@@ -1105,7 +1105,7 @@
 			"publicKey":
 				"addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9",
 			"username": "genesis_100",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=25e9932aaa4c885bdcafb1913058fce6&cipherText=94cd85840ca2397e609e39d9c2902000d90d98bc3a24d0d5f086219c8365b84ab67a82e4e7680e9cec0da71b6c7f930e326d3bbece8e963d9664fcfaa80bd6f2e96befb033ad84ab3e6b0e32300cb304512f3f&iv=6bff91449f495bae345ab15a&tag=91c1eaa254a80c5d51a15b75929ca335&version=1"
 		},
@@ -1116,7 +1116,7 @@
 			"publicKey":
 				"904c294899819cce0283d8d351cb10febfa0e9f0acd90a820ec8eb90a7084c37",
 			"username": "genesis_101",
-			"key": "elephant tree paris dragon chair galaxy",
+			"password": "elephant tree paris dragon chair galaxy",
 			"encryptedSecret":
 				"iterations=1&salt=b05e7929f524a64d5c762e6acce2f05d&cipherText=0047c8769059f9f03eb0044ab45b97ec7ef8bd3a38e6f3e673ca0efd24c91310b00f5294e758f17cb87e12bdfcbcb4424020cd76e94e11f1292f29b99eecd56bd31878d4918ac6&iv=abb4e450db5550ac2da6e0ee&tag=8c3f973e1e51387c148e3b0ec0d893e8&version=1"
 		}

--- a/test/fixtures/accounts.js
+++ b/test/fixtures/accounts.js
@@ -23,7 +23,7 @@ const accounts = {};
 accounts.existingDelegate = {
 	address: '10881167371402274308L',
 	publicKey: 'addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9',
-	password:
+	secret:
 		'actress route auction pudding shiver crater forum liquid blouse imitate seven front',
 	balance: '0',
 	delegateName: 'genesis_100',
@@ -33,12 +33,12 @@ accounts.existingDelegate = {
 accounts.genesis = {
 	address: '16313739661670634666L',
 	publicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
-	password:
+	secret:
 		'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
 	balance: '10000000000000000',
 	encryptedSecret:
 		'iterations=1&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1',
-	key: 'elephant tree paris dragon chair galaxy',
+	password: 'elephant tree paris dragon chair galaxy',
 };
 
 accounts.mem_accountsFields = [

--- a/test/fixtures/accounts.js
+++ b/test/fixtures/accounts.js
@@ -23,7 +23,7 @@ const accounts = {};
 accounts.existingDelegate = {
 	address: '10881167371402274308L',
 	publicKey: 'addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9',
-	secret:
+	passphrase:
 		'actress route auction pudding shiver crater forum liquid blouse imitate seven front',
 	balance: '0',
 	delegateName: 'genesis_100',
@@ -33,7 +33,7 @@ accounts.existingDelegate = {
 accounts.genesis = {
 	address: '16313739661670634666L',
 	publicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
-	secret:
+	passphrase:
 		'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
 	balance: '10000000000000000',
 	encryptedSecret:

--- a/test/functional/common/scenarios.js
+++ b/test/functional/common/scenarios.js
@@ -50,7 +50,7 @@ function Multisig(options) {
 	});
 	this.creditTransaction = lisk.transaction.transfer({
 		amount: this.amount,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: this.account.address,
 	});
 	this.secondSignatureTransaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/common/scenarios.js
+++ b/test/functional/common/scenarios.js
@@ -50,7 +50,7 @@ function Multisig(options) {
 	});
 	this.creditTransaction = lisk.transaction.transfer({
 		amount: this.amount,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: this.account.address,
 	});
 	this.secondSignatureTransaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/http/get/accounts/accounts.js
+++ b/test/functional/http/get/accounts/accounts.js
@@ -181,7 +181,7 @@ describe('GET /accounts', () => {
 			var secondPublicKeyAccount = randomUtil.account();
 			var creditTransaction = lisk.transaction.transfer({
 				amount: constants.fees.secondSignature,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: secondPublicKeyAccount.address,
 			});
 			var signatureTransaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/http/get/accounts/accounts.js
+++ b/test/functional/http/get/accounts/accounts.js
@@ -181,7 +181,7 @@ describe('GET /accounts', () => {
 			var secondPublicKeyAccount = randomUtil.account();
 			var creditTransaction = lisk.transaction.transfer({
 				amount: constants.fees.secondSignature,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: secondPublicKeyAccount.address,
 			});
 			var signatureTransaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/http/get/dapps.js
+++ b/test/functional/http/get/dapps.js
@@ -41,7 +41,7 @@ describe('GET /dapps', () => {
 	before(() => {
 		var transaction = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: account.address,
 		});
 		transactionsToWaitFor.push(transaction.id);

--- a/test/functional/http/get/dapps.js
+++ b/test/functional/http/get/dapps.js
@@ -41,7 +41,7 @@ describe('GET /dapps', () => {
 	before(() => {
 		var transaction = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: account.address,
 		});
 		transactionsToWaitFor.push(transaction.id);

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -104,7 +104,7 @@ describe('GET /delegates', () => {
 
 			var creditTransaction = lisk.transaction.transfer({
 				amount: constants.fees.secondSignature + constants.fees.delegate,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: secondSecretAccount.address,
 			});
 			var signatureTransaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -104,7 +104,7 @@ describe('GET /delegates', () => {
 
 			var creditTransaction = lisk.transaction.transfer({
 				amount: constants.fees.secondSignature + constants.fees.delegate,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: secondSecretAccount.address,
 			});
 			var signatureTransaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/http/get/node/transactions_unconfirmed.js
+++ b/test/functional/http/get/node/transactions_unconfirmed.js
@@ -46,7 +46,7 @@ describe('GET /api/node', () => {
 					transactionList.push(
 						lisk.transaction.transfer({
 							amount: (i + 1) * constants.normalizer,
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: account.address,
 							data,
 						})

--- a/test/functional/http/get/node/transactions_unconfirmed.js
+++ b/test/functional/http/get/node/transactions_unconfirmed.js
@@ -46,7 +46,7 @@ describe('GET /api/node', () => {
 					transactionList.push(
 						lisk.transaction.transfer({
 							amount: (i + 1) * constants.normalizer,
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: account.address,
 							data,
 						})

--- a/test/functional/http/get/node/transactions_unprocessed.js
+++ b/test/functional/http/get/node/transactions_unprocessed.js
@@ -44,7 +44,7 @@ describe('GET /api/node', () => {
 					transactionList.push(
 						lisk.transaction.transfer({
 							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: account.address,
 							data,
 						})

--- a/test/functional/http/get/node/transactions_unprocessed.js
+++ b/test/functional/http/get/node/transactions_unprocessed.js
@@ -44,7 +44,7 @@ describe('GET /api/node', () => {
 					transactionList.push(
 						lisk.transaction.transfer({
 							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: account.address,
 							data,
 						})

--- a/test/functional/http/get/node/transactions_unsigned.js
+++ b/test/functional/http/get/node/transactions_unsigned.js
@@ -48,7 +48,7 @@ describe('GET /api/node', () => {
 				// Credit account with some funds
 				transaction = lisk.transaction.transfer({
 					amount: 1000 * constants.normalizer,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					recipientId: senderAccount.address,
 				});
 

--- a/test/functional/http/get/node/transactions_unsigned.js
+++ b/test/functional/http/get/node/transactions_unsigned.js
@@ -48,7 +48,7 @@ describe('GET /api/node', () => {
 				// Credit account with some funds
 				transaction = lisk.transaction.transfer({
 					amount: 1000 * constants.normalizer,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					recipientId: senderAccount.address,
 				});
 

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -39,12 +39,12 @@ describe('GET /api/transactions', () => {
 	var maxAmount = 100 * constants.normalizer; // 100 LSK
 	var transaction1 = lisk.transaction.transfer({
 		amount: maxAmount,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account.address,
 	});
 	var transaction2 = lisk.transaction.transfer({
 		amount: minAmount,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account2.address,
 	});
 

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -39,12 +39,12 @@ describe('GET /api/transactions', () => {
 	var maxAmount = 100 * constants.normalizer; // 100 LSK
 	var transaction1 = lisk.transaction.transfer({
 		amount: maxAmount,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account.address,
 	});
 	var transaction2 = lisk.transaction.transfer({
 		amount: minAmount,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account2.address,
 	});
 

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -245,7 +245,7 @@ describe('GET /api/voters', () => {
 						constants.fees.delegate +
 						constants.fees.vote +
 						constants.fees.secondSignature,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					recipientId: validExtraDelegateVoter.address,
 				});
 

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -245,7 +245,7 @@ describe('GET /api/voters', () => {
 						constants.fees.delegate +
 						constants.fees.vote +
 						constants.fees.secondSignature,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					recipientId: validExtraDelegateVoter.address,
 				});
 

--- a/test/functional/http/get/votes.js
+++ b/test/functional/http/get/votes.js
@@ -361,7 +361,7 @@ describe('GET /api/votes', () => {
 				var account = randomUtil.account();
 				var creditTransaction = lisk.transaction.transfer({
 					amount: constants.fees.delegate + constants.fees.vote,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					recipientId: account.address,
 				});
 				var delegateTransaction = lisk.transaction.registerDelegate({

--- a/test/functional/http/get/votes.js
+++ b/test/functional/http/get/votes.js
@@ -361,7 +361,7 @@ describe('GET /api/votes', () => {
 				var account = randomUtil.account();
 				var creditTransaction = lisk.transaction.transfer({
 					amount: constants.fees.delegate + constants.fees.vote,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					recipientId: account.address,
 				});
 				var delegateTransaction = lisk.transaction.registerDelegate({

--- a/test/functional/http/post/0.transfer.js
+++ b/test/functional/http/post/0.transfer.js
@@ -90,7 +90,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 		it('using zero amount should fail', () => {
 			transaction = lisk.transaction.transfer({
 				amount: 0,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 
@@ -124,7 +124,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 		it('using entire balance should fail', () => {
 			transaction = lisk.transaction.transfer({
 				amount: Math.floor(accountFixtures.genesis.balance),
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 
@@ -214,7 +214,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 			it('using -10000 should be ok', () => {
 				transaction = lisk.transaction.transfer({
 					amount: 1,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					recipientId: accountOffset.address,
 					timeOffset: -10000,
 				});
@@ -228,7 +228,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 			it('using future timestamp should fail', () => {
 				transaction = lisk.transaction.transfer({
 					amount: 1,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					recipientId: accountOffset.address,
 					timeOffset: 10000,
 				});
@@ -256,7 +256,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						var accountAdditionalData = randomUtil.account();
 						transaction = lisk.transaction.transfer({
 							amount: 1,
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: accountAdditionalData.address,
 						});
 						transaction.asset.data = test.input;
@@ -282,7 +282,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						var accountAdditionalData = randomUtil.account();
 						transaction = lisk.transaction.transfer({
 							amount: 1,
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: accountAdditionalData.address,
 							data: test.input,
 						});

--- a/test/functional/http/post/0.transfer.js
+++ b/test/functional/http/post/0.transfer.js
@@ -90,7 +90,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 		it('using zero amount should fail', () => {
 			transaction = lisk.transaction.transfer({
 				amount: 0,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 
@@ -124,7 +124,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 		it('using entire balance should fail', () => {
 			transaction = lisk.transaction.transfer({
 				amount: Math.floor(accountFixtures.genesis.balance),
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 
@@ -214,7 +214,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 			it('using -10000 should be ok', () => {
 				transaction = lisk.transaction.transfer({
 					amount: 1,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					recipientId: accountOffset.address,
 					timeOffset: -10000,
 				});
@@ -228,7 +228,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 			it('using future timestamp should fail', () => {
 				transaction = lisk.transaction.transfer({
 					amount: 1,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					recipientId: accountOffset.address,
 					timeOffset: 10000,
 				});
@@ -256,7 +256,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						var accountAdditionalData = randomUtil.account();
 						transaction = lisk.transaction.transfer({
 							amount: 1,
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: accountAdditionalData.address,
 						});
 						transaction.asset.data = test.input;
@@ -282,7 +282,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						var accountAdditionalData = randomUtil.account();
 						transaction = lisk.transaction.transfer({
 							amount: 1,
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: accountAdditionalData.address,
 							data: test.input,
 						});

--- a/test/functional/http/post/1.second_secret.js
+++ b/test/functional/http/post/1.second_secret.js
@@ -41,17 +41,17 @@ describe('POST /api/transactions (type 1) register second secret', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.secondSignature,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMinimalFunds.address,
 		});
 		var transaction3 = lisk.transaction.transfer({
 			amount: constants.fees.secondSignature,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountNoSecondPassword.address,
 		});
 

--- a/test/functional/http/post/1.second_secret.js
+++ b/test/functional/http/post/1.second_secret.js
@@ -41,17 +41,17 @@ describe('POST /api/transactions (type 1) register second secret', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.secondSignature,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMinimalFunds.address,
 		});
 		var transaction3 = lisk.transaction.transfer({
 			amount: constants.fees.secondSignature,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountNoSecondPassword.address,
 		});
 

--- a/test/functional/http/post/2.delegate.js
+++ b/test/functional/http/post/2.delegate.js
@@ -47,22 +47,22 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 		var transactions = [];
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.delegate,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMinimalFunds.address,
 		});
 		var transaction3 = lisk.transaction.transfer({
 			amount: constants.fees.delegate,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountUpperCase.address,
 		});
 		var transaction4 = lisk.transaction.transfer({
 			amount: constants.fees.delegate,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountFormerDelegate.address,
 		});
 		transactions.push(transaction1);

--- a/test/functional/http/post/2.delegate.js
+++ b/test/functional/http/post/2.delegate.js
@@ -47,22 +47,22 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 		var transactions = [];
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.delegate,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMinimalFunds.address,
 		});
 		var transaction3 = lisk.transaction.transfer({
 			amount: constants.fees.delegate,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountUpperCase.address,
 		});
 		var transaction4 = lisk.transaction.transfer({
 			amount: constants.fees.delegate,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountFormerDelegate.address,
 		});
 		transactions.push(transaction1);

--- a/test/functional/http/post/3.votes.js
+++ b/test/functional/http/post/3.votes.js
@@ -65,27 +65,27 @@ describe('POST /api/transactions (type 3) votes', () => {
 		var transactions = [];
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: delegateAccount.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.vote,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMinimalFunds.address,
 		});
 		var transaction3 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountFixtures.existingDelegate.address,
 		});
 		var transaction4 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMaxVotesPerTransaction.address,
 		});
 		var transaction5 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMaxVotesPerAccount.address,
 		});
 		transactions.push(
@@ -117,7 +117,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 					delegatesMaxVotesPerTransaction.push(tempAccount);
 					var transaction = lisk.transaction.transfer({
 						amount: constants.fees.delegate,
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						recipientId: tempAccount.address,
 					});
 					transactionsCreditMaxVotesPerTransaction.push(transaction);
@@ -147,7 +147,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 					delegatesMaxVotesPerAccount.push(tempAccount);
 					var transaction = lisk.transaction.transfer({
 						amount: constants.fees.delegate,
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						recipientId: tempAccount.address,
 					});
 					transactionsCreditMaxVotesPerAccount.push(transaction);

--- a/test/functional/http/post/3.votes.js
+++ b/test/functional/http/post/3.votes.js
@@ -65,27 +65,27 @@ describe('POST /api/transactions (type 3) votes', () => {
 		var transactions = [];
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: delegateAccount.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.vote,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMinimalFunds.address,
 		});
 		var transaction3 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountFixtures.existingDelegate.address,
 		});
 		var transaction4 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMaxVotesPerTransaction.address,
 		});
 		var transaction5 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMaxVotesPerAccount.address,
 		});
 		transactions.push(
@@ -117,7 +117,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 					delegatesMaxVotesPerTransaction.push(tempAccount);
 					var transaction = lisk.transaction.transfer({
 						amount: constants.fees.delegate,
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						recipientId: tempAccount.address,
 					});
 					transactionsCreditMaxVotesPerTransaction.push(transaction);
@@ -147,7 +147,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 					delegatesMaxVotesPerAccount.push(tempAccount);
 					var transaction = lisk.transaction.transfer({
 						amount: constants.fees.delegate,
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						recipientId: tempAccount.address,
 					});
 					transactionsCreditMaxVotesPerAccount.push(transaction);

--- a/test/functional/http/post/5.dapps.js
+++ b/test/functional/http/post/5.dapps.js
@@ -43,12 +43,12 @@ describe('POST /api/transactions (type 5) register dapp', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.dappRegistration,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMinimalFunds.address,
 		});
 		var promises = [];

--- a/test/functional/http/post/5.dapps.js
+++ b/test/functional/http/post/5.dapps.js
@@ -43,12 +43,12 @@ describe('POST /api/transactions (type 5) register dapp', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.dappRegistration,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMinimalFunds.address,
 		});
 		var promises = [];

--- a/test/functional/http/post/6.dapps.in_transfer.js
+++ b/test/functional/http/post/6.dapps.in_transfer.js
@@ -43,12 +43,12 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.dappRegistration,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMinimalFunds.address,
 		});
 		var promises = [];
@@ -103,7 +103,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 				delete transaction.asset.inTransfer.dappId;
 
@@ -122,7 +122,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 				transaction.asset.inTransfer.dappId = 1;
 
@@ -141,7 +141,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 				transaction.asset.inTransfer.dappId = 1.2;
 
@@ -160,7 +160,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 				transaction.asset.inTransfer.dappId = [];
 
@@ -179,7 +179,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 				transaction.asset.inTransfer.dappId = {};
 
@@ -217,7 +217,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					invalidDappId,
 					1,
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 
 				return sendTransactionPromise(
@@ -237,7 +237,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					-1,
-					accountFixtures.genesis.secret
+					accountFixtures.genesis.passphrase
 				);
 
 				return sendTransactionPromise(
@@ -288,7 +288,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = lisk.transfer.createInTransfer(
 				unknownDappId,
 				1,
-				accountFixtures.genesis.secret
+				accountFixtures.genesis.passphrase
 			);
 
 			return sendTransactionPromise(
@@ -325,7 +325,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = lisk.transfer.createInTransfer(
 				transactionsToWaitFor[0],
 				1,
-				accountFixtures.genesis.secret
+				accountFixtures.genesis.passphrase
 			);
 
 			return sendTransactionPromise(
@@ -343,7 +343,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = lisk.transfer.createInTransfer(
 				randomUtil.guestbookDapp.id,
 				10 * constants.normalizer,
-				accountFixtures.genesis.secret
+				accountFixtures.genesis.passphrase
 			);
 
 			return sendTransactionPromise(transaction).then(res => {
@@ -393,7 +393,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 	describe('check frozen type', () => {
 		it('transaction should be rejected', () => {
 			transaction = lisk.transaction.transferIntoDapp({
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				amount: 10 * constants.normalizer,
 				dappId: randomUtil.guestbookDapp.id,
 			});

--- a/test/functional/http/post/6.dapps.in_transfer.js
+++ b/test/functional/http/post/6.dapps.in_transfer.js
@@ -43,12 +43,12 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.dappRegistration,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMinimalFunds.address,
 		});
 		var promises = [];
@@ -103,7 +103,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 				delete transaction.asset.inTransfer.dappId;
 
@@ -122,7 +122,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 				transaction.asset.inTransfer.dappId = 1;
 
@@ -141,7 +141,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 				transaction.asset.inTransfer.dappId = 1.2;
 
@@ -160,7 +160,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 				transaction.asset.inTransfer.dappId = [];
 
@@ -179,7 +179,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					Date.now(),
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 				transaction.asset.inTransfer.dappId = {};
 
@@ -217,7 +217,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					invalidDappId,
 					1,
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 
 				return sendTransactionPromise(
@@ -237,7 +237,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				transaction = lisk.transfer.createInTransfer(
 					randomUtil.guestbookDapp.id,
 					-1,
-					accountFixtures.genesis.password
+					accountFixtures.genesis.secret
 				);
 
 				return sendTransactionPromise(
@@ -288,7 +288,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = lisk.transfer.createInTransfer(
 				unknownDappId,
 				1,
-				accountFixtures.genesis.password
+				accountFixtures.genesis.secret
 			);
 
 			return sendTransactionPromise(
@@ -325,7 +325,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = lisk.transfer.createInTransfer(
 				transactionsToWaitFor[0],
 				1,
-				accountFixtures.genesis.password
+				accountFixtures.genesis.secret
 			);
 
 			return sendTransactionPromise(
@@ -343,7 +343,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = lisk.transfer.createInTransfer(
 				randomUtil.guestbookDapp.id,
 				10 * constants.normalizer,
-				accountFixtures.genesis.password
+				accountFixtures.genesis.secret
 			);
 
 			return sendTransactionPromise(transaction).then(res => {
@@ -393,7 +393,7 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 	describe('check frozen type', () => {
 		it('transaction should be rejected', () => {
 			transaction = lisk.transaction.transferIntoDapp({
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				amount: 10 * constants.normalizer,
 				dappId: randomUtil.guestbookDapp.id,
 			});

--- a/test/functional/http/post/7.dapps.out_transfer.js
+++ b/test/functional/http/post/7.dapps.out_transfer.js
@@ -43,12 +43,12 @@ describe('POST /api/transactions (type 7) outTransfer dapp', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.dappRegistration,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: accountMinimalFunds.address,
 		});
 		var promises = [];

--- a/test/functional/http/post/7.dapps.out_transfer.js
+++ b/test/functional/http/post/7.dapps.out_transfer.js
@@ -43,12 +43,12 @@ describe('POST /api/transactions (type 7) outTransfer dapp', () => {
 	before(() => {
 		var transaction1 = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: account.address,
 		});
 		var transaction2 = lisk.transaction.transfer({
 			amount: constants.fees.dappRegistration,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: accountMinimalFunds.address,
 		});
 		var promises = [];

--- a/test/functional/http/post/common.js
+++ b/test/functional/http/post/common.js
@@ -30,26 +30,26 @@ function invalidAssets(option, badTransactions) {
 			switch (option) {
 				case 'signature':
 					transaction = lisk.transaction.registerSecondPassphrase({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						secondPassphrase: randomUtil.password(),
 					});
 					break;
 				case 'delegate':
 					transaction = lisk.transaction.registerDelegate({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						username: randomUtil.delegateName(),
 					});
 					break;
 				case 'votes':
 					transaction = lisk.transaction.castVotes({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						votes: [],
 						unvotes: [],
 					});
 					break;
 				case 'multisignature':
 					transaction = lisk.transaction.registerMultisignature({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						keysgroup: [`${accountFixtures.existingDelegate.publicKey}`],
 						lifetime: 1,
 						minimum: 2,
@@ -57,20 +57,20 @@ function invalidAssets(option, badTransactions) {
 					break;
 				case 'dapp':
 					transaction = lisk.transaction.createDapp({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						options: randomUtil.guestbookDapp,
 					});
 					break;
 				case 'inTransfer':
 					transaction = lisk.transaction.transferIntoDapp({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						amount: Date.now(),
 						dappId: randomUtil.guestbookDapp.id,
 					});
 					break;
 				case 'outTransfer':
 					transaction = lisk.transaction.transferOutOfDapp({
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						amount: Date.now(),
 						dappId: randomUtil.guestbookDapp.id,
 						transactionId: randomUtil.transaction().id,

--- a/test/functional/http/post/common.js
+++ b/test/functional/http/post/common.js
@@ -30,26 +30,26 @@ function invalidAssets(option, badTransactions) {
 			switch (option) {
 				case 'signature':
 					transaction = lisk.transaction.registerSecondPassphrase({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						secondPassphrase: randomUtil.password(),
 					});
 					break;
 				case 'delegate':
 					transaction = lisk.transaction.registerDelegate({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						username: randomUtil.delegateName(),
 					});
 					break;
 				case 'votes':
 					transaction = lisk.transaction.castVotes({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						votes: [],
 						unvotes: [],
 					});
 					break;
 				case 'multisignature':
 					transaction = lisk.transaction.registerMultisignature({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						keysgroup: [`${accountFixtures.existingDelegate.publicKey}`],
 						lifetime: 1,
 						minimum: 2,
@@ -57,20 +57,20 @@ function invalidAssets(option, badTransactions) {
 					break;
 				case 'dapp':
 					transaction = lisk.transaction.createDapp({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						options: randomUtil.guestbookDapp,
 					});
 					break;
 				case 'inTransfer':
 					transaction = lisk.transaction.transferIntoDapp({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						amount: Date.now(),
 						dappId: randomUtil.guestbookDapp.id,
 					});
 					break;
 				case 'outTransfer':
 					transaction = lisk.transaction.transferOutOfDapp({
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						amount: Date.now(),
 						dappId: randomUtil.guestbookDapp.id,
 						transactionId: randomUtil.transaction().id,

--- a/test/functional/http/put/node.js
+++ b/test/functional/http/put/node.js
@@ -76,17 +76,17 @@ describe('PUT /node/status/forging', () => {
 			});
 	});
 
-	it('using invalid key should fail', () => {
+	it('using invalid password should fail', () => {
 		var params = {
 			publicKey: validDelegate.publicKey,
-			password: 'invalid key',
+			password: 'invalid password',
 		};
 
 		return toggleForgingEndpoint
 			.makeRequest({ data: params }, 404)
 			.then(res => {
 				expect(res.body.message).to.contain(
-					'Invalid key and public key combination'
+					'Invalid password and public key combination'
 				);
 			});
 	});

--- a/test/functional/http/put/node.js
+++ b/test/functional/http/put/node.js
@@ -37,7 +37,7 @@ describe('PUT /node/status/forging', () => {
 							{
 								data: {
 									publicKey: validDelegate.publicKey,
-									decryptionKey: validDelegate.key,
+									password: validDelegate.key,
 								},
 							},
 							200
@@ -66,7 +66,7 @@ describe('PUT /node/status/forging', () => {
 			'9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9fff0a';
 		var params = {
 			publicKey: invalidPublicKey,
-			decryptionKey: validDelegate.key,
+			password: validDelegate.key,
 		};
 
 		return toggleForgingEndpoint
@@ -79,7 +79,7 @@ describe('PUT /node/status/forging', () => {
 	it('using invalid key should fail', () => {
 		var params = {
 			publicKey: validDelegate.publicKey,
-			decryptionKey: 'invalid key',
+			password: 'invalid key',
 		};
 
 		return toggleForgingEndpoint
@@ -94,7 +94,7 @@ describe('PUT /node/status/forging', () => {
 	it('using valid params should be ok', () => {
 		var params = {
 			publicKey: validDelegate.publicKey,
-			decryptionKey: validDelegate.key,
+			password: validDelegate.key,
 		};
 
 		return toggleForgingEndpoint
@@ -108,7 +108,7 @@ describe('PUT /node/status/forging', () => {
 	it('using valid params should toggle forging status', () => {
 		var params = {
 			publicKey: validDelegate.publicKey,
-			decryptionKey: validDelegate.key,
+			password: validDelegate.key,
 		};
 
 		return forgingStatusEndpoint

--- a/test/functional/http/put/node.js
+++ b/test/functional/http/put/node.js
@@ -37,7 +37,7 @@ describe('PUT /node/status/forging', () => {
 							{
 								data: {
 									publicKey: validDelegate.publicKey,
-									password: validDelegate.key,
+									password: validDelegate.password,
 								},
 							},
 							200
@@ -66,7 +66,7 @@ describe('PUT /node/status/forging', () => {
 			'9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9fff0a';
 		var params = {
 			publicKey: invalidPublicKey,
-			password: validDelegate.key,
+			password: validDelegate.password,
 		};
 
 		return toggleForgingEndpoint
@@ -94,7 +94,7 @@ describe('PUT /node/status/forging', () => {
 	it('using valid params should be ok', () => {
 		var params = {
 			publicKey: validDelegate.publicKey,
-			password: validDelegate.key,
+			password: validDelegate.password,
 		};
 
 		return toggleForgingEndpoint
@@ -108,7 +108,7 @@ describe('PUT /node/status/forging', () => {
 	it('using valid params should toggle forging status', () => {
 		var params = {
 			publicKey: validDelegate.publicKey,
-			password: validDelegate.key,
+			password: validDelegate.password,
 		};
 
 		return forgingStatusEndpoint

--- a/test/functional/system/blocks/chain/apply_block.js
+++ b/test/functional/system/blocks/chain/apply_block.js
@@ -64,25 +64,25 @@ describe('system test (blocks) - chain/applyBlock', () => {
 
 		const fundTrsForAccount1 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: blockAccount1.address,
 		});
 
 		const fundTrsForAccount2 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: blockAccount2.address,
 		});
 
 		const fundTrsForAccount3 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: poolAccount3.address,
 		});
 
 		const fundTrsForAccount4 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: poolAccount4.address,
 		});
 

--- a/test/functional/system/blocks/chain/apply_block.js
+++ b/test/functional/system/blocks/chain/apply_block.js
@@ -64,25 +64,25 @@ describe('system test (blocks) - chain/applyBlock', () => {
 
 		const fundTrsForAccount1 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: blockAccount1.address,
 		});
 
 		const fundTrsForAccount2 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: blockAccount2.address,
 		});
 
 		const fundTrsForAccount3 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: poolAccount3.address,
 		});
 
 		const fundTrsForAccount4 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: poolAccount4.address,
 		});
 

--- a/test/functional/system/blocks/chain/delete_last_block_accounts.js
+++ b/test/functional/system/blocks/chain/delete_last_block_accounts.js
@@ -50,7 +50,7 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 				testAccount = randomUtil.account();
 				var sendTransaction = lisk.transaction.transfer({
 					amount: 100000000 * 100,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					recipientId: testAccount.address,
 				});
 				localCommon.addTransactionsAndForge(library, [sendTransaction], done);
@@ -570,7 +570,7 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 					});
 					var signature = lisk.transaction.utils.multiSignTransaction(
 						multisigTransaction,
-						accountFixtures.existingDelegate.password
+						accountFixtures.existingDelegate.secret
 					);
 					multisigTransaction.signatures = [signature];
 					multisigTransaction.ready = true;

--- a/test/functional/system/blocks/chain/delete_last_block_accounts.js
+++ b/test/functional/system/blocks/chain/delete_last_block_accounts.js
@@ -50,7 +50,7 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 				testAccount = randomUtil.account();
 				var sendTransaction = lisk.transaction.transfer({
 					amount: 100000000 * 100,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					recipientId: testAccount.address,
 				});
 				localCommon.addTransactionsAndForge(library, [sendTransaction], done);
@@ -570,7 +570,7 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 					});
 					var signature = lisk.transaction.utils.multiSignTransaction(
 						multisigTransaction,
-						accountFixtures.existingDelegate.secret
+						accountFixtures.existingDelegate.passphrase
 					);
 					multisigTransaction.signatures = [signature];
 					multisigTransaction.ready = true;

--- a/test/functional/system/blocks/chain/delete_last_block_db_trs.js
+++ b/test/functional/system/blocks/chain/delete_last_block_db_trs.js
@@ -59,7 +59,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 		blockAccount1 = randomUtil.account();
 		fundTrsForAccount1 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: blockAccount1.address,
 		});
 		fundTrsForAccount1.amount = parseInt(fundTrsForAccount1.amount);

--- a/test/functional/system/blocks/chain/delete_last_block_db_trs.js
+++ b/test/functional/system/blocks/chain/delete_last_block_db_trs.js
@@ -59,7 +59,7 @@ describe('system test (blocks) - chain/popLastBlock', () => {
 		blockAccount1 = randomUtil.account();
 		fundTrsForAccount1 = lisk.transaction.transfer({
 			amount: transferAmount,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: blockAccount1.address,
 		});
 		fundTrsForAccount1.amount = parseInt(fundTrsForAccount1.amount);

--- a/test/functional/system/blocks/process/on_receive_block.js
+++ b/test/functional/system/blocks/process/on_receive_block.js
@@ -264,7 +264,7 @@ describe('system test (blocks) - process onReceiveBlock()', () => {
 					beforeEach(done => {
 						lastBlock = library.modules.blocks.lastBlock.get();
 						var slot = slots.getSlotNumber();
-						var nonDelegateKeypair = getKeypair(accountFixtures.genesis.secret);
+						var nonDelegateKeypair = getKeypair(accountFixtures.genesis.passphrase);
 						block = createBlock(
 							[],
 							slots.getSlotTime(slot),

--- a/test/functional/system/blocks/process/on_receive_block.js
+++ b/test/functional/system/blocks/process/on_receive_block.js
@@ -264,9 +264,7 @@ describe('system test (blocks) - process onReceiveBlock()', () => {
 					beforeEach(done => {
 						lastBlock = library.modules.blocks.lastBlock.get();
 						var slot = slots.getSlotNumber();
-						var nonDelegateKeypair = getKeypair(
-							accountFixtures.genesis.password
-						);
+						var nonDelegateKeypair = getKeypair(accountFixtures.genesis.secret);
 						block = createBlock(
 							[],
 							slots.getSlotTime(slot),

--- a/test/functional/system/get/transactions_unconfirmed.js
+++ b/test/functional/system/get/transactions_unconfirmed.js
@@ -26,12 +26,12 @@ describe('system test - get unconfirmed transactions', () => {
 	var account2 = randomUtil.account();
 	var transaction1 = lisk.transaction.transfer({
 		amount: 1100 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account1.address,
 	});
 	var transaction2 = lisk.transaction.transfer({
 		amount: 1100 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account2.address,
 	});
 

--- a/test/functional/system/get/transactions_unconfirmed.js
+++ b/test/functional/system/get/transactions_unconfirmed.js
@@ -26,12 +26,12 @@ describe('system test - get unconfirmed transactions', () => {
 	var account2 = randomUtil.account();
 	var transaction1 = lisk.transaction.transfer({
 		amount: 1100 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account1.address,
 	});
 	var transaction2 = lisk.transaction.transfer({
 		amount: 1100 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account2.address,
 	});
 

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -523,7 +523,7 @@ describe('rounds', () => {
 				const transaction = elements.transaction.transfer({
 					recipientId: randomUtil.account().address,
 					amount: randomUtil.number(100000000, 1000000000),
-					passphrase: accountsFixtures.genesis.secret,
+					passphrase: accountsFixtures.genesis.passphrase,
 				});
 				transactions.push(transaction);
 				done();
@@ -542,7 +542,7 @@ describe('rounds', () => {
 					const transaction = elements.transaction.transfer({
 						recipientId: randomUtil.account().address,
 						amount: randomUtil.number(100000000, 1000000000),
-						passphrase: accountsFixtures.genesis.secret,
+						passphrase: accountsFixtures.genesis.passphrase,
 					});
 					transactions.push(transaction);
 				}
@@ -565,7 +565,7 @@ describe('rounds', () => {
 						const transaction = elements.transaction.transfer({
 							recipientId: randomUtil.account().address,
 							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountsFixtures.genesis.secret,
+							passphrase: accountsFixtures.genesis.passphrase,
 						});
 						transactions.push(transaction);
 					}
@@ -591,7 +591,7 @@ describe('rounds', () => {
 				const transaction = elements.transaction.transfer({
 					recipientId: randomUtil.account().address,
 					amount: randomUtil.number(100000000, 1000000000),
-					passphrase: accountsFixtures.genesis.secret,
+					passphrase: accountsFixtures.genesis.passphrase,
 				});
 				transactions.push(transaction);
 
@@ -735,7 +735,7 @@ describe('rounds', () => {
 
 					// Create unvote transaction
 					const transaction = elements.transaction.castVotes({
-						passphrase: accountsFixtures.genesis.secret,
+						passphrase: accountsFixtures.genesis.passphrase,
 						unvotes: [lastBlockForger],
 					});
 					transactions.push(transaction);
@@ -868,7 +868,7 @@ describe('rounds', () => {
 					let transaction = elements.transaction.transfer({
 						recipientId: tmpAccount.address,
 						amount: 5000000000,
-						passphrase: accountsFixtures.genesis.secret,
+						passphrase: accountsFixtures.genesis.passphrase,
 					});
 					transactions.transfer.push(transaction);
 
@@ -880,7 +880,7 @@ describe('rounds', () => {
 					transactions.delegate.push(transaction);
 
 					transaction = elements.transaction.castVotes({
-						passphrase: accountsFixtures.genesis.secret,
+						passphrase: accountsFixtures.genesis.passphrase,
 						unvotes: [lastBlockForger],
 						votes: [tmpAccount.publicKey],
 					});
@@ -1036,7 +1036,7 @@ describe('rounds', () => {
 							const transaction = elements.transaction.transfer({
 								recipientId: randomUtil.account().address,
 								amount: randomUtil.number(100000000, 1000000000),
-								passphrase: accountsFixtures.genesis.secret,
+								passphrase: accountsFixtures.genesis.passphrase,
 							});
 							transactions.push(transaction);
 						}
@@ -1091,7 +1091,7 @@ describe('rounds', () => {
 							const transaction = elements.transaction.transfer({
 								recipientId: randomUtil.account().address,
 								amount: randomUtil.number(100000000, 1000000000),
-								passphrase: accountsFixtures.genesis.secret,
+								passphrase: accountsFixtures.genesis.passphrase,
 							});
 							transactions.push(transaction);
 						}

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -523,7 +523,7 @@ describe('rounds', () => {
 				const transaction = elements.transaction.transfer({
 					recipientId: randomUtil.account().address,
 					amount: randomUtil.number(100000000, 1000000000),
-					passphrase: accountsFixtures.genesis.password,
+					passphrase: accountsFixtures.genesis.secret,
 				});
 				transactions.push(transaction);
 				done();
@@ -542,7 +542,7 @@ describe('rounds', () => {
 					const transaction = elements.transaction.transfer({
 						recipientId: randomUtil.account().address,
 						amount: randomUtil.number(100000000, 1000000000),
-						passphrase: accountsFixtures.genesis.password,
+						passphrase: accountsFixtures.genesis.secret,
 					});
 					transactions.push(transaction);
 				}
@@ -565,7 +565,7 @@ describe('rounds', () => {
 						const transaction = elements.transaction.transfer({
 							recipientId: randomUtil.account().address,
 							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountsFixtures.genesis.password,
+							passphrase: accountsFixtures.genesis.secret,
 						});
 						transactions.push(transaction);
 					}
@@ -591,7 +591,7 @@ describe('rounds', () => {
 				const transaction = elements.transaction.transfer({
 					recipientId: randomUtil.account().address,
 					amount: randomUtil.number(100000000, 1000000000),
-					passphrase: accountsFixtures.genesis.password,
+					passphrase: accountsFixtures.genesis.secret,
 				});
 				transactions.push(transaction);
 
@@ -735,7 +735,7 @@ describe('rounds', () => {
 
 					// Create unvote transaction
 					const transaction = elements.transaction.castVotes({
-						passphrase: accountsFixtures.genesis.password,
+						passphrase: accountsFixtures.genesis.secret,
 						unvotes: [lastBlockForger],
 					});
 					transactions.push(transaction);
@@ -868,7 +868,7 @@ describe('rounds', () => {
 					let transaction = elements.transaction.transfer({
 						recipientId: tmpAccount.address,
 						amount: 5000000000,
-						passphrase: accountsFixtures.genesis.password,
+						passphrase: accountsFixtures.genesis.secret,
 					});
 					transactions.transfer.push(transaction);
 
@@ -880,7 +880,7 @@ describe('rounds', () => {
 					transactions.delegate.push(transaction);
 
 					transaction = elements.transaction.castVotes({
-						passphrase: accountsFixtures.genesis.password,
+						passphrase: accountsFixtures.genesis.secret,
 						unvotes: [lastBlockForger],
 						votes: [tmpAccount.publicKey],
 					});
@@ -1036,7 +1036,7 @@ describe('rounds', () => {
 							const transaction = elements.transaction.transfer({
 								recipientId: randomUtil.account().address,
 								amount: randomUtil.number(100000000, 1000000000),
-								passphrase: accountsFixtures.genesis.password,
+								passphrase: accountsFixtures.genesis.secret,
 							});
 							transactions.push(transaction);
 						}
@@ -1091,7 +1091,7 @@ describe('rounds', () => {
 							const transaction = elements.transaction.transfer({
 								recipientId: randomUtil.account().address,
 								amount: randomUtil.number(100000000, 1000000000),
-								passphrase: accountsFixtures.genesis.password,
+								passphrase: accountsFixtures.genesis.secret,
 							});
 							transactions.push(transaction);
 						}

--- a/test/functional/system/transactions/0.0.address_collision.js
+++ b/test/functional/system/transactions/0.0.address_collision.js
@@ -72,7 +72,7 @@ describe('system test (type 0) - address collision', () => {
 	before(done => {
 		var creditTransaction = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.password,
+			passphrase: accountFixtures.genesis.secret,
 			recipientId: collision.address,
 			data: 'addtional data from 2',
 		});

--- a/test/functional/system/transactions/0.0.address_collision.js
+++ b/test/functional/system/transactions/0.0.address_collision.js
@@ -72,7 +72,7 @@ describe('system test (type 0) - address collision', () => {
 	before(done => {
 		var creditTransaction = lisk.transaction.transfer({
 			amount: 1000 * constants.normalizer,
-			passphrase: accountFixtures.genesis.secret,
+			passphrase: accountFixtures.genesis.passphrase,
 			recipientId: collision.address,
 			data: 'addtional data from 2',
 		});

--- a/test/functional/system/transactions/0.0.transfer.js
+++ b/test/functional/system/transactions/0.0.transfer.js
@@ -34,7 +34,7 @@ describe('system test (type 0) - double transfers', () => {
 			var account = randomUtil.account();
 			var transaction = lisk.transaction.transfer({
 				amount: 1100 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 			var transaction1;

--- a/test/functional/system/transactions/0.0.transfer.js
+++ b/test/functional/system/transactions/0.0.transfer.js
@@ -34,7 +34,7 @@ describe('system test (type 0) - double transfers', () => {
 			var account = randomUtil.account();
 			var transaction = lisk.transaction.transfer({
 				amount: 1100 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 			var transaction1;

--- a/test/functional/system/transactions/1.second_signature/1.1.second_signature.js
+++ b/test/functional/system/transactions/1.second_signature/1.1.second_signature.js
@@ -26,7 +26,7 @@ describe('system test (type 1) - double second signature registrations', () => {
 	var account = randomUtil.account();
 	var transaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account.address,
 	});
 	var transaction1;

--- a/test/functional/system/transactions/1.second_signature/1.1.second_signature.js
+++ b/test/functional/system/transactions/1.second_signature/1.1.second_signature.js
@@ -26,7 +26,7 @@ describe('system test (type 1) - double second signature registrations', () => {
 	var account = randomUtil.account();
 	var transaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account.address,
 	});
 	var transaction1;

--- a/test/functional/system/transactions/1.second_signature/1.1.second_signature_from_pool_peer.js
+++ b/test/functional/system/transactions/1.second_signature/1.1.second_signature_from_pool_peer.js
@@ -53,7 +53,7 @@ describe('system test (type 1) - second signature transactions from pool and pee
 			signatureAccount = randomUtil.account();
 			const sendTransaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: signatureAccount.address,
 			});
 			sendTransaction.amount = parseInt(sendTransaction.amount);

--- a/test/functional/system/transactions/1.second_signature/1.1.second_signature_from_pool_peer.js
+++ b/test/functional/system/transactions/1.second_signature/1.1.second_signature_from_pool_peer.js
@@ -53,7 +53,7 @@ describe('system test (type 1) - second signature transactions from pool and pee
 			signatureAccount = randomUtil.account();
 			const sendTransaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: signatureAccount.address,
 			});
 			sendTransaction.amount = parseInt(sendTransaction.amount);

--- a/test/functional/system/transactions/1.second_signature/1.X.second_signature_unconfirmed.js
+++ b/test/functional/system/transactions/1.second_signature/1.X.second_signature_unconfirmed.js
@@ -27,7 +27,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 	var account = randomUtil.account();
 	var transaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account.address,
 	});
 	var dapp = randomUtil.application();

--- a/test/functional/system/transactions/1.second_signature/1.X.second_signature_unconfirmed.js
+++ b/test/functional/system/transactions/1.second_signature/1.X.second_signature_unconfirmed.js
@@ -27,7 +27,7 @@ describe('system test (type 1) - sending transactions on top of unconfirmed seco
 	var account = randomUtil.account();
 	var transaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account.address,
 	});
 	var dapp = randomUtil.application();

--- a/test/functional/system/transactions/1.second_signature/1.X.second_signature_validated.js
+++ b/test/functional/system/transactions/1.second_signature/1.X.second_signature_validated.js
@@ -27,7 +27,7 @@ describe('system test (type 1) - checking validated second signature registratio
 	var account = randomUtil.account();
 	var creditTransaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account.address,
 	});
 	var transaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/system/transactions/1.second_signature/1.X.second_signature_validated.js
+++ b/test/functional/system/transactions/1.second_signature/1.X.second_signature_validated.js
@@ -27,7 +27,7 @@ describe('system test (type 1) - checking validated second signature registratio
 	var account = randomUtil.account();
 	var creditTransaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account.address,
 	});
 	var transaction = lisk.transaction.registerSecondPassphrase({

--- a/test/functional/system/transactions/2.delegates/1.same.account.same.username.js
+++ b/test/functional/system/transactions/2.delegates/1.same.account.same.username.js
@@ -37,7 +37,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var transaction2;
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 

--- a/test/functional/system/transactions/2.delegates/1.same.account.same.username.js
+++ b/test/functional/system/transactions/2.delegates/1.same.account.same.username.js
@@ -37,7 +37,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var transaction2;
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 

--- a/test/functional/system/transactions/2.delegates/2.same.account.different.usernames.js
+++ b/test/functional/system/transactions/2.delegates/2.same.account.different.usernames.js
@@ -38,7 +38,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var differentDelegateName = randomUtil.delegateName();
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 

--- a/test/functional/system/transactions/2.delegates/2.same.account.different.usernames.js
+++ b/test/functional/system/transactions/2.delegates/2.same.account.different.usernames.js
@@ -38,7 +38,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var differentDelegateName = randomUtil.delegateName();
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 

--- a/test/functional/system/transactions/2.delegates/3.different.accounts.same.username.js
+++ b/test/functional/system/transactions/2.delegates/3.different.accounts.same.username.js
@@ -38,7 +38,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var transaction2;
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 
@@ -53,7 +53,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 				before(done => {
 					transaction = lisk.transaction.transfer({
 						amount: 1000 * constants.normalizer,
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						recipientId: account2.address,
 					});
 					localCommon.addTransactionsAndForge(library, [transaction], done);

--- a/test/functional/system/transactions/2.delegates/3.different.accounts.same.username.js
+++ b/test/functional/system/transactions/2.delegates/3.different.accounts.same.username.js
@@ -38,7 +38,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var transaction2;
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 
@@ -53,7 +53,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 				before(done => {
 					transaction = lisk.transaction.transfer({
 						amount: 1000 * constants.normalizer,
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						recipientId: account2.address,
 					});
 					localCommon.addTransactionsAndForge(library, [transaction], done);

--- a/test/functional/system/transactions/2.delegates/4.different.accounts.different.usernames.js
+++ b/test/functional/system/transactions/2.delegates/4.different.accounts.different.usernames.js
@@ -39,7 +39,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var transaction2;
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 
@@ -54,12 +54,12 @@ describe('system test (type 2) - double delegate registrations', () => {
 				before(done => {
 					transaction1 = lisk.transaction.transfer({
 						amount: 1000 * constants.normalizer,
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						recipientId: account.address,
 					});
 					transaction2 = lisk.transaction.transfer({
 						amount: 1000 * constants.normalizer,
-						passphrase: accountFixtures.genesis.secret,
+						passphrase: accountFixtures.genesis.passphrase,
 						recipientId: account2.address,
 					});
 					localCommon.addTransactionsAndForge(

--- a/test/functional/system/transactions/2.delegates/4.different.accounts.different.usernames.js
+++ b/test/functional/system/transactions/2.delegates/4.different.accounts.different.usernames.js
@@ -39,7 +39,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 			var transaction2;
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 
@@ -54,12 +54,12 @@ describe('system test (type 2) - double delegate registrations', () => {
 				before(done => {
 					transaction1 = lisk.transaction.transfer({
 						amount: 1000 * constants.normalizer,
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						recipientId: account.address,
 					});
 					transaction2 = lisk.transaction.transfer({
 						amount: 1000 * constants.normalizer,
-						passphrase: accountFixtures.genesis.password,
+						passphrase: accountFixtures.genesis.secret,
 						recipientId: account2.address,
 					});
 					localCommon.addTransactionsAndForge(

--- a/test/functional/system/transactions/2.delegates/5.same_account_from_pool_and_peer.js
+++ b/test/functional/system/transactions/2.delegates/5.same_account_from_pool_and_peer.js
@@ -52,7 +52,7 @@ describe('delegate', () => {
 			delegateAccount = randomUtil.account();
 			const sendTransaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: delegateAccount.address,
 			});
 			localCommon.addTransactionsAndForge(library, [sendTransaction], done);

--- a/test/functional/system/transactions/2.delegates/5.same_account_from_pool_and_peer.js
+++ b/test/functional/system/transactions/2.delegates/5.same_account_from_pool_and_peer.js
@@ -52,7 +52,7 @@ describe('delegate', () => {
 			delegateAccount = randomUtil.account();
 			const sendTransaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: delegateAccount.address,
 			});
 			localCommon.addTransactionsAndForge(library, [sendTransaction], done);

--- a/test/functional/system/transactions/3.3.votes.js
+++ b/test/functional/system/transactions/3.3.votes.js
@@ -41,7 +41,7 @@ describe('system test (type 3) - voting with duplicate submissions', () => {
 			account = randomUtil.account();
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				recipientId: account.address,
 			});
 

--- a/test/functional/system/transactions/3.3.votes.js
+++ b/test/functional/system/transactions/3.3.votes.js
@@ -41,7 +41,7 @@ describe('system test (type 3) - voting with duplicate submissions', () => {
 			account = randomUtil.account();
 			transaction = lisk.transaction.transfer({
 				amount: 1000 * constants.normalizer,
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				recipientId: account.address,
 			});
 

--- a/test/functional/system/transactions/4.multisignature/4.multisignature_account.js
+++ b/test/functional/system/transactions/4.multisignature/4.multisignature_account.js
@@ -28,7 +28,7 @@ describe('system test (type 4) - effect of multisignature registration on memory
 	var multisigTransaction;
 	var creditTransaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: multisigAccount.address,
 	});
 	var signer1 = randomUtil.account();

--- a/test/functional/system/transactions/4.multisignature/4.multisignature_account.js
+++ b/test/functional/system/transactions/4.multisignature/4.multisignature_account.js
@@ -28,7 +28,7 @@ describe('system test (type 4) - effect of multisignature registration on memory
 	var multisigTransaction;
 	var creditTransaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: multisigAccount.address,
 	});
 	var signer1 = randomUtil.account();

--- a/test/functional/system/transactions/5.5.dapps.js
+++ b/test/functional/system/transactions/5.5.dapps.js
@@ -27,7 +27,7 @@ describe('system test (type 5) - dapp registrations with repeated values', () =>
 	var account = randomUtil.account();
 	var transaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.secret,
+		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: account.address,
 	});
 	var dapp = randomUtil.application();

--- a/test/functional/system/transactions/5.5.dapps.js
+++ b/test/functional/system/transactions/5.5.dapps.js
@@ -27,7 +27,7 @@ describe('system test (type 5) - dapp registrations with repeated values', () =>
 	var account = randomUtil.account();
 	var transaction = lisk.transaction.transfer({
 		amount: 1000 * constants.normalizer,
-		passphrase: accountFixtures.genesis.password,
+		passphrase: accountFixtures.genesis.secret,
 		recipientId: account.address,
 	});
 	var dapp = randomUtil.application();

--- a/test/integration/peers.integration.js
+++ b/test/integration/peers.integration.js
@@ -281,7 +281,7 @@ function enableForgingOnDelegates(done) {
 					'Content-Type': 'application/json',
 				},
 				body: {
-					decryptionKey: 'elephant tree paris dragon chair galaxy',
+					password: 'elephant tree paris dragon chair galaxy',
 					publicKey: keys.publicKey,
 				},
 			});

--- a/test/integration/scenarios/stress/0.transfer.js
+++ b/test/integration/scenarios/stress/0.transfer.js
@@ -60,7 +60,7 @@ module.exports = function(params) {
 						) {
 							var transaction = lisk.transaction.transfer({
 								amount: randomUtil.number(100000000, 1000000000),
-								passphrase: accountFixtures.genesis.password,
+								passphrase: accountFixtures.genesis.secret,
 								recipientId: randomUtil.account().address,
 							});
 							transactions.push(transaction);
@@ -95,7 +95,7 @@ module.exports = function(params) {
 					_.range(maximum).map(() => {
 						var transaction = lisk.transaction.transfer({
 							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: randomUtil.account().address,
 						});
 						transactions.push(transaction);

--- a/test/integration/scenarios/stress/0.transfer.js
+++ b/test/integration/scenarios/stress/0.transfer.js
@@ -60,7 +60,7 @@ module.exports = function(params) {
 						) {
 							var transaction = lisk.transaction.transfer({
 								amount: randomUtil.number(100000000, 1000000000),
-								passphrase: accountFixtures.genesis.secret,
+								passphrase: accountFixtures.genesis.passphrase,
 								recipientId: randomUtil.account().address,
 							});
 							transactions.push(transaction);
@@ -95,7 +95,7 @@ module.exports = function(params) {
 					_.range(maximum).map(() => {
 						var transaction = lisk.transaction.transfer({
 							amount: randomUtil.number(100000000, 1000000000),
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: randomUtil.account().address,
 						});
 						transactions.push(transaction);

--- a/test/integration/scenarios/stress/2.register_delegate.js
+++ b/test/integration/scenarios/stress/2.register_delegate.js
@@ -54,7 +54,7 @@ module.exports = function(params) {
 						var tmpAccount = randomUtil.account();
 						var transaction = lisk.transaction.transfer({
 							amount: 2500000000,
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: tmpAccount.address,
 						});
 						accounts.push(tmpAccount);

--- a/test/integration/scenarios/stress/2.register_delegate.js
+++ b/test/integration/scenarios/stress/2.register_delegate.js
@@ -54,7 +54,7 @@ module.exports = function(params) {
 						var tmpAccount = randomUtil.account();
 						var transaction = lisk.transaction.transfer({
 							amount: 2500000000,
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: tmpAccount.address,
 						});
 						accounts.push(tmpAccount);

--- a/test/integration/scenarios/stress/3.cast_vote.js
+++ b/test/integration/scenarios/stress/3.cast_vote.js
@@ -54,7 +54,7 @@ module.exports = function(params) {
 						var tmpAccount = randomUtil.account();
 						var transaction = lisk.transaction.transfer({
 							amount: 500000000,
-							passphrase: accountFixtures.genesis.secret,
+							passphrase: accountFixtures.genesis.passphrase,
 							recipientId: tmpAccount.address,
 						});
 						accounts.push(tmpAccount);

--- a/test/integration/scenarios/stress/3.cast_vote.js
+++ b/test/integration/scenarios/stress/3.cast_vote.js
@@ -54,7 +54,7 @@ module.exports = function(params) {
 						var tmpAccount = randomUtil.account();
 						var transaction = lisk.transaction.transfer({
 							amount: 500000000,
-							passphrase: accountFixtures.genesis.password,
+							passphrase: accountFixtures.genesis.secret,
 							recipientId: tmpAccount.address,
 						});
 						accounts.push(tmpAccount);

--- a/test/integration/utils/http.js
+++ b/test/integration/utils/http.js
@@ -146,7 +146,7 @@ module.exports = {
 				),
 				headers,
 				body: {
-					decryptionKey: 'elephant tree paris dragon chair galaxy',
+					password: 'elephant tree paris dragon chair galaxy',
 					publicKey: keys.publicKey,
 				},
 			})

--- a/test/unit/logic/delegate.js
+++ b/test/unit/logic/delegate.js
@@ -35,14 +35,14 @@ var validKeypair = ed.makeKeypair(
 );
 
 var validSender = {
-	secret:
+	passphrase:
 		'actress route auction pudding shiver crater forum liquid blouse imitate seven front',
 	address: '10881167371402274308L',
 	publicKey: 'addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9',
 	username: 'genesis_100',
 	encryptedSecret:
 		'iterations=1&salt=25e9932aaa4c885bdcafb1913058fce6&cipherText=94cd85840ca2397e609e39d9c2902000d90d98bc3a24d0d5f086219c8365b84ab67a82e4e7680e9cec0da71b6c7f930e326d3bbece8e963d9664fcfaa80bd6f2e96befb033ad84ab3e6b0e32300cb304512f3f&iv=6bff91449f495bae345ab15a&tag=91c1eaa254a80c5d51a15b75929ca335&version=1',
-	key: 'elephant tree paris dragon chair galaxy',
+	password: 'elephant tree paris dragon chair galaxy',
 	nameexist: 1,
 };
 

--- a/test/unit/logic/multisignature.js
+++ b/test/unit/logic/multisignature.js
@@ -180,7 +180,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 1,
@@ -200,7 +200,7 @@ describe('multisignature', () => {
 			var minimum = constants.multisigConstraints.min.maximum + 1;
 			var keysgroup = [multiSigAccount1.publicKey, multiSigAccount2.publicKey];
 			var transaction = lisk.transaction.registerMultisignature({
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				keysgroup,
 				lifetime: 1,
 				minimum,
@@ -888,7 +888,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 1,
@@ -909,7 +909,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 1,
@@ -930,7 +930,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum,
@@ -950,7 +950,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum,
@@ -970,7 +970,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -993,7 +993,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1014,7 +1014,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime,
 					minimum: 2,
@@ -1034,7 +1034,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime,
 					minimum: 2,
@@ -1054,7 +1054,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1073,7 +1073,7 @@ describe('multisignature', () => {
 			it('should return error when it is not an array', () => {
 				var keysgroup = [multiSigAccount1.publicKey];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1090,7 +1090,7 @@ describe('multisignature', () => {
 			it('should return error when array length is smaller than minimum acceptable value', () => {
 				var keysgroup = [multiSigAccount1.publicKey];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1113,7 +1113,7 @@ describe('multisignature', () => {
 					}`;
 				});
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1133,7 +1133,7 @@ describe('multisignature', () => {
 			});
 
 			var transaction = lisk.transaction.registerMultisignature({
-				passphrase: accountFixtures.genesis.secret,
+				passphrase: accountFixtures.genesis.passphrase,
 				keysgroup,
 				lifetime: 1,
 				minimum: 2,

--- a/test/unit/logic/multisignature.js
+++ b/test/unit/logic/multisignature.js
@@ -180,7 +180,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 1,
@@ -200,7 +200,7 @@ describe('multisignature', () => {
 			var minimum = constants.multisigConstraints.min.maximum + 1;
 			var keysgroup = [multiSigAccount1.publicKey, multiSigAccount2.publicKey];
 			var transaction = lisk.transaction.registerMultisignature({
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				keysgroup,
 				lifetime: 1,
 				minimum,
@@ -888,7 +888,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 1,
@@ -909,7 +909,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 1,
@@ -930,7 +930,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum,
@@ -950,7 +950,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum,
@@ -970,7 +970,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -993,7 +993,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1014,7 +1014,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime,
 					minimum: 2,
@@ -1034,7 +1034,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime,
 					minimum: 2,
@@ -1054,7 +1054,7 @@ describe('multisignature', () => {
 					multiSigAccount2.publicKey,
 				];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1073,7 +1073,7 @@ describe('multisignature', () => {
 			it('should return error when it is not an array', () => {
 				var keysgroup = [multiSigAccount1.publicKey];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1090,7 +1090,7 @@ describe('multisignature', () => {
 			it('should return error when array length is smaller than minimum acceptable value', () => {
 				var keysgroup = [multiSigAccount1.publicKey];
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1113,7 +1113,7 @@ describe('multisignature', () => {
 					}`;
 				});
 				var transaction = lisk.transaction.registerMultisignature({
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					keysgroup,
 					lifetime: 1,
 					minimum: 2,
@@ -1133,7 +1133,7 @@ describe('multisignature', () => {
 			});
 
 			var transaction = lisk.transaction.registerMultisignature({
-				passphrase: accountFixtures.genesis.password,
+				passphrase: accountFixtures.genesis.secret,
 				keysgroup,
 				lifetime: 1,
 				minimum: 2,

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -41,7 +41,7 @@ var validKeypair = ed.makeKeypair(
 		.digest()
 );
 
-var senderPassword = accountFixtures.genesis.secret;
+var senderPassword = accountFixtures.genesis.passphrase;
 var senderHash = crypto
 	.createHash('sha256')
 	.update(senderPassword, 'utf8')

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -41,7 +41,7 @@ var validKeypair = ed.makeKeypair(
 		.digest()
 );
 
-var senderPassword = accountFixtures.genesis.password;
+var senderPassword = accountFixtures.genesis.secret;
 var senderHash = crypto
 	.createHash('sha256')
 	.update(senderPassword, 'utf8')

--- a/test/unit/logic/transfer.js
+++ b/test/unit/logic/transfer.js
@@ -35,7 +35,7 @@ var validKeypair = ed.makeKeypair(
 
 var senderHash = crypto
 	.createHash('sha256')
-	.update(accountFixtures.genesis.password, 'utf8')
+	.update(accountFixtures.genesis.secret, 'utf8')
 	.digest();
 var senderKeypair = ed.makeKeypair(senderHash);
 

--- a/test/unit/logic/transfer.js
+++ b/test/unit/logic/transfer.js
@@ -35,7 +35,7 @@ var validKeypair = ed.makeKeypair(
 
 var senderHash = crypto
 	.createHash('sha256')
-	.update(accountFixtures.genesis.secret, 'utf8')
+	.update(accountFixtures.genesis.passphrase, 'utf8')
 	.digest();
 var senderKeypair = ed.makeKeypair(senderHash);
 

--- a/test/unit/modules/cache.js
+++ b/test/unit/modules/cache.js
@@ -335,7 +335,7 @@ describe('cache', () => {
 				expect(status).to.equal('OK');
 				var transaction = lisk.transaction.transfer({
 					amount: 1,
-					passphrase: accountFixtures.genesis.password,
+					passphrase: accountFixtures.genesis.secret,
 					secondPassphrase: accountFixtures.genesis.secondPassword,
 					recipientId: '1L',
 				});

--- a/test/unit/modules/cache.js
+++ b/test/unit/modules/cache.js
@@ -335,7 +335,7 @@ describe('cache', () => {
 				expect(status).to.equal('OK');
 				var transaction = lisk.transaction.transfer({
 					amount: 1,
-					passphrase: accountFixtures.genesis.secret,
+					passphrase: accountFixtures.genesis.passphrase,
 					secondPassphrase: accountFixtures.genesis.secondPassword,
 					recipientId: '1L',
 				});

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -131,7 +131,7 @@ describe('node', () => {
 			it('should return error with non delegate account', done => {
 				node_module.internal.toggleForgingStatus(
 					accountFixtures.genesis.publicKey,
-					accountFixtures.genesis.secret,
+					accountFixtures.genesis.passphrase,
 					err => {
 						expect(err).equal(
 							'Delegate with publicKey: c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f not found'

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -88,7 +88,7 @@ describe('node', () => {
 					} else {
 						cb(err, {
 							publicKey: testDelegate.publicKey,
-							key: testDelegate.password,
+							password: testDelegate.password,
 						});
 					}
 				}
@@ -101,7 +101,7 @@ describe('node', () => {
 				done();
 			});
 
-			it('should return error with invalid key', done => {
+			it('should return error with invalid password', done => {
 				node_module.internal.toggleForgingStatus(
 					testDelegate.publicKey,
 					'Invalid password',

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -82,13 +82,13 @@ describe('node', () => {
 					) {
 						node_module.internal.toggleForgingStatus(
 							testDelegate.publicKey,
-							testDelegate.key,
+							testDelegate.password,
 							cb
 						);
 					} else {
 						cb(err, {
 							publicKey: testDelegate.publicKey,
-							key: testDelegate.key,
+							key: testDelegate.password,
 						});
 					}
 				}

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -21,7 +21,7 @@ var application = require('../../common/application');
 
 describe('node', () => {
 	var testDelegate = genesisDelegates.delegates[0];
-	var defaultKey;
+	var defaultPassword;
 	var library;
 
 	before(done => {
@@ -97,7 +97,7 @@ describe('node', () => {
 
 		describe('toggleForgingStatus', () => {
 			before(done => {
-				defaultKey = library.config.forging.defaultKey;
+				defaultPassword = library.config.forging.defaultPassword;
 				done();
 			});
 
@@ -118,7 +118,7 @@ describe('node', () => {
 
 				node_module.internal.toggleForgingStatus(
 					invalidPublicKey,
-					defaultKey,
+					defaultPassword,
 					err => {
 						expect(err).equal(
 							'Delegate with publicKey: 9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9fff0a not found'
@@ -147,7 +147,7 @@ describe('node', () => {
 
 					node_module.internal.toggleForgingStatus(
 						testDelegate.publicKey,
-						defaultKey,
+						defaultPassword,
 						(err, res) => {
 							expect(err).to.not.exist;
 							expect(res).to.eql({
@@ -166,7 +166,7 @@ describe('node', () => {
 
 					node_module.internal.toggleForgingStatus(
 						testDelegate.publicKey,
-						defaultKey,
+						defaultPassword,
 						(err, res) => {
 							expect(err).to.not.exist;
 							expect(res).to.eql({
@@ -211,7 +211,7 @@ describe('node', () => {
 			it('should return delegate status when publicKey is provided and toggle forging from enabled to disabled', done => {
 				node_module.internal.toggleForgingStatus(
 					testDelegate.publicKey,
-					defaultKey,
+					defaultPassword,
 					(err, res) => {
 						expect(err).to.not.exist;
 						expect(res).to.eql({

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -131,7 +131,7 @@ describe('node', () => {
 			it('should return error with non delegate account', done => {
 				node_module.internal.toggleForgingStatus(
 					accountFixtures.genesis.publicKey,
-					accountFixtures.genesis.passphrase,
+					accountFixtures.genesis.password,
 					err => {
 						expect(err).equal(
 							'Delegate with publicKey: c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f not found'

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -131,7 +131,7 @@ describe('node', () => {
 			it('should return error with non delegate account', done => {
 				node_module.internal.toggleForgingStatus(
 					accountFixtures.genesis.publicKey,
-					accountFixtures.genesis.password,
+					accountFixtures.genesis.secret,
 					err => {
 						expect(err).equal(
 							'Delegate with publicKey: c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f not found'

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -104,9 +104,9 @@ describe('node', () => {
 			it('should return error with invalid key', done => {
 				node_module.internal.toggleForgingStatus(
 					testDelegate.publicKey,
-					'Invalid key',
+					'Invalid password',
 					err => {
-						expect(err).to.equal('Invalid key and public key combination');
+						expect(err).to.equal('Invalid password and public key combination');
 						done();
 					}
 				);


### PR DESCRIPTION
### What was the problem?
The secret ingredient you need to encrypt/decrypt a passphrase in the current implementation is a "password", not a "key". All namings should reflect that.
### How did I fix it?
Rename:
- `password` -> `passphrase` (fixtures)
- `key` -> `password`
- `defaultKey` -> `defaultPassword`
- `decryptionKey` -> `password`
### How to test it?
Run test suite.
### Review checklist

* The PR solves #1923
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
