### PR TITLE
Adjust the frequency of P2P discovery - Closes #1943

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -29,6 +29,8 @@ let self;
 const __private = {};
 let definitions;
 
+const peerDiscoveryFrequency = 30000;
+
 /**
  * Main peers methods. Initializes library with scope content.
  *
@@ -851,8 +853,12 @@ Peers.prototype.onPeersReady = function() {
 			() => setImmediate(cb)
 		);
 	}
-	// Loop in 10 sec intervals (5 sec + 5 sec connection timeout from pingPeer)
-	jobsQueue.register('peersDiscoveryAndUpdate', peersDiscoveryAndUpdate, 5000);
+	// Loop in 30 sec intervals for less new insertion after removal
+	jobsQueue.register(
+		'peersDiscoveryAndUpdate',
+		peersDiscoveryAndUpdate,
+		peerDiscoveryFrequency
+	);
 };
 
 /**

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -899,7 +899,7 @@ describe('peers', () => {
 			return expect(jobsQueueSpy).calledWith(
 				'peersDiscoveryAndUpdate',
 				sinon.match.func,
-				5000
+				30000
 			);
 		});
 	});


### PR DESCRIPTION
### What was the problem?
For websocket p2p discovery, 5sec was too often, which increased the chance to re-insert deleted peers too quick.

### How did I fix it?
Decrease the timer to 30 sec.

### How to test it?
Observe log where it successfully or to fail the discovery.

### Review checklist

* The PR solves #1943 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
