### PR TITLE
Set api get forges and votes limit to 101 - Closes #1800

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -16,7 +16,7 @@ swagger: '2.0'
 info:
   description: Lisk API Documentation
   title: Lisk API Documentation
-  version: '1.0.25'
+  version: '1.0.26'
   contact:
     email: admin@lisk.io
   license:

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -582,8 +582,15 @@ paths:
       produces:
         - application/json
       parameters:
-        - $ref: '#/parameters/limit'
         - $ref: '#/parameters/offset'
+        - name: limit
+          in: query
+          description: Limit applied to results
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 101
+          default: 10
       responses:
         200:
           description: Search results matching criteria
@@ -766,7 +773,14 @@ paths:
         - $ref: '#/parameters/publicKey'
         - $ref: '#/parameters/secondPublicKey'
         - $ref: '#/parameters/offset'
-        - $ref: '#/parameters/limit'
+        - name: limit
+          in: query
+          description: Limit applied to results
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 101
+          default: 10
         - in: query
           name: sort
           description: Fields to sort results by

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -553,6 +553,14 @@ describe('GET /delegates', () => {
 				});
 		});
 
+		it('using limit=101 should be ok', () => {
+			return forgersEndpoint
+				.makeRequest({ limit: 101 }, 200)
+				.then(res => {
+					expect(res.body.data).to.have.length(101);
+				});
+		});
+
 		describe('slot numbers are correct', () => {
 			var forgersData;
 

--- a/test/functional/http/get/votes.js
+++ b/test/functional/http/get/votes.js
@@ -328,6 +328,16 @@ describe('GET /api/votes', () => {
 				});
 			});
 
+			describe('limit=101', () => {
+				it('should return 101 voters', () => {
+					return votesEndpoint
+						.makeRequest({ limit: 101, publicKey: voterDelegate.publicKey }, 200)
+						.then(res => {
+							expect(res.body.data.votes).to.have.length(101);
+						});
+				});
+			});
+
 			describe('limit=2 & offset=1', () => {
 				it('should return 2 voters, containing 1 from the previous result', () => {
 					var votes = null;


### PR DESCRIPTION
It provokes a bump in the API versioning to `1.0.26`

### Review checklist

* The PR solves #1800
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
