### PR TITLE
Inconsistent IPv4 and IPv6 addresses - Closes #1947

### DIFF
--- a/app.js
+++ b/app.js
@@ -583,6 +583,7 @@ d.run(() => {
 					var webSocketConfig = {
 						workers: scope.config.wsWorkers,
 						port: scope.config.wsPort,
+						host: '0.0.0.0',
 						wsEngine: 'sc-uws',
 						appName: 'lisk',
 						workerController: workersControllerPath,


### PR DESCRIPTION
### What was the problem?

Inconsistent use of IPv4 and IPv6 addresses on worker and master processes.
We don't know for sure if this is causing problems but it's not a good practice and it could lead to issues in identifying peers.

### How did I fix it?

Explicitly tell Node.js HTTP server to listen for all IPv4 addresses. See https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback

### How to test it?

Connect two peer nodes on localhost on trace log level, inbound connections should now show `127.0.0.1` instead of `:ffff::127.0.0.1`.

### Review checklist

* The PR solves #1947
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
