### PR TITLE
Fix error occured on loading transport modules on application restart - Closes #1830

### DIFF
--- a/app.js
+++ b/app.js
@@ -813,7 +813,7 @@ d.run(() => {
 				},
 			],
 
-			wsListen: [
+			listenWebSocket: [
 				'ready',
 				/**
 				 * Description of the function.
@@ -851,7 +851,7 @@ d.run(() => {
 				},
 			],
 
-			httplisten: [
+			listenHttp: [
 				'ready',
 				/**
 				 * Description of the function.

--- a/app.js
+++ b/app.js
@@ -788,15 +788,37 @@ d.run(() => {
 				},
 			],
 
-			api: [
+			ready: [
+				'swagger',
 				'modules',
-				'logger',
-				'network',
-				'webSocket',
+				'bus',
+				'logic',
 				/**
 				 * Description of the function.
 				 *
-				 * @func api[4]
+				 * @func ready[4]
+				 * @memberof! app
+				 * @param {Object} scope
+				 * @param {function} cb - Callback function
+				 * @todo Add description for the function and its params
+				 */
+				function(scope, cb) {
+					scope.modules.swagger = scope.swagger;
+
+					// Fire onBind event in every module
+					scope.bus.message('bind', scope.modules);
+
+					scope.logic.peers.bindModules(scope.modules);
+					cb();
+				},
+			],
+
+			wsListen: [
+				'ready',
+				/**
+				 * Description of the function.
+				 *
+				 * @func api[1]
 				 * @param {Object} scope
 				 * @param {function} cb - Callback function
 				 */
@@ -829,32 +851,7 @@ d.run(() => {
 				},
 			],
 
-			ready: [
-				'swagger',
-				'modules',
-				'bus',
-				'logic',
-				/**
-				 * Description of the function.
-				 *
-				 * @func ready[4]
-				 * @memberof! app
-				 * @param {Object} scope
-				 * @param {function} cb - Callback function
-				 * @todo Add description for the function and its params
-				 */
-				function(scope, cb) {
-					scope.modules.swagger = scope.swagger;
-
-					// Fire onBind event in every module
-					scope.bus.message('bind', scope.modules);
-
-					scope.logic.peers.bindModules(scope.modules);
-					cb();
-				},
-			],
-
-			listen: [
+			httplisten: [
 				'ready',
 				/**
 				 * Description of the function.


### PR DESCRIPTION
### What was the problem?
Application logs following error on restarts sometimes:
```
2018-04-09 09:45:10 529: [FTL] 2018-04-09 09:45:10 | Domain master - {"message":"Cannot read property 'peers' of undefined","stack":"TypeError: Cannot read property 'peers' of undefined\n    at Object.list (/home/lisk/lisk-1.0.0-beta.2-Linux-x86_64/modules/transport.js:615:13)\n    at MasterWAMPServer.processWAMPRequest (/home/lisk/lisk-1.0.0-beta.2-Linux-x86_64/node_modules/wamp-socket-cluster/WAMPServer.js:58:48)\n    at EventEmitter.MasterWAMPServer.socketCluster.on (/home/lisk/lisk-1.0.0-beta.2-Linux-x86_64/node_modules/wamp-socket-cluster/MasterWAMPServer.js:23:10)\n    at emitThree (events.js:116:13)\n    at EventEmitter.emit (events.js:194:7)\n    at ChildProcess.workerHandler (/home/lisk/lisk-1.0.0-beta.2-Linux-x86_64/node_modules/socketcluster/index.js:706:12)\n    at emitTwo (events.js:106:13)\n    at ChildProcess.emit (events.js:191:7)\n    at process.nextTick (internal/child_process.js:787:12)\n    at _combinedTickCallback (internal/process/next_tick.js:73:7)\n    at process._tickDomainCallback (internal/process/next_tick.js:128:9)"}
```

### How did I fix it?
Make webSocket listen task dependent on `ready` job.
### How to test it?

### Review checklist
/bin/bash lisk.sh reload
* The PR solves #1830 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
