### PR TITLE
CTRL+C on OSX throws error - Closes #1958

### DIFF
--- a/app.js
+++ b/app.js
@@ -906,6 +906,7 @@ d.run(() => {
 					scope.logger.fatal(error.toString());
 				}
 				scope.logger.info('Cleaning up...');
+				scope.socketCluster.removeAllListeners('fail');
 				scope.socketCluster.destroy();
 				async.eachSeries(
 					modules,


### PR DESCRIPTION
### What was the problem?

SocketCluster subprocess shut down errors would be shown when shutting down Lisk instance.

### How did I fix it?

When shutting down we ignore subprocess shutdown errors.

### How to test it?

Start the instance with console logLevel set to trace, then Ctrl+C - Error should not appear anymore.

### Review checklist

* The PR solves #1958
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
