### PR TITLE
Make transactions endpoint pagination consistent - Closes #1884

### DIFF
--- a/db/repos/transactions/index.js
+++ b/db/repos/transactions/index.js
@@ -336,7 +336,7 @@ const Queries = {
 			params.sortField
 				? `ORDER BY ${[params.sortField, params.sortMethod].join(
 						' '
-					)}, t_id DESC`
+					)}, t_id ASC`
 				: '',
 			'LIMIT ${limit} OFFSET ${offset}',
 		]

--- a/db/repos/transactions/index.js
+++ b/db/repos/transactions/index.js
@@ -334,7 +334,9 @@ const Queries = {
 				? ` AND ${params.owner}`
 				: params.owner,
 			params.sortField
-				? `ORDER BY ${[params.sortField, params.sortMethod].join(' ')}`
+				? `ORDER BY ${[params.sortField, params.sortMethod].join(
+						' '
+					)}, t_id DESC`
 				: '',
 			'LIMIT ${limit} OFFSET ${offset}',
 		]


### PR DESCRIPTION
### What was the problem?
In case the first sorting param for transaction is not precise enough, pagination of the transactions endpoint was not consistent.

### How did I fix it?
Added a second sorting param, which determines the  order in that the transactions get returned, if the first sorting param is not precise enough.

### How to test it?
the last entry of this call:
`http://localhost:4000/api/transactions?blockId=6524861224470851795&sort=timestamp:desc&offset=0&limit=51`
and the first entry of this call:
`http://localhost:4000/api/transactions?blockId=6524861224470851795&sort=timestamp:desc&offset=50&limit=51`
should be always identical.

### Review checklist

* The PR solves #1884
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
