### PR TITLE
Network height sometimes off - Closes #1913

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -722,9 +722,9 @@ Peers.prototype.networkHeight = function(options, cb) {
 		if (err) {
 			return setImmediate(cb, err, 0);
 		}
-		const peersGroupByHeight = _.groupBy(peers, 'height');
-		const popularHeights = Object.keys(peersGroupByHeight);
-		const networkHeight = Number(_.max(popularHeights));
+		const peersGroupedByHeight = _.groupBy(peers, 'height');
+		const popularHeights = Object.keys(peersGroupedByHeight).map(Number);
+		const networkHeight = _.max(popularHeights);
 
 		library.logger.debug(`Network height is: ${networkHeight}`);
 		library.logger.trace(popularHeights);

--- a/test/fixtures/peers.js
+++ b/test/fixtures/peers.js
@@ -51,7 +51,7 @@ const Peer = stampit({
 	},
 	init({ broadhash, nonce, state }) {
 		this.dappid = null;
-		this.height = faker.random.number({ max: 9999, min: 1 });
+		this.height = _.sampleSize([50, 70, 90, 110], 1);
 		this.ip = faker.internet.ip();
 		this.os = faker.lorem.slug();
 		this.wsPort = `5${faker.random.number({ max: 999, min: 100 })}`;

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -375,6 +375,33 @@ describe('peers', () => {
 				});
 			});
 		});
+
+		describe('networkHeight', () => {
+			before(done => {
+				randomPeers = _.range(1000).map(() => {
+					return generateRandomActivePeer();
+				});
+				peersLogicMock.list = sinonSandbox.stub().returns(randomPeers);
+				done();
+			});
+
+			const randomPeerNetworkHeight = randomPeers => {
+				const peersGroupedByHeight = _.groupBy(randomPeers, 'height');
+				const popularHeights = Object.keys(peersGroupedByHeight).map(Number);
+				return _.max(popularHeights);
+			};
+
+			it('should return all 1000 peers', done => {
+				peers.networkHeight(validOptions, (err, networkHeight) => {
+					expect(err).to.be.null;
+					expect(networkHeight);
+					expect(networkHeight)
+						.to.be.an('number')
+						.and.to.deep.eql(randomPeerNetworkHeight(randomPeers));
+					done();
+				});
+			});
+		});
 	});
 
 	describe('update', () => {


### PR DESCRIPTION
### What was the problem?
Network height switches every few seconds to a different value.
### How did I fix it?
The group by `lodash` function was returning heights value as a string so the popular height was picked inconsistently.
### How to test it?
Run `mocha test/unit/modules/peers.js` to verify the `network height` among peers.
### Review checklist

* The PR solves #1913
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
