### PR TITLE
Make Access-Control-Allow-Origin header configurable - Closes #1973

### DIFF
--- a/api/fittings/lisk_cors.js
+++ b/api/fittings/lisk_cors.js
@@ -36,8 +36,8 @@ module.exports = function create(fittingDef) {
 	var config = modules.getConfig();
 
 	var middleware = CORS({
-		origin: config.api.cors.origin,
-		methods: config.api.cors.headers,
+		origin: config.api.options.cors.origin,
+		methods: config.api.options.cors.headers,
 	});
 
 	/**

--- a/api/fittings/lisk_cors.js
+++ b/api/fittings/lisk_cors.js
@@ -15,8 +15,8 @@
 'use strict';
 
 var debug = require('debug')('swagger:lisk:cors');
-var _ = require('lodash');
 var CORS = require('cors');
+var modules = require('../../helpers/swagger_module_registry');
 
 /**
  * Description of the function.
@@ -33,9 +33,12 @@ var CORS = require('cors');
  */
 module.exports = function create(fittingDef) {
 	debug('config: %j', fittingDef);
+	var config = modules.getConfig();
 
-	var validCorsOptions = ['origin', 'methods', 'allowedHeaders'];
-	var middleware = CORS(_.pick(fittingDef, validCorsOptions));
+	var middleware = CORS({
+		origin: config.api.cors.origin,
+		methods: config.api.cors.headers,
+	});
 
 	/**
 	 * Description of the function.

--- a/api/fittings/lisk_cors.js
+++ b/api/fittings/lisk_cors.js
@@ -37,7 +37,7 @@ module.exports = function create(fittingDef) {
 
 	var middleware = CORS({
 		origin: config.api.options.cors.origin,
-		methods: config.api.options.cors.headers,
+		methods: config.api.options.cors.methods,
 	});
 
 	/**

--- a/config.json
+++ b/config.json
@@ -42,11 +42,11 @@
 				"delayMs": 0,
 				"delayAfter": 0,
 				"windowMs": 60000
+			},
+			"cors": {
+				"origin": "*",
+				"headers": ["GET", "POST", "PUT"]
 			}
-		},
-		"cors": {
-			"origin": "*",
-			"headers": ["GET", "POST", "PUT"]
 		}
 	},
 	"peers": {

--- a/config.json
+++ b/config.json
@@ -43,6 +43,10 @@
 				"delayAfter": 0,
 				"windowMs": 60000
 			}
+		},
+		"cors": {
+			"origin": "*",
+			"headers": ["GET", "POST", "PUT"]
 		}
 	},
 	"peers": {

--- a/config.json
+++ b/config.json
@@ -45,7 +45,7 @@
 			},
 			"cors": {
 				"origin": "*",
-				"headers": ["GET", "POST", "PUT"]
+				"methods": ["GET", "POST", "PUT"]
 			}
 		}
 	},

--- a/config/swagger/default.yml
+++ b/config/swagger/default.yml
@@ -29,11 +29,6 @@ swagger:
 
     _cors:
       name: lisk_cors
-      origin: '*'
-      methods:
-        - GET
-        - PUT
-        - POST
 
     _compression:
       name: lisk_compression

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -110,6 +110,17 @@ function Config(packageJson) {
 		appConfig.coverage = true;
 	}
 
+	if (!appConfig.api.cors.origin) {
+		appConfig.api.cors.origin = '*';
+	}
+
+	if (
+		!appConfig.api.cors.methods ||
+		!Array.isArray(appConfig.api.cors.methods)
+	) {
+		appConfig.api.cors.methods = ['GET', 'POST', 'PUT'];
+	}
+
 	var validator = new z_schema();
 	var valid = validator.validate(appConfig, configSchema.config);
 

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -110,12 +110,16 @@ function Config(packageJson) {
 		appConfig.coverage = true;
 	}
 
-	if (!appConfig.api.options.cors.origin) {
+	if (
+		appConfig.api.options.cors.origin === undefined ||
+		appConfig.api.options.cors.origin === null
+	) {
 		appConfig.api.options.cors.origin = '*';
 	}
 
 	if (
-		!appConfig.api.options.cors.methods ||
+		appConfig.api.options.cors.methods === undefined ||
+		appConfig.api.options.cors.methods === null ||
 		!Array.isArray(appConfig.api.options.cors.methods)
 	) {
 		appConfig.api.options.cors.methods = ['GET', 'POST', 'PUT'];

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -110,15 +110,15 @@ function Config(packageJson) {
 		appConfig.coverage = true;
 	}
 
-	if (!appConfig.api.cors.origin) {
-		appConfig.api.cors.origin = '*';
+	if (!appConfig.api.options.cors.origin) {
+		appConfig.api.options.cors.origin = '*';
 	}
 
 	if (
-		!appConfig.api.cors.methods ||
-		!Array.isArray(appConfig.api.cors.methods)
+		!appConfig.api.options.cors.methods ||
+		!Array.isArray(appConfig.api.options.cors.methods)
 	) {
-		appConfig.api.cors.methods = ['GET', 'POST', 'PUT'];
+		appConfig.api.options.cors.methods = ['GET', 'POST', 'PUT'];
 	}
 
 	var validator = new z_schema();

--- a/schema/config.js
+++ b/schema/config.js
@@ -175,8 +175,20 @@ module.exports = {
 						},
 						required: ['limits'],
 					},
+					cors: {
+						type: 'object',
+						properties: {
+							origin: {
+								type: 'string',
+							},
+							methods: {
+								type: 'array',
+							},
+						},
+						required: ['origin'],
+					},
 				},
-				required: ['enabled', 'access', 'options'],
+				required: ['enabled', 'access', 'options', 'cors'],
 			},
 			peers: {
 				type: 'object',

--- a/schema/config.js
+++ b/schema/config.js
@@ -172,23 +172,23 @@ module.exports = {
 								},
 								required: ['max', 'delayMs', 'delayAfter', 'windowMs'],
 							},
-						},
-						required: ['limits'],
-					},
-					cors: {
-						type: 'object',
-						properties: {
-							origin: {
-								type: 'string',
+							cors: {
+								type: 'object',
+								properties: {
+									origin: {
+										type: 'string',
+									},
+									methods: {
+										type: 'array',
+									},
+								},
+								required: ['origin'],
 							},
-							methods: {
-								type: 'array',
-							},
 						},
-						required: ['origin'],
+						required: ['limits', 'cors'],
 					},
 				},
-				required: ['enabled', 'access', 'options', 'cors'],
+				required: ['enabled', 'access', 'options'],
 			},
 			peers: {
 				type: 'object',

--- a/schema/config.js
+++ b/schema/config.js
@@ -176,7 +176,7 @@ module.exports = {
 								type: 'object',
 								properties: {
 									origin: {
-										type: 'string',
+										anyOf: [{ type: 'string' }, { type: 'boolean' }],
 									},
 									methods: {
 										type: 'array',

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -42,11 +42,11 @@
 				"delayMs": 0,
 				"delayAfter": 0,
 				"windowMs": 60000
+			},
+			"cors": {
+				"origin": "*",
+				"headers": ["GET", "POST", "PUT"]
 			}
-		},
-		"cors": {
-			"origin": "*",
-			"headers": ["GET", "POST", "PUT"]
 		}
 	},
 	"peers": {

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -43,6 +43,10 @@
 				"delayAfter": 0,
 				"windowMs": 60000
 			}
+		},
+		"cors": {
+			"origin": "*",
+			"headers": ["GET", "POST", "PUT"]
 		}
 	},
 	"peers": {

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -45,7 +45,7 @@
 			},
 			"cors": {
 				"origin": "*",
-				"headers": ["GET", "POST", "PUT"]
+				"methods": ["GET", "POST", "PUT"]
 			}
 		}
 	},

--- a/test/unit/api/fittings/lisk_cors.js
+++ b/test/unit/api/fittings/lisk_cors.js
@@ -95,6 +95,48 @@ describe('lisk_cors', () => {
 		done();
 	});
 
+	it('should return actual request origin if cors origin set to true', done => {
+		var originalOrigin = __testContext.config.api.options.cors.origin;
+		__testContext.config.api.options.cors.origin = true;
+		cors_fititng = fitting();
+		context.request.headers.origin = 'my-custom-origin.com';
+		context.request.method = 'OPTIONS';
+
+		cors_fititng(context, next);
+		expect(next).to.have.not.been.called;
+		expect(context.response.statusCode).to.be.equal(204);
+		expect(
+			context.response.getHeader('Access-Control-Allow-Origin')
+		).to.be.equal('my-custom-origin.com');
+		expect(
+			context.response.getHeader('Access-Control-Allow-Methods')
+		).to.be.equal('GET,POST,PUT');
+
+		__testContext.config.api.options.cors.origin = originalOrigin;
+		done();
+	});
+
+	it('should disable cors request completely if cors origin set to false', done => {
+		var originalOrigin = __testContext.config.api.options.cors.origin;
+		__testContext.config.api.options.cors.origin = false;
+		cors_fititng = fitting();
+		context.request.headers.origin = 'my-custom-origin.com';
+		context.request.method = 'OPTIONS';
+
+		cors_fititng(context, next);
+		expect(next).to.be.calledOnce;
+		expect(context.response.statusCode).to.be.equal(200);
+		expect(
+			context.response.getHeader('Access-Control-Allow-Origin')
+		).to.be.equal(undefined);
+		expect(
+			context.response.getHeader('Access-Control-Allow-Methods')
+		).to.be.equal(undefined);
+
+		__testContext.config.api.options.cors.origin = originalOrigin;
+		done();
+	});
+
 	it('should enable requests for GET, POST when provided methods = GET POST', done => {
 		var originalMethods = __testContext.config.api.options.cors.methods;
 		__testContext.config.api.options.cors.methods = ['GET', 'POST'];

--- a/test/unit/api/fittings/lisk_cors.js
+++ b/test/unit/api/fittings/lisk_cors.js
@@ -15,6 +15,7 @@
 'use strict';
 
 var httpMocks = require('node-mocks-http');
+var swaggerModuleRegistry = require('../../../../helpers/swagger_module_registry');
 var fitting = require('../../../../api/fittings/lisk_cors');
 
 describe('lisk_cors', () => {
@@ -27,6 +28,13 @@ describe('lisk_cors', () => {
 			request: httpMocks.createRequest(),
 			response: httpMocks.createResponse(),
 		};
+		swaggerModuleRegistry.bind({
+			config: __testContext.config,
+			logger: __testContext.logger,
+			modules: {
+				cache: null,
+			},
+		});
 		cors_fititng = fitting();
 		next = sinonSandbox.spy();
 		done();
@@ -62,12 +70,14 @@ describe('lisk_cors', () => {
 		).to.be.equal('*');
 		expect(
 			context.response.getHeader('Access-Control-Allow-Methods')
-		).to.be.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
+		).to.be.equal('GET,POST,PUT');
 		done();
 	});
 
 	it('should enable requests for test.com when provided origin = test.com', done => {
-		cors_fititng = fitting({ origin: 'test.com' }, null);
+		var originalOrigin = __testContext.config.api.options.cors.origin;
+		__testContext.config.api.options.cors.origin = 'test.com';
+		cors_fititng = fitting();
 		context.request.method = 'OPTIONS';
 
 		cors_fititng(context, next);
@@ -79,12 +89,16 @@ describe('lisk_cors', () => {
 		).to.be.equal('test.com');
 		expect(
 			context.response.getHeader('Access-Control-Allow-Methods')
-		).to.be.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
+		).to.be.equal('GET,POST,PUT');
+
+		__testContext.config.api.options.cors.origin = originalOrigin;
 		done();
 	});
 
 	it('should enable requests for GET, POST when provided methods = GET POST', done => {
-		cors_fititng = fitting({ methods: ['GET', 'POST'] }, null);
+		var originalMethods = __testContext.config.api.options.cors.methods;
+		__testContext.config.api.options.cors.methods = ['GET', 'POST'];
+		cors_fititng = fitting();
 		context.request.method = 'OPTIONS';
 
 		cors_fititng(context, next);
@@ -97,52 +111,7 @@ describe('lisk_cors', () => {
 		expect(
 			context.response.getHeader('Access-Control-Allow-Methods')
 		).to.be.equal('GET,POST');
-		done();
-	});
-
-	it('should block custom headers if no "allowedHeaders" provided', done => {
-		cors_fititng = fitting({ allowedHeaders: [] }, null);
-		context.request.headers['my-custom-header'] = 'my-custom-value';
-		context.request.method = 'OPTIONS';
-
-		cors_fititng(context, next);
-
-		expect(next).to.have.not.been.called;
-		expect(context.response.statusCode).to.be.equal(204);
-		expect(context.response.getHeader('my-custom-header')).to.be.undefined;
-		done();
-	});
-
-	it('should enable requests for X-MY-HEADER when provided allowedHeaders = X-MY-HEADER', done => {
-		cors_fititng = fitting({ allowedHeaders: ['X-MY-HEADER'] }, null);
-		context.request.method = 'OPTIONS';
-
-		cors_fititng(context, next);
-
-		expect(next).to.have.not.been.called;
-		expect(context.response.statusCode).to.be.equal(204);
-		expect(
-			context.response.getHeader('Access-Control-Allow-Headers')
-		).to.include('X-MY-HEADER');
-		done();
-	});
-
-	it('should enable requests for multiple headers when provided allowedHeaders with multiple values', done => {
-		cors_fititng = fitting(
-			{ allowedHeaders: ['X-1-HEADER', 'X-2-HEADER'] },
-			null
-		);
-		context.request.method = 'OPTIONS';
-
-		cors_fititng(context, next);
-
-		expect(next).to.have.not.been.called;
-		expect(context.response.statusCode).to.be.equal(204);
-		var headers = context.response
-			.getHeader('Access-Control-Allow-Headers')
-			.split(',');
-		expect(headers).to.include('X-1-HEADER');
-		expect(headers).to.include('X-2-HEADER');
+		__testContext.config.api.options.cors.methods = originalMethods;
 		done();
 	});
 });


### PR DESCRIPTION
### What was the problem?
CORS origin and methods were not configureable from json file. 

### How did I fix it?
Moved the confirmation from yml file to json configuration file. 

### How to test it?
Run the unit test for cors_fititng. 

### Review checklist

* The PR solves #1973
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
