### PR TITLE
Update functional system rounds tests to new behavior - Closes #1953

### DIFF
--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -933,13 +933,11 @@ describe('rounds', () => {
 					return expect(lastBlock.height).to.equal(101);
 				});
 
-				// FIXME: Unskip that tests and fix the order (or not) after issue https://github.com/LiskHQ/lisk-js/issues/625 is closed
-				// eslint-disable-next-line
-				it.skip('after finishing round, should unvote expected forger of last block of round and vote new delegate (block data)', () => {
+				it('after finishing round, should unvote expected forger of last block of round and vote new delegate (block data)', () => {
 					return Queries.getFullBlock(lastBlock.height).then(blocks => {
 						expect(blocks[0].transactions[0].asset.votes).to.deep.equal([
-							`-${lastBlockForger}`,
 							`+${tmpAccount.publicKey}`,
+							`-${lastBlockForger}`,
 						]);
 					});
 				});


### PR DESCRIPTION
### What was the problem?
Scenario `after finishing round, should unvote expected forger of last block of round and vote new delegate (block data)` should pass. Issue https://github.com/LiskHQ/lisk-js/issues/625 is closed, so we should change expectations and un-skip that test.
### How did I fix it?
Reverse expected order of votes, un-skip the test.
### How to test it?
Run functional system rounds tests.
### Review checklist

* The PR solves #1953
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
