### PR TITLE
Simplify peer headers

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -42,6 +42,8 @@ const connect = (peer, logger) => {
 
 const connectSteps = {
 	addConnectionOptions: peer => {
+		const systemHeaders = System.getHeaders();
+
 		peer.connectionOptions = {
 			autoConnect: false, // Lazy connection establishment
 			autoReconnect: false,
@@ -50,7 +52,14 @@ const connectSteps = {
 			pingTimeoutDisabled: true,
 			port: peer.wsPort,
 			hostname: peer.ip,
-			query: System.getHeaders(),
+			query: {
+				os: systemHeaders.os,
+				version: systemHeaders.version,
+				wsPort: systemHeaders.wsPort,
+				httpPort: systemHeaders.httpPort,
+				nethash: systemHeaders.nethash,
+				nonce: systemHeaders.nonce,
+			},
 			multiplex: true,
 		};
 		return peer;

--- a/api/ws/workers/middlewares/handshake.js
+++ b/api/ws/workers/middlewares/handshake.js
@@ -137,7 +137,9 @@ var extractHeaders = function(request) {
 	headers.ip = request.remoteAddress.split(':').pop();
 	headers.httpPort = +headers.httpPort;
 	headers.wsPort = +headers.wsPort;
-	headers.height = +headers.height;
+	if (headers.height != null) {
+		headers.height = +headers.height;
+	}
 	return headers;
 };
 

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -60,11 +60,9 @@ PeersManager.prototype.add = function(peer) {
 		// Create client WS connection to peer
 		connect(peer, this.logger);
 	}
+	this.addressToNonceMap[peer.string] = peer.nonce;
 	if (peer.nonce) {
-		this.addressToNonceMap[peer.string] = peer.nonce;
 		this.nonceToAddressMap[peer.nonce] = peer.string;
-	} else if (this.addressToNonceMap[peer.string]) {
-		delete this.addressToNonceMap[peer.string];
 	}
 
 	return true;

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -2581,9 +2581,7 @@ definitions:
     required:
       - httpPort
       - wsPort
-      - os
       - version
-      - height
       - nethash
       - nonce
     properties:


### PR DESCRIPTION
### What was the problem?

- The WebSocket handshake query string contained dynamic fields such as 'broadhash' and 'height' which change over time and do not help to identify the connection.
- Because the broadhash and height keep changing every time a node tries to reconnect to a peer, the previous socket associated with that peer could not be identified for reuse.
- A regression was introduced in PR https://github.com/LiskHQ/lisk/pull/1909 which caused strange behaviour with rediscovering a previously discovered peer. 

### How did I fix it?

- Do not include broadhash and height in the query string.
- Loosened schema validation.
- Fixed the regression from PR https://github.com/LiskHQ/lisk/pull/1909

### How to test it?

- Run two nodes on localhost and check that they can connect to each other (including after restarts) and check that they can still sync blocks.
- Run the nodes on beta net.

### Review checklist

* The PR solves #1841
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
