### PR TITLE
Inconsistent peers data from /api/peers - Closes #1955

### DIFF
--- a/logic/peer.js
+++ b/logic/peer.js
@@ -114,17 +114,13 @@ class Peer {
 		// Accept only supported properties
 		_.each(this.properties, key => {
 			// Change value only when is defined
-			if (
-				peer[key] !== null &&
-				peer[key] !== undefined &&
-				!_.includes(this.required, key)
-			) {
+			if (peer[key] && !this.required.includes(key)) {
 				// Update optional httpPort and nonce
 				// for the first time when peer object
 				// has httpPort and nonce as undefined
-				if (!this[key] && _.includes(this.optional, key)) {
-					this[key] = peer[key];
-				} else if (!_.includes(this.optional, key)) {
+				const isOptional = this.optional.includes(key);
+				const isExists = this[key];
+				if (!isOptional || (!isExists && isOptional)) {
 					this[key] = peer[key];
 				}
 			}

--- a/logic/peer.js
+++ b/logic/peer.js
@@ -117,9 +117,16 @@ class Peer {
 			if (
 				peer[key] !== null &&
 				peer[key] !== undefined &&
-				!_.includes(this.immutable, key)
+				!_.includes(this.required, key)
 			) {
-				this[key] = peer[key];
+				// Update optional httpPort and nonce
+				// for the first time when peer object
+				// has httpPort and nonce as undefined
+				if (!this[key] && _.includes(this.optional, key)) {
+					this[key] = peer[key];
+				} else if (!_.includes(this.optional, key)) {
+					this[key] = peer[key];
+				}
 			}
 		});
 
@@ -175,7 +182,9 @@ Peer.prototype.properties = [
 	'httpPort',
 ];
 
-Peer.prototype.immutable = ['ip', 'wsPort', 'httpPort', 'string'];
+Peer.prototype.required = ['ip', 'wsPort', 'string'];
+
+Peer.prototype.optional = ['httpPort', 'nonce'];
 
 Peer.prototype.connectionProperties = ['rpc', 'socket', 'connectionOptions'];
 

--- a/test/integration/scenarios/network/peers.js
+++ b/test/integration/scenarios/network/peers.js
@@ -76,21 +76,49 @@ module.exports = function(params) {
 
 	describe('Peers', () => {
 		describe('mutual connections', () => {
+			var mutualPeers = [];
+			before(() => {
+				return getAllPeers().then(peers => {
+					mutualPeers = peers;
+				});
+			});
+
 			it('should return a list of peers mutually interconnected', () => {
-				return getAllPeers().then(mutualPeers => {
-					mutualPeers.forEach(mutualPeer => {
-						expect(mutualPeer).to.have.property('success').to.be.true;
-						expect(mutualPeer)
-							.to.have.property('peers')
-							.to.be.an('array');
-						var peerPorts = mutualPeer.peers.map(peer => {
-							return peer.wsPort;
-						});
-						var allPorts = params.configurations.map(configuration => {
-							return configuration.wsPort;
-						});
-						expect(_.intersection(allPorts, peerPorts)).to.be.an('array').and
-							.not.to.be.empty;
+				return mutualPeers.forEach(mutualPeer => {
+					expect(mutualPeer).to.have.property('success').to.be.true;
+					expect(mutualPeer)
+						.to.have.property('peers')
+						.to.be.an('array');
+					var peerPorts = mutualPeer.peers.map(peer => {
+						return peer.wsPort;
+					});
+					var allPorts = params.configurations.map(configuration => {
+						return configuration.wsPort;
+					});
+					expect(_.intersection(allPorts, peerPorts)).to.be.an('array').and.not
+						.to.be.empty;
+				});
+			});
+
+			it('should have all the required peer properties', () => {
+				const peerProps = [
+					'ip',
+					'wsPort',
+					'state',
+					'os',
+					'version',
+					'broadhash',
+					'httpPort',
+					'height',
+					'nonce',
+				];
+				return mutualPeers.forEach(mutualPeer => {
+					mutualPeer.peers.every(peer => {
+						// delete the not required properties from ws peer list call
+						// to keep consistency with api/controllers/peers.js/getPeers
+						delete peer.updated;
+						delete peer.clock;
+						expect(peer).to.have.all.keys(peerProps);
 					});
 				});
 			});

--- a/test/unit/logic/peer.js
+++ b/test/unit/logic/peer.js
@@ -169,22 +169,42 @@ describe('peer', () => {
 			});
 		});
 
-		it('should not update immutable properties', () => {
+		it('should not update required properties once peer is created', () => {
 			var peerBeforeUpdate = _.clone(peer);
-			var updateImmutableData = {
+			var updateRequiredData = {
 				ip: prefixedPeer.ip,
 				wsPort: prefixedPeer.wsPort,
-				httpPort: prefixedPeer.httpPort,
 				string: `${prefixedPeer.ip}:${prefixedPeer.wsPort}`,
 			};
 
-			expect(_.isEqual(_.keys(updateImmutableData), peer.immutable)).to.be.ok;
-			peer.update(updateImmutableData);
+			expect(_.isEqual(_.keys(updateRequiredData), peer.required)).to.be.ok;
+			peer.update(updateRequiredData);
 			return peer.headers.forEach(header => {
 				expect(peer[header])
 					.equals(peerBeforeUpdate[header])
-					.and.not.equal(updateImmutableData);
+					.and.not.equal(updateRequiredData);
 			});
+		});
+
+		it('should update the optional properties only for the first time', () => {
+			var updateOptionalData = {
+				httpPort: prefixedPeer.httpPort,
+				nonce: 'nonce added first time after peer creation',
+			};
+			var updateOptionalDataForSecondTime = {
+				httpPort: 10909,
+				nonce: 'update after nonce exists should fail',
+			};
+
+			expect(_.isEqual(_.keys(updateOptionalData), peer.optional)).to.be.ok;
+			expect(_.isEqual(_.keys(updateOptionalDataForSecondTime), peer.optional))
+				.to.be.ok;
+
+			peer.update(updateOptionalData);
+			expect(peer).to.include(updateOptionalData);
+
+			peer.update(updateOptionalDataForSecondTime);
+			return expect(peer).to.not.include(updateOptionalDataForSecondTime);
 		});
 
 		it('should not delete values which were previously set but are not updated now', () => {


### PR DESCRIPTION
### What was the problem?
`GET /api/peers` returns list of peers with missing `httpPort` in the response.
### How did I fix it?
When the peer is created for the first time using the peer seed list the peer is created with params `ip, wsPort` after handshake with the other peer the remaining peer properties are updated, since the `logic/peer/update` function checks the immutable properties before update the current peer, the `httpPort` is never updated if the peer was created from the seed list.
### How to test it?

1. Run the integration tests and when nodes are up
2. Call curl http://127.0.0.1:4000/api/peers
3. The response should have peer list with these properties `'ip','wsPort','state','os','version','broadhash','httpPort','height','nonce'`


### Review checklist

* The PR solves #1955
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
