### PR TITLE
Remove istanbul-middleware module - Closes #1999

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,19 +1,3 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.10.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  'npm:qs:20170213':
-    - istanbul-middleware > body-parser > qs:
-        reason: None given
-        expires: '2018-03-08T16:18:03.803Z'
-# patches apply the minimum changes required to fix a vulnerability
-patch:
-  'npm:debug:20170905':
-    - istanbul-middleware > body-parser > debug:
-        patched: '2018-02-06T16:13:04.525Z'
-  'npm:minimatch:20160620':
-    - istanbul-middleware > archiver > glob > minimatch:
-        patched: '2018-02-06T16:13:04.525Z'
-  'npm:ms:20170412':
-    - istanbul-middleware > body-parser > debug > ms:
-        patched: '2018-02-06T16:13:04.525Z'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,12 +71,6 @@ module.exports = function(grunt) {
 				maxBuffer: maxBufferSize,
 			},
 
-			fetchCoverage: {
-				command:
-					'rm -rf ./test/.coverage-func.zip; curl -o ./test/.coverage-func.zip $HOST/coverage/download',
-				maxBuffer: maxBufferSize,
-			},
-
 			coverageReport: {
 				command:
 					'rm -f ./test/.coverage-unit/lcov.info; ./node_modules/.bin/istanbul report --root ./test/.coverage-unit/ --dir ./test/.coverage-unit',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,10 +128,8 @@ def reportCoverage(node) {
 		export HOST=127.0.0.1:4000
 		# Gathers tests into single lcov.info
 		npm run cover:report
-		npm run cover:fetch
 		# Submit coverage reports to Master
 		scp -r test/.coverage-unit/* jenkins@master-01:/var/lib/jenkins/coverage/coverage-unit/
-		scp test/.coverage-func.zip jenkins@master-01:/var/lib/jenkins/coverage/coverage-func-node-${node}.zip
 		"""
 	} catch (err) {
 		echo "Error: ${err}"
@@ -375,11 +373,6 @@ lock(resource: "Lisk-Core-Nodes", inversePrecedence: true) {
 			try {
 				sh '''
 				cd /var/lib/jenkins/coverage/
-				unzip coverage-func-node-01.zip -d node-01
-				unzip coverage-func-node-02.zip -d node-02
-				unzip coverage-func-node-03.zip -d node-03
-				unzip coverage-func-node-04.zip -d node-04
-				unzip coverage-func-node-05.zip -d node-05
 				bash merge_lcov.sh . merged-lcov.info
 				cp merged-lcov.info $WORKSPACE/merged-lcov.info
 				cp .coveralls.yml $WORKSPACE/.coveralls.yml

--- a/app.js
+++ b/app.js
@@ -257,15 +257,6 @@ d.run(() => {
 					var express = require('express');
 					var app = express();
 
-					if (appConfig.coverage) {
-						var im = require('istanbul-middleware');
-						logger.debug(
-							'Hook loader for coverage - Do not use in production environment!'
-						);
-						im.hookLoader(__dirname);
-						app.use('/coverage', im.createHandler());
-					}
-
 					if (appConfig.trustProxy) {
 						app.enable('trust proxy');
 					}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
 		"find": "=0.2.7",
 		"fs-extra": "=5.0.0",
 		"ip": "=1.1.5",
-		"istanbul-middleware": "=0.2.2",
 		"js-yaml": "=3.10.0",
 		"json-refs": "=3.0.3",
 		"lodash": "=4.17.4",

--- a/test/common/utils/random.js
+++ b/test/common/utils/random.js
@@ -113,7 +113,9 @@ random.account = function() {
 	account.secondPassword = random.password();
 	account.username = random.delegateName();
 	account.publicKey = lisk.cryptography.getKeys(account.password).publicKey;
-	account.address = lisk.cryptography.getAddressFromPublicKey(account.publicKey);
+	account.address = lisk.cryptography.getAddressFromPublicKey(
+		account.publicKey
+	);
 	account.secondPublicKey = lisk.cryptography.getKeys(
 		account.secondPassword
 	).publicKey;

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -554,11 +554,9 @@ describe('GET /delegates', () => {
 		});
 
 		it('using limit=101 should be ok', () => {
-			return forgersEndpoint
-				.makeRequest({ limit: 101 }, 200)
-				.then(res => {
-					expect(res.body.data).to.have.length(101);
-				});
+			return forgersEndpoint.makeRequest({ limit: 101 }, 200).then(res => {
+				expect(res.body.data).to.have.length(101);
+			});
 		});
 
 		describe('slot numbers are correct', () => {

--- a/test/functional/http/get/votes.js
+++ b/test/functional/http/get/votes.js
@@ -331,7 +331,10 @@ describe('GET /api/votes', () => {
 			describe('limit=101', () => {
 				it('should return 101 voters', () => {
 					return votesEndpoint
-						.makeRequest({ limit: 101, publicKey: voterDelegate.publicKey }, 200)
+						.makeRequest(
+							{ limit: 101, publicKey: voterDelegate.publicKey },
+							200
+						)
 						.then(res => {
 							expect(res.body.data.votes).to.have.length(101);
 						});

--- a/test/functional/http/post/6.dapps.in_transfer.js
+++ b/test/functional/http/post/6.dapps.in_transfer.js
@@ -395,12 +395,14 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 			transaction = {
 				amount: '100000000',
 				recipientId: '',
-				senderPublicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
+				senderPublicKey:
+					'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
 				timestamp: 60731530,
 				type: 6,
 				fee: '10000000',
 				asset: { inTransfer: { dappId: '7670083247477258129' } },
-				signature: '0845ea4121c868d11f04397fc8e2af518c530f0b1c0cfb0009da2bd688a58711146068b35eed70d55e89714ace1b8ec350c25178e5c4cc016ff517a76ded3f00',
+				signature:
+					'0845ea4121c868d11f04397fc8e2af518c530f0b1c0cfb0009da2bd688a58711146068b35eed70d55e89714ace1b8ec350c25178e5c4cc016ff517a76ded3f00',
 				id: '10457544900900787263',
 			};
 

--- a/test/functional/http/post/7.dapps.out_transfer.js
+++ b/test/functional/http/post/7.dapps.out_transfer.js
@@ -680,18 +680,17 @@ describe('POST /api/transactions (type 7) outTransfer dapp', () => {
 			transaction = {
 				amount: '100000000',
 				recipientId: '16313739661670634666L',
-				senderPublicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
+				senderPublicKey:
+					'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
 				timestamp: 60731685,
 				type: 7,
 				fee: '10000000',
-				asset:
-					{
-						outTransfer:
-							{
-								dappId: randomUtil.guestbookDapp.id,
-								transactionId: '10457544900900787263',
-							},
+				asset: {
+					outTransfer: {
+						dappId: randomUtil.guestbookDapp.id,
+						transactionId: '10457544900900787263',
 					},
+				},
 			};
 
 			transaction = elements.redoSignature(

--- a/test/functional/system/blocks/process/on_receive_block.js
+++ b/test/functional/system/blocks/process/on_receive_block.js
@@ -264,7 +264,9 @@ describe('system test (blocks) - process onReceiveBlock()', () => {
 					beforeEach(done => {
 						lastBlock = library.modules.blocks.lastBlock.get();
 						var slot = slots.getSlotNumber();
-						var nonDelegateKeypair = getKeypair(accountFixtures.genesis.passphrase);
+						var nonDelegateKeypair = getKeypair(
+							accountFixtures.genesis.passphrase
+						);
 						block = createBlock(
 							[],
 							slots.getSlotTime(slot),

--- a/test/functional/system/transactions/1.second_signature/1.X.second_signature_validated.js
+++ b/test/functional/system/transactions/1.second_signature/1.X.second_signature_validated.js
@@ -95,7 +95,11 @@ describe('system test (type 1) - checking validated second signature registratio
 
 		describe('adding to pool other transaction types from the same account', () => {
 			Object.keys(transactionTypes).forEach((key, index) => {
-				if (key != 'SIGNATURE' && key != 'IN_TRANSFER' && key != 'OUT_TRANSFER') {
+				if (
+					key != 'SIGNATURE' &&
+					key != 'IN_TRANSFER' &&
+					key != 'OUT_TRANSFER'
+				) {
 					it(`type ${index}: ${key} without second signature should fail`, done => {
 						localCommon.loadTransactionType(
 							key,
@@ -134,14 +138,10 @@ describe('system test (type 1) - checking validated second signature registratio
 							dapp,
 							null,
 							transaction => {
-								localCommon.addTransaction(
-									library,
-									transaction,
-									(err, res) => {
-										expect(res).to.equal(transaction.id);
-										done();
-									}
-								);
+								localCommon.addTransaction(library, transaction, (err, res) => {
+									expect(res).to.equal(transaction.id);
+									done();
+								});
 							}
 						);
 					});

--- a/test/unit/db/repos/blocks.js
+++ b/test/unit/db/repos/blocks.js
@@ -277,9 +277,9 @@ describe('db', () => {
 			});
 
 			it('should resolve with null if block with particular height does not exists', () => {
-				return expect(db.blocks.deleteBlocksAfterHeight(1234)).to.be.eventually.eql(
-					null
-				);
+				return expect(
+					db.blocks.deleteBlocksAfterHeight(1234)
+				).to.be.eventually.eql(null);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

Snyk is continuously warning about that unmaintained module. 

### How did I fix it?
Decision is to remove the library due to the provided feature is useless.

### Review checklist

* The PR solves #1999
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
