### PR TITLE
Fix invalid broadhash consensus reported in logs - Closes #1832

### DIFF
--- a/config.json
+++ b/config.json
@@ -97,7 +97,8 @@
 			"blackList": []
 		},
 		"options": {
-			"timeout": 5000
+			"timeout": 5000,
+			"broadhashConsensusCalculationInterval": 5000
 		}
 	},
 	"broadcasts": {

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -266,7 +266,7 @@ __private.forge = function(cb) {
 
 			if (modules.transport.poorConsensus()) {
 				const consensusErr = [
-					'Inadequate broadhash consensus',
+					'Inadequate broadhash consensus before forging a block:',
 					modules.peers.getLastConsensus(),
 					'%',
 				].join(' ');
@@ -279,9 +279,11 @@ __private.forge = function(cb) {
 			}
 
 			library.logger.info(
-				['Broadhash consensus now', modules.peers.getLastConsensus(), '%'].join(
-					' '
-				)
+				[
+					'Broadhash consensus before forging a block:',
+					modules.peers.getLastConsensus(),
+					'%',
+				].join(' ')
 			);
 
 			modules.blocks.process.generateBlock(

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -69,6 +69,8 @@ class Peers {
 		};
 		self = this;
 		self.consensus = scope.config.forging.force ? 100 : 0;
+		self.broadhashConsensusCalculationInterval =
+			scope.config.peers.options.broadhashConsensusCalculationInterval;
 		setImmediate(cb, null, self);
 	}
 }
@@ -853,11 +855,25 @@ Peers.prototype.onPeersReady = function() {
 			() => setImmediate(cb)
 		);
 	}
+
+	function calculateConsensus(cb) {
+		self.calculateConsensus();
+		library.logger
+			.debug(['Broadhash consensus:', self.getLastConsensus(), '%'])
+			.join(' ');
+		return setImmediate(cb);
+	}
 	// Loop in 30 sec intervals for less new insertion after removal
 	jobsQueue.register(
 		'peersDiscoveryAndUpdate',
 		peersDiscoveryAndUpdate,
 		peerDiscoveryFrequency
+	);
+
+	jobsQueue.register(
+		'calculateConsensus',
+		calculateConsensus,
+		self.broadhashConsensusCalculationInterval
 	);
 };
 

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -858,9 +858,9 @@ Peers.prototype.onPeersReady = function() {
 
 	function calculateConsensus(cb) {
 		self.calculateConsensus();
-		library.logger
-			.debug(['Broadhash consensus:', self.getLastConsensus(), '%'])
-			.join(' ');
+		library.logger.debug(
+			['Broadhash consensus:', self.getLastConsensus(), '%'].join(' ')
+		);
 		return setImmediate(cb);
 	}
 	// Loop in 30 sec intervals for less new insertion after removal

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -61,7 +61,8 @@
 			"blackList": []
 		},
 		"options": {
-			"timeout": 5000
+			"timeout": 5000,
+			"broadhashConsensusCalculationInterval": 5000
 		}
 	},
 	"broadcasts": {


### PR DESCRIPTION
### What was the problem?
Broadhash consensus logged was not recalculated properly.
### How did I fix it?
Created a new job for calculating broadhash consensus every 5 seconds.
### How to test it?
Look at the logs
### Review checklist

* The PR solves #1832 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
