### PR TITLE
Next forgers endpoint returning invalid data - Closes #1998

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -893,7 +893,7 @@ Delegates.prototype.getForgers = function(query, cb) {
 	const forgerKeys = [];
 
 	self.generateDelegateList(
-		currentBlock.height,
+		currentBlock.height + 1,
 		null,
 		(err, activeDelegates) => {
 			if (err) {

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -892,6 +892,8 @@ Delegates.prototype.getForgers = function(query, cb) {
 	const currentSlot = slots.getSlotNumber();
 	const forgerKeys = [];
 
+	// We pass height + 1 as seed for generating the list, because we want the list to be generated for next block.
+	// For example: last block height is 101 (still round 1, but already finished), then we want the list for round 2 (height 102)
 	self.generateDelegateList(
 		currentBlock.height + 1,
 		null,


### PR DESCRIPTION
### What was the problem?
`/api/delegates/getNextForgers` endpoint returns wrong delegates list when called on last block on round.
### How did I fix it?
Add `+ 1` to height passed.
### How to test it?
Manually.
### Review checklist

* The PR solves #1998
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
