### PR TITLE
If a peer object for a specific nonce already exists and has a socket, destroy the socket - Closes #2012

### DIFF
--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -51,6 +51,12 @@ PeersManager.prototype.add = function(peer) {
 		return false;
 	}
 
+	const existingPeer = this.peers[peer.string];
+
+	if (existingPeer && existingPeer.socket) {
+		existingPeer.socket.destroy();
+		delete existingPeer.socket;
+	}
 	this.peers[peer.string] = peer;
 
 	if (peer.socket && peer.socket.active) {


### PR DESCRIPTION
### What was the problem?

It's possible that two different peer objects could be added to peer manager with the same nonce; in this case, it's possible that the previous peer object might still have an open socket which is no longer needed.

### How did I fix it?

When adding a new peer to the peerManager, if a peer already exists with that nonce, delete the socket object on the existing peer.

### How to test it?

Beta net.
This was tested on the latest beta net on a single node before and after the change (checking for outbound connections) and it appears to solve the issue with leaking active handles (outbound).

### Review checklist

* The PR solves #2012 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
