### PR TITLE
If a peer object for a specific nonce already exists and has a socket, destroy the socket - Closes #2012

### DIFF
--- a/api/ws/rpc/disconnect.js
+++ b/api/ws/rpc/disconnect.js
@@ -16,7 +16,7 @@
 
 const disconnect = peer => {
 	if (peer.socket) {
-		peer.socket.disconnect(
+		peer.socket.destroy(
 			1000,
 			'Intentionally disconnected from peer because of disconnect call'
 		);

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -51,6 +51,12 @@ PeersManager.prototype.add = function(peer) {
 		return false;
 	}
 
+	const existingPeer = this.peers[peer.string];
+
+	if (existingPeer && existingPeer.socket) {
+		existingPeer.socket.destroy();
+		delete existingPeer.socket;
+	}
 	this.peers[peer.string] = peer;
 
 	if (peer.socket && peer.socket.active) {

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -54,13 +54,17 @@ PeersManager.prototype.add = function(peer) {
 	const existingPeer = this.peers[peer.string];
 
 	if (existingPeer && existingPeer.socket) {
-		existingPeer.socket.destroy();
-		delete existingPeer.socket;
+		if (peer.socket && peer.socket !== existingPeer.socket) {
+			// Destroy with error code 1000.
+			peer.socket.destroy(1000, 'Client intentionally disconnected the socket');
+		}
+		peer.socket = existingPeer.socket;
 	}
 	this.peers[peer.string] = peer;
 
 	if (peer.socket && peer.socket.active) {
-		// Reconnect existing socket
+		// Reconnect existing socket if it exists and is closed.
+		// If it's already open then peer.socket.connect() will do nothing.
 		peer.socket.connect();
 	} else {
 		// Create client WS connection to peer

--- a/helpers/peers_manager.js
+++ b/helpers/peers_manager.js
@@ -54,10 +54,6 @@ PeersManager.prototype.add = function(peer) {
 	const existingPeer = this.peers[peer.string];
 
 	if (existingPeer && existingPeer.socket) {
-		if (peer.socket && peer.socket !== existingPeer.socket) {
-			// Destroy with error code 1000.
-			peer.socket.destroy(1000, 'Client intentionally disconnected the socket');
-		}
 		peer.socket = existingPeer.socket;
 	}
 	this.peers[peer.string] = peer;
@@ -89,16 +85,17 @@ PeersManager.prototype.remove = function(peer) {
 	if (!peer || !this.peers[peer.string]) {
 		return false;
 	}
-	this.nonceToAddressMap[peer.nonce] = null;
-	delete this.nonceToAddressMap[peer.nonce];
+	const existingPeer = this.peers[peer.string];
+	this.nonceToAddressMap[existingPeer.nonce] = null;
+	delete this.nonceToAddressMap[existingPeer.nonce];
 
-	this.addressToNonceMap[peer.string] = null;
-	delete this.addressToNonceMap[peer.string];
+	this.addressToNonceMap[existingPeer.string] = null;
+	delete this.addressToNonceMap[existingPeer.string];
 
-	this.peers[peer.string] = null;
-	delete this.peers[peer.string];
+	this.peers[existingPeer.string] = null;
+	delete this.peers[existingPeer.string];
 
-	disconnect(peer);
+	disconnect(existingPeer);
 	return true;
 };
 

--- a/test/unit/api/ws/rpc/disconnect.js
+++ b/test/unit/api/ws/rpc/disconnect.js
@@ -45,7 +45,7 @@ describe('disconnect', () => {
 			disconnect(validPeer);
 			// The socket should be deleted.
 			expect(validPeer.socket, undefined);
-			return expect(socket.disconnect).calledOnce;
+			return expect(socket.destroy).calledOnce;
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

It's possible that two different peer objects could be added to peer manager with the same nonce; in this case, it's possible that the previous peer object might still have an open socket which is no longer needed.

Also, the peer object which is passed to the peer manager remove method might not be the same as the one that is inside the peer manager and it may not have a socket on it; we should destroy the one from our internal peers map.

### How did I fix it?

When adding a new peer to the peerManager, if a peer already exists with that nonce, delete the socket object on the existing peer.

When removing a peer from the peerManager, use the peers map to find the reference to the peer before trying to disconnect its socket.

### How to test it?

Beta net.
This was tested on the latest beta net on a single node before and after the change (checking for outbound connections) and it appears to solve the issue with leaking active handles (outbound).

### Review checklist

* The PR solves #2012 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
