### PR TITLE
Fix non-called callback - Closes #2021

### DIFF
--- a/api/ws/rpc/connect.js
+++ b/api/ws/rpc/connect.js
@@ -145,9 +145,10 @@ const connectSteps = {
 								setImmediate(rpcCallback, err);
 							});
 					} else {
-						logger.debug(
-							'Tried to call RPC function on outbound peer socket which no longer exists'
-						);
+						const rpcNotExistError =
+							'Tried to call RPC function on outbound peer socket which no longer exists';
+						logger.debug(rpcNotExistError);
+						setImmediate(rpcCallback, rpcNotExistError);
 					}
 				};
 				return peerExtendedWithRPC;


### PR DESCRIPTION
### What was the problem?
On RPC call, if socket does not exist it logs error, but it did not call the callback.

### How did I fix it?
Call the callback with the error message which was logged before.


### Review checklist

* The PR solves #2021 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
