### PR TITLE
Peers list should include some unmatched broadhash peers to broadcast to - Closes #2025

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -74,6 +74,7 @@ var constants = {
 	maxAmount: 100000000,
 	maxPayloadLength: 1024 * 1024,
 	maxPeers: 100,
+	matchingPeersRatio: 0.5,
 	maxSharedTransactions: 100,
 	maxTransactionsPerBlock: 25,
 	maxVotesPerTransaction: 33,

--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -103,6 +103,9 @@ class Broadcaster {
 	 */
 	getPeers(params, cb) {
 		params.limit = params.limit || this.config.peerLimit;
+		// Leave some room in the broadcast list for peers with a
+		// non-matching broadhash in order to avoid forks.
+		params.matchingPeersRatio = constants.matchingPeersRatio;
 		params.broadhash = params.broadhash || null;
 		params.normalized = false;
 

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -29,7 +29,7 @@ let self;
 const __private = {};
 let definitions;
 
-const peerDiscoveryFrequency = 30000;
+const peerDiscoveryFrequency = 10000;
 
 /**
  * Main peers methods. Initializes library with scope content.

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -91,6 +91,29 @@ __private.countByFilter = function(filter, cb) {
 };
 
 /**
+ * Shuffles peers (using Fisher-Yates-Durstenfeld shuffle algorithm).
+ *
+ * @todo Add @param tags
+ * @todo Add @returns tag
+ * @todo Add description of the function
+ */
+__private.shuffle = function(array) {
+	let m = array.length;
+	let t;
+	let i;
+	// While there remain elements to shuffle
+	while (m) {
+		// Pick a remaining element
+		i = Math.floor(Math.random() * m--);
+		// And swap it with the current element
+		t = array[m];
+		array[m] = array[i];
+		array[i] = t;
+	}
+	return array;
+};
+
+/**
  * Gets randomly ordered list of peers by filter.
  *
  * @private
@@ -170,29 +193,6 @@ __private.getByFilter = function(filter, cb) {
 		};
 	};
 
-	/**
-	 * Shuffles peers (using Fisher-Yates-Durstenfeld shuffle algorithm).
-	 *
-	 * @todo Add @param tags
-	 * @todo Add @returns tag
-	 * @todo Add description of the function
-	 */
-	const shuffle = function(array) {
-		let m = array.length;
-		let t;
-		let i;
-		// While there remain elements to shuffle
-		while (m) {
-			// Pick a remaining element
-			i = Math.floor(Math.random() * m--);
-			// And swap it with the current element
-			t = array[m];
-			array[m] = array[i];
-			array[i] = t;
-		}
-		return array;
-	};
-
 	// Apply filters (by AND)
 	const normalized = filter.normalized === undefined ? true : filter.normalized;
 	let peers = library.logic.peers.list(normalized);
@@ -225,7 +225,7 @@ __private.getByFilter = function(filter, cb) {
 		}
 	} else {
 		// Sort randomly by default
-		peers = shuffle(peers);
+		peers = __private.shuffle(peers);
 	}
 
 	// Apply limit if supplied
@@ -716,6 +716,7 @@ Peers.prototype.list = function(options, cb) {
 					// Unmatched broadhash
 					return randomList(peers, waterCb);
 				}
+				peers = __private.shuffle(peers);
 				return setImmediate(waterCb, null, peers);
 			},
 		],

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -644,7 +644,9 @@ Peers.prototype.acceptable = function(peers) {
  * @returns {setImmediateCallback} cb, err, peers
  */
 Peers.prototype.list = function(options, cb) {
+	const matchingPeersRatio = options.matchingPeersRatio || 1;
 	let limit = options.limit || constants.maxPeers;
+	const matchingPeersLimit = Math.ceil(limit * matchingPeersRatio);
 	const broadhash = options.broadhash || modules.system.getBroadhash();
 	const allowedStates = options.allowedStates || [Peer.STATE.CONNECTED];
 	const attempts =
@@ -683,7 +685,11 @@ Peers.prototype.list = function(options, cb) {
 				});
 				const matched = peersList.length;
 				// Apply limit
-				peersList = peersList.slice(0, limit);
+				if (attempt === 0) {
+					peersList = peersList.slice(0, matchingPeersLimit);
+				} else {
+					peersList = peersList.slice(0, limit);
+				}
 				const picked = peersList.length;
 				const accepted = peers.concat(peersList);
 				library.logger.debug('Listing peers', {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -376,40 +376,43 @@ Transport.prototype.onUnconfirmedTransaction = function(
  * @returns {setImmediateCallback} cb
  */
 Transport.prototype.broadcastHeaders = cb => {
-	// Grab list of all connected peers
-	modules.peers.list({ normalized: false }, (err, peers) => {
-		if (!peers || peers.length === 0) {
-			library.logger.debug('Transport->broadcastHeaders: No peers found');
-			return setImmediate(cb);
+	// Grab some connected peers. Try to include some peers with non-matching broadhash in the list.
+	modules.peers.list(
+		{ normalized: false, matchingPeersRatio: constants.matchingPeersRatio },
+		(err, peers) => {
+			if (!peers || peers.length === 0) {
+				library.logger.debug('Transport->broadcastHeaders: No peers found');
+				return setImmediate(cb);
+			}
+
+			library.logger.debug(
+				'Transport->broadcastHeaders: Broadcasting headers to remote peers',
+				{ count: peers.length }
+			);
+
+			// Execute remote procedure updateMyself for every peer
+			async.each(
+				peers,
+				(peer, eachCb) => {
+					peer.rpc.updateMyself(library.logic.peers.me(), err => {
+						if (err) {
+							library.logger.debug(
+								'Transport->broadcastHeaders: Failed to notify peer about self',
+								{ peer: peer.string, err }
+							);
+						} else {
+							library.logger.debug(
+								'Transport->broadcastHeaders: Successfully notified peer about self',
+								{ peer: peer.string }
+							);
+						}
+						return eachCb();
+					});
+				},
+				() => setImmediate(cb)
+			);
 		}
-
-		library.logger.debug(
-			'Transport->broadcastHeaders: Broadcasting headers to remote peers',
-			{ count: peers.length }
-		);
-
-		// Execute remote procedure updateMyself for every peer
-		async.each(
-			peers,
-			(peer, eachCb) => {
-				peer.rpc.updateMyself(library.logic.peers.me(), err => {
-					if (err) {
-						library.logger.debug(
-							'Transport->broadcastHeaders: Failed to notify peer about self',
-							{ peer: peer.string, err }
-						);
-					} else {
-						library.logger.debug(
-							'Transport->broadcastHeaders: Successfully notified peer about self',
-							{ peer: peer.string }
-						);
-					}
-					return eachCb();
-				});
-			},
-			() => setImmediate(cb)
-		);
-	});
+	);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
 		"valid-url": "=1.0.9",
 		"validator": "=7.0.0",
 		"validator.js": "=2.0.3",
-		"wamp-socket-cluster": "=2.0.0-beta.2",
+		"wamp-socket-cluster":
+			"LiskHQ/wamp-socket-cluster#59548fe7f7cb3703554d0943018f48bd1160026c",
 		"z-schema": "=3.18.2"
 	},
 	"devDependencies": {

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -899,7 +899,7 @@ describe('peers', () => {
 			return expect(jobsQueueSpy).calledWith(
 				'peersDiscoveryAndUpdate',
 				sinon.match.func,
-				30000
+				10000
 			);
 		});
 	});

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1353,10 +1353,14 @@ describe('transport', () => {
 				transportInstance.broadcastHeaders(done);
 			});
 
-			it('should call modules.peers.list with {normalized: false}', () => {
+			it('should call modules.peers.list with {normalized: false, matchingPeersRatio: constants.matchingPeersRatio}', () => {
 				expect(modules.peers.list.calledOnce).to.be.true;
-				return expect(modules.peers.list.calledWith({ normalized: false })).to
-					.be.true;
+				return expect(
+					modules.peers.list.calledWith({
+						normalized: false,
+						matchingPeersRatio: constants.matchingPeersRatio,
+					})
+				).to.be.true;
 			});
 
 			describe('when peers = undefined', () => {


### PR DESCRIPTION
### What was the problem?

When launching a network, there was a situation where a node would only broadcast to peers that had a matching broadhash and ignore the others which were slightly delayed; in the early stages of a network there is a short timeframe when the broadhash only exists for half of the nodes (since the broadhash only exits after the 5th block); this may be the cause of a fork in the early stages of a network (from the 6th block).

### How did I fix it?

Half of all peers selected to receive our broadcast will be ones that do not match our own broadhash.

### How to test it?

Betanet.

### Review checklist

* The PR solves #2025
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
