### PR TITLE
Application gets stuck when deleting last block of the same round twice - Closes #2032

### DIFF
--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -154,6 +154,15 @@ class RoundsRepository {
 	}
 
 	/**
+	 * Checks round snapshot availability for particular round.
+	 *
+	 * @returns {Promise}
+	 */
+	checkSnapshotAvailability(round) {
+		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round });
+	}
+
+	/**
 	 * Create table for the round snapshot.
 	 *
 	 * @returns {Promise}

--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -159,7 +159,11 @@ class RoundsRepository {
 	 * @returns {Promise}
 	 */
 	checkSnapshotAvailability(round) {
-		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round }, a => a ? a.available : null );
+		return this.db.oneOrNone(
+			sql.checkSnapshotAvailability,
+			{ round },
+			a => (a ? a.available : null)
+		);
 	}
 
 	/**

--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -159,10 +159,10 @@ class RoundsRepository {
 	 * @returns {Promise}
 	 */
 	checkSnapshotAvailability(round) {
-		return this.db.oneOrNone(
+		return this.db.one(
 			sql.checkSnapshotAvailability,
 			{ round },
-			a => (a ? a.available : null)
+			a => a.available
 		);
 	}
 

--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -159,7 +159,16 @@ class RoundsRepository {
 	 * @returns {Promise}
 	 */
 	checkSnapshotAvailability(round) {
-		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round }, a => a ? a.available : null );
+		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round }, a => a ? a.available : null);
+	}
+
+	/**
+	 * Get number of records from mem_round_snapshot table.
+	 *
+	 * @returns {Promise}
+	 */
+	countRoundSnapshot() {
+		return this.db.one(sql.countRoundSnapshot, [], a => +a.count);
 	}
 
 	/**

--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -159,7 +159,7 @@ class RoundsRepository {
 	 * @returns {Promise}
 	 */
 	checkSnapshotAvailability(round) {
-		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round });
+		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round }, a => a ? a.available : null );
 	}
 
 	/**

--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -159,11 +159,7 @@ class RoundsRepository {
 	 * @returns {Promise}
 	 */
 	checkSnapshotAvailability(round) {
-		return this.db.one(
-			sql.checkSnapshotAvailability,
-			{ round },
-			a => a.available
-		);
+		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round }, a => a ? a.available : null );
 	}
 
 	/**

--- a/db/repos/rounds.js
+++ b/db/repos/rounds.js
@@ -159,7 +159,11 @@ class RoundsRepository {
 	 * @returns {Promise}
 	 */
 	checkSnapshotAvailability(round) {
-		return this.db.oneOrNone(sql.checkSnapshotAvailability, { round }, a => a ? a.available : null);
+		return this.db.oneOrNone(
+			sql.checkSnapshotAvailability,
+			{ round },
+			a => (a ? a.available : null)
+		);
 	}
 
 	/**

--- a/db/sql/index.js
+++ b/db/sql/index.js
@@ -103,6 +103,7 @@ module.exports = {
 		performVotesSnapshot: link('rounds/perform_votes_snapshot.sql'),
 		restoreVotesSnapshot: link('rounds/restore_votes_snapshot.sql'),
 		checkSnapshotAvailability: link('rounds/check_snapshot_availability.sql'),
+		countRoundSnapshot: link('rounds/count_round_snapshot.sql'),
 		getMemRounds: link('rounds/get_mem_rounds.sql'),
 		flush: link('rounds/flush.sql'),
 		truncateBlocks: link('rounds/truncate_blocks.sql'),

--- a/db/sql/index.js
+++ b/db/sql/index.js
@@ -102,6 +102,7 @@ module.exports = {
 		clearVotesSnapshot: link('rounds/clear_votes_snapshot.sql'),
 		performVotesSnapshot: link('rounds/perform_votes_snapshot.sql'),
 		restoreVotesSnapshot: link('rounds/restore_votes_snapshot.sql'),
+		checkSnapshotAvailability: link('rounds/check_snapshot_availability.sql'),
 		getMemRounds: link('rounds/get_mem_rounds.sql'),
 		flush: link('rounds/flush.sql'),
 		truncateBlocks: link('rounds/truncate_blocks.sql'),

--- a/db/sql/rounds/check_snapshot_availability.sql
+++ b/db/sql/rounds/check_snapshot_availability.sql
@@ -14,9 +14,22 @@
 
 
 /*
-  DESCRIPTION: Check round snapshot availability for a particular round.
+  DESCRIPTION: Check round snapshot availability for a particular round
+               Returns TRUE when snapshot available or table is empty, FALSE otherwise
 
   PARAMETERS: round - Round for we are checking availability
 */
 
-SELECT 1 AS available FROM mem_round_snapshot WHERE round = ${round} LIMIT 1
+SELECT (
+	CASE WHEN (
+		SELECT 1 AS available FROM mem_round_snapshot WHERE round = ${round} LIMIT 1
+	) = 1 THEN TRUE
+	ELSE (
+		CASE WHEN (
+			SELECT COUNT(*) FROM mem_round_snapshot
+		) = 0 THEN TRUE
+		ELSE FALSE
+		END
+	)
+	END
+) AS available

--- a/db/sql/rounds/check_snapshot_availability.sql
+++ b/db/sql/rounds/check_snapshot_availability.sql
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: Check round snapshot availability for a particular round.
+
+  PARAMETERS: round - Round for we are checking availability
+*/
+
+SELECT 1 FROM mem_round_snapshot WHERE round = ${round} LIMIT 1

--- a/db/sql/rounds/check_snapshot_availability.sql
+++ b/db/sql/rounds/check_snapshot_availability.sql
@@ -14,22 +14,9 @@
 
 
 /*
-  DESCRIPTION: Check round snapshot availability for a particular round
-               Returns TRUE when snapshot available or table is empty, FALSE otherwise
+  DESCRIPTION: Check round snapshot availability for a particular round.
 
   PARAMETERS: round - Round for we are checking availability
 */
 
-SELECT (
-	CASE WHEN (
-		SELECT 1 AS available FROM mem_round_snapshot WHERE round = ${round} LIMIT 1
-	) = 1 THEN TRUE
-	ELSE (
-		CASE WHEN (
-			SELECT COUNT(*) FROM mem_round_snapshot
-		) = 0 THEN TRUE
-		ELSE FALSE
-		END
-	)
-	END
-) AS available
+SELECT 1 AS available FROM mem_round_snapshot WHERE round = ${round} LIMIT 1

--- a/db/sql/rounds/check_snapshot_availability.sql
+++ b/db/sql/rounds/check_snapshot_availability.sql
@@ -19,4 +19,4 @@
   PARAMETERS: round - Round for we are checking availability
 */
 
-SELECT 1 FROM mem_round_snapshot WHERE round = ${round} LIMIT 1
+SELECT 1 AS available FROM mem_round_snapshot WHERE round = ${round} LIMIT 1

--- a/db/sql/rounds/count_round_snapshot.sql
+++ b/db/sql/rounds/count_round_snapshot.sql
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: Counts all records from mem_round_snapshot table.
+
+  PARAMETERS: none
+*/
+
+SELECT COUNT(*) FROM mem_round_snapshot

--- a/db/sql/rounds/restore_round_snapshot.sql
+++ b/db/sql/rounds/restore_round_snapshot.sql
@@ -20,5 +20,3 @@
 */
 
 INSERT INTO mem_round SELECT * FROM mem_round_snapshot;
-
-DROP TABLE IF EXISTS mem_round_snapshot;

--- a/db/sql/rounds/restore_votes_snapshot.sql
+++ b/db/sql/rounds/restore_votes_snapshot.sql
@@ -23,5 +23,3 @@ UPDATE mem_accounts m
 SET vote = b.vote
 FROM mem_votes_snapshot b
 WHERE m.address = b.address;
-
-DROP TABLE IF EXISTS mem_votes_snapshot;

--- a/logic/round.js
+++ b/logic/round.js
@@ -243,9 +243,7 @@ class Round {
 						// Throw an error when round snapshot table is not empty
 						if (count) {
 							throw new Error(
-								`Snapshot for round ${
-									this.scope.round
-								} not available, unable to perform round rollback`
+								`Snapshot for round ${this.scope.round} not available`
 							);
 						}
 					});

--- a/logic/round.js
+++ b/logic/round.js
@@ -228,6 +228,25 @@ class Round {
 	}
 
 	/**
+	 * Checks round snapshot availability for current round.
+	 *
+	 * @returns {Promise}
+	 */
+	checkSnapshotAvailability() {
+		return this.t.rounds
+			.checkSnapshotAvailability(this.scope.round)
+			.then(isAvailable => {
+				if (!isAvailable) {
+					throw new Error(
+						`Snapshot for round ${
+							this.scope.round
+						} not available, unable to perform round rollback`
+					);
+				}
+			});
+	}
+
+	/**
 	 * Calls sql deleteRoundRewards:
 	 * - Removes rewards for entire round from round_rewards table.
 	 * - Performed only when rollback last block of round.

--- a/logic/round.js
+++ b/logic/round.js
@@ -239,18 +239,16 @@ class Round {
 				if (!isAvailable) {
 					// Snapshot for current round is not available, check if round snapshot table is empty,
 					// because we need to allow to restore snapshot in that case (no transactions during entire round)
-					return this.t.rounds
-						.countRoundSnapshot()
-						.then(count => {
-							// Throw an error when round snapshot table is not empty
-							if (count) {
-								throw new Error(
-									`Snapshot for round ${
-										this.scope.round
-										} not available, unable to perform round rollback`
-								);
-							}
-						});
+					return this.t.rounds.countRoundSnapshot().then(count => {
+						// Throw an error when round snapshot table is not empty
+						if (count) {
+							throw new Error(
+								`Snapshot for round ${
+									this.scope.round
+								} not available, unable to perform round rollback`
+							);
+						}
+					});
 				}
 			});
 	}

--- a/logic/round.js
+++ b/logic/round.js
@@ -237,11 +237,20 @@ class Round {
 			.checkSnapshotAvailability(this.scope.round)
 			.then(isAvailable => {
 				if (!isAvailable) {
-					throw new Error(
-						`Snapshot for round ${
-							this.scope.round
-						} not available, unable to perform round rollback`
-					);
+					// Snapshot for current round is not available, check if round snapshot table is empty,
+					// because we need to allow to restore snapshot in that case (no transactions during entire round)
+					return this.t.rounds
+						.countRoundSnapshot()
+						.then(count => {
+							// Throw an error when round snapshot table is not empty
+							if (count) {
+								throw new Error(
+									`Snapshot for round ${
+										this.scope.round
+										} not available, unable to perform round rollback`
+								);
+							}
+						});
 				}
 			});
 	}

--- a/logic/round.js
+++ b/logic/round.js
@@ -450,6 +450,7 @@ class Round {
 			.then(this.applyRound.bind(this))
 			.then(this.updateVotes.bind(this))
 			.then(this.flushRound.bind(this))
+			.then(this.checkSnapshotAvailability.bind(this))
 			.then(this.restoreRoundSnapshot.bind(this))
 			.then(this.restoreVotesSnapshot.bind(this))
 			.then(this.deleteRoundRewards.bind(this))

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1130,6 +1130,22 @@ describe('rounds', () => {
 		});
 	});
 
+	describe('deleting last block of round twice in a row', () => {
+		before(() => {
+			return deleteLastBlockPromise().then(() => {
+				return addTransactionsAndForgePromise(library, [], 0);
+			});
+		});
+
+		after(() => {
+			return addTransactionsAndForgePromise(library, [], 0);
+		});
+
+		it('should be able to delete last block of round again', () => {
+			return deleteLastBlockPromise();
+		});
+	});
+
 	describe('rollback more than 1 round of blocks', () => {
 		let lastBlock;
 

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1182,4 +1182,22 @@ describe('rounds', () => {
 			return expect(lastBlock.height).to.equal(101);
 		});
 	});
+
+	describe('deleting last block of round twice in a row - no transactions during round', () => {
+		before(() => {
+			return Promise.mapSeries([...Array(202)], () => {
+				return addTransactionsAndForgePromise(library, [], 0);
+			});
+		});
+
+		it('should be able to delete last block of round', () => {
+			return deleteLastBlockPromise();
+		});
+
+		it('should be able to delete last block of round again', () => {
+			return addTransactionsAndForgePromise(library, [], 0).then(() => {
+				return deleteLastBlockPromise();
+			});
+		});
+	});
 });

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1173,7 +1173,7 @@ describe('rounds', () => {
 
 		it('should fail when try to delete one more block (last block of round 1)', () => {
 			return expect(deleteLastBlockPromise()).to.eventually.be.rejectedWith(
-				'Snapshot for round 1 not available, unable to perform round rollback'
+				'Snapshot for round 1 not available'
 			);
 		});
 

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1173,7 +1173,7 @@ describe('rounds', () => {
 
 		it('should fail when try to delete one more block (last block of round 1)', () => {
 			return expect(deleteLastBlockPromise()).to.eventually.be.rejectedWith(
-				'relation "mem_round_snapshot" does not exist'
+				'Snapshot for round 1 not available, unable to perform round rollback'
 			);
 		});
 

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -726,6 +726,33 @@ describe('rounds', () => {
 			});
 		});
 
+		describe('deleting last block of round twice in a row', () => {
+			before(() => {
+				return addTransactionsAndForgePromise(library, [], 0);
+			});
+
+			it('should be able to delete last block of round again', () => {
+				return deleteLastBlockPromise();
+			});
+
+			// FIXME: Unskip that test after https://github.com/LiskHQ/lisk/issues/1781 is closed
+			// eslint-disable-next-line
+			it.skip('mem_accounts table should be equal to one generated before last block of round deletion', () => {
+				return getMemAccounts().then(_accounts => {
+					expect(_accounts).to.deep.equal(round.accountsBeforeLastBlock);
+				});
+			});
+
+			it('delegates list should be equal to one generated at the beginning of round 1', () => {
+				const lastBlock = library.modules.blocks.lastBlock.get();
+				return generateDelegateListPromise(lastBlock.height + 1, null).then(
+					delegatesList => {
+						expect(delegatesList).to.deep.equal(round.delegatesList);
+					}
+				);
+			});
+		});
+
 		describe('round rollback when forger of last block of round is unvoted', () => {
 			let lastBlock;
 			let lastBlockForger;
@@ -1127,22 +1154,6 @@ describe('rounds', () => {
 					);
 				});
 			});
-		});
-	});
-
-	describe('deleting last block of round twice in a row', () => {
-		before(() => {
-			return deleteLastBlockPromise().then(() => {
-				return addTransactionsAndForgePromise(library, [], 0);
-			});
-		});
-
-		after(() => {
-			return addTransactionsAndForgePromise(library, [], 0);
-		});
-
-		it('should be able to delete last block of round again', () => {
-			return deleteLastBlockPromise();
 		});
 	});
 

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -618,6 +618,12 @@ describe('db', () => {
 				expect(count).to.be.an('number');
 				return expect(count).to.be.eql(0);
 			});
+
+			it('should reject with error if called without performing the snapshot', () => {
+				return expect(db.rounds.countRoundSnapshot()).to.be.rejectedWith(
+					'relation "mem_round_snapshot" does not exist'
+				);
+			});
 		});
 
 		describe('getDelegatesSnapshot()', () => {

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -490,6 +490,80 @@ describe('db', () => {
 			});
 		});
 
+		describe('checkSnapshotAvailability()', () => {
+			afterEach(() => {
+				return db.rounds.clearRoundSnapshot();
+			});
+
+			it('should use the correct SQL file with one parameter', function*() {
+				sinonSandbox.spy(db, 'oneOrNone');
+
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				yield db.rounds.checkSnapshotAvailability('1');
+
+				expect(db.oneOrNone.firstCall.args[0]).to.eql(roundsSQL.checkSnapshotAvailability);
+				expect(db.oneOrNone.firstCall.args[1]).to.eql({ round: '1' });
+				return expect(db.oneOrNone).to.be.calledOnce;
+			});
+
+			it('should return 1 when snapshot for requested round is available', function*() {
+				const account = accountsFixtures.Account();
+
+				const round1 = roundsFixtures.Round({
+					round: 1,
+					delegate: account.publicKey,
+				});
+
+				yield db.query(
+					db.rounds.pgp.helpers.insert(round1, null, { table: 'mem_round' })
+				);
+
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				const result = yield db.rounds.checkSnapshotAvailability(round1.round);
+
+				return expect(result).to.be.be.eql(1);
+			});
+
+			it('should return null when snapshot for requested round is not available', function*() {
+				const account = accountsFixtures.Account();
+
+				const round1 = roundsFixtures.Round({
+					round: 1,
+					delegate: account.publicKey,
+				});
+
+				yield db.query(
+					db.rounds.pgp.helpers.insert(round1, null, { table: 'mem_round' })
+				);
+
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				const result = yield db.rounds.checkSnapshotAvailability(round1.round + 1);
+
+				return expect(result).to.be.be.eql(null);
+			});
+
+			it('should return null when no round number is provided', function*() {
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				const result = yield db.rounds.checkSnapshotAvailability();
+
+				return expect(result).to.be.be.eql(null);
+			});
+
+			it('should reject with error if called without performing the snapshot', () => {
+				return expect(db.rounds.checkSnapshotAvailability(1)).to.be.rejectedWith(
+					'relation "mem_round_snapshot" does not exist'
+				);
+			});
+		});
+
 		describe('getDelegatesSnapshot()', () => {
 			afterEach(() => {
 				return db.rounds.clearVotesSnapshot();

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -503,7 +503,9 @@ describe('db', () => {
 
 				yield db.rounds.checkSnapshotAvailability('1');
 
-				expect(db.oneOrNone.firstCall.args[0]).to.eql(roundsSQL.checkSnapshotAvailability);
+				expect(db.oneOrNone.firstCall.args[0]).to.eql(
+					roundsSQL.checkSnapshotAvailability
+				);
 				expect(db.oneOrNone.firstCall.args[1]).to.eql({ round: '1' });
 				return expect(db.oneOrNone).to.be.calledOnce;
 			});
@@ -543,7 +545,9 @@ describe('db', () => {
 				// Perform round snapshot
 				yield db.rounds.performRoundSnapshot();
 
-				const result = yield db.rounds.checkSnapshotAvailability(round1.round + 1);
+				const result = yield db.rounds.checkSnapshotAvailability(
+					round1.round + 1
+				);
 
 				return expect(result).to.be.be.eql(null);
 			});
@@ -558,9 +562,9 @@ describe('db', () => {
 			});
 
 			it('should reject with error if called without performing the snapshot', () => {
-				return expect(db.rounds.checkSnapshotAvailability(1)).to.be.rejectedWith(
-					'relation "mem_round_snapshot" does not exist'
-				);
+				return expect(
+					db.rounds.checkSnapshotAvailability(1)
+				).to.be.rejectedWith('relation "mem_round_snapshot" does not exist');
 			});
 		});
 

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -496,18 +496,18 @@ describe('db', () => {
 			});
 
 			it('should use the correct SQL file with one parameter', function*() {
-				sinonSandbox.spy(db, 'oneOrNone');
+				sinonSandbox.spy(db, 'one');
 
 				// Perform round snapshot
 				yield db.rounds.performRoundSnapshot();
 
 				yield db.rounds.checkSnapshotAvailability('1');
 
-				expect(db.oneOrNone.firstCall.args[0]).to.eql(
+				expect(db.one.firstCall.args[0]).to.eql(
 					roundsSQL.checkSnapshotAvailability
 				);
-				expect(db.oneOrNone.firstCall.args[1]).to.eql({ round: '1' });
-				return expect(db.oneOrNone).to.be.calledOnce;
+				expect(db.one.firstCall.args[1]).to.eql({ round: '1' });
+				return expect(db.one).to.be.calledOnce;
 			});
 
 			it('should return true when snapshot for requested round is available', function*() {

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -564,6 +564,61 @@ describe('db', () => {
 			});
 		});
 
+		describe('countRoundSnapshot()', () => {
+			afterEach(() => {
+				return db.rounds.clearRoundSnapshot();
+			});
+
+			it('should use the correct SQL file with one parameter', function*() {
+				sinonSandbox.spy(db, 'one');
+
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				yield db.rounds.countRoundSnapshot();
+
+				expect(db.one.firstCall.args[0]).to.eql(roundsSQL.countRoundSnapshot);
+				expect(db.one.firstCall.args[1]).to.eql([]);
+				return expect(db.one).to.be.calledOnce;
+			});
+
+			it('should return proper number of records when table is not empty', function*() {
+				// Seed some data to mem_rounds
+				const rounds = [
+					roundsFixtures.Round(),
+					roundsFixtures.Round(),
+					roundsFixtures.Round(),
+				];
+
+				yield db.query(
+					db.rounds.pgp.helpers.insert(rounds[0], null, { table: 'mem_round' })
+				);
+				yield db.query(
+					db.rounds.pgp.helpers.insert(rounds[1], null, { table: 'mem_round' })
+				);
+				yield db.query(
+					db.rounds.pgp.helpers.insert(rounds[2], null, { table: 'mem_round' })
+				);
+
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				const count = yield db.rounds.countRoundSnapshot();
+
+				expect(count).to.be.an('number');
+				return expect(count).to.be.eql(rounds.length);
+			});
+
+			it('should return 0 when table is empty', function*() {
+				// Perform round snapshot
+				yield db.rounds.performRoundSnapshot();
+
+				const count = yield db.rounds.countRoundSnapshot();
+
+				expect(count).to.be.an('number');
+				return expect(count).to.be.eql(0);
+			});
+		});
 
 		describe('getDelegatesSnapshot()', () => {
 			afterEach(() => {

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -680,7 +680,7 @@ describe('rounds', () => {
 			res = round.checkSnapshotAvailability();
 
 			return expect(res).to.eventually.be.rejectedWith(
-				'Snapshot for round 2 not available, unable to perform round rollback'
+				'Snapshot for round 2 not available'
 			);
 		});
 	});

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -619,8 +619,14 @@ describe('rounds', () => {
 
 		before(done => {
 			// Init stubs and scope
-			stubs.checkSnapshotAvailability = sinonSandbox.stub(db.rounds, 'checkSnapshotAvailability');
-			stubs.countRoundSnapshot = sinonSandbox.stub(db.rounds, 'countRoundSnapshot');
+			stubs.checkSnapshotAvailability = sinonSandbox.stub(
+				db.rounds,
+				'checkSnapshotAvailability'
+			);
+			stubs.countRoundSnapshot = sinonSandbox.stub(
+				db.rounds,
+				'countRoundSnapshot'
+			);
 			scope = _.cloneDeep(validScope);
 			done();
 		});

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -620,8 +620,8 @@ describe('rounds', () => {
 		before(done => {
 			// Init stubs
 			stub = sinonSandbox.stub(db.rounds, 'checkSnapshotAvailability');
-			stub.withArgs(1).resolves(1);
-			stub.withArgs(2).resolves(null);
+			stub.withArgs(1).resolves(true);
+			stub.withArgs(2).resolves(false);
 
 			scope = _.cloneDeep(validScope);
 			scope.round = 1;

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -431,11 +431,15 @@ describe('blocks/chain', () => {
 			});
 
 			it('should call a callback with error', done => {
-				blocksChainModule.deleteBlock(1, err => {
-					expect(err).to.equal('Blocks#deleteBlock error');
-					expect(loggerStub.error.args[0][0]).to.contains('deleteBlock-ERR');
-					done();
-				}, library.db);
+				blocksChainModule.deleteBlock(
+					1,
+					err => {
+						expect(err).to.equal('Blocks#deleteBlock error');
+						expect(loggerStub.error.args[0][0]).to.contains('deleteBlock-ERR');
+						done();
+					},
+					library.db
+				);
 			});
 		});
 
@@ -445,9 +449,13 @@ describe('blocks/chain', () => {
 			});
 
 			it('should call a callback with no error', done => {
-				blocksChainModule.deleteBlock(1, () => {
-					done();
-				}, library.db);
+				blocksChainModule.deleteBlock(
+					1,
+					() => {
+						done();
+					},
+					library.db
+				);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?
Unable to delete last block of round twice in a row because round snapshot was not available.
### How did I fix it?
- Keep `mem_round_snapshot` and `mem_votes_snapshot` tables after round rollback, so those tables can be reused for same round.
- Check if there is snapshot available for current round before we restore it, to prevent usage of wrong snapshot (results with corrupted data) when going back more than one round of blocks.

It's not the best solution, but not so hard to implement and reliable. 
### How to test it?
Run test suite.
### Review checklist

* The PR solves #2032
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
