### PR TITLE
Undo on transactions called with wrong block - Closes #2037

### DIFF
--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -704,7 +704,7 @@ __private.popLastBlock = function(oldLastBlock, cb) {
 						oldLastBlock.transactions.reverse(),
 						transaction =>
 							__private
-								.undoStep(transaction, secondLastBlock, tx)
+								.undoStep(transaction, oldLastBlock, tx)
 								.then(() => __private.undoUnconfirmStep(transaction, tx))
 					);
 				})


### PR DESCRIPTION
### What was the problem?
Undo on transactions should be called with block which those transactions come from.
### How did I fix it?
Pass proper block to undoStep from popLastBlock.
### How to test it?
There are no complete unit tests for that function. However described scenario is covered in functional system rounds tests as part of https://github.com/LiskHQ/lisk/pull/2035.
### Review checklist

* The PR solves #2037
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
