### PR TITLE
Peer updates itself every-time during peers discovery and update - Closes #2029

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -813,11 +813,15 @@ Peers.prototype.onPeersReady = function() {
 				updatePeers(seriesCb) {
 					let updated = 0;
 					const peers = library.logic.peers.list();
+					library.logger.trace('Total list of peers', { count: peers.length });
 
-					library.logger.trace('Updating peers', { count: peers.length });
+					const acceptablePeers = self.acceptable(peers);
+					library.logger.trace('Acceptable peers to update', {
+						count: acceptablePeers.length,
+					});
 
 					async.each(
-						peers,
+						acceptablePeers,
 						(peer, eachCb) => {
 							// If peer is not banned and not been updated during last 3 sec - ping
 							if (

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -813,15 +813,11 @@ Peers.prototype.onPeersReady = function() {
 				updatePeers(seriesCb) {
 					let updated = 0;
 					const peers = library.logic.peers.list();
-					library.logger.trace('Total list of peers', { count: peers.length });
 
-					const acceptablePeers = self.acceptable(peers);
-					library.logger.trace('Acceptable peers to update', {
-						count: acceptablePeers.length,
-					});
+					library.logger.trace('Updating peers', { count: peers.length });
 
 					async.each(
-						acceptablePeers,
+						peers,
 						(peer, eachCb) => {
 							// If peer is not banned and not been updated during last 3 sec - ping
 							if (

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -274,7 +274,7 @@ __private.updatePeerStatus = function(err, status, peer) {
 			// state so that the node doesn't keep trying to reconnect to itself.
 			peer.applyHeaders({
 				state: Peer.STATE.BANNED,
-				nonce: self.me().nonce,
+				nonce: library.logic.peers.me().nonce,
 			});
 		} else {
 			library.logic.peers.remove(peer);


### PR DESCRIPTION
### What was the problem?
- Bug in the way calling `self.me()`
- In the process of `peersDiscoveryAndUpdate` (every 10 sec) the peer updates itself
### How did I fix it?
- Updated calling `self.me()` to `library.logic.peers.me()`
- Before the update, the peer list will be filtered by calling `self.acceptable(peers)`
### How to test it?
Run integration test and enable `trace` level log there should be any update happening to self-peer during the discovery process.
### Review checklist

* The PR solves #2029 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
