### PR TITLE
Update wamp-socket-cluster to v1.0.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"valid-url": "=1.0.9",
 		"validator": "=7.0.0",
 		"validator.js": "=2.0.3",
-		"wamp-socket-cluster": "=2.0.0-beta.2",
+		"wamp-socket-cluster": "=2.0.0-beta.3",
 		"z-schema": "=3.18.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### What was the problem?
`wamp-socket-cluster` 1.0.0-beta.2 limits call for a specific procedure to 100.
### How did I fix it?
`wamp-socket-cluster` 1.0.0-beta.3 removes the call of a specific procedure.
### How to test it?
The error `exceeded max calls limit` should not be visible.
### Review checklist

* The PR solves #2044 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
