### PR TITLE
Fix unreachable peers code of self-update - Closes #2029

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -272,7 +272,7 @@ __private.updatePeerStatus = function(err, status, peer) {
 			// state so that the node doesn't keep trying to reconnect to itself.
 			peer.applyHeaders({
 				state: Peer.STATE.BANNED,
-				nonce: self.me().nonce,
+				nonce: library.logic.peers.me().nonce,
 			});
 		} else {
 			library.logic.peers.remove(peer);


### PR DESCRIPTION
### What was the problem?
- Bug in the way calling `self.me()`
### How did I fix it?
- Updated calling `self.me()` to `library.logic.peers.me()`
### How to test it?
Run integration test and enable `trace` level log there should be any update happening to self-peer during the discovery process.
### Review checklist

* The PR solves #2029 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
