### PR TITLE
Count peers after applying filter instead of total - Closes #2020 

### DIFF
--- a/api/controllers/peers.js
+++ b/api/controllers/peers.js
@@ -77,7 +77,7 @@ PeersController.getPeers = function(context, next) {
 			meta: {
 				offset: filters.offset,
 				limit: filters.limit,
-				total: modules.peers.shared.getPeersCount(),
+				count: modules.peers.shared.getPeersCount(),
 			},
 		});
 	});

--- a/api/controllers/peers.js
+++ b/api/controllers/peers.js
@@ -77,7 +77,7 @@ PeersController.getPeers = function(context, next) {
 			meta: {
 				offset: filters.offset,
 				limit: filters.limit,
-				count: modules.peers.shared.getPeersCount(),
+				count: modules.peers.shared.getPeersCountByFilter(filters),
 			},
 		});
 	});

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -77,19 +77,18 @@ class Peers {
 
 // Private methods
 /**
- * Returns peers length after getting them by filter.
+ * Returns peers length by filter but without offset and limit.
  *
  * @private
  * @param {Object} filter
- * @param {function} cb - Callback function
- * @returns {setImmediateCallback} cb, null, peers length
+ * @returns {int} count
  * @todo Add description for the params
  */
-__private.countByFilter = function(filter, cb) {
-	filter.normalized = false;
-	__private.getByFilter(filter, (err, peers) =>
-		setImmediate(cb, null, peers.length)
-	);
+__private.getCountByFilter = function(filter) {
+	delete filter.limit;
+	delete filter.offset;
+	var peers = __private.getByFilter(filter);
+	return peers.length;
 };
 
 /**
@@ -937,6 +936,26 @@ Peers.prototype.shared = {
 	 */
 	getPeersCount() {
 		return library.logic.peers.list(true).length;
+	},
+
+	/**
+	 * Utility method to get peers count by filter.
+	 *
+	 * @param {Object} parameters - Object of all parameters
+	 * @param {string} parameters.ip - IP of the peer
+	 * @param {string} parameters.wsPort - WS Port of the peer
+	 * @param {string} parameters.httpPort - Web Socket Port of the peer
+	 * @param {string} parameters.os - OS of the peer
+	 * @param {string} parameters.version - Version the peer is running
+	 * @param {int} parameters.state - Peer State
+	 * @param {int} parameters.height - Current peer height
+	 * @param {string} parameters.broadhash - Peer broadhash
+	 * @returns {int} count
+	 * @todo Add description for the return value
+	 */
+	getPeersCountByFilter(parameters) {
+		parameters.normalized = true;
+		return __private.getCountByFilter(parameters);
 	},
 };
 

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -85,6 +85,7 @@ class Peers {
  * @todo Add description for the params
  */
 __private.getCountByFilter = function(filter) {
+	filter.normalized = false;
 	delete filter.limit;
 	delete filter.offset;
 	var peers = __private.getByFilter(filter);
@@ -945,7 +946,6 @@ Peers.prototype.shared = {
 	 * @todo Add description for the return value
 	 */
 	getPeersCountByFilter(parameters) {
-		parameters.normalized = true;
 		return __private.getCountByFilter(parameters);
 	},
 };

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -930,15 +930,6 @@ Peers.prototype.shared = {
 	},
 
 	/**
-	 * Description for getPeersCount.
-	 *
-	 * @todo Add description for the function
-	 */
-	getPeersCount() {
-		return library.logic.peers.list(true).length;
-	},
-
-	/**
 	 * Utility method to get peers count by filter.
 	 *
 	 * @param {Object} parameters - Object of all parameters

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -58,7 +58,7 @@ info:
     ## List of Endpoints
     All possible API endpoints for Lisk Core are listed below.
     Click on an endpoint to show descriptions, details and examples.
-  version: '1.0.27'
+  version: '1.0.28'
   contact:
     email: admin@lisk.io
   license:

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -1341,14 +1341,14 @@ definitions:
        required:
          - offset
          - limit
-         - total
+         - count
        properties:
          offset:
            $ref: '#/definitions/Offset'
          limit:
            $ref: '#/definitions/Limit'
-         total:
-           description: Total number of available peers
+         count:
+           description: Number of peers in the response
            type: integer
            example: 100
       links:


### PR DESCRIPTION
### What was the problem?

Endpoint returned always the total number of peers no matter which filter we were requesting.

### How did I fix it?

Instead of ~peers.getPeersCount~, we use now `peers.getCountByFilter` + removing offset and limit before using the filter. 

### How to test it?

`mocha tes/functional/http/get/peers.js`

### Review checklist

* The PR solves #2020
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated