### PR TITLE
Remove rank parameter in delegates endpoint - Closes #1988

### DIFF
--- a/api/controllers/delegates.js
+++ b/api/controllers/delegates.js
@@ -54,7 +54,6 @@ DelegatesController.getDelegates = function(context, next) {
 		offset: params.offset.value,
 		sort: params.sort.value,
 		search: params.search.value,
-		rank: params.rank.value,
 	};
 
 	// Remove filters with null values

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -58,7 +58,7 @@ info:
     ## List of Endpoints
     All possible API endpoints for Lisk Core are listed below.
     Click on an endpoint to show descriptions, details and examples.
-  version: '1.0.27'
+  version: '1.0.28'
   contact:
     email: admin@lisk.io
   license:

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -563,12 +563,6 @@ paths:
           type: string
           minLength: 1
           maxLength: 20
-        - name: rank
-          in: query
-          description: Delegate rank
-          type: string
-          minLength: 1
-          maxLength: 20
         - in: query
           name: sort
           description: Fields to sort results by


### PR DESCRIPTION
### What was the problem?
The endpoint /api/delegates was taking a rank parameter which provided all the delegates rather than providing the delegates with the provided rank.

### How did I fix it?
Removed the rank parameter from swagger, also removed it from controllers/delegates.js

### How to test it?
View the /api/delegates endpoint with a rank parameter.

### Review checklist

* The PR solves #1988
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated