### PR TITLE
Nightly builds changes - Closes #2027

### DIFF
--- a/Jenkinsfile.nightly-build
+++ b/Jenkinsfile.nightly-build
@@ -14,7 +14,11 @@
 
 import java.text.SimpleDateFormat
 
-properties([pipelineTriggers([cron('15 2 * * *')])])
+properties([pipelineTriggers([cron('15 2 * * *')]),
+    parameters([
+    string(defaultValue: "dev", description: 'Network', name: 'NETWORK'),
+   ])
+])
 
 def dateFormat = new SimpleDateFormat("yyyyMMdd")
 def date = new Date()
@@ -32,18 +36,18 @@ pipeline {
         skipDefaultCheckout true
     }
     stages {
-        stage("Prepare workspace") {
+    	stage("Prepare workspace") {
             steps {
-                library identifier: 'lisk-jenkins@ab-lisk-build', retriever: modernSCM(
-                [$class: 'GitSCMSource',
-                remote: 'https://github.com/LiskHQ/lisk-jenkins.git'])
+            	library identifier: 'lisk-jenkins@master', retriever: modernSCM(
+                    [$class: 'GitSCMSource',
+                    remote: 'https://github.com/LiskHQ/lisk-jenkins.git'])
             }
-        }
+    	}
         stage('Build release') {
             steps {
-                script {
-                    def release = liskBuild(branch: "${env.BRANCH_NAME}", network: "dev")
-                    env.VERSION =  release.version
+            	script {
+                    def release = liskBuild(branch: env.BRANCH_NAME, network: params.NETWORK)
+                    env.VERSION = release.version
                     env.RELEASE_FILE =  release.file
                     env.DESTINATION_FILE = "lisk-${env.VERSION}-${timestamp}-Linux-x86_64.tar.gz"
                 }
@@ -59,10 +63,14 @@ pipeline {
         stage('Upload nightly release.') {
             steps {
                 dir("${env.WORKSPACE}") {
-                    sh """
-                    s3cmd put --acl-public ${env.DESTINATION_FILE} s3:///lisk-nightly/lisk-core/${env.DESTINATION_FILE}
-                    s3cmd put --acl-public ${env.DESTINATION_FILE}.SHA256 s3:///lisk-nightly/lisk-core/${env.DESTINATION_FILE}.SHA256
-                    """
+                    script {
+                        if (params.NETWORK == 'dev') {
+                            sh """
+                            s3cmd put --acl-public ${env.DESTINATION_FILE} s3:///lisk-releases/lisk-core/devnet/${env.DESTINATION_FILE}
+                            s3cmd put --acl-public ${env.DESTINATION_FILE}.SHA256 s3:///lisk-releases/lisk-core/devnet/${env.DESTINATION_FILE}.SHA256
+                            """
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile.nightly-build
+++ b/Jenkinsfile.nightly-build
@@ -32,20 +32,20 @@ pipeline {
         skipDefaultCheckout true
     }
     stages {
-    	stage("Prepare workspace") {
-    		steps {
-    			library identifier: 'lisk-jenkins@nh-lisk-build', retriever: modernSCM(
-                 	[$class: 'GitSCMSource',
-                 	remote: 'https://github.com/LiskHQ/lisk-jenkins.git'])
-    		}
-    	}
+        stage("Prepare workspace") {
+            steps {
+                library identifier: 'lisk-jenkins@ab-lisk-build', retriever: modernSCM(
+                [$class: 'GitSCMSource',
+                remote: 'https://github.com/LiskHQ/lisk-jenkins.git'])
+            }
+        }
         stage('Build release') {
             steps {
-            	script {
-					def release = liskBuild(branch: '1.0.0', network: 'dev')
-                 	env.VERSION =  release.version
-                 	env.RELEASE_FILE =  release.file
-                 	env.DESTINATION_FILE = "lisk-${env.VERSION}-${timestamp}-Linux-x86_64.tar.gz"
+                script {
+                    def release = liskBuild(branch: "${env.BRANCH_NAME}", network: "dev")
+                    env.VERSION =  release.version
+                    env.RELEASE_FILE =  release.file
+                    env.DESTINATION_FILE = "lisk-${env.VERSION}-${timestamp}-Linux-x86_64.tar.gz"
                 }
                 dir("${env.WORKSPACE}") {
                     sh """


### PR DESCRIPTION
### What was the problem?

The current nightly build pipeline uses `nh-lisk-build` branch for libs and it should use `master`.
Also, the bucket to push the tarballs has changed to `lisk-releases`.

### How did I fix it?

Changed the branch and the bucket. Also some indentation.

### How to test it?

Already tested the branch in jenkins job `lisk-nightly-build`

### Review checklist

* The PR solves #2027 
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
