### PR TITLE
Add integration test to cover Peer disconnects - Fixes #2002

### DIFF
--- a/test/integration/scenarios/network/peer_disconnect.js
+++ b/test/integration/scenarios/network/peer_disconnect.js
@@ -119,18 +119,27 @@ module.exports = params => {
 			});
 
 			describe('node stop and start', () => {
-				it('stop all the nodes in the network', done => {
-					for (let i = 0; i < totalPeers; i++) {
+				// To validate peers holding socket connection
+				// Need to keep one peer so that we can validate
+				// Duplicate socket connection exists or not
+				it('stop all the nodes in the network except one node', done => {
+					for (let i = 1; i < totalPeers; i++) {
 						stopNode(`node_${i}`);
 					}
-					done();
+					setTimeout(() => {
+						console.info('Wait for nodes to be stopped');
+						done();
+					}, 10000);
 				});
 
 				it('start all nodes that were stopped', done => {
-					for (let i = 0; i < totalPeers; i++) {
+					for (let i = 1; i < totalPeers; i++) {
 						startNode(`node_${i}`);
 					}
-					done();
+					setTimeout(() => {
+						console.info('Wait for nodes to be started');
+						done();
+					}, 10000);
 				});
 
 				describe('after all the node restarts', () => {
@@ -149,7 +158,9 @@ module.exports = params => {
 						);
 					});
 
-					it(`there should be ${expectedOutgoingConnections} established connections from 500[0-9] ports`, done => {
+					// The expected connection becomes 180(new connection) + 18 (previously held connections)
+					it(`there should be ${expectedOutgoingConnections +
+						18} established connections from 500[0-9] ports`, done => {
 						utils.getEstablishedConnections(
 							Array.from(wsPorts),
 							(err, numOfConnections) => {
@@ -157,7 +168,7 @@ module.exports = params => {
 									return done(err);
 								}
 
-								if (numOfConnections <= expectedOutgoingConnections) {
+								if (numOfConnections <= expectedOutgoingConnections + 18) {
 									done();
 								} else {
 									done(

--- a/test/integration/scenarios/network/peer_disconnect.js
+++ b/test/integration/scenarios/network/peer_disconnect.js
@@ -122,7 +122,7 @@ module.exports = params => {
 				// To validate peers holding socket connection
 				// Need to keep one peer so that we can validate
 				// Duplicate socket connection exists or not
-				it('stop all the nodes in the network except one node', done => {
+				it('stop all the nodes in the network except node_0', done => {
 					for (let i = 1; i < totalPeers; i++) {
 						stopNode(`node_${i}`);
 					}
@@ -159,7 +159,7 @@ module.exports = params => {
 					});
 
 					// The expected connection becomes 180(new connection) + 18 (previously held connections)
-					it(`there should be ${expectedOutgoingConnections +
+					it(`should be ${expectedOutgoingConnections +
 						18} established connections from 500[0-9] ports`, done => {
 						utils.getEstablishedConnections(
 							Array.from(wsPorts),

--- a/test/integration/transport.js
+++ b/test/integration/transport.js
@@ -170,7 +170,6 @@ describe('given configurations for 10 nodes with address "127.0.0.1", WS ports 5
 					});
 
 					scenarios.network.peers(params);
-					scenarios.network.peerDisconnect(params);
 
 					describe('when functional tests are successfully executed against 127.0.0.1:5000', () => {
 						before(done => {
@@ -216,6 +215,8 @@ describe('given configurations for 10 nodes with address "127.0.0.1", WS ports 5
 							);
 						});
 					});
+
+					scenarios.network.peerDisconnect(params);
 				});
 			});
 		});


### PR DESCRIPTION
### What was the problem?
The peer disconnect integration test was failing
### How did I fix it?
When all the nodes are stoped except one, and when we start all the nodes again and establish the connection then we will have 180 connections from the new "establish connection" and previous 18 connections
### How to test it?
Run integration test
### Review checklist

* The PR solves #2002 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
