### PR TITLE
Update discovery and update time to get latest information - Closes #2073

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -29,7 +29,7 @@ let self;
 const __private = {};
 let definitions;
 
-const peerDiscoveryFrequency = 30000;
+const peerDiscoveryFrequency = 10000;
 
 /**
  * Main peers methods. Initializes library with scope content.

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -922,11 +922,11 @@ describe('peers', () => {
 			return expect(peers.discover.calledOnce).to.be.ok;
 		});
 
-		it('should start peers discovery process by registering it in jobsQueue every 5 sec', () => {
+		it('should start peers discovery process by registering it in jobsQueue every 10 sec', () => {
 			return expect(jobsQueueSpy).calledWith(
 				'peersDiscoveryAndUpdate',
 				sinon.match.func,
-				30000
+				10000
 			);
 		});
 	});


### PR DESCRIPTION
### What was the problem?
Because peer information update only happens for random 100 peers, and only fetching the peer information every 30s, consensus calculation is most likely to be off.
It causes delegates not to be able to forge right away.

### How did I fix it?
Revert the increased discovery time to 10s.

### How to test it?
Observe update of peers happen every 10s.
### Review checklist

* The PR solves #2076  
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
