### PR TITLE
Move and improve log messages for fork scenarios - Closes #2084

### DIFF
--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -200,7 +200,6 @@ __private.receiveForkFive = function(block, lastBlock, cb) {
 		library.logger.info('Last block stands');
 		return setImmediate(cb); // Discard received block
 	}
-	library.logger.info('Last block loses');
 	async.series(
 		[
 			function(seriesCb) {
@@ -231,6 +230,7 @@ __private.receiveForkFive = function(block, lastBlock, cb) {
 			},
 			// Delete last block
 			function(seriesCb) {
+				library.logger.info('Last block loses due to fork 5');
 				modules.blocks.chain.deleteLastBlock(seriesCb);
 			},
 			// Process received block

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -128,7 +128,6 @@ __private.receiveForkOne = function(block, lastBlock, cb) {
 		library.logger.info('Last block stands');
 		return setImmediate(cb); // Discard received block
 	}
-	library.logger.info('Last block and parent loses');
 	async.series(
 		[
 			function(seriesCb) {
@@ -155,6 +154,7 @@ __private.receiveForkOne = function(block, lastBlock, cb) {
 					// Return first error from checks
 					return setImmediate(seriesCb, check.errors[0]);
 				}
+				library.logger.info('Last block and parent loses due to fork 1');
 				return setImmediate(seriesCb);
 			},
 			// Delete last 2 blocks

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -337,9 +337,6 @@ describe('blocks/process', () => {
 			});
 
 			afterEach(() => {
-				expect(loggerStub.info.args[0][0]).to.equal(
-					'Last block and parent loses'
-				);
 				return expect(
 					modules.delegates.fork.calledWithExactly(sinonSandbox.match.object, 1)
 				).to.be.true;
@@ -439,6 +436,11 @@ describe('blocks/process', () => {
 
 								describe('when succeeds', () => {
 									describe('modules.blocks.chain.deleteLastBlock (first call)', () => {
+										afterEach(() => {
+											return expect(loggerStub.info.args[0][0]).to.equal(
+												'Last block and parent loses due to fork 1'
+											);
+										});
 										describe('when fails', () => {
 											beforeEach(() => {
 												library.logic.block.objectNormalize.returns({
@@ -635,10 +637,9 @@ describe('blocks/process', () => {
 			});
 
 			afterEach(() => {
-				expect(
+				return expect(
 					modules.delegates.fork.calledWithExactly(sinonSandbox.match.object, 5)
 				).to.be.true;
-				return expect(loggerStub.info.args[0][0]).to.equal('Last block loses');
 			});
 
 			describe('library.logic.block.objectNormalize', () => {
@@ -740,6 +741,12 @@ describe('blocks/process', () => {
 										return modules.blocks.verify.verifyReceipt.returns({
 											verified: true,
 										});
+									});
+
+									afterEach(() => {
+										return expect(loggerStub.info.args[0][0]).to.equal(
+											'Last block loses due to fork 5'
+										);
 									});
 
 									describe('modules.blocks.chain.deleteLastBlock', () => {


### PR DESCRIPTION
### What was the problem?
We log Last block and parent loses and Last block stands before actually validating the block. Which means that we may not delete the block, but we log these messages.
### How did I fix it?
Corrected log positions.
### How to test it?
Look at the logs.
### Review checklist

* The PR solves #2084 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
