### PR TITLE
Adjust configuration parameters for broadcasting - Closes #2077

### DIFF
--- a/config.json
+++ b/config.json
@@ -104,10 +104,10 @@
 	"broadcasts": {
 		"active": true,
 		"broadcastInterval": 5000,
-		"broadcastLimit": 20,
+		"broadcastLimit": 25,
 		"parallelLimit": 20,
 		"releaseLimit": 25,
-		"relayLimit": 2
+		"relayLimit": 3
 	},
 	"transactions": {
 		"maxTransactionsPerQueue": 1000

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -68,10 +68,10 @@
 	"broadcasts": {
 		"active": true,
 		"broadcastInterval": 5000,
-		"broadcastLimit": 20,
+		"broadcastLimit": 25,
 		"parallelLimit": 20,
 		"releaseLimit": 25,
-		"relayLimit": 2
+		"relayLimit": 3
 	},
 	"transactions": {
 		"maxTransactionsPerQueue": 1000


### PR DESCRIPTION
### What was the problem?
Relays and broadcasting limit parameters were not properly set. Which caused delaying in broadcasting of blocks. Causing network instability.
### How did I fix it?
Thanks to the great work from @nazarhussain and @shuse2 after mathematically figuring out correct values, we change the value of relayLimit and broadcastingLimit based on our findings described in #2077.
### How to test it?
Set up a devnet, and investigate propagation.
### Review checklist

* The PR solves #2077
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
