### PR TITLE
Backport 0.9.15 changes to 1.0.0 - Closes #2097

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -412,6 +412,8 @@ class Transaction {
 	verify(transaction, sender, requester, checkExists, cb, tx) {
 		let valid = false;
 		let err = null;
+		const INT_32_MIN = -2147483648;
+		const INT_32_MAX = 2147483647;
 
 		if (requester === null || requester === undefined) {
 			requester = {};
@@ -662,6 +664,15 @@ class Transaction {
 		}
 
 		// Check timestamp
+		if (
+			transaction.timestamp < INT_32_MIN ||
+			transaction.timestamp > INT_32_MAX
+		) {
+			return setImmediate(
+				cb,
+				'Invalid transaction timestamp. Timestamp is not in the int32 range'
+			);
+		}
 		if (slots.getSlotNumber(transaction.timestamp) > slots.getSlotNumber()) {
 			return setImmediate(
 				cb,

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -737,7 +737,9 @@ describe('transaction', () => {
 			delete transaction.signature;
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.eql('Invalid transaction timestamp. Timestamp is not in the int32 range');
+				expect(err).to.eql(
+					'Invalid transaction timestamp. Timestamp is not in the int32 range'
+				);
 				done();
 			});
 		});
@@ -748,7 +750,9 @@ describe('transaction', () => {
 			delete transaction.signature;
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.eql('Invalid transaction timestamp. Timestamp is not in the int32 range');
+				expect(err).to.eql(
+					'Invalid transaction timestamp. Timestamp is not in the int32 range'
+				);
 				done();
 			});
 		});
@@ -761,7 +765,9 @@ describe('transaction', () => {
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.eql('Invalid transaction timestamp. Timestamp is in the future');
+				expect(err).to.eql(
+					'Invalid transaction timestamp. Timestamp is in the future'
+				);
 				done();
 			});
 		});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -731,6 +731,28 @@ describe('transaction', () => {
 			});
 		});
 
+		it('should return error on timestamp below the int32 range', done => {
+			var transaction = _.cloneDeep(validTransaction);
+			transaction.timestamp = -2147483648 - 1;
+			delete transaction.signature;
+			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
+			transactionLogic.verify(transaction, sender, null, null, err => {
+				expect(err).to.eql('Invalid transaction timestamp. Timestamp is not in the int32 range');
+				done();
+			});
+		});
+
+		it('should return error on timestamp above the int32 range', done => {
+			var transaction = _.cloneDeep(validTransaction);
+			transaction.timestamp = 2147483647 + 1;
+			delete transaction.signature;
+			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
+			transactionLogic.verify(transaction, sender, null, null, err => {
+				expect(err).to.include('Invalid transaction timestamp. Timestamp is not in the int32 range');
+				done();
+			});
+		});
+
 		it('should return error on future timestamp', done => {
 			var transaction = _.cloneDeep(validTransaction);
 			transaction.timestamp = slots.getTime() + 100;
@@ -739,7 +761,7 @@ describe('transaction', () => {
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.include('Invalid transaction timestamp');
+				expect(err).to.eql('Invalid transaction timestamp. Timestamp is in the future');
 				done();
 			});
 		});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -748,7 +748,7 @@ describe('transaction', () => {
 			delete transaction.signature;
 			transaction.signature = transactionLogic.sign(senderKeypair, transaction);
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.include('Invalid transaction timestamp. Timestamp is not in the int32 range');
+				expect(err).to.eql('Invalid transaction timestamp. Timestamp is not in the int32 range');
 				done();
 			});
 		});


### PR DESCRIPTION
### What was the problem?
Changes included in `0.9.15` needs to be backported.
### How did I fix it?
Backported changes from `0.9.15`.
### How to test it?
Run unit tests for logic/transaction.
### Review checklist

* The PR solves #2097
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
