### PR TITLE
Backport 0.9.16 changes to 1.0.0 - Closes #2098, #2102

### DIFF
--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -429,8 +429,6 @@ __private.applyConfirmedStep = function(block, tx) {
  */
 __private.saveBlockStep = function(block, saveBlock, tx) {
 	return new Promise((resolve, reject) => {
-		modules.blocks.lastBlock.set(block);
-
 		if (saveBlock) {
 			// DATABASE: write
 			self.saveBlock(
@@ -448,7 +446,6 @@ __private.saveBlockStep = function(block, saveBlock, tx) {
 							block.transactions.length
 						} transactions`
 					);
-					library.bus.message('newBlock', block);
 
 					// DATABASE write. Update delegates accounts
 					modules.rounds.tick(
@@ -457,6 +454,9 @@ __private.saveBlockStep = function(block, saveBlock, tx) {
 							if (err) {
 								return setImmediate(reject, err);
 							}
+
+							library.bus.message('newBlock', block);
+							modules.blocks.lastBlock.set(block);
 							return setImmediate(resolve);
 						},
 						tx
@@ -465,8 +465,6 @@ __private.saveBlockStep = function(block, saveBlock, tx) {
 				tx
 			);
 		} else {
-			library.bus.message('newBlock', block);
-
 			// DATABASE write. Update delegates accounts
 			modules.rounds.tick(
 				block,
@@ -474,6 +472,9 @@ __private.saveBlockStep = function(block, saveBlock, tx) {
 					if (err) {
 						return setImmediate(reject, err);
 					}
+
+					library.bus.message('newBlock', block);
+					modules.blocks.lastBlock.set(block);
 					return setImmediate(resolve);
 				},
 				tx

--- a/test/functional/system/blocks/chain/apply_block.js
+++ b/test/functional/system/blocks/chain/apply_block.js
@@ -358,6 +358,80 @@ describe('system test (blocks) - chain/applyBlock', () => {
 			});
 		});
 
+		describe('saveBlock', () => {
+			describe('when block contains invalid transaction - timestamp out of postgres integer range', () => {
+				const block = {
+					blockSignature:
+						'56d63b563e00332ec31451376f5f2665fcf7e118d45e68f8db0b00db5963b56bc6776a42d520978c1522c39545c9aff62a7d5bdcf851bf65904b2c2158870f00',
+					generatorPublicKey:
+						'9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f',
+					numberOfTransactions: 2,
+					payloadHash:
+						'be0df321b1653c203226add63ac0d13b3411c2f4caf0a213566cbd39edb7ce3b',
+					payloadLength: 494,
+					previousBlock: genesisBlock.id,
+					height: 2,
+					reward: 0,
+					timestamp: 32578370,
+					totalAmount: 10000000000000000,
+					totalFee: 0,
+					transactions: [
+						{
+							type: 0,
+							amount: 10000000000000000,
+							fee: 0,
+							timestamp: -3704634000,
+							recipientId: '16313739661670634666L',
+							senderId: '1085993630748340485L',
+							senderPublicKey:
+								'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+							signature:
+								'd8103d0ea2004c3dea8076a6a22c6db8bae95bc0db819240c77fc5335f32920e91b9f41f58b01fc86dfda11019c9fd1c6c3dcbab0a4e478e3c9186ff6090dc05',
+							id: '1465651642158264048',
+						},
+					],
+					version: 0,
+					id: '884740302254229983',
+				};
+
+				it('should call a callback with proper error', done => {
+					library.modules.blocks.chain.saveBlock(block, err => {
+						expect(err).to.eql('Blocks#saveBlock error');
+						done();
+					});
+				});
+			});
+
+			describe('when block is invalid - previousBlockId not exists', () => {
+				const block = {
+					blockSignature:
+						'56d63b563e00332ec31451376f5f2665fcf7e118d45e68f8db0b00db5963b56bc6776a42d520978c1522c39545c9aff62a7d5bdcf851bf65904b2c2158870f00',
+					generatorPublicKey:
+						'9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f',
+					numberOfTransactions: 2,
+					payloadHash:
+						'be0df321b1653c203226add63ac0d13b3411c2f4caf0a213566cbd39edb7ce3b',
+					payloadLength: 494,
+					previousBlock: '123',
+					height: 2,
+					reward: 0,
+					timestamp: 32578370,
+					totalAmount: 10000000000000000,
+					totalFee: 0,
+					version: 0,
+					id: '884740302254229983',
+					transactions: [],
+				};
+
+				it('should call a callback with proper error', done => {
+					library.modules.blocks.chain.saveBlock(block, err => {
+						expect(err).to.eql('Blocks#saveBlock error');
+						done();
+					});
+				});
+			});
+		});
+
 		describe('saveBlockStep', () => {
 			describe('after applying new block fails', () => {
 				let blockId;

--- a/test/functional/system/blocks/chain/apply_block.js
+++ b/test/functional/system/blocks/chain/apply_block.js
@@ -303,8 +303,7 @@ describe('system test (blocks) - chain/applyBlock', () => {
 					);
 				});
 
-				// Should be unskipped once transaction
-				it.skip('should revert applyconfirmedStep on block transactions', done => {
+				it('should revert applyconfirmedStep on block transactions', done => {
 					async.forEach(
 						[blockAccount1, blockAccount2],
 						(account, eachCb) => {

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -972,10 +972,6 @@ describe('blocks/chain', () => {
 
 		afterEach(done => {
 			blocksChainModule.saveBlock = saveBlockTemp;
-			expect(modules.blocks.lastBlock.set.calledOnce).to.be.true;
-			expect(modules.blocks.lastBlock.set.args[0][0]).to.deep.equal(
-				blockWithTransactions
-			);
 			done();
 		});
 
@@ -1006,6 +1002,7 @@ describe('blocks/chain', () => {
 							expect(blocksChainModule.saveBlock.args[0][0]).to.deep.equal(
 								blockWithTransactions
 							);
+							expect(modules.blocks.lastBlock.set.calledOnce).to.be.false;
 							done();
 						});
 				});
@@ -1020,12 +1017,7 @@ describe('blocks/chain', () => {
 					expect(loggerStub.debug.args[0][0]).to.contains(
 						'Block applied correctly with 3 transactions'
 					);
-					expect(blocksChainModule.saveBlock.args[0][0]).to.deep.equal(
-						blockWithTransactions
-					);
-					expect(library.bus.message.calledOnce).to.be.true;
-					expect(library.bus.message.args[0][0]).to.deep.equal('newBlock');
-					return expect(library.bus.message.args[0][1]).to.deep.equal(
+					return expect(blocksChainModule.saveBlock.args[0][0]).to.deep.equal(
 						blockWithTransactions
 					);
 				});
@@ -1040,6 +1032,7 @@ describe('blocks/chain', () => {
 							.saveBlockStep(blockWithTransactions, true, dbStub.tx)
 							.catch(err => {
 								expect(err).to.equal('tick-ERR');
+								expect(library.bus.message.calledOnce).to.be.false;
 								done();
 							});
 					});
@@ -1055,6 +1048,13 @@ describe('blocks/chain', () => {
 							.saveBlockStep(blockWithTransactions, true, dbStub.tx)
 							.then(resolve => {
 								expect(resolve).to.be.undefined;
+								expect(library.bus.message.calledOnce).to.be.true;
+								expect(library.bus.message.args[0][0]).to.deep.equal(
+									'newBlock'
+								);
+								expect(library.bus.message.args[0][1]).to.deep.equal(
+									blockWithTransactions
+								);
 								done();
 							});
 					});
@@ -1063,14 +1063,6 @@ describe('blocks/chain', () => {
 		});
 
 		describe('when saveBlock is false', () => {
-			afterEach(() => {
-				expect(library.bus.message.calledOnce).to.be.true;
-				expect(library.bus.message.args[0][0]).to.deep.equal('newBlock');
-				return expect(library.bus.message.args[0][1]).to.deep.equal(
-					blockWithTransactions
-				);
-			});
-
 			describe('when modules.rounds.tick fails', () => {
 				beforeEach(() => {
 					return modules.rounds.tick.callsArgWith(1, 'tick-ERR', null);
@@ -1081,6 +1073,7 @@ describe('blocks/chain', () => {
 						.saveBlockStep(blockWithTransactions, true, dbStub.tx)
 						.catch(err => {
 							expect(err).to.equal('tick-ERR');
+							expect(library.bus.message.calledOnce).to.be.false;
 							done();
 						});
 				});
@@ -1096,6 +1089,11 @@ describe('blocks/chain', () => {
 						.saveBlockStep(blockWithTransactions, true, dbStub.tx)
 						.then(resolve => {
 							expect(resolve).to.be.undefined;
+							expect(library.bus.message.calledOnce).to.be.true;
+							expect(library.bus.message.args[0][0]).to.deep.equal('newBlock');
+							expect(library.bus.message.args[0][1]).to.deep.equal(
+								blockWithTransactions
+							);
 							done();
 						});
 				});


### PR DESCRIPTION
### What was the problem?
Changes included in `0.9.16` needs to be backported.
### How did I fix it?
Backported changes from `0.9.16`.
### How to test it?
Run tests.
### Review checklist

* The PR solves #2098, #2102 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
