### PR TITLE
During syncing, reject blocks received through broadcasts

### DIFF
--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -628,23 +628,26 @@ __private.validateBlockSlot = function(block, lastBlock, cb) {
  * @todo Add @returns tag
  */
 Process.prototype.onReceiveBlock = function(block) {
-	let lastBlock;
+	// When client is not loaded, is syncing
+	// Do not receive new blocks as client is not ready
+	if (!__private.loaded) {
+		return library.logger.debug(
+			'Client is not ready to receive block',
+			block.id
+		);
+	}
+
+	if (modules.loader.syncing()) {
+		return library.logger.debug(
+			"Client is syncing. Can't receive block at the moment.",
+			block.id
+		);
+	}
 
 	// Execute in sequence via sequence
 	library.sequence.add(cb => {
-		// When client is not loaded, is syncing or round is ticking
-		// Do not receive new blocks as client is not ready
-		if (
-			!__private.loaded ||
-			modules.loader.syncing() ||
-			modules.rounds.ticking()
-		) {
-			library.logger.debug('Client not ready to receive block', block.id);
-			return setImmediate(cb);
-		}
-
 		// Get the last block
-		lastBlock = modules.blocks.lastBlock.get();
+		const lastBlock = modules.blocks.lastBlock.get();
 
 		// Detect sane block
 		if (

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -2107,29 +2107,21 @@ describe('blocks/process', () => {
 		var tempReceiveForkOne;
 		var tempReceiveForkFive;
 
-		before(done => {
+		beforeEach(done => {
 			tempReceiveBlock = __private.receiveBlock;
 			tempReceiveForkOne = __private.receiveForkOne;
 			tempReceiveForkFive = __private.receiveForkFive;
 			done();
 		});
 
-		after(done => {
+		afterEach(done => {
 			__private.receiveBlock = tempReceiveBlock;
 			__private.receiveForkOne = tempReceiveForkOne;
 			__private.receiveForkFive = tempReceiveForkFive;
 			done();
 		});
 
-		describe('client not ready to receive block', () => {
-			afterEach(() => {
-				expect(loggerStub.debug.args[0][0]).to.equal(
-					'Client not ready to receive block'
-				);
-				expect(loggerStub.debug.args[0][1]).to.equal(5);
-				return expect(modules.blocks.lastBlock.get.calledOnce).to.be.false;
-			});
-
+		describe('Client is syncing and not ready to receive block', () => {
 			describe('when __private.loaded is false', () => {
 				beforeEach(done => {
 					__private.loaded = false;
@@ -2141,14 +2133,14 @@ describe('blocks/process', () => {
 					done();
 				});
 
-				it('should return without process block', done => {
-					library.sequence.add = function(cb) {
-						var fn = Promise.promisify(cb);
-						fn().then(() => {
-							done();
-						});
-					};
+				it('should return without process block', () => {
 					blocksProcessModule.onReceiveBlock({ id: 5 });
+
+					expect(loggerStub.debug.args[0][0]).to.equal(
+						'Client is not ready to receive block'
+					);
+					expect(loggerStub.debug.args[0][1]).to.equal(5);
+					return expect(modules.blocks.lastBlock.get.calledOnce).to.be.false;
 				});
 			});
 
@@ -2161,34 +2153,14 @@ describe('blocks/process', () => {
 					return modules.loader.syncing.returns(false);
 				});
 
-				it('should return without process block', done => {
-					library.sequence.add = function(cb) {
-						var fn = Promise.promisify(cb);
-						fn().then(() => {
-							done();
-						});
-					};
+				it('should return without process block', () => {
 					blocksProcessModule.onReceiveBlock({ id: 5 });
-				});
-			});
 
-			describe('when modules.rounds.ticking is true', () => {
-				beforeEach(() => {
-					return modules.rounds.ticking.returns(true);
-				});
-
-				afterEach(() => {
-					return modules.rounds.ticking.returns(false);
-				});
-
-				it('should return without process block', done => {
-					library.sequence.add = function(cb) {
-						var fn = Promise.promisify(cb);
-						fn().then(() => {
-							done();
-						});
-					};
-					blocksProcessModule.onReceiveBlock({ id: 5 });
+					expect(loggerStub.debug.args[0][0]).to.equal(
+						"Client is syncing. Can't receive block at the moment."
+					);
+					expect(loggerStub.debug.args[0][1]).to.equal(5);
+					return expect(modules.blocks.lastBlock.get.calledOnce).to.be.false;
 				});
 			});
 		});


### PR DESCRIPTION
### What was the problem?
Blocks received from the network through broadcasts are added to the balance sequence. So, if the node is syncing, it can hit the memory limit because blocks received from the network keep piling up. 

### How did I fix it?
Reject the block outside the balance sequence. 

### How to test it?
`npx mocha test/unit/modules/blocks/process.js`

### Review checklist

* The PR solves #2096
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
