### PR TITLE
Improve Lisk Timestamps explanation - Closes #2109

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -57,7 +57,7 @@ info:
     ## List of Endpoints
     All possible API endpoints for Lisk Core are listed below.
     Click on an endpoint to show descriptions, details and examples.
-  version: '1.0.28'
+  version: '1.0.29'
   contact:
     email: admin@lisk.io
   license:

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -52,7 +52,7 @@ info:
     ## Pagination
     One can paginate nicely through the results by providing `limit` and `offset` parameters to the requests.
     `limit` and `offset` can be found in the `meta`-object of the response of an API request.
-    If no limit and offset are provided, they are set to 10 and 0 by default, what will give display the first 10 results.
+    If no limit and offset are provided, they are set to 10 and 0 by default, what will display the first 10 results.
 
     ## List of Endpoints
     All possible API endpoints for Lisk Core are listed below.

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -44,10 +44,9 @@ info:
     ```
 
     ## Date Formats
-    Most of the timestamp parameters are in the Unix timestamp format.
-    The Unix timestamp (or Unix time or POSIX time or Unix epoch time) is the number of seconds that have elapsed since January 1, 1970 , not counting leap seconds.
-    Some of them though, are are accepted or returned in the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format, combined date and time: `YYYY-MM-DDThh:mm:ssZ`.
-    2 valid examples for ISO 8601: 1970-01-01T00:00:00Z, 2016-05-24T17:00:00.000Z.
+    Most of the timestamp parameters are in the Lisk Timestamp format, which is similar to the Unix Timestamp format.
+    The **Lisk Timestamp** is the number of seconds that have elapsed since the Lisk epoch time (2016-05-24T17:00:00.000Z), not counting leap seconds.
+    The **Lisk Epoch Time** is returned in the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format, combined date and time: `YYYY-MM-DDThh:mm:ssZ`.
     For details, see the descriptions and examples at the respective endpoint.
 
     ## Pagination


### PR DESCRIPTION
### What was the problem?
Explanation of the timestamps does not explain the difference between unix timestamps and Lisk Timestamps precisely enough

### How did I fix it?
Removed the explanation of unit timestamps and added explanation of Lisk timestamps in relation to Lisk Epoch Time.

### How to test it?
Open the Lisk Core API documentation in swagger

### Review checklist

* The PR solves #2109
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
