### PR TITLE
Allow client socket to behave as an RPC server

### DIFF
--- a/api/ws/rpc/ws_rpc.js
+++ b/api/ws/rpc/ws_rpc.js
@@ -74,15 +74,6 @@ const wsRPC = {
 	},
 };
 
-const remoteAction = function() {
-	throw new Error('Function invoked on master instead of slave process');
-};
-
-const slaveRPCStub = {
-	updateMyself: remoteAction,
-};
-
 module.exports = {
 	wsRPC,
-	slaveRPCStub,
 };

--- a/api/ws/rpc/ws_rpc.js
+++ b/api/ws/rpc/ws_rpc.js
@@ -74,6 +74,16 @@ const wsRPC = {
 	},
 };
 
+const remoteAction = function(query, cb) {
+	const err = 'Function invoked on master instead of slave process';
+	return setImmediate(cb, err);
+};
+
+const slaveRPCStub = {
+	updateMyself: remoteAction,
+};
+
 module.exports = {
 	wsRPC,
+	slaveRPCStub,
 };

--- a/test/unit/helpers/peers_manager.js
+++ b/test/unit/helpers/peers_manager.js
@@ -17,8 +17,13 @@
 var prefixedPeer = require('../../fixtures/peers').randomNormalizedPeer;
 var Peer = require('../../../logic/peer');
 var PeersManager = require('../../../helpers/peers_manager');
+var wsRPC = require('../../../api/ws/rpc/ws_rpc').wsRPC;
 
 var peersManagerInstance;
+var masterWAMPServerMock;
+
+var validRPCProcedureName = 'rpcProcedureA';
+var validEventProcedureName = 'eventProcedureB';
 
 describe('PeersManager', () => {
 	beforeEach(done => {
@@ -29,6 +34,18 @@ describe('PeersManager', () => {
 			debug: sinonSandbox.stub(),
 			trace: sinonSandbox.stub(),
 		});
+		masterWAMPServerMock = {
+			upgradeToWAMP: sinonSandbox.stub(),
+			endpoints: {
+				rpc: {
+					[validRPCProcedureName]: sinonSandbox.stub().callsArg(1),
+				},
+				event: {
+					[validEventProcedureName]: sinonSandbox.stub(),
+				},
+			},
+		};
+		wsRPC.getServer = sinonSandbox.stub().returns(masterWAMPServerMock);
 		done();
 	});
 

--- a/test/unit/logic/peers.js
+++ b/test/unit/logic/peers.js
@@ -21,6 +21,12 @@ var prefixedPeer = require('../../fixtures/peers').randomNormalizedPeer;
 var RandomPeer = require('../../fixtures/peers').Peer;
 var Peers = require('../../../logic/peers.js');
 var Peer = require('../../../logic/peer.js');
+var wsRPC = require('../../../api/ws/rpc/ws_rpc').wsRPC;
+
+var masterWAMPServerMock;
+
+var validRPCProcedureName = 'rpcProcedureA';
+var validEventProcedureName = 'eventProcedureB';
 
 describe('peers', () => {
 	var peersModuleMock;
@@ -38,6 +44,19 @@ describe('peers', () => {
 			peers.bindModules({ peers: peersModuleMock });
 			done();
 		});
+
+		masterWAMPServerMock = {
+			upgradeToWAMP: sinonSandbox.stub(),
+			endpoints: {
+				rpc: {
+					[validRPCProcedureName]: sinonSandbox.stub().callsArg(1),
+				},
+				event: {
+					[validEventProcedureName]: sinonSandbox.stub(),
+				},
+			},
+		};
+		wsRPC.getServer = sinonSandbox.stub().returns(masterWAMPServerMock);
 	});
 
 	beforeEach(done => {


### PR DESCRIPTION
### What was the problem?

Peers could not send RPCs on inbound connections.

### How did I fix it?

Allowed the client socket on the peer to act as an RPC server.

### How to test it?

Currently it supports all the RPCs except of `updateMyself` (because it is not currently designed to be invoked directly from the master process).

### Review checklist

* The PR solves #2069
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
