### PR TITLE
Integration test failed to load blockchain - Closes #2116

### DIFF
--- a/test/integration/setup/network.js
+++ b/test/integration/setup/network.js
@@ -22,13 +22,15 @@ var utils = require('../utils');
 
 module.exports = {
 	waitForAllNodesToBeReady(configurations, cb) {
+		const retries = 20;
+		const timeout = 3000;
 		async.forEachOf(
 			configurations,
 			(configuration, index, eachCb) => {
 				waitUntilBlockchainReady(
 					eachCb,
-					20,
-					2000,
+					retries,
+					timeout,
 					`http://${configuration.ip}:${configuration.httpPort}`
 				);
 			},


### PR DESCRIPTION
### What was the problem?
Integration tests fail while loading the blockchain, this happens mainly because we are waiting 40 seconds for all the 10 nodes to load the blockchain, however, it takes more than `40 seconds` to load the blockchain across all the nodes.
### How did I fix it?
Increase the timeout to `60 seconds`
### How to test it?
Run integration test, it should pass consistantly
### Review checklist

* The PR solves #2116 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
