### PR TITLE
Balances in mem_accounts off after snapshotting - Closes #2126

### DIFF
--- a/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
+++ b/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
@@ -39,7 +39,7 @@ CREATE TABLE "rounds_rewards"(
 );
 
 -- Insert record for dummy round 1 when genesis block is in database
-INSERT INTO rounds_rewards SELECT timestamp, 0, 0, 1, "generatorPublicKey" FROM blocks WHERE height = 1;
+INSERT INTO rounds_rewards (timestamp, fees, reward, round, "publicKey") SELECT timestamp, 0, 0, 1, "generatorPublicKey" FROM blocks WHERE height = 1;
 
 -- Compute all rewards for previous rounds and insert them to 'rounds_rewards'
 DO $$

--- a/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
+++ b/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
@@ -39,7 +39,7 @@ CREATE TABLE "rounds_rewards"(
 );
 
 -- Insert record for dummy round 1 when genesis block is in database
-INSERT INTO rounds_rewards SELECT timestamp, 0, 0, 1, "publicKey" FROM blocks WHERE height = 1;
+INSERT INTO rounds_rewards SELECT timestamp, 0, 0, 1, "generatorPublicKey" FROM blocks WHERE height = 1;
 
 -- Compute all rewards for previous rounds and insert them to 'rounds_rewards'
 DO $$

--- a/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
+++ b/db/sql/migrations/updates/20180205000003_create_rounds_rewards_table.sql
@@ -38,6 +38,9 @@ CREATE TABLE "rounds_rewards"(
 	"publicKey" BYTEA  NOT NULL
 );
 
+-- Insert record for dummy round 1 when genesis block is in database
+INSERT INTO rounds_rewards SELECT timestamp, 0, 0, 1, "publicKey" FROM blocks WHERE height = 1;
+
 -- Compute all rewards for previous rounds and insert them to 'rounds_rewards'
 DO $$
 	DECLARE
@@ -66,11 +69,8 @@ DO $$
 					FROM blocks b
 					WHERE ceil(b.height / 101::float)::int = row.round
 				),
-				filtered_round AS (
-					SELECT * FROM round WHERE height > 1
-				),
 				-- Calculating total fees of round
-				fees AS (SELECT sum(fees) AS total, floor(sum(fees) / 101) AS single FROM filtered_round),
+				fees AS (SELECT sum(fees) AS total, floor(sum(fees) / 101) AS single FROM round),
 				-- Get last delegate and timestamp of round's last block
 				last AS (SELECT "publicKey", timestamp FROM filtered_round ORDER BY height DESC LIMIT 1)
 			INSERT INTO rounds_rewards

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -387,6 +387,16 @@ __private.getOutsiders = function(scope, cb, tx) {
  * @todo Add description for the params and the return value
  */
 __private.sumRound = function(scope, cb, tx) {
+	// When we need to sum round just after genesis block (height: 1)
+	// - set data manually directly from genesis block object
+	if (scope.block.height === 1) {
+		library.logger.debug(`Summing round - ${scope.round} (genesis block)`);
+		scope.roundFees = scope.block.totalFee;
+		scope.roundRewards = [scope.block.reward];
+		scope.roundDelegates = [scope.block.generatorPublicKey];
+		return setImmediate(cb);
+	}
+
 	library.logger.debug('Summing round', scope.round);
 
 	(tx || library.db).rounds

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -388,11 +388,11 @@ __private.getOutsiders = function(scope, cb, tx) {
  */
 __private.sumRound = function(scope, cb, tx) {
 	// When we need to sum round just after genesis block (height: 1)
-	// - set data manually directly from genesis block object
+	// - set data manually to 0, they will be distributed when actual round 1 is summed
 	if (scope.block.height === 1) {
 		library.logger.debug(`Summing round - ${scope.round} (genesis block)`);
-		scope.roundFees = scope.block.totalFee;
-		scope.roundRewards = [scope.block.reward];
+		scope.roundFees = 0;
+		scope.roundRewards = [0];
 		scope.roundDelegates = [scope.block.generatorPublicKey];
 		return setImmediate(cb);
 	}

--- a/test/functional/system/snapshotting.js
+++ b/test/functional/system/snapshotting.js
@@ -15,6 +15,9 @@
 'use strict';
 
 const Promise = require('bluebird');
+const elements = require('lisk-elements').default;
+const randomUtil = require('../../common/utils/random');
+const accountsFixtures = require('../../fixtures/accounts');
 const constants = require('../../../helpers/constants');
 const queriesHelper = require('../common/sql/queriesHelper.js');
 const localCommon = require('./common');
@@ -51,18 +54,32 @@ describe('snapshotting', () => {
 
 		before(() => {
 			// Forge 201 blocks to reach height 202 (genesis block is already tyhere)
-			return Promise.mapSeries([...Array(201)], () => {
+			return Promise.mapSeries([...Array(99)], () => {
 				return addTransactionsAndForgePromise(library, [], 0);
-			}).then(() => {
-				return getMemAccounts().then(_accounts => {
-					// Save copy of mem_accounts table
-					memAccountsBeforeSnapshot = _.cloneDeep(_accounts);
-					// Forge one more round (blocks from that round should be deleted during snapshotting process)
+			})
+				.then(() => {
+					const transaction = elements.transaction.transfer({
+						recipientId: randomUtil.account().address,
+						amount: randomUtil.number(100000000, 1000000000),
+						passphrase: accountsFixtures.genesis.passphrase,
+					});
+					return addTransactionsAndForgePromise(library, [transaction], 0);
+				})
+				.then(() => {
 					return Promise.mapSeries([...Array(101)], () => {
 						return addTransactionsAndForgePromise(library, [], 0);
 					});
+				})
+				.then(() => {
+					return getMemAccounts().then(_accounts => {
+						// Save copy of mem_accounts table
+						memAccountsBeforeSnapshot = _.cloneDeep(_accounts);
+						// Forge one more round (blocks from that round should be deleted during snapshotting process)
+						return Promise.mapSeries([...Array(101)], () => {
+							return addTransactionsAndForgePromise(library, [], 0);
+						});
+					});
 				});
-			});
 		});
 
 		it('mem_accounts states after snapshotting should match copy taken after round 2', done => {

--- a/test/functional/system/snapshotting.js
+++ b/test/functional/system/snapshotting.js
@@ -53,10 +53,11 @@ describe('snapshotting', () => {
 		let memAccountsBeforeSnapshot;
 
 		before(() => {
-			// Forge 201 blocks to reach height 202 (genesis block is already tyhere)
+			// Forge 99 blocks to reach height 100 (genesis block is already there)
 			return Promise.mapSeries([...Array(99)], () => {
 				return addTransactionsAndForgePromise(library, [], 0);
 			})
+				// Forge 1 block with transaction to reach height 101
 				.then(() => {
 					const transaction = elements.transaction.transfer({
 						recipientId: randomUtil.account().address,
@@ -65,6 +66,7 @@ describe('snapshotting', () => {
 					});
 					return addTransactionsAndForgePromise(library, [transaction], 0);
 				})
+				// Forge 101 block with transaction to reach height 202
 				.then(() => {
 					return Promise.mapSeries([...Array(101)], () => {
 						return addTransactionsAndForgePromise(library, [], 0);
@@ -74,7 +76,8 @@ describe('snapshotting', () => {
 					return getMemAccounts().then(_accounts => {
 						// Save copy of mem_accounts table
 						memAccountsBeforeSnapshot = _.cloneDeep(_accounts);
-						// Forge one more round (blocks from that round should be deleted during snapshotting process)
+						// Forge one more round of blocks to reach height 303
+						// blocks from that round should be deleted during snapshotting process)
 						return Promise.mapSeries([...Array(101)], () => {
 							return addTransactionsAndForgePromise(library, [], 0);
 						});

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -370,7 +370,7 @@ describe('rounds', () => {
 		var sumRound;
 		var stub;
 
-		before(done => {
+		beforeEach(done => {
 			sumRound = get('__private.sumRound');
 			done();
 		});
@@ -413,7 +413,7 @@ describe('rounds', () => {
 			const scope = { round: 1, block: { height: 2 } };
 
 			describe('when summedRound query is successful', () => {
-				before(done => {
+				beforeEach(done => {
 					var rows = [
 						{
 							rewards: [1.001, 2, 3],
@@ -425,7 +425,7 @@ describe('rounds', () => {
 					done();
 				});
 
-				after(() => {
+				afterEach(() => {
 					return stub.restore();
 				});
 

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -369,29 +369,22 @@ describe('rounds', () => {
 	describe('__private.sumRound', () => {
 		var sumRound;
 		var stub;
-		var scope = { round: 1 };
 
 		before(done => {
 			sumRound = get('__private.sumRound');
 			done();
 		});
 
-		describe('when summedRound query is successful', () => {
-			before(done => {
-				var rows = [
-					{
-						rewards: [1.001, 2, 3],
-						fees: 100.001,
-						delegates: ['delegate1', 'delegate2', 'delegate3'],
-					},
-				];
-				stub = sinon.stub(db.rounds, 'summedRound').resolves(rows);
-				done();
-			});
-
-			after(() => {
-				return stub.restore();
-			});
+		describe('when last block is genesis block', () => {
+			const scope = {
+				round: 1,
+				block: {
+					height: 1,
+					totalFee: 123,
+					reward: 456,
+					generatorPublicKey: 'aaa',
+				},
+			};
 
 			it('should call a callback', done => {
 				sumRound(scope, err => {
@@ -402,36 +395,80 @@ describe('rounds', () => {
 			});
 
 			it('should set scope.roundFees correctly', () => {
-				return expect(scope.roundFees).to.equal(100);
+				return expect(scope.roundFees).to.equal(scope.block.totalFee);
 			});
 
 			it('should set scope.roundRewards correctly', () => {
-				return expect(scope.roundRewards).to.deep.equal([1, 2, 3]);
+				return expect(scope.roundRewards).to.deep.equal([scope.block.reward]);
 			});
 
 			it('should set scope.roundDelegates', () => {
 				return expect(scope.roundDelegates).to.deep.equal([
-					'delegate1',
-					'delegate2',
-					'delegate3',
+					scope.block.generatorPublicKey,
 				]);
 			});
 		});
 
-		describe('when summedRound query fails', () => {
-			before(done => {
-				stub = sinon.stub(db.rounds, 'summedRound').rejects('fail');
-				done();
-			});
+		describe('when last block is not genesis block', () => {
+			const scope = { round: 1, block: { height: 2 } };
 
-			after(() => {
-				return stub.restore();
-			});
-
-			it('should call a callback with error = fail', done => {
-				sumRound(scope, err => {
-					expect(err.name).to.equal('fail');
+			describe('when summedRound query is successful', () => {
+				before(done => {
+					var rows = [
+						{
+							rewards: [1.001, 2, 3],
+							fees: 100.001,
+							delegates: ['delegate1', 'delegate2', 'delegate3'],
+						},
+					];
+					stub = sinon.stub(db.rounds, 'summedRound').resolves(rows);
 					done();
+				});
+
+				after(() => {
+					return stub.restore();
+				});
+
+				it('should call a callback', done => {
+					sumRound(scope, err => {
+						_.cloneDeep(scope);
+						expect(err).to.not.exist;
+						done();
+					});
+				});
+
+				it('should set scope.roundFees correctly', () => {
+					return expect(scope.roundFees).to.equal(100);
+				});
+
+				it('should set scope.roundRewards correctly', () => {
+					return expect(scope.roundRewards).to.deep.equal([1, 2, 3]);
+				});
+
+				it('should set scope.roundDelegates', () => {
+					return expect(scope.roundDelegates).to.deep.equal([
+						'delegate1',
+						'delegate2',
+						'delegate3',
+					]);
+				});
+			});
+
+			describe('when summedRound query fails', () => {
+				before(done => {
+					stub = sinon.stub(db.rounds, 'summedRound').rejects('fail');
+					done();
+				});
+
+				after(() => {
+					return stub.restore();
+				});
+
+				it('should call a callback with error = fail', done => {
+					sumRound(scope, err => {
+						expect(err.name).to.equal('fail');
+						done();
+					});
 				});
 			});
 		});

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -394,11 +394,11 @@ describe('rounds', () => {
 				});
 			});
 
-			it('should set scope.roundFees correctly', () => {
+			it('should set scope.roundFees to 0', () => {
 				return expect(scope.roundFees).to.equal(0);
 			});
 
-			it('should set scope.roundRewards correctly', () => {
+			it('should set scope.roundRewards to 0', () => {
 				return expect(scope.roundRewards).to.deep.equal([0]);
 			});
 

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -395,11 +395,11 @@ describe('rounds', () => {
 			});
 
 			it('should set scope.roundFees correctly', () => {
-				return expect(scope.roundFees).to.equal(scope.block.totalFee);
+				return expect(scope.roundFees).to.equal(0);
 			});
 
 			it('should set scope.roundRewards correctly', () => {
-				return expect(scope.roundRewards).to.deep.equal([scope.block.reward]);
+				return expect(scope.roundRewards).to.deep.equal([0]);
 			});
 
 			it('should set scope.roundDelegates', () => {


### PR DESCRIPTION
### What was the problem?
Rewards for round 1 were applied twice during snapshotting.
### How did I fix it?
Forced sumRound to return `0` fees/rewards and genesis block generator when round is summed just after genesis block (dummy round 1 for electing delegates).
### How to test it?
- Run test suite.
- Run migration and check results manually.
### Review checklist

* The PR solves #2126
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
