### PR TITLE
Update configuration migration script to use correct wsPort for peers - Closes #2132

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -57,7 +57,7 @@ delete oldConfig.minVersion;
 
 // Rename old port to new wsPort
 oldConfig.httpPort = oldConfig.port;
-oldConfig.wsPort = oldConfig.httpPort + 1;
+oldConfig.wsPort = oldConfig.port + 1;
 delete oldConfig.port;
 
 oldConfig.db.max = oldConfig.db.poolSize;
@@ -74,7 +74,7 @@ delete oldConfig.dapp;
 
 // Peers migration
 oldConfig.peers.list = oldConfig.peers.list.map(p => {
-	p.wsPort = p.port;
+	p.wsPort = p.port + 1;
 	delete p.port;
 	return p;
 });


### PR DESCRIPTION
### What was the problem?
Wrong mapping for `peers.list[].wsPort` mapping 
### How did I fix it?
Corrected as per convention descried in issue. 
### How to test it?
Running the migration from `0.9.x` to `1.0.0`
### Review checklist

* The PR solves #2132
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
