### PR TITLE
Replace libsodium wrapper - Closes #1797

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"socket.io": "=2.0.3",
 		"socketcluster": "=11.4.1",
 		"socketcluster-client": "=11.2.0",
-		"sodium": "LiskHQ/node-sodium#895ac4482a56a34eba81205e43e0c859490fb99d",
+		"sodium-native": "=2.1.6",
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",
 		"sway": "=1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"socket.io": "=2.0.3",
 		"socketcluster": "=11.4.1",
 		"socketcluster-client": "=11.2.0",
-		"sodium-native": "=2.1.6",
+		"sodium-native": "LiskHQ/sodium-native#a5f28e5",
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",
 		"sway": "=1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"socket.io": "=2.0.3",
 		"socketcluster": "=11.4.1",
 		"socketcluster-client": "=11.2.0",
-		"sodium-native": "LiskHQ/sodium-native#a5f28e5",
+		"sodium-native": "LiskHQ/sodium-native#dd0319f",
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",
 		"sway": "=1.0.0",


### PR DESCRIPTION
### What was the problem?

Lisk Core was using a fork of an outdated libsodium wrapper which was causing build issues on some platforms and could cause potential security issues later.

### How did I fix it?

I replaced the libsodium implementation with an actively maintained drop-in replacement that is recommended in the official documentation https://download.libsodium.org/doc/bindings_for_other_languages/

This was recommended by @webmaster128 in #1797

### How to test it?

Since this is a drop-in replacement with direct native bindings existing tests already cover the relevant cryptographic functions.

### Review checklist

* The PR solves #1797 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
