### PR TITLE
Change default delegate sorting to rank:asc - Closes #2138

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -57,7 +57,7 @@ info:
     ## List of Endpoints
     All possible API endpoints for Lisk Core are listed below.
     Click on an endpoint to show descriptions, details and examples.
-  version: '1.0.30'
+  version: '1.0.31'
   contact:
     email: admin@lisk.io
   license:
@@ -581,7 +581,7 @@ paths:
             - productivity:desc
             - missedBlocks:asc
             - missedBlocks:desc
-          default: rank:desc
+          default: rank:asc
       responses:
         200:
           description: Search results matching criteria


### PR DESCRIPTION
### What was the problem?

Default sorting for the list of delegates in Lisk Core API was `rank:desc`

### How did I fix it?

Changed it to `rank:asc`, as this is the behaviour which is expected as default.

### How to test it?

Make `GET /api/delegates` request without specifying the `sort` parameter.
Response should be sorted by rank in ascending order.

### Review checklist

* The PR solves #2138 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
