### PR TITLE
Send back better error when disconnecting because of invalid peer headers - Closes #2068

### DIFF
--- a/api/ws/workers/middlewares/handshake.js
+++ b/api/ws/workers/middlewares/handshake.js
@@ -72,11 +72,17 @@ var middleware = {
 		return function(headers, cb) {
 			z_schema.validate(headers, definitions.WSPeerHeaders, error => {
 				if (error) {
+					var errorDescription;
+					if (error[0].path && error[0].path.length) {
+						errorDescription = `${error[0].path}: ${error[0].message}`;
+					} else {
+						errorDescription = `${error[0].message}`;
+					}
 					return setImmediate(
 						cb,
 						{
 							code: failureCodes.INVALID_HEADERS,
-							description: `${error[0].path}: ${error[0].message}`,
+							description: errorDescription,
 						},
 						null
 					);
@@ -125,11 +131,11 @@ var middleware = {
 				// TODO : double check socket IP
 				if (config.blackListedPeers.includes(headers.ip)) {
 					return setImmediate(
-						cb, {
+						cb,
+						{
 							code: failureCodes.BLACKLISTED_PEER,
-							description: failureCodes.errorMessages[
-								failureCodes.BLACKLISTED_PEER
-							],
+							description:
+								failureCodes.errorMessages[failureCodes.BLACKLISTED_PEER],
 						},
 						peer
 					);

--- a/api/ws/workers/middlewares/handshake.js
+++ b/api/ws/workers/middlewares/handshake.js
@@ -72,11 +72,9 @@ var middleware = {
 		return function(headers, cb) {
 			z_schema.validate(headers, definitions.WSPeerHeaders, error => {
 				if (error) {
-					var errorDescription;
+					var errorDescription = error[0].message;
 					if (error[0].path && error[0].path.length) {
-						errorDescription = `${error[0].path}: ${error[0].message}`;
-					} else {
-						errorDescription = `${error[0].message}`;
+						errorDescription = `${error[0].path}: ${errorDescription}`;
 					}
 					return setImmediate(
 						cb,

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -403,5 +403,26 @@ describe('RPC Client', () => {
 				done();
 			});
 		});
+
+		describe('makes request with incompatible version', () => {
+			beforeEach(done => {
+				// Set a non-matching version.
+				validHeaders.version = '0.0.0-beta.1';
+				System.setHeaders(validHeaders);
+				reconnect();
+				validClientRPCStub.status(() => {});
+				captureConnectionResult(() => {
+					done();
+				});
+			});
+
+			it('should close connection with code 4103', done => {
+				expect(closeErrorCode).equal(4103);
+				expect(closeErrorReason).equal(
+					'Expected version: >=0.0.0 but received: 0.0.0-beta.1'
+				);
+				done();
+			});
+		});
 	});
 });

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -31,6 +31,17 @@ describe('RPC Client', () => {
 	let closeErrorCode;
 	let closeErrorReason;
 
+	function createLoggerMock() {
+		const loggerMock = {
+			error: sinonSandbox.stub(),
+			warn: sinonSandbox.stub(),
+			log: sinonSandbox.stub(),
+			debug: sinonSandbox.stub(),
+			trace: sinonSandbox.stub(),
+		};
+		return loggerMock;
+	}
+
 	function reconnect(ip = validWSServerIp, wsPort = validWSServerPort) {
 		if (
 			validPeerStub &&
@@ -39,13 +50,7 @@ describe('RPC Client', () => {
 		) {
 			validPeerStub.socket.disconnect();
 		}
-		const loggerMock = {
-			error: sinonSandbox.stub(),
-			warn: sinonSandbox.stub(),
-			log: sinonSandbox.stub(),
-			debug: sinonSandbox.stub(),
-			trace: sinonSandbox.stub(),
-		};
+		const loggerMock = createLoggerMock();
 		validPeerStub = connect({ ip, wsPort }, loggerMock);
 		validClientRPCStub = validPeerStub.rpc;
 	}
@@ -373,7 +378,7 @@ describe('RPC Client', () => {
 				});
 			});
 
-			it('should close connection with code 4101', done => {
+			it('should close connection with code 4101 and reason string', done => {
 				expect(closeErrorCode).equal(4101);
 				expect(closeErrorReason).equal(
 					`Expected nonce to be not equal to: ${validHeaders.nonce}`
@@ -395,7 +400,7 @@ describe('RPC Client', () => {
 				});
 			});
 
-			it('should close connection with code 4102', done => {
+			it('should close connection with code 4102 and reason string', done => {
 				expect(closeErrorCode).equal(4102);
 				expect(closeErrorReason).equal(
 					'Expected nethash: 198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d but received: 123f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d'
@@ -416,7 +421,7 @@ describe('RPC Client', () => {
 				});
 			});
 
-			it('should close connection with code 4103', done => {
+			it('should close connection with code 4103 and reason string', done => {
 				expect(closeErrorCode).equal(4103);
 				expect(closeErrorReason).equal(
 					'Expected version: >=0.0.0 but received: 0.0.0-beta.1'

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -356,7 +356,7 @@ describe('RPC Client', () => {
 			});
 		});
 
-		describe('node makes request to itself', () => {
+		describe('makes request to itself', () => {
 			beforeEach(done => {
 				System.setHeaders(validHeaders);
 				reconnect();
@@ -377,6 +377,28 @@ describe('RPC Client', () => {
 				expect(closeErrorCode).equal(4101);
 				expect(closeErrorReason).equal(
 					`Expected nonce to be not equal to: ${validHeaders.nonce}`
+				);
+				done();
+			});
+		});
+
+		describe('makes request to the wrong network', () => {
+			beforeEach(done => {
+				// Set a non-matching nethash.
+				validHeaders.nethash =
+					'123f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d';
+				System.setHeaders(validHeaders);
+				reconnect();
+				validClientRPCStub.status(() => {});
+				captureConnectionResult(() => {
+					done();
+				});
+			});
+
+			it('should close connection with code 4102', done => {
+				expect(closeErrorCode).equal(4102);
+				expect(closeErrorReason).equal(
+					'Expected nethash: 198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d but received: 123f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d'
 				);
 				done();
 			});

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -43,22 +43,15 @@ describe('RPC Client', () => {
 		validClientRPCStub = validPeerStub.rpc;
 	}
 
-	function unbindConnectionHandlers() {
-		validPeerStub.socket.removeAllListeners('close');
-		validPeerStub.socket.removeAllListeners('connect');
-	}
-
 	function captureConnectionResult() {
 		closeErrorCode = null;
 		closeErrorReason = null;
-		unbindConnectionHandlers();
+		validPeerStub.socket.removeAllListeners('close');
+		validPeerStub.socket.removeAllListeners('connect');
+
 		validPeerStub.socket.on('close', (code, reason) => {
-			unbindConnectionHandlers();
 			closeErrorCode = code;
 			closeErrorReason = reason;
-		});
-		validPeerStub.socket.on('connect', () => {
-			unbindConnectionHandlers();
 		});
 	}
 

--- a/test/functional/ws/transport/client.js
+++ b/test/functional/ws/transport/client.js
@@ -429,5 +429,22 @@ describe('RPC Client', () => {
 				done();
 			});
 		});
+
+		describe('cannot connect - socket hung up', () => {
+			beforeEach(done => {
+				System.setHeaders(validHeaders);
+				// Target unused port.
+				reconnect(validWSServerIp, 4567);
+				validClientRPCStub.status(() => {});
+				captureConnectionResult(() => {
+					done();
+				});
+			});
+
+			it('should close connection with code 1006', done => {
+				expect(closeErrorCode).equal(1006);
+				done();
+			});
+		});
 	});
 });

--- a/test/unit/api/ws/middleware/handshake.js
+++ b/test/unit/api/ws/middleware/handshake.js
@@ -133,7 +133,7 @@ describe('Handshake', () => {
 					}`, done => {
 						handshake(type.input, err => {
 							expect(err.description).to.equal(
-								`: Expected type object but found type ${type.expectation}`
+								`Expected type object but found type ${type.expectation}`
 							);
 							done();
 						});
@@ -317,7 +317,7 @@ describe('Handshake', () => {
 						headers[property] = undefined;
 						handshake(headers, err => {
 							expect(err.description).to.equal(
-								`: Missing required property: ${property}`
+								`Missing required property: ${property}`
 							);
 							done();
 						});


### PR DESCRIPTION
### What was the problem?

When a peer tried to connect with invalid headers, the error messages were not ideal.
Note that a descriptive error message was sent back to the peer's close event handler before (and it was logged correctly by the peer) but it wasn't always formatted correctly.

### How did I fix it?

- Fixed the formatting related to failed handshake errors.
- Added test cases which shows how to handle the connection error.

### How to test it?

`npm run mocha test/functional/ws/transport/client.js`

### Review checklist

* The PR solves #2068
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
