### PR TITLE
Round fixes - Closes #216, #1783

### DIFF
--- a/api/controllers/accounts.js
+++ b/api/controllers/accounts.js
@@ -71,8 +71,6 @@ AccountsController.getAccounts = function(context, next) {
 				delete account.delegate;
 			} else {
 				account.delegate.rank = parseInt(account.delegate.rank);
-				account.delegate.missedBlocks = account.delegate.missedBlocks;
-				account.delegate.producedBlocks = account.delegate.producedBlocks;
 			}
 			if (_.isNull(account.publicKey)) {
 				account.publicKey = '';

--- a/api/controllers/accounts.js
+++ b/api/controllers/accounts.js
@@ -71,10 +71,8 @@ AccountsController.getAccounts = function(context, next) {
 				delete account.delegate;
 			} else {
 				account.delegate.rank = parseInt(account.delegate.rank);
-				account.delegate.missedBlocks = parseInt(account.delegate.missedBlocks);
-				account.delegate.producedBlocks = parseInt(
-					account.delegate.producedBlocks
-				);
+				account.delegate.missedBlocks = account.delegate.missedBlocks;
+				account.delegate.producedBlocks = account.delegate.producedBlocks;
 			}
 			if (_.isNull(account.publicKey)) {
 				account.publicKey = '';

--- a/api/controllers/delegates.js
+++ b/api/controllers/delegates.js
@@ -77,8 +77,8 @@ DelegatesController.getDelegates = function(context, next) {
 			delete delegate.publicKey;
 			delete delegate.address;
 
-			delegate.missedBlocks = parseInt(delegate.missedBlocks);
-			delegate.producedBlocks = parseInt(delegate.producedBlocks);
+			delegate.missedBlocks = delegate.missedBlocks;
+			delegate.producedBlocks = delegate.producedBlocks;
 			delegate.rank = parseInt(delegate.rank);
 
 			return delegate;

--- a/api/controllers/delegates.js
+++ b/api/controllers/delegates.js
@@ -77,8 +77,6 @@ DelegatesController.getDelegates = function(context, next) {
 			delete delegate.publicKey;
 			delete delegate.address;
 
-			delegate.missedBlocks = delegate.missedBlocks;
-			delegate.producedBlocks = delegate.producedBlocks;
 			delegate.rank = parseInt(delegate.rank);
 
 			return delegate;

--- a/db/repos/accounts.js
+++ b/db/repos/accounts.js
@@ -40,8 +40,8 @@ const normalFields = [
 	{ name: 'fees', cast: 'bigint', def: '0', skip: ifNotExists },
 	{ name: 'rewards', cast: 'bigint', def: '0', skip: ifNotExists },
 	{ name: 'vote', cast: 'bigint', def: '0', skip: ifNotExists },
-	{ name: 'producedBlocks', cast: 'bigint', def: '0', skip: ifNotExists },
-	{ name: 'missedBlocks', cast: 'bigint', def: '0', skip: ifNotExists },
+	{ name: 'producedBlocks', def: 0, skip: ifNotExists },
+	{ name: 'missedBlocks', def: 0, skip: ifNotExists },
 	{ name: 'username', def: null, skip: ifNotExists },
 	{ name: 'u_username', def: null, skip: ifNotExists },
 	{

--- a/db/sql/rounds/perform_votes_snapshot.sql
+++ b/db/sql/rounds/perform_votes_snapshot.sql
@@ -20,6 +20,6 @@
 */
 
 CREATE TABLE mem_votes_snapshot AS
-SELECT address, "publicKey", vote
+SELECT address, "publicKey", vote, "producedBlocks", "missedBlocks"
 FROM mem_accounts
 WHERE "isDelegate" = 1

--- a/db/sql/rounds/restore_votes_snapshot.sql
+++ b/db/sql/rounds/restore_votes_snapshot.sql
@@ -20,6 +20,6 @@
 */
 
 UPDATE mem_accounts m
-SET vote = b.vote
+SET vote = b.vote, "missedBlocks" = b."missedBlocks", "producedBlocks" = b."producedBlocks"
 FROM mem_votes_snapshot b
 WHERE m.address = b.address;

--- a/db/sql/rounds/restore_votes_snapshot.sql
+++ b/db/sql/rounds/restore_votes_snapshot.sql
@@ -19,7 +19,7 @@
   PARAMETERS: ?
 */
 
-UPDATE mem_accounts m
-SET vote = b.vote, "missedBlocks" = b."missedBlocks", "producedBlocks" = b."producedBlocks"
-FROM mem_votes_snapshot b
-WHERE m.address = b.address;
+UPDATE mem_accounts accounts
+SET vote = snapshot.vote, "missedBlocks" = snapshot."missedBlocks", "producedBlocks" = snapshot."producedBlocks"
+FROM mem_votes_snapshot snapshot
+WHERE accounts.address = snapshot.address;

--- a/logic/account.js
+++ b/logic/account.js
@@ -410,8 +410,8 @@ class Account {
 	/**
 	 * Calculates productivity of a delegate account.
 	 *
-	 * @param {String} producedBlocks
-	 * @param {String} missedBlocks
+	 * @param {number} producedBlocks
+	 * @param {number} missedBlocks
 	 * @returns {number}
 	 */
 	// eslint-disable-next-line class-methods-use-this
@@ -790,12 +790,12 @@ Account.prototype.model = [
 	},
 	{
 		name: 'producedBlocks',
-		type: 'BigInt',
+		type: 'integer',
 		conv: Number,
 	},
 	{
 		name: 'missedBlocks',
-		type: 'BigInt',
+		type: 'integer',
 		conv: Number,
 	},
 	{

--- a/logic/round.js
+++ b/logic/round.js
@@ -382,9 +382,7 @@ class Round {
 
 	/**
 	 * Calls:
-	 * - updateVotes
 	 * - updateMissedBlocks
-	 * - flushRound
 	 * - applyRound
 	 * - updateVotes
 	 * - flushRound
@@ -392,9 +390,8 @@ class Round {
 	 * @returns {function} Call result
 	 */
 	land() {
-		return this.updateVotes()
+		return Promise.resolve()
 			.then(this.updateMissedBlocks.bind(this))
-			.then(this.flushRound.bind(this))
 			.then(this.applyRound.bind(this))
 			.then(this.updateVotes.bind(this))
 			.then(this.flushRound.bind(this))
@@ -403,23 +400,18 @@ class Round {
 
 	/**
 	 * Calls:
-	 * - updateVotes
-	 * - updateMissedBlocks
-	 * - flushRound
 	 * - applyRound
-	 * - updateVotes
 	 * - flushRound
+	 * - checkSnapshotAvailability
 	 * - restoreRoundSnapshot
 	 * - restoreVotesSnapshot
+	 * - deleteRoundRewards
 	 *
 	 * @returns {function} Call result
 	 */
 	backwardLand() {
-		return this.updateVotes()
-			.then(this.updateMissedBlocks.bind(this))
-			.then(this.flushRound.bind(this))
+		return Promise.resolve()
 			.then(this.applyRound.bind(this))
-			.then(this.updateVotes.bind(this))
 			.then(this.flushRound.bind(this))
 			.then(this.checkSnapshotAvailability.bind(this))
 			.then(this.restoreRoundSnapshot.bind(this))

--- a/test/fixtures/accounts.js
+++ b/test/fixtures/accounts.js
@@ -96,8 +96,8 @@ const Account = stampit({
 		u_multilifetime: 0,
 		nameexist: 0,
 		u_nameexist: 0,
-		producedBlocks: '9',
-		missedBlocks: '0',
+		producedBlocks: 9,
+		missedBlocks: 0,
 		fees: '0',
 		rewards: '0',
 	},
@@ -124,7 +124,7 @@ const Account = stampit({
 
 		this.vote = randomstring.generate({ charset: '123456789', length: 5 });
 
-		this.missedBlocks = missedBlocks || '0';
+		this.missedBlocks = missedBlocks || 0;
 		this.balance = balance || '0';
 	},
 });

--- a/test/functional/system/blocks/chain/delete_last_block_accounts.js
+++ b/test/functional/system/blocks/chain/delete_last_block_accounts.js
@@ -316,8 +316,8 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 							expect(res.u_isDelegate).to.equal(false);
 							expect(res.username).to.be.null;
 							expect(res.u_username).to.be.null;
-							expect(res.missedBlocks).to.equal('0');
-							expect(res.producedBlocks).to.equal('0');
+							expect(res.missedBlocks).to.equal(0);
+							expect(res.producedBlocks).to.equal(0);
 							expect(res.rank).to.be.null;
 							expect(res.rewards).to.equal('0');
 							expect(res.vote).to.equal('0');
@@ -349,8 +349,8 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 							expect(res.u_isDelegate).to.equal(true);
 							expect(res.username).to.be.equal(testAccount.username);
 							expect(res.u_username).to.be.equal(testAccount.username);
-							expect(res.missedBlocks).to.equal('0');
-							expect(res.producedBlocks).to.equal('0');
+							expect(res.missedBlocks).to.equal(0);
+							expect(res.producedBlocks).to.equal(0);
 							expect(res.rank).to.equal('102');
 							expect(res.rewards).to.equal('0');
 							expect(res.vote).to.equal('0');
@@ -378,8 +378,8 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 							expect(res.u_isDelegate).to.equal(false);
 							expect(res.username).to.be.null;
 							expect(res.u_username).to.be.null;
-							expect(res.missedBlocks).to.equal('0');
-							expect(res.producedBlocks).to.equal('0');
+							expect(res.missedBlocks).to.equal(0);
+							expect(res.producedBlocks).to.equal(0);
 							expect(res.rank).to.be.null;
 							expect(res.rewards).to.equal('0');
 							expect(res.vote).to.equal('0');
@@ -413,8 +413,8 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 							expect(res.u_username).to.be.equal(
 								testAccountDataAfterBlock.username
 							);
-							expect(res.missedBlocks).to.equal('0');
-							expect(res.producedBlocks).to.equal('0');
+							expect(res.missedBlocks).to.equal(0);
+							expect(res.producedBlocks).to.equal(0);
 							expect(res.rank).to.equal('102');
 							expect(res.rewards).to.equal('0');
 							expect(res.vote).to.equal('0');

--- a/test/functional/system/rounds.js
+++ b/test/functional/system/rounds.js
@@ -1018,9 +1018,7 @@ describe('rounds', () => {
 					});
 				});
 
-				// FIXME: Unskip that test after issue https://github.com/LiskHQ/lisk/issues/1783 is closed
-				// eslint-disable-next-line
-				it.skip('delegate who replaced last block forger should have vote, producedBlocks, missedBlocks = 0', () => {
+				it('delegate who replaced last block forger should have vote, producedBlocks, missedBlocks = 0', () => {
 					return getDelegates().then(_delegates => {
 						expect(_delegates[tmpAccount.publicKey].vote).to.equal('0');
 						expect(_delegates[tmpAccount.publicKey].producedBlocks).to.equal(0);

--- a/test/unit/db/repos/accounts.js
+++ b/test/unit/db/repos/accounts.js
@@ -1059,19 +1059,19 @@ describe('db', () => {
 						});
 					});
 
-					it('should return "producedBlocks" as "bigint"', () => {
+					it('should return "producedBlocks" as "number"', () => {
 						return db.accounts
 							.list({}, ['producedBlocks'], { limit: 1 })
 							.then(data => {
-								expect(data[0].producedBlocks).to.be.a('string');
+								expect(data[0].producedBlocks).to.be.a('number');
 							});
 					});
 
-					it('should return "missedBlocks" as "bigint"', () => {
+					it('should return "missedBlocks" as "number"', () => {
 						return db.accounts
 							.list({}, ['missedBlocks'], { limit: 1 })
 							.then(data => {
-								expect(data[0].missedBlocks).to.be.a('string');
+								expect(data[0].missedBlocks).to.be.a('number');
 							});
 					});
 				});

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -716,7 +716,13 @@ describe('db', () => {
 				expect(result).to.have.lengthOf(2);
 				return expect(result).to.have.deep.members(
 					delegates.map(d => {
-						return { publicKey: d.publicKey, address: d.address, vote: d.vote, producedBlocks: d.producedBlocks, missedBlocks: d.missedBlocks };
+						return {
+							publicKey: d.publicKey,
+							address: d.address,
+							vote: d.vote,
+							producedBlocks: d.producedBlocks,
+							missedBlocks: d.missedBlocks,
+						};
 					})
 				);
 			});

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -692,7 +692,7 @@ describe('db', () => {
 				return expect(db.none).to.be.calledOnce;
 			});
 
-			it('should copy the "address", "publicKey", "vote" from table "mem_accounts" to snapshot table "mem_votes_snapshot" for delegates', function*() {
+			it('should copy the "address", "publicKey", "vote", "producedBlocks", "missedBlocks" from table "mem_accounts" to snapshot table "mem_votes_snapshot" for delegates', function*() {
 				// Seed some account
 				const account1 = accountsFixtures.Account({ isDelegate: true });
 				const account2 = accountsFixtures.Account({ isDelegate: true });
@@ -716,7 +716,7 @@ describe('db', () => {
 				expect(result).to.have.lengthOf(2);
 				return expect(result).to.have.deep.members(
 					delegates.map(d => {
-						return { publicKey: d.publicKey, address: d.address, vote: d.vote };
+						return { publicKey: d.publicKey, address: d.address, vote: d.vote, producedBlocks: d.producedBlocks, missedBlocks: d.missedBlocks };
 					})
 				);
 			});

--- a/test/unit/db/repos/rounds.js
+++ b/test/unit/db/repos/rounds.js
@@ -193,9 +193,7 @@ describe('db', () => {
 				const after = (yield db.accounts.list({ address: account.address }))[0]
 					.missedBlocks;
 
-				return expect(after).to.be.eql(
-					new BigNumber(before).plus(1).toString()
-				);
+				return expect(after).to.be.eql(before + 1);
 			});
 
 			it('should decrement missed blocks for an account if backward flag is set to true', function*() {
@@ -206,9 +204,7 @@ describe('db', () => {
 				const after = (yield db.accounts.list({ address: account.address }))[0]
 					.missedBlocks;
 
-				return expect(after).to.be.eql(
-					new BigNumber(before).minus(1).toString()
-				);
+				return expect(after).to.be.eql(before - 1);
 			});
 		});
 

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -1914,21 +1914,20 @@ describe('rounds', () => {
 			return expect(isPromise(res)).to.be.true;
 		});
 
-		it('query getVotes should be called twice', () => {
-			// 2x updateVotes which calls 1x getVotes
-			return expect(getVotes_stub.callCount).to.equal(2);
+		it('query getVotes should be called once', () => {
+			return expect(getVotes_stub.callCount).to.equal(1);
 		});
 
-		it('query updateVotes should be called twice', () => {
-			return expect(updateVotes_stub.callCount).to.equal(2);
+		it('query updateVotes should be called once', () => {
+			return expect(updateVotes_stub.callCount).to.equal(1);
 		});
 
 		it('query updateMissedBlocks should be called once', () => {
 			return expect(roundOutsiders_stub.callCount).to.equal(1);
 		});
 
-		it('query flushRound should be called twice', () => {
-			return expect(flush_stub.callCount).to.equal(2);
+		it('query flushRound should be called once', () => {
+			return expect(flush_stub.callCount).to.equal(1);
 		});
 
 		it('modules.accounts.mergeAccountAndGet should be called 4 times', () => {
@@ -2004,21 +2003,20 @@ describe('rounds', () => {
 			return expect(isPromise(res)).to.be.true;
 		});
 
-		it('query getVotes should be called twice', () => {
-			// 2x updateVotes which calls 1x getVotes
-			return expect(getVotes_stub.callCount).to.equal(2);
+		it('query getVotes should not be called', () => {
+			return expect(getVotes_stub.called).to.be.false;
 		});
 
-		it('query updateVotes should be called twice', () => {
-			return expect(updateVotes_stub.callCount).to.equal(2);
+		it('query updateVotes should not be called', () => {
+			return expect(updateVotes_stub.called).to.be.false;
 		});
 
-		it('query updateMissedBlocks should be called once', () => {
-			return expect(roundOutsiders_stub.callCount).to.equal(1);
+		it('query updateMissedBlocks not be called', () => {
+			return expect(roundOutsiders_stub.called).to.be.false;
 		});
 
-		it('query flushRound should be called twice', () => {
-			return expect(flush_stub.callCount).to.equal(2);
+		it('query flushRound should be called once', () => {
+			return expect(flush_stub.callCount).to.equal(1);
 		});
 
 		it('modules.accounts.mergeAccountAndGet should be called 4 times', () => {


### PR DESCRIPTION
### What was the problem?
Inconsistencies in round module:
- `missedBlocks` and `producedBlocks` skipped during round snapshot creation
- redundant calls during `land` and `backwardLand` in round logic
- `missedBlocks` and `producedBlocks` casted to big integer (database type is `INT`)
### How did I fix it?
- snapshot `missedBlocks` and `producedBlocks` during round snapshot and then restoring them when we restore the snapshot
- simplify logic in `land` (removed `flushRound` call)
- simplify logic in `backwardLand` (removed `updateMissedBlocks`, `flushRound`, `updateVotes` calls - because they will be overwritten anyway from snapshot)
- remove `BIGINT` cast on `missedBlocks` and `producedBlocks`
- adjust expectations in various tests
- unskip scenario in functional system rounds test (previously failing)
### How to test it?
Run test suite.
### Review checklist

* The PR solves #216, #1783
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
