### PR TITLE
forge should be called after fillPool and not before - Closes #2170

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -907,7 +907,7 @@ Delegates.prototype.onBind = function(scope) {
  * @param {function} cb - Callback function
  */
 __private.nextForge = function(cb) {
-	async.series([__private.forge, modules.transactions.fillPool], cb);
+	async.series([modules.transactions.fillPool, __private.forge], cb);
 };
 
 /**


### PR DESCRIPTION
### What was the problem?
`forge` was called before `fillPool`.
### How did I fix it?
Switch the order and call `fillPool` before `forge`.
### How to test it?
Run test suite, we have correct order in all functional system tests already.
### Review checklist

* The PR solves #2170
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
