### PR TITLE
Forging status broken after resync with beta7 - Closes #2058

### DIFF
--- a/api/fittings/lisk_response_formatter.js
+++ b/api/fittings/lisk_response_formatter.js
@@ -45,7 +45,11 @@ module.exports = function create() {
 
 		if (_.isEmpty(context.input)) {
 			context.headers = { 'content-type': 'application/json' };
-			next(null, {});
+			next(null, {
+				meta: {},
+				data: context.input,
+				links: {},
+			});
 			return;
 		}
 


### PR DESCRIPTION
### What was the problem?
When the delegate list was empty the response status was 200 and body was`{}`
### How did I fix it?
Update the response formatter to to send valid response when the result is empty```{
				meta: {},
				data: context.input,
				links: {},
			}```
### How to test it?
Run the node with the empty delegate list and you should see 
response ```{
				meta: {},
				data:[],
				links: {},
			}```
for `http://localhost:4000/api/node/status/forging`
### Review checklist

* The PR solves #2058 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
