### PR TITLE
Add sorting by producedBlocks - Closes #1716

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -581,6 +581,8 @@ paths:
             - productivity:desc
             - missedBlocks:asc
             - missedBlocks:desc
+            - producedBlocks:asc
+            - producedBlocks:desc
           default: rank:asc
       responses:
         200:

--- a/test/functional/http/get/delegates.js
+++ b/test/functional/http/get/delegates.js
@@ -424,6 +424,28 @@ describe('GET /delegates', () => {
 					});
 			});
 
+			it('using sort="producedBlocks:asc" should sort results in ascending order', () => {
+				return delegatesEndpoint
+					.makeRequest({ sort: 'producedBlocks:asc' }, 200)
+					.then(res => {
+						expect(_.map(res.data, 'producedBlocks').sort()).to.eql(
+							_.map(res.data, 'producedBlocks')
+						);
+					});
+			});
+
+			it('using sort="producedBlocks:desc" should sort results in descending order', () => {
+				return delegatesEndpoint
+					.makeRequest({ sort: 'producedBlocks:desc' }, 200)
+					.then(res => {
+						expect(
+							_.map(res.data, 'producedBlocks')
+								.sort()
+								.reverse()
+						).to.eql(_.map(res.data, 'producedBlocks'));
+					});
+			});
+
 			it('using sort="productivity:asc" should sort results in ascending order', () => {
 				return delegatesEndpoint
 					.makeRequest({ sort: 'productivity:asc' }, 200)


### PR DESCRIPTION
### What was the problem?

Sorting results of `/api/delegates` by `producedBlocks` was not supported

### How did I fix it?

Added support for sorting delegates results by producedBlocks in ascending and descending order.
Added functional tests for sorting by produced blocks.

### How to test it?

Call `/api/delegates?sort=producedBlocks:asc` for produced blocks in ascending order
Cal `/api/delegates?sort=producedBlocks:desc` for produced blocks in descending order

### Review checklist

* The PR solves #1716 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
