### PR TITLE
Update jenkins integration to use the dedicated build server - Closes #2182

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -34,7 +34,7 @@ def cleanUp() {
 	'''
 }
 
-node('node-06') {
+node('lisk-integration') {
 	lock(resource: "core-integration-tests", inversePrecedence: true) {
 
 		properties([


### PR DESCRIPTION
### What was the problem?
The integration test was failing consistently when it was running in parallel with other builds.
### How did I fix it?
Use dedicated build server for integration test
### How to test it?
Run integration test on jenkins in parallel with the other builds like lisk-core, lisk-hub and observe the integration build succeeds.
### Review checklist

* The PR solves #2182 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
