### PR TITLE
Improve vote transaction verification performance

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -360,7 +360,7 @@ __private.checkDelegates = function(senderPublicKey, votes, state, cb, tx) {
 
 	// Converting publicKeys to addresses because module.accounts do not support fetching multiple accounts by publicKeys
 	// TODO: Use Hashmap to improve performance further.
-	const actionWithAddresses = votes.map(vote => {
+	const voteAddressesWithActions = votes.map(vote => {
 		const action = vote[0];
 		let voteAddress;
 
@@ -413,7 +413,7 @@ __private.checkDelegates = function(senderPublicKey, votes, state, cb, tx) {
 			function validateVotes(existingVotedAddresses, waterfallCb) {
 				modules.accounts.getAccounts(
 					{
-						address: actionWithAddresses.map(({ address }) => address),
+						address: voteAddressesWithActions.map(({ address }) => address),
 						isDelegate: 1,
 					},
 					(err, votesAccounts) => {
@@ -423,12 +423,12 @@ __private.checkDelegates = function(senderPublicKey, votes, state, cb, tx) {
 
 						if (
 							!votesAccounts ||
-							votesAccounts.length < actionWithAddresses.length
+							votesAccounts.length < voteAddressesWithActions.length
 						) {
 							library.logger.error(
 								'Delegates with addresses not found',
 								_.differenceWith(
-									actionWithAddresses,
+									voteAddressesWithActions,
 									votesAccounts,
 									(
 										{ address: addressFromTransaction },
@@ -440,14 +440,14 @@ __private.checkDelegates = function(senderPublicKey, votes, state, cb, tx) {
 						}
 
 						const upvoteAccounts = votesAccounts.filter(voteAccount =>
-							actionWithAddresses.find(
+							voteAddressesWithActions.find(
 								actionWithAddress =>
 									actionWithAddress.action === '+' &&
 									actionWithAddress.address === voteAccount.address
 							)
 						);
 						const downvoteAccounts = votesAccounts.filter(voteAccount =>
-							actionWithAddresses.find(
+							voteAddressesWithActions.find(
 								actionWithAddress =>
 									actionWithAddress.action === '-' &&
 									actionWithAddress.address === voteAccount.address

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -434,7 +434,7 @@ __private.checkDelegates = function(senderPublicKey, votes, state, cb, tx) {
 										{ address: addressFromTransaction },
 										{ addressFromAccount }
 									) => addressFromTransaction === addressFromAccount
-								)
+								).map(({ address }) => address)
 							);
 							return setImmediate(waterfallCb, 'Delegate not found');
 						}

--- a/test/functional/http/post/3.votes.js
+++ b/test/functional/http/post/3.votes.js
@@ -381,6 +381,21 @@ describe('POST /api/transactions (type 3) votes', () => {
 			});
 		});
 
+		it('upvoting non delegate should be fail', () => {
+			transaction = lisk.transaction.castVotes({
+				passphrase: accountMinimalFunds.passphrase,
+				votes: [`${accountMinimalFunds.publicKey}`],
+			});
+
+			return sendTransactionPromise(
+				transaction,
+				errorCodes.PROCESSING_ERROR
+			).then(res => {
+				expect(res.body.message).to.equal('Delegate not found');
+				badTransactions.push(transaction);
+			});
+		});
+
 		it('upvoting with minimal required amount of funds should be ok', () => {
 			transaction = lisk.transaction.castVotes({
 				passphrase: accountMinimalFunds.passphrase,

--- a/test/unit/logic/vote.js
+++ b/test/unit/logic/vote.js
@@ -28,7 +28,8 @@ var constants = require('../../../helpers/constants');
 var Vote = require('../../../logic/vote');
 var Transfer = require('../../../logic/transfer');
 
-var validPassphrase = 'robust weapon course unknown head trial pencil latin acid';
+var validPassphrase =
+	'robust weapon course unknown head trial pencil latin acid';
 var validKeypair = ed.makeKeypair(
 	crypto
 		.createHash('sha256')
@@ -413,7 +414,7 @@ describe('vote', () => {
 			});
 			vote.checkConfirmedDelegates(transaction, err => {
 				expect(err).to.equal(
-					'Failed to add vote, delegate "genesis_99" already voted for'
+					'Failed to add vote, delegate "genesis_95" already voted for'
 				);
 				done();
 			});
@@ -468,7 +469,7 @@ describe('vote', () => {
 			});
 			vote.checkUnconfirmedDelegates(transaction, err => {
 				expect(err).to.equal(
-					'Failed to add vote, delegate "genesis_99" already voted for'
+					'Failed to add vote, delegate "genesis_95" already voted for'
 				);
 
 				done();


### PR DESCRIPTION
### What was the problem?
The vote transaction verification was slow because the dependent rows for validating a transaction were fetched from the database in series. 
### How did I fix it?
When verifying a transaction, the application now aggregates addresses of all accounts in memory first and then runs one query to fetch all accounts.
### How to test it?
Create alpha-net and run vote transactions stress tests. Compare performance with the older version. 
### Review checklist
Check behavior is exactly the same.
Check there are significant performance improvements.
* The PR solves #2168
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
