### PR TITLE
Compilation of µWebSockets has failed and there is no pre-compiled binary available for your system - Closes #1835

### DIFF
--- a/app.js
+++ b/app.js
@@ -473,7 +473,7 @@ d.run(() => {
 						workers: scope.config.wsWorkers,
 						port: scope.config.wsPort,
 						host: '0.0.0.0',
-						wsEngine: scope.config.wsEngine || 'sc-uws',
+						wsEngine: scope.config.wsEngine,
 						appName: 'lisk',
 						workerController: workersControllerPath,
 						perMessageDeflate: false,

--- a/app.js
+++ b/app.js
@@ -473,7 +473,7 @@ d.run(() => {
 						workers: scope.config.wsWorkers,
 						port: scope.config.wsPort,
 						host: '0.0.0.0',
-						wsEngine: scope.config.wsEngine,
+						wsEngine: scope.config.peers.options.wsEngine,
 						appName: 'lisk',
 						workerController: workersControllerPath,
 						perMessageDeflate: false,

--- a/app.js
+++ b/app.js
@@ -473,7 +473,7 @@ d.run(() => {
 						workers: scope.config.wsWorkers,
 						port: scope.config.wsPort,
 						host: '0.0.0.0',
-						wsEngine: 'sc-uws',
+						wsEngine: scope.config.wsEngine || 'sc-uws',
 						appName: 'lisk',
 						workerController: workersControllerPath,
 						perMessageDeflate: false,
@@ -522,6 +522,11 @@ d.run(() => {
 					// The 'fail' event aggregates errors from all SocketCluster processes.
 					scope.socketCluster.on('fail', err => {
 						scope.logger.error(err);
+						if (err.name === 'WSEngineInitError') {
+							var extendedError =
+								'If you are not able to install sc-uws, you can try setting the wsEngine property in config.json to "ws" before starting the node';
+							scope.logger.error(extendedError);
+						}
 					});
 
 					scope.socketCluster.on('workerExit', workerInfo => {

--- a/config/alphanet/config.json
+++ b/config/alphanet/config.json
@@ -62,7 +62,8 @@
 		},
 		"options": {
 			"timeout": 5000,
-			"broadhashConsensusCalculationInterval": 5000
+			"broadhashConsensusCalculationInterval": 5000,
+			"wsEngine": "sc-uws"
 		}
 	},
 	"broadcasts": {

--- a/config/betanet/config.json
+++ b/config/betanet/config.json
@@ -78,7 +78,8 @@
 		},
 		"options": {
 			"timeout": 5000,
-			"broadhashConsensusCalculationInterval": 5000
+			"broadhashConsensusCalculationInterval": 5000,
+			"wsEngine": "sc-uws"
 		}
 	},
 	"broadcasts": {

--- a/config/devnet/config.json
+++ b/config/devnet/config.json
@@ -62,7 +62,8 @@
 		},
 		"options": {
 			"timeout": 5000,
-			"broadhashConsensusCalculationInterval": 5000
+			"broadhashConsensusCalculationInterval": 5000,
+			"wsEngine": "sc-uws"
 		}
 	},
 	"broadcasts": {

--- a/config/mainnet/config.json
+++ b/config/mainnet/config.json
@@ -98,7 +98,8 @@
 		},
 		"options": {
 			"timeout": 5000,
-			"broadhashConsensusCalculationInterval": 5000
+			"broadhashConsensusCalculationInterval": 5000,
+			"wsEngine": "sc-uws"
 		}
 	},
 	"broadcasts": {

--- a/config/testnet/config.json
+++ b/config/testnet/config.json
@@ -78,7 +78,8 @@
 		},
 		"options": {
 			"timeout": 5000,
-			"broadhashConsensusCalculationInterval": 5000
+			"broadhashConsensusCalculationInterval": 5000,
+			"wsEngine": "sc-uws"
 		}
 	},
 	"broadcasts": {

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -146,6 +146,10 @@ function Config(packageJson) {
 		appConfig.coverage = true;
 	}
 
+	if (appConfig.wsEngine === undefined || appConfig.wsEngine === null) {
+		appConfig.wsEngine = 'sc-uws';
+	}
+
 	if (
 		appConfig.api.options.cors.origin === undefined ||
 		appConfig.api.options.cors.origin === null

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -146,8 +146,11 @@ function Config(packageJson) {
 		appConfig.coverage = true;
 	}
 
-	if (appConfig.wsEngine === undefined || appConfig.wsEngine === null) {
-		appConfig.wsEngine = 'sc-uws';
+	if (
+		appConfig.peers.options.wsEngine === undefined ||
+		appConfig.peers.options.wsEngine === null
+	) {
+		appConfig.peers.options.wsEngine = 'sc-uws';
 	}
 
 	if (

--- a/schema/config.js
+++ b/schema/config.js
@@ -213,6 +213,12 @@ module.exports = {
 							timeout: {
 								type: 'integer',
 							},
+							broadhashConsensusCalculationInterval: {
+								type: 'integer',
+							},
+							wsEngine: {
+								type: 'string',
+							},
 						},
 						required: ['timeout'],
 					},


### PR DESCRIPTION
### What was the problem?

On some systems, running the Lisk node causes an error to be thrown related to the uws/sc-uws module.

### How did I fix it?

Added support for a new `wsEngine` config option which allows switching to the `'ws'` module which is slower but compatible with more systems.

### How to test it?

Try running the Lisk node on an older OS which is not supported by the uws module.
Alternatively, for testing, you can force the `sc-uws` module to always throw an error (I.e. in `sc-uws/uws.js`, you can force the `'Compilation of µWebSockets has failed and ...'` error to be thrown).

### Review checklist

* The PR solves #1835 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
