### PR TITLE
Remove "Broadhash consensus now" log messages - Closes #2263

### DIFF
--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -104,11 +104,6 @@ class Broadcaster {
 	getPeers(params, cb) {
 		params.limit = params.limit || this.config.peerLimit;
 		const peers = library.logic.peers.listRandomConnected(params);
-		library.logger.info(
-			['Broadhash consensus now', modules.peers.getLastConsensus(), '%'].join(
-				' '
-			)
-		);
 		return setImmediate(cb, null, peers);
 	}
 

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -760,7 +760,7 @@ __private.sync = function(cb) {
 
 	async.series(
 		{
-			getPeersBefore(seriesCb) {
+			getConsensusBefore(seriesCb) {
 				library.logger.debug(
 					`Establishing broadhash consensus before sync: ${modules.peers.getLastConsensus()} %`
 				);
@@ -777,7 +777,7 @@ __private.sync = function(cb) {
 				// Notify all remote peers about our new headers
 				modules.transport.broadcastHeaders(seriesCb);
 			},
-			getPeersAfter(seriesCb) {
+			calculateConsensusAfter(seriesCb) {
 				library.logger.debug(
 					`Establishing broadhash consensus after sync: ${modules.peers.calculateConsensus()} %`
 				);

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -761,7 +761,9 @@ __private.sync = function(cb) {
 	async.series(
 		{
 			getPeersBefore(seriesCb) {
-				library.logger.debug(`Establishing broadhash consensus before sync: ${ modules.peers.calculateConsensus() } %`);
+				library.logger.debug(
+					`Establishing broadhash consensus before sync: ${modules.peers.getLastConsensus()} %`
+				);
 				return seriesCb();
 			},
 			loadBlocksFromNetwork(seriesCb) {
@@ -776,7 +778,9 @@ __private.sync = function(cb) {
 				modules.transport.broadcastHeaders(seriesCb);
 			},
 			getPeersAfter(seriesCb) {
-				library.logger.debug(`Establishing broadhash consensus after sync: ${ modules.peers.calculateConsensus() } %`);
+				library.logger.debug(
+					`Establishing broadhash consensus after sync: ${modules.peers.calculateConsensus()} %`
+				);
 				return seriesCb();
 			},
 		},

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -761,11 +761,8 @@ __private.sync = function(cb) {
 	async.series(
 		{
 			getPeersBefore(seriesCb) {
-				library.logger.debug('Establishing broadhash consensus before sync');
-				return modules.transport.getPeers(
-					{ limit: constants.maxPeers },
-					seriesCb
-				);
+				library.logger.debug(`Establishing broadhash consensus before sync: ${ modules.peers.calculateConsensus() } %`);
+				return seriesCb();
 			},
 			loadBlocksFromNetwork(seriesCb) {
 				return __private.loadBlocksFromNetwork(seriesCb);
@@ -779,11 +776,8 @@ __private.sync = function(cb) {
 				modules.transport.broadcastHeaders(seriesCb);
 			},
 			getPeersAfter(seriesCb) {
-				library.logger.debug('Establishing broadhash consensus after sync');
-				return modules.transport.getPeers(
-					{ limit: constants.maxPeers },
-					seriesCb
-				);
+				library.logger.debug(`Establishing broadhash consensus after sync: ${ modules.peers.calculateConsensus() } %`);
+				return seriesCb();
 			},
 		},
 		err => {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -760,9 +760,9 @@ __private.sync = function(cb) {
 
 	async.series(
 		{
-			getConsensusBefore(seriesCb) {
+			calculateConsensusBefore(seriesCb) {
 				library.logger.debug(
-					`Establishing broadhash consensus before sync: ${modules.peers.getLastConsensus()} %`
+					`Establishing broadhash consensus before sync: ${modules.peers.calculateConsensus()} %`
 				);
 				return seriesCb();
 			},

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -288,18 +288,6 @@ Transport.prototype.poorConsensus = function() {
 	return modules.peers.calculateConsensus() < constants.minBroadhashConsensus;
 };
 
-/**
- * Calls getPeers method from Broadcaster class.
- *
- * @param {Object} params
- * @param {function} cb - Callback function
- * @returns {Broadcaster.getPeers} Calls getPeers
- * @todo Add description for the params
- */
-Transport.prototype.getPeers = function(params, cb) {
-	return __private.broadcaster.getPeers(params, cb);
-};
-
 // Events
 /**
  * Bounds scope to private broadcaster amd initialize headers.

--- a/test/unit/logic/broadcaster.js
+++ b/test/unit/logic/broadcaster.js
@@ -203,10 +203,6 @@ describe('Broadcaster', () => {
 				expect(peersStub.listRandomConnected.args[0][1]).to.not.be.a(
 					'function'
 				);
-				expect(loggerStub.info.calledOnce).to.be.true;
-				expect(loggerStub.info.args[0][0]).to.eql(
-					'Broadhash consensus now 101 %'
-				);
 				done();
 			});
 		});

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1158,29 +1158,6 @@ describe('transport', () => {
 			});
 		});
 
-		describe('getPeers', () => {
-			var paramsArg = {};
-			var callbackArg = {};
-
-			beforeEach(done => {
-				__private.broadcaster = {
-					getPeers: sinonSandbox.stub().callsArgWith(1, null, []),
-				};
-
-				paramsArg = {};
-				callbackArg = () => {};
-
-				transportInstance.getPeers(paramsArg, callbackArg);
-				done();
-			});
-
-			it('should call __private.broadcaster.getPeers with paramsArg and callbackArg as arguments', () => {
-				return expect(
-					__private.broadcaster.getPeers.calledWith(paramsArg, callbackArg)
-				).to.be.true;
-			});
-		});
-
 		describe('onBind', () => {
 			beforeEach(done => {
 				// Create a new TransportModule instance.


### PR DESCRIPTION
### What was the problem?

The log message "Broadhash consensus now" is very misleading for users who consider it the primary source of broadhash consensus observation, since it is in the info log level.

There are multiple issues with the log command:
1. it is misplaces because getPeers is a helper that can be called from multiple places and not a lifecycle method. The log content is unrelated to the functionality of getPeers.
2. it is delayed, since the logged value is not calculated before the call. So it can be multiple seconds old
3. it only represents half (or less) of the consensus values available. Since getPeers is usually called in a block broadcast step, it is called about every 10 seconds. But broadhash consensus is recalculated every 5 seconds, which covers different positions within the 10 second slot instead of one.

### How did I fix it?

- delete the misplaces log command
- if broadhash consensus logging should remain in the app lifecycle every 10 seconds, create a new logging with the text "Last broadhash consensus was" instead of "Broadhash consensus now". This should be called no matter if broadcasting happens or not. However, having a log always at the same second of a slot can lead to problematic values (in second 0, I might be the only one that received a fresh block).
- if the best available data should be logged to info, upgrade log level in the [calculateConsensus job](https://github.com/LiskHQ/lisk/blob/v1.0.0-rc.1/modules/peers.js#L876) from debug to info.

I choose to implement the first point only since it avoids spam and let's users find the true broadhash consensus via debug logging.

### How to test it?

See this user logs:

```
[dbg] 2018-07-01 22:30:07 | Broadhash consensus: 100 %
[dbg] 2018-07-01 22:30:12 | Broadhash consensus: 100 %
[dbg] 2018-07-01 22:30:17 | Broadhash consensus: 100 %
[inf] 2018-07-01 22:30:20 | Broadhash consensus now 100 %
[dbg] 2018-07-01 22:30:22 | Broadhash consensus: 93 %
[dbg] 2018-07-01 22:30:27 | Broadhash consensus: 94 %
[dbg] 2018-07-01 22:30:32 | Broadhash consensus: 95 %
[dbg] 2018-07-01 22:30:37 | Broadhash consensus: 98 %
[inf] 2018-07-01 22:30:40 | Broadhash consensus now 98 %
[dbg] 2018-07-01 22:30:42 | Broadhash consensus: 89 %
[dbg] 2018-07-01 22:30:47 | Broadhash consensus: 100 %
[inf] 2018-07-01 22:30:50 | Broadhash consensus now 100 %
[dbg] 2018-07-01 22:30:52 | Broadhash consensus: 83 %
[dbg] 2018-07-01 22:30:57 | Broadhash consensus: 82 %
[inf] 2018-07-01 22:31:00 | Broadhash consensus now 82 %
[dbg] 2018-07-01 22:31:02 | Broadhash consensus: 92 %
[dbg] 2018-07-01 22:31:07 | Broadhash consensus: 93 %
[dbg] 2018-07-01 22:31:12 | Broadhash consensus: 96 %
[dbg] 2018-07-01 22:31:17 | Broadhash consensus: 98 %
```

### Review checklist

* The PR solves #2263
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
