### PR TITLE
Clean the version and minVersion config from all config files - Closes #2184

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ RUN curl --silent --show-error --location --output /tmp/confd \
 	exit 1; \
     fi
 
-RUN LISK_VERSION=$( jq --raw-output .version /home/lisk/lisk/config.json ) && \
-    LISK_MIN_VERSION=$( jq --raw-output .minVersion /home/lisk/lisk/config.json ) && \
+RUN LISK_VERSION=$( jq --raw-output .version /home/lisk/lisk/package.json ) && \
+    LISK_MIN_VERSION=$( jq --raw-output .lisk.minVersion /home/lisk/lisk/package.json ) && \
     sed --in-place --expression \
         "s/__LISK_VERSION__REPLACE_ME__/$LISK_VERSION/;s/__LISK_MIN_VERSION__REPLACE_ME__/$LISK_MIN_VERSION/" \
 	/etc/confd/templates/config.json.tmpl

--- a/config/alphanet/config.json
+++ b/config/alphanet/config.json
@@ -2,8 +2,6 @@
 	"wsPort": 5000,
 	"httpPort": 4000,
 	"address": "0.0.0.0",
-	"version": "1.1.0-alpha.0",
-	"minVersion": "1.0.0-beta.9.2",
 	"fileLogLevel": "debug",
 	"logFileName": "logs/lisk.log",
 	"consoleLogLevel": "info",

--- a/config/betanet/config.json
+++ b/config/betanet/config.json
@@ -2,8 +2,6 @@
 	"wsPort": 5001,
 	"httpPort": 5000,
 	"address": "0.0.0.0",
-	"version": "1.1.0-alpha.0",
-	"minVersion": "1.0.0-beta.9",
 	"fileLogLevel": "debug",
 	"logFileName": "logs/lisk.log",
 	"consoleLogLevel": "error",

--- a/config/devnet/config.json
+++ b/config/devnet/config.json
@@ -2,8 +2,6 @@
 	"wsPort": 5000,
 	"httpPort": 4000,
 	"address": "0.0.0.0",
-	"version": "1.1.0-alpha.0",
-	"minVersion": "1.0.0-beta.9.2",
 	"fileLogLevel": "debug",
 	"logFileName": "logs/lisk.log",
 	"consoleLogLevel": "info",

--- a/config/mainnet/config.json
+++ b/config/mainnet/config.json
@@ -2,8 +2,6 @@
 	"wsPort": 8001,
 	"httpPort": 8000,
 	"address": "0.0.0.0",
-	"version": "1.1.0-alpha.0",
-	"minVersion": "0.9.5",
 	"fileLogLevel": "info",
 	"logFileName": "logs/lisk.log",
 	"consoleLogLevel": "none",

--- a/config/testnet/config.json
+++ b/config/testnet/config.json
@@ -2,8 +2,6 @@
 	"wsPort": 7001,
 	"httpPort": 7000,
 	"address": "0.0.0.0",
-	"version": "1.0.0-rc.0.1",
-	"minVersion": "1.0.0-rc.0.1",
 	"fileLogLevel": "info",
 	"logFileName": "logs/lisk.log",
 	"consoleLogLevel": "none",

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -80,6 +80,8 @@ function Config(packageJson) {
 		}
 	}
 
+	appConfig.version = packageJson.version;
+	appConfig.minVersion = packageJson.lisk.minVersion;
 	appConfig.network = network;
 	appConfig.genesisBlock = JSON.parse(
 		fs.readFileSync(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lisk",
-	"version": "0.9.8",
+	"version": "1.1.0-alpha.0",
 	"description": "Lisk blockchain application platform",
 	"author":
 		"Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
@@ -121,5 +121,8 @@
 		"stampit": "=4.0.2",
 		"supertest": "=3.0.0"
 	},
-	"snyk": true
+	"snyk": true,
+	"lisk": {
+		"minVersion": ">=1.0.0-beta.9.2"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -123,6 +123,6 @@
 	},
 	"snyk": true,
 	"lisk": {
-		"minVersion": ">=1.0.0-beta.9.2"
+		"minVersion": "1.0.0-beta.9.2"
 	}
 }

--- a/schema/config.js
+++ b/schema/config.js
@@ -33,13 +33,6 @@ module.exports = {
 				type: 'string',
 				format: 'ip',
 			},
-			version: {
-				type: 'string',
-				format: 'version',
-			},
-			minVersion: {
-				type: 'string',
-			},
 			fileLogLevel: {
 				type: 'string',
 			},
@@ -348,8 +341,6 @@ module.exports = {
 			'wsPort',
 			'httpPort',
 			'address',
-			'version',
-			'minVersion',
 			'fileLogLevel',
 			'logFileName',
 			'consoleLogLevel',

--- a/test/setup.js
+++ b/test/setup.js
@@ -23,6 +23,7 @@ var sinonChai = require('sinon-chai');
 var chaiAsPromised = require('chai-as-promised');
 var supertest = require('supertest');
 var _ = require('lodash');
+const packageJson = require('../package.json');
 
 coMocha(mocha);
 
@@ -35,6 +36,9 @@ var testContext = {};
 
 testContext.config = require('../config/devnet/config.json');
 testContext.config.genesisBlock = require('../config/devnet/genesis_block.json');
+
+testContext.config.version = packageJson.version;
+testContext.config.minVersion = packageJson.lisk.minVersion;
 
 testContext.config.nethash = Buffer.from(
 	testContext.config.genesisBlock.payloadHash,


### PR DESCRIPTION
### What was the problem?
`version` of the lisk itself is identifier for the software so should not be configureable. So instead `version` inside `package.json` is the right place to specify the version of the current software package. 

### How did I fix it?
Removed the `version` and `minVersion` from all configuration files and moved it to `package.json`

### How to test it?
Run core and integration tests. 

### Review checklist

* The PR solves #2184
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
