### PR TITLE
Check if socket cluster exists before calling remove

### DIFF
--- a/app.js
+++ b/app.js
@@ -773,8 +773,10 @@ d.run(() => {
 					scope.logger.fatal(error.toString());
 				}
 				scope.logger.info('Cleaning up...');
-				scope.socketCluster.removeAllListeners('fail');
-				scope.socketCluster.destroy();
+				if (scope.socketCluster) {
+					scope.socketCluster.removeAllListeners('fail');
+					scope.socketCluster.destroy();
+				}
 				async.eachSeries(
 					modules,
 					(module, cb) => {


### PR DESCRIPTION
### What was the problem?
The process clean up was failing due to socket cluster was not initialized as the database initialization failed.
### How did I fix it?
Since database initialization happens first and then the socket cluster, before removing and destroying the socket connection, checking of the socket cluster was initialized.
### How to test it?
1. Change the DB name in config which actually does not exist 
2. Start the app with `node app.js`
### Review checklist

* The PR solves #2188 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
