### PR TITLE
Fix config usage in worker_controller - Closes #2216

### DIFF
--- a/workers_controller.js
+++ b/workers_controller.js
@@ -29,7 +29,7 @@ var Rules = require('./api/ws/workers/rules');
 var failureCodes = require('./api/ws/rpc/failure_codes');
 var Logger = require('./logger');
 var AppConfig = require('./helpers/config.js');
-var config = AppConfig(require('./package.json'));
+var config = AppConfig(require('./package.json'), false);
 
 /**
  * Instantiate the SocketCluster SCWorker instance with custom logic

--- a/workers_controller.js
+++ b/workers_controller.js
@@ -14,8 +14,6 @@
 
 'use strict';
 
-var path = require('path');
-var fs = require('fs');
 var async = require('async');
 var SCWorker = require('socketcluster/scworker');
 var SlaveWAMPServer = require('wamp-socket-cluster/SlaveWAMPServer');
@@ -30,14 +28,8 @@ var PeersUpdateRules = require('./api/ws/workers/peers_update_rules');
 var Rules = require('./api/ws/workers/rules');
 var failureCodes = require('./api/ws/rpc/failure_codes');
 var Logger = require('./logger');
-
-var config = fs.readFileSync(
-	path.resolve(
-		process.cwd(),
-		`./config/${process.env.LISK_NETWORK}/config.json`
-	),
-	'utf8'
-);
+var AppConfig = require('./helpers/config.js');
+var config = AppConfig(require('./package.json'));
 
 /**
  * Instantiate the SocketCluster SCWorker instance with custom logic


### PR DESCRIPTION
### What was the problem?
`worker_controller.js` was using the outdated way of getting the config.

### How did I fix it?
Use the latest way of getting the config as the `app.js`

### How to test it?
Observe if the child process is successfully started

### Review checklist

* The PR solves #2216
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
