### PR TITLE
Change default scheme to https - Closes #2221

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -91,8 +91,8 @@ tags:
   description: Votes related API calls
 
 schemes:
-  - http
   - https
+  - http
 
 paths:
   /accounts:


### PR DESCRIPTION
### What was the problem?
When using interactive mode of swagger-ui, the requests fail.
This is because the default scheme is HTTP and has to be changed manually to HTTPS.

### How did I fix it?
Changed order of schemes in `swagger.yml`

### How to test it?
run `node app.js`
explore `http://localhost:4000/api/spec` with http://petstore.swagger.io/
Link to Lisk Core API documentation: https://lisk.io/documentation/lisk-core/user-guide/api/1-0

### Review checklist

* The PR solves #2221 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
