### PR TITLE
Do not write defaultPassword to config when migrating - Closes #2208

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -127,7 +127,6 @@ function migrateSecrets(password) {
 	}
 
 	console.info('\nMigrating your secrets...');
-	oldConfig.forging.defaultPassword = password;
 	oldConfig.forging.secret.forEach(secret => {
 		console.info('.......');
 		oldConfig.forging.delegates.push({


### PR DESCRIPTION
### What was the problem?
We were migrating the encryption password as `defaultPassword` during the config migration. 

### How did I fix it?
Only used for encryption and didn't copied over to config file.

### How to test it?
```
node scripts/update_config.js ../lisk-0.9/test/config.json ./config.json
```

### Review checklist

* The PR solves #2208
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated