### PR TITLE
SSL breaks Websocket connection - Closes #2154

### DIFF
--- a/app.js
+++ b/app.js
@@ -277,9 +277,9 @@ d.run(() => {
 					var https;
 					var https_io;
 
-					if (scope.config.ssl.enabled) {
-						privateKey = fs.readFileSync(scope.config.ssl.options.key);
-						certificate = fs.readFileSync(scope.config.ssl.options.cert);
+					if (scope.config.api.ssl.enabled) {
+						privateKey = fs.readFileSync(scope.config.api.ssl.options.key);
+						certificate = fs.readFileSync(scope.config.api.ssl.options.cert);
 
 						https = require('https').createServer(
 							{
@@ -721,15 +721,15 @@ d.run(() => {
 							);
 
 							if (!err) {
-								if (scope.config.ssl.enabled) {
+								if (scope.config.api.ssl.enabled) {
 									scope.network.https.listen(
-										scope.config.ssl.options.port,
-										scope.config.ssl.options.address,
+										scope.config.api.ssl.options.port,
+										scope.config.api.ssl.options.address,
 										err => {
 											scope.logger.info(
 												`Lisk https started: ${
-													scope.config.ssl.options.address
-												}:${scope.config.ssl.options.port}`
+													scope.config.api.ssl.options.address
+												}:${scope.config.api.ssl.options.port}`
 											);
 
 											cb(err, scope.network);

--- a/app.js
+++ b/app.js
@@ -17,7 +17,6 @@
 var path = require('path');
 var fs = require('fs');
 var d = require('domain').create();
-var extend = require('extend');
 var SocketCluster = require('socketcluster');
 var async = require('async');
 var randomstring = require('randomstring');
@@ -38,7 +37,6 @@ var swaggerHelper = require('./helpers/swagger');
  * @namespace app
  * @requires async
  * @requires domain.create
- * @requires extend
  * @requires fs
  * @requires socketcluster
  * @requires genesis_block.json
@@ -483,18 +481,6 @@ d.run(() => {
 						processTermTimeout: 10000,
 						logLevel: 0,
 					};
-
-					if (scope.config.ssl.enabled) {
-						extend(webSocketConfig, {
-							protocol: 'https',
-							protocolOptions: {
-								key: fs.readFileSync(scope.config.ssl.options.key),
-								cert: fs.readFileSync(scope.config.ssl.options.cert),
-								ciphers:
-									'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA',
-							},
-						});
-					}
 
 					var childProcessOptions = {
 						version: scope.config.version,

--- a/config.json
+++ b/config.json
@@ -36,6 +36,15 @@
 			"public": false,
 			"whiteList": ["127.0.0.1"]
 		},
+		"ssl": {
+			"enabled": false,
+			"options": {
+				"port": 443,
+				"address": "0.0.0.0",
+				"key": "./ssl/lisk.key",
+				"cert": "./ssl/lisk.crt"
+			}
+		},
 		"options": {
 			"limits": {
 				"max": 0,
@@ -124,15 +133,6 @@
 	},
 	"loading": {
 		"loadPerIteration": 5000
-	},
-	"ssl": {
-		"enabled": false,
-		"options": {
-			"port": 443,
-			"address": "0.0.0.0",
-			"key": "./ssl/lisk.key",
-			"cert": "./ssl/lisk.crt"
-		}
 	},
 	"nethash": "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"
 }

--- a/schema/config.js
+++ b/schema/config.js
@@ -151,6 +151,34 @@ module.exports = {
 						},
 						required: ['public', 'whiteList'],
 					},
+					ssl: {
+						type: 'object',
+						properties: {
+							enabled: {
+								type: 'boolean',
+							},
+							options: {
+								type: 'object',
+								properties: {
+									port: {
+										type: 'integer',
+									},
+									address: {
+										type: 'string',
+										format: 'ip',
+									},
+									key: {
+										type: 'string',
+									},
+									cert: {
+										type: 'string',
+									},
+								},
+								required: ['port', 'address', 'key', 'cert'],
+							},
+						},
+						required: ['enabled', 'options'],
+					},
 					options: {
 						type: 'object',
 						properties: {
@@ -188,7 +216,7 @@ module.exports = {
 						required: ['limits', 'cors'],
 					},
 				},
-				required: ['enabled', 'access', 'options'],
+				required: ['enabled', 'access', 'ssl', 'options'],
 			},
 			peers: {
 				type: 'object',
@@ -315,34 +343,6 @@ module.exports = {
 				},
 				required: ['loadPerIteration'],
 			},
-			ssl: {
-				type: 'object',
-				properties: {
-					enabled: {
-						type: 'boolean',
-					},
-					options: {
-						type: 'object',
-						properties: {
-							port: {
-								type: 'integer',
-							},
-							address: {
-								type: 'string',
-								format: 'ip',
-							},
-							key: {
-								type: 'string',
-							},
-							cert: {
-								type: 'string',
-							},
-						},
-						required: ['port', 'address', 'key', 'cert'],
-					},
-				},
-				required: ['enabled', 'options'],
-			},
 			nethash: {
 				type: 'string',
 				format: 'hex',
@@ -366,7 +366,6 @@ module.exports = {
 			'transactions',
 			'forging',
 			'loading',
-			'ssl',
 			'nethash',
 			'cacheEnabled',
 			'redis',

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -51,6 +51,9 @@ console.info('Starting configuration migration...');
 const oldConfig = JSON.parse(fs.readFileSync(oldConfigPath, 'utf8'));
 const newConfig = JSON.parse(fs.readFileSync(newConfigPath, 'utf8'));
 
+newConfig.api.ssl = extend(true, {}, oldConfig.ssl);
+delete oldConfig.ssl;
+
 // Values to keep from new config file
 delete oldConfig.version;
 delete oldConfig.minVersion;

--- a/test/data/config.json
+++ b/test/data/config.json
@@ -36,6 +36,15 @@
 			"public": true,
 			"whiteList": ["127.0.0.1"]
 		},
+		"ssl": {
+			"enabled": false,
+			"options": {
+				"port": 443,
+				"address": "0.0.0.0",
+				"key": "./ssl/lisk.key",
+				"cert": "./ssl/lisk.crt"
+			}
+		},
 		"options": {
 			"limits": {
 				"max": 0,
@@ -696,15 +705,6 @@
 	},
 	"loading": {
 		"loadPerIteration": 5000
-	},
-	"ssl": {
-		"enabled": false,
-		"options": {
-			"port": 443,
-			"address": "0.0.0.0",
-			"key": "./ssl/lisk.key",
-			"cert": "./ssl/lisk.crt"
-		}
 	},
 	"nethash": "198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d"
 }


### PR DESCRIPTION
### What was the problem?
Turning on SSL/TLS broke the P2P layer because peers expect unencrypted `ws://` protocol (not `wss://`).

### How did I fix it?
Turning on SSL in the config file (for the node) will only enable it for for the HTTP API; it will not affect/break the WebSockets P2P API.

Despite this fix, note that the recommended approach for SSL/TLS termination is still to setup a proxy like nginx or HAProxy in front of the Lisk node as it offers more flexibility. See discussion https://github.com/LiskHQ/lisk/issues/2154


### How to test it?
Enable `ssl` in config.json and specify the path to a SSL/TLS certificate and private key file as options.
In the browser, navigate to any API endpoint on your node using the https:// prefix; e.g. https://localhost:4001/api/peers (Note that the browser may show a warning if using a self-signed certificate, but you can continue and it should work). Check that the node can still connect to peers over `ws://` and can sync blocks, etc...

### Review checklist

* The PR solves #2154
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
