### PR TITLE
NetworkHeight in /api/node/status is wrong - Closes #2179

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -750,17 +750,17 @@ Peers.prototype.networkHeight = function(options, cb) {
 			return setImmediate(cb, err, 0);
 		}
 		// count by number of peers at one height
-		const heights = _.countBy(peers, 'height');
-		const height = Object.keys(heights).reduce((curr, next) => {
-			if (heights[next] > heights[curr]) {
-				return next;
-			}
-			return curr;
-		});
-		const networkHeight = Number(height);
+		const mostPopularHeight = _(peers)
+			.countBy('height')
+			.map((count, height) => ({
+				height,
+				count,
+			}))
+			.maxBy('count');
+		const networkHeight = Number(mostPopularHeight.height);
 
 		library.logger.debug(`Network height is: ${networkHeight}`);
-		library.logger.trace(heights);
+		library.logger.trace(mostPopularHeight);
 
 		return setImmediate(cb, null, networkHeight);
 	});

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -736,17 +736,31 @@ Peers.prototype.list = function(options, cb) {
 	);
 };
 
+/**
+ * Gets the height of maximum number of peers at one particular height.
+ *
+ * @param {Object} options
+ * @param {string} [options.normalized=false] - Return peers in normalized (json) form
+ * @param {function} cb - Callback function
+ * @returns {setImmediateCallback} cb, err, peers
+ */
 Peers.prototype.networkHeight = function(options, cb) {
 	self.list(options, (err, peers) => {
-		if (err) {
+		if (err || peers.length === 0) {
 			return setImmediate(cb, err, 0);
 		}
-		const peersGroupedByHeight = _.groupBy(peers, 'height');
-		const popularHeights = Object.keys(peersGroupedByHeight).map(Number);
-		const networkHeight = _.max(popularHeights);
+		// count by number of peers at one height
+		const heights = _.countBy(peers, 'height');
+		const height = Object.keys(heights).reduce((curr, next) => {
+			if (next === undefined || heights[next] > heights[curr]) {
+				return next;
+			}
+			return curr;
+		});
+		const networkHeight = Number(height);
 
-		library.logger.debug(`Network height is: ${networkHeight}`);
-		library.logger.trace(popularHeights);
+		library.logger.error(`Network height is: ${networkHeight}`);
+		library.logger.trace(heights);
 
 		return setImmediate(cb, null, networkHeight);
 	});

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -752,14 +752,14 @@ Peers.prototype.networkHeight = function(options, cb) {
 		// count by number of peers at one height
 		const heights = _.countBy(peers, 'height');
 		const height = Object.keys(heights).reduce((curr, next) => {
-			if (next === undefined || heights[next] > heights[curr]) {
+			if (heights[next] > heights[curr]) {
 				return next;
 			}
 			return curr;
 		});
 		const networkHeight = Number(height);
 
-		library.logger.error(`Network height is: ${networkHeight}`);
+		library.logger.debug(`Network height is: ${networkHeight}`);
 		library.logger.trace(heights);
 
 		return setImmediate(cb, null, networkHeight);

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -378,23 +378,6 @@ describe('peers', () => {
 		});
 
 		describe('networkHeight', () => {
-			before(done => {
-				randomPeers = _.range(100).map(() => {
-					return generateRandomActivePeer();
-				});
-				done();
-			});
-
-			const randomPeerNetworkHeight = randomPeers => {
-				const heights = _.countBy(randomPeers, 'height');
-				const height = Object.keys(heights).reduce((curr, next) => {
-					return next === undefined || heights[next] > heights[curr]
-						? next
-						: curr;
-				});
-				return Number(height);
-			};
-
 			it('should return networkHeight 0 when no peers available', done => {
 				peersLogicMock.list = sinonSandbox.stub().returns([]);
 				peers.networkHeight(validOptions, (err, networkHeight) => {
@@ -421,13 +404,28 @@ describe('peers', () => {
 			});
 
 			it('should return the height of maximum number of peers at one particular height', done => {
-				peersLogicMock.list = sinonSandbox.stub().returns(randomPeers);
+				// generate 10 peer list with height 0
+				const peerList = _.range(10).map(() => {
+					return generateRandomActivePeer();
+				});
+
+				// create group of peers with height 5,3,2
+				// and they also indicate the number of peers
+				// in that specific height, so the majority is 5
+				let count = 0;
+				[5, 3, 2].map(height => {
+					_.range(height).map(() => {
+						peerList[count].height = height;
+						count++;
+					});
+				});
+				peersLogicMock.list = sinonSandbox.stub().returns(peerList);
 				peers.networkHeight(validOptions, (err, networkHeight) => {
 					expect(err).to.be.null;
 					expect(networkHeight);
 					expect(networkHeight)
 						.to.be.an('number')
-						.and.to.deep.eql(randomPeerNetworkHeight(randomPeers));
+						.and.to.deep.eql(5);
 					done();
 				});
 			});

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -390,19 +390,6 @@ describe('peers', () => {
 				});
 			});
 
-			it('should return height as the networkHeight when node is running alone', done => {
-				const myself = [generateRandomActivePeer()];
-				peersLogicMock.list = sinonSandbox.stub().returns(myself);
-				peers.networkHeight(validOptions, (err, networkHeight) => {
-					expect(err).to.be.null;
-					expect(networkHeight);
-					expect(networkHeight)
-						.to.be.an('number')
-						.and.to.deep.eql(myself[0].height);
-					done();
-				});
-			});
-
 			it('should return the height of maximum number of peers at one particular height', done => {
 				// generate 10 peer list with height 0
 				const peerList = _.range(10).map(() => {


### PR DESCRIPTION
### What was the problem?
Currently, NetworkHeight is picking the highest height seen in the network.
### How did I fix it?
The NetworkHeight should be the height of the most popular height among all the peers, instead of taking the highest height in the network, taking the most popular height.
### How to test it?
In the network, whichever group of peers are in a majority, that should be the most popular height and the NetworkHeight should reflect the same.
### Review checklist

* The PR solves #2179 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
