### PR TITLE
Set default db username during configuration migration - Closes #2227

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -75,6 +75,10 @@ delete oldConfig.transactions.maxTxsPerQueue;
 delete oldConfig.loading.verifyOnLoading;
 delete oldConfig.dapp;
 
+if (oldConfig.db.user.trim() === '') {
+	oldConfig.db.user = 'lisk';
+}
+
 // Peers migration
 oldConfig.peers.list = oldConfig.peers.list.map(p => {
 	p.wsPort = p.port + 1;


### PR DESCRIPTION
### What was the problem?
During configuration migration, if the db user is not set the node was not starting in compiled builds.

### How did I fix it?
Set the `lisk` username in case its empty 

### How to test it?
```
node scripts/update_config.js ../lisk-0.9/test/config.json ./config.json
```

### Review checklist

* The PR solves #2227
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
