### PR TITLE
Change the precedence of configurations to override custom configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ test/integration/configs/
 
 # Coverage directory used by tools like istanbul
 test/.coverage-unit/
+
+# Local config file useful for development
+config.local.json

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ You can pass any of `devnet`, `alphanet`, `betanet`, `testnet` or `mainnet` for 
 4. You can find network specific configurations under `config/<network>/config.json`
 5. Don't override any value in above mentioned files if you need custom configuration.
 6. Create your own `json` file and pass it as command line options `-c` or `LISK_CONFIG_FILE`
-7. Configurations will be loaded in following order, highest in the list have highest priority:
-   1. Default configuration file
-   2. Network specific configuration file
-   3. Custom configuration file (if specified by user)
-   4. Command line configurations, specified as command `flags` or `env` variables
+7. Configurations will be loaded in following order, lowest in the list have highest priority:
+   * Default configuration file
+   * Network specific configuration file
+   * Custom configuration file (if specified by user)
+   * Command line configurations, specified as command `flags` or `env` variables
 8. For development purposes use `devnet` as network option, others network are specific to public lisk networks.
 
 ### Command Line Options

--- a/README.md
+++ b/README.md
@@ -222,11 +222,15 @@ You can pass any of `devnet`, `alphanet`, `betanet`, `testnet` or `mainnet` for 
 
 1. The Lisk configuration is managed under different folder structures.
 2. Root folder for all configuration is `./config/`.
-3. You can find network specific configuration folder there as well.
-4. Main file that used as base is `config/default/config.json`
-5. Don't override any value in above mentioned file if you need custom configuration.
-6. Either modify network specific `config.json` or create your own `json` file and pass it as command line options.
-7. What ever `config.json` provided will be merged on top of `config/default/config.json` to generate final configuration to start the lisk.
+3. Default configuration file that used as base is `config/default/config.json`
+4. You can find network specific configurations under `config/<network>/config.json`
+5. Don't override any value in above mentioned files if you need custom configuration.
+6. Create your own `json` file and pass it as command line options `-c` or `LISK_CONFIG_FILE`
+7. Configurations will be loaded in following order, highest in the list have highest priority:
+   1. Default configuration file
+   2. Network specific configuration file
+   3. Custom configuration file (if specified by user)
+   4. Command line configurations, specified as command `flags` or `env` variables
 8. For development purposes use `devnet` as network option, others network are specific to public lisk networks.
 
 ### Command Line Options

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -66,17 +66,17 @@ function Config(packageJson, parseCommandLineOptions = true) {
 	const genesisBlock = loadJSONFile(`./config/${network}/genesis_block.json`);
 
 	const defaultConstants = require('../config/default/constants.js');
-	const customConstants = require(`../config/${network}/constants.js`); // eslint-disable-line import/no-dynamic-require
+	const networkConstants = require(`../config/${network}/constants.js`); // eslint-disable-line import/no-dynamic-require
 
 	const defaultExceptions = require('../config/default/exceptions.js');
-	const customExceptions = require(`../config/${network}/exceptions.js`); // eslint-disable-line import/no-dynamic-require
+	const networkExceptions = require(`../config/${network}/exceptions.js`); // eslint-disable-line import/no-dynamic-require
 
 	const defaultConfig = loadJSONFile('config/default/config.json');
-	const customConfig = loadJSONFile(
-		program.config ||
-			process.env.LISK_CONFIG_FILE ||
-			`config/${network}/config.json`
-	);
+	const networkConfig = loadJSONFile(`config/${network}/config.json`);
+	let customConfig = {};
+	if (program.config || process.env.LISK_CONFIG_FILE) {
+		customConfig = loadJSONFile(program.config || process.env.LISK_CONFIG_FILE);
+	}
 
 	const runtimeConfig = {
 		network,
@@ -109,9 +109,10 @@ function Config(packageJson, parseCommandLineOptions = true) {
 
 	const appConfig = _.merge(
 		defaultConfig,
+		networkConfig,
 		customConfig,
-		runtimeConfig,
-		commandLineConfig
+		commandLineConfig,
+		runtimeConfig
 	);
 
 	var validator = new z_schema();
@@ -123,9 +124,9 @@ function Config(packageJson, parseCommandLineOptions = true) {
 	} else {
 		appConfig.genesisBlock = genesisBlock;
 
-		appConfig.constants = _.merge(defaultConstants, customConstants);
+		appConfig.constants = _.merge(defaultConstants, networkConstants);
 
-		appConfig.exceptions = _.merge(defaultExceptions, customExceptions);
+		appConfig.exceptions = _.merge(defaultExceptions, networkExceptions);
 
 		validateForce(appConfig);
 


### PR DESCRIPTION
### What was the problem?
Custom configuration is overrides on default config values, which was skipping any configuration which is important for any network.

### How did I fix it?
Fixed the order of configuration during initialization. 

### How to test it?
```
node app.js -c my_config.json
```

### Review checklist

* The PR solves #2231
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
