### PR TITLE
In update_config.js, set "lisk" user for database if its empty - Closes #2178

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -151,6 +151,9 @@ function migrateSecrets(password) {
 
 function copyTheConfigFile() {
 	const modifiedConfig = extend(true, {}, newConfig, oldConfig);
+	if (!modifiedConfig.db.user) {
+		modifiedConfig.db.user = 'lisk';
+	}
 
 	fs.writeFile(
 		newConfigPath,


### PR DESCRIPTION
### What was the problem?
When migrating config.json, if the previous config has db.user set to '', that gets migrated when it should default to 'lisk'
### How did I fix it?
I added a final check at the end to see of modifiedConfig.db.user is set. If not, we set it to 'lisk'.
### How to test it?
I tested this with a default 0.9.16a config and a default release 1.0.0-rc.1 config with the scenarios listed below.
* Without this change:
  * if db.user is set to '' in the old config and 'lisk' in the new one, db.user in new config is set to ''
  * if db.user is set to 'arbitrary' in old config and 'lisk' in the new one, 'arbitary' is preserved
* With this change:
  * if db.user is set to '' in the old config and 'lisk' in the new one, db.user in new config is set to 'lisk'
  * if db.user is set to 'arbitrary' in old config and 'lisk' in the new one, 'arbitary' is preserved