### PR TITLE
Fix unstable unit test for vote - Closes #2207

### DIFF
--- a/logic/account.js
+++ b/logic/account.js
@@ -327,6 +327,7 @@ class Account {
 				'missedBlocks',
 				'vote',
 				'publicKey',
+				'address',
 			];
 			sort = sortBy.sortBy(filter.sort, {
 				sortFields: allowedSortFields,

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -419,6 +419,7 @@ __private.checkDelegates = function(senderPublicKey, votes, state, cb, tx) {
 					{
 						address: voteAddressesWithActions.map(({ address }) => address),
 						isDelegate: 1,
+						sort: 'address:desc',
 					},
 					(err, votesAccounts) => {
 						if (err) {

--- a/test/unit/logic/account.js
+++ b/test/unit/logic/account.js
@@ -510,6 +510,22 @@ describe('account', () => {
 					done();
 				});
 			});
+
+			it('should sort the result according to address in ascending order', done => {
+				account.getAll({ sort: 'address:asc' }, ['address'], (err, res) => {
+					expect(err).to.not.exist;
+					expect(res).to.eql(_.sortBy(res, 'address'));
+					done();
+				});
+			});
+
+			it('should sort the result according to address in descending order', done => {
+				account.getAll({ sort: 'address:desc' }, ['address'], (err, res) => {
+					expect(err).to.not.exist;
+					expect(res).to.eql(_.sortBy(res, 'address').reverse());
+					done();
+				});
+			});
 		});
 
 		describe('sort using object as argument', () => {


### PR DESCRIPTION
### What was the problem?
Vote unit tests were unstable.
### How did I fix it?
Fixed instability by introducing sorting on the database query.
### How to test it?
Run the tests
### Review checklist

* The PR solves #2207 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
