### PR TITLE
Set db user in default config to 'lisk' - Closes #2248

### DIFF
--- a/config/default/config.json
+++ b/config/default/config.json
@@ -13,7 +13,7 @@
 		"host": "localhost",
 		"port": 5432,
 		"database": "",
-		"user": "",
+		"user": "lisk",
 		"password": "password",
 		"min": 10,
 		"max": 95,


### PR DESCRIPTION
### What was the problem?
lisk-scripts in 1.1 and later expects a db.user in the config and no longer uses the user environment variable for this at all

### How did I fix it?
Added 'lisk' as the default db user 

* The PR solves #2248
