### PR TITLE
Ban peers when validation of their blocks fails during sync - Closes #2252

### DIFF
--- a/api/ws/rpc/failure_codes.js
+++ b/api/ws/rpc/failure_codes.js
@@ -76,6 +76,7 @@ module.exports = {
 			CHECK_PRESENCE: 4200,
 			INVALID_PEER: 4201,
 			TRANSPORT: 4202,
+			BANNED: 4203,
 		},
 		REMOVE: {
 			NOT_ON_LIST: 4210,
@@ -103,6 +104,7 @@ module.exports.errorMessages = {
 	4200: 'Failed to check if peer is already present',
 	4201: 'Unable to match an address to the peer',
 	4202: 'Transport error while invoking update procedure',
+	4203: 'Attempt to update a state of banned peer',
 	4210: 'Peer is not listed',
 	4211: 'Attempting to remove a frozen peer',
 	4230: 'Insert only update failed - peer is already listed',

--- a/app.js
+++ b/app.js
@@ -604,7 +604,7 @@ d.run(() => {
 							peers: [
 								'logger',
 								function(scope, cb) {
-									new Peers(scope.logger, cb);
+									new Peers(scope.logger, scope.config, cb);
 								},
 							],
 						},

--- a/app.js
+++ b/app.js
@@ -431,7 +431,9 @@ d.run(() => {
 				db
 					.connect(config.db, dbLogger)
 					.then(db => cb(null, db))
-					.catch(cb);
+					.catch(err => {
+						console.error(err);
+					});
 			},
 
 			/**
@@ -540,6 +542,9 @@ d.run(() => {
 						{
 							bus(cb) {
 								cb(null, scope.bus);
+							},
+							config(cb) {
+								cb(null, scope.config);
 							},
 							db(cb) {
 								cb(null, scope.db);

--- a/app.js
+++ b/app.js
@@ -603,6 +603,7 @@ d.run(() => {
 							],
 							peers: [
 								'logger',
+								'config',
 								function(scope, cb) {
 									new Peers(scope.logger, scope.config, cb);
 								},

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -47,7 +47,7 @@ BanManager.BAN_TIMEOUT = 2000;
  * Hardcoded ban length - 2 minutes also needs justification.
  */
 BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
-	// Don't ban temporarily (ban forever) a peer hardcoded in config.json by a user.
+	// Peer hardcoded in config.json by a user should stays always banned.
 	if (this.config.peers.access.blackList.includes(peer.ip)) {
 		return;
 	}

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -29,12 +29,6 @@ function BanManager(logger, config) {
 }
 
 /**
- * Ban every peer for 2 minutes.
- * @type {number}
- */
-BanManager.BAN_TIMEOUT = 2000;
-
-/**
  * Temporarily bans a peer for 2 minutes.
  * Calls externally provided unbanPeer.
  *
@@ -52,6 +46,7 @@ BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
 		return;
 	}
 
+	const BAN_TIMEOUT = 120000; // Ban a peer for 2 min.
 	const alreadyBannedPeer = this.bannedPeers[peer.string];
 	if (alreadyBannedPeer) {
 		clearTimeout(alreadyBannedPeer.banTimeoutId);
@@ -62,7 +57,7 @@ BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
 		banTimeoutId: setTimeout(() => {
 			onBanFinished(peer);
 			delete this.bannedPeers[peer.string];
-		}),
+		}, BAN_TIMEOUT),
 	};
 };
 

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+/**
+ * Temporarily peers banning mechanism.
+ *
+ * @class
+ * @memberof helpers
+ * @param {Logger} logger
+ * @param {Object} config - app configuration
+ * @param {function} unbanPeer - app configuration
+ */
+function BanManager(logger, config, unbanPeer) {
+	this.bannedPeers = {};
+	this.config = config;
+	this.logger = logger;
+	this.unbanPeer = unbanPeer;
+}
+
+/**
+ * Ban every peer for 2 minutes.
+ * @type {number}
+ */
+BanManager.BAN_TIMEOUT = 2000;
+
+/**
+ * Temporarily bans a peer for 2 minutes.
+ * Calls externally provided unbanPeer.
+ *
+ * @param {Peer} peer
+ *
+ * ToDo: Introduce well-designed and reasonable peer banning mechanism.
+ *
+ * For now no penalties for banning a peer multiple times are given.
+ * Hardcoded ban length - 2 minutes also needs justification.
+ */
+BanManager.prototype.ban = function(peer) {
+
+	// Don't ban temporarily (ban forever) a peer hardcoded in config.json by a user.
+	if (this.config.peers.access.blackList.includes(peer.ip)) {
+		return;
+	}
+
+	const alreadyBannedPeer = this.bannedPeers[peer.ip];
+	if (alreadyBannedPeer) {
+		clearTimeout(alreadyBannedPeer.banTimeoutId);
+	}
+
+	this.bannedPeers[peer.ip] = {
+		peer: peer,
+		banTimeoutId: setTimeout(() => {
+			this.unbanPeer(peer);
+			delete this.bannedPeers[peer.ip];
+		})
+	}
+};
+
+module.exports = BanManager;

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -48,7 +48,6 @@ BanManager.BAN_TIMEOUT = 2000;
  * Hardcoded ban length - 2 minutes also needs justification.
  */
 BanManager.prototype.ban = function(peer) {
-
 	// Don't ban temporarily (ban forever) a peer hardcoded in config.json by a user.
 	if (this.config.peers.access.blackList.includes(peer.ip)) {
 		return;
@@ -64,8 +63,8 @@ BanManager.prototype.ban = function(peer) {
 		banTimeoutId: setTimeout(() => {
 			this.unbanPeer(peer);
 			delete this.bannedPeers[peer.ip];
-		})
-	}
+		}),
+	};
 };
 
 module.exports = BanManager;

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -55,8 +55,8 @@ BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
 	this.bannedPeers[peer.string] = {
 		peer,
 		banTimeoutId: setTimeout(() => {
-			onBanFinished(peer);
 			delete this.bannedPeers[peer.string];
+			return onBanFinished(peer);
 		}, BAN_TIMEOUT),
 	};
 };

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -53,7 +53,7 @@ BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
 	}
 
 	this.bannedPeers[peer.string] = {
-		peer: peer,
+		peer,
 		banTimeoutId: setTimeout(() => {
 			onBanFinished(peer);
 			delete this.bannedPeers[peer.string];

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -21,13 +21,11 @@
  * @memberof helpers
  * @param {Logger} logger
  * @param {Object} config - app configuration
- * @param {function} unbanPeer - app configuration
  */
-function BanManager(logger, config, unbanPeer) {
+function BanManager(logger, config) {
 	this.bannedPeers = {};
 	this.config = config;
 	this.logger = logger;
-	this.unbanPeer = unbanPeer;
 }
 
 /**
@@ -41,13 +39,14 @@ BanManager.BAN_TIMEOUT = 2000;
  * Calls externally provided unbanPeer.
  *
  * @param {Peer} peer
+ * @param {function} onBanFinished - called when temporarily ban finished.
  *
  * ToDo: Introduce well-designed and reasonable peer banning mechanism.
  *
  * For now no penalties for banning a peer multiple times are given.
  * Hardcoded ban length - 2 minutes also needs justification.
  */
-BanManager.prototype.ban = function(peer) {
+BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
 	// Don't ban temporarily (ban forever) a peer hardcoded in config.json by a user.
 	if (this.config.peers.access.blackList.includes(peer.ip)) {
 		return;
@@ -61,7 +60,7 @@ BanManager.prototype.ban = function(peer) {
 	this.bannedPeers[peer.ip] = {
 		peer: peer,
 		banTimeoutId: setTimeout(() => {
-			this.unbanPeer(peer);
+			onBanFinished(peer);
 			delete this.bannedPeers[peer.ip];
 		}),
 	};

--- a/helpers/ban_manager.js
+++ b/helpers/ban_manager.js
@@ -52,16 +52,16 @@ BanManager.prototype.banTemporarily = function(peer, onBanFinished) {
 		return;
 	}
 
-	const alreadyBannedPeer = this.bannedPeers[peer.ip];
+	const alreadyBannedPeer = this.bannedPeers[peer.string];
 	if (alreadyBannedPeer) {
 		clearTimeout(alreadyBannedPeer.banTimeoutId);
 	}
 
-	this.bannedPeers[peer.ip] = {
+	this.bannedPeers[peer.string] = {
 		peer: peer,
 		banTimeoutId: setTimeout(() => {
 			onBanFinished(peer);
-			delete this.bannedPeers[peer.ip];
+			delete this.bannedPeers[peer.string];
 		}),
 	};
 };

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -127,7 +127,7 @@ Peers.prototype.ban = function(peer) {
 			'Attempt to ban a peer failed and resulted with removal'
 		);
 	}
-	self.banManager.ban(peer);
+	self.banManager.banTemporarily(peer, self.unban);
 	library.logger.info(`Peer ${peer.string} banned successfully`);
 };
 

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -50,7 +50,7 @@ class Peers {
 		self = this;
 
 		this.peersManager = new PeersManager(logger);
-		this.banManager = new BanManager(logger, config, self.unban);
+		this.banManager = new BanManager(logger, config);
 
 		return setImmediate(cb, null, this);
 	}

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -122,13 +122,16 @@ Peers.prototype.ban = function(peer) {
 	// Happens when we cannot obtain the proper address of a given peer.
 	// In such a case peer will be removed.
 	if (self.upsert(peer) === false) {
+		library.logger.info('Failed to ban peer', peer.string);
+		library.logger.debug('Failed to ban peer', {
+			err: 'INVALID_PEER',
+			peer: peer.object(),
+		});
 		self.remove(peer);
-		library.logger.info(
-			'Attempt to ban a peer failed and resulted with removal'
-		);
 	}
 	self.banManager.banTemporarily(peer, self.unban);
-	library.logger.info(`Peer ${peer.string} banned successfully`);
+	library.logger.info('Banned peer', peer.string);
+	library.logger.debug('Banned peer', { peer: peer.object() });
 };
 
 /**
@@ -142,14 +145,15 @@ Peers.prototype.unban = function(peer) {
 	// Happens when we cannot obtain the proper address of a given peer.
 	// In such a case peer will be removed.
 	if (self.upsert(peer) === false) {
+		library.logger.info('Failed to unban peer', peer.string);
+		library.logger.debug('Failed to unban peer', {
+			err: 'INVALID_PEER',
+			peer: peer.object(),
+		});
 		self.remove(peer);
-		library.logger.info(
-			'Attempt to unban a peer failed and resulted with removal'
-		);
 	}
-	library.logger.info(
-		`Peer ${peer.string} unbanned successfully and moved to disconnected`
-	);
+	library.logger.info('Unbanned peer', peer.string);
+	library.logger.debug('Unbanned peer', { peer: peer.object() });
 };
 
 /**

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -108,6 +108,18 @@ Peers.prototype.get = function(peer) {
 	return self.peersManager.getByAddress(peer.string);
 };
 
+Peers.prototype.ban = function(peer) {
+	peer.state = Peer.STATE.BANNED;
+	// Banning peer can only fail with ON_MASTER.UPDATE.INVALID_PEER error.
+	// Happens when we cannot obtain the proper address of a given peer.
+	// In such a case peer will be removed.
+	if (self.upsert(peer) === false) {
+		self.remove(peer);
+		library.logger.info('Attempt to ban a peer failed and resulted with removal');
+	}
+	library.logger.info(`Peer ${peer.string} banned succesfully`);
+};
+
 /**
  * Inserts or updates a peer.
  *

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -123,7 +123,9 @@ Peers.prototype.ban = function(peer) {
 	// In such a case peer will be removed.
 	if (self.upsert(peer) === false) {
 		self.remove(peer);
-		library.logger.info('Attempt to ban a peer failed and resulted with removal');
+		library.logger.info(
+			'Attempt to ban a peer failed and resulted with removal'
+		);
 	}
 	self.banManager.ban(peer);
 	library.logger.info(`Peer ${peer.string} banned successfully`);
@@ -141,9 +143,13 @@ Peers.prototype.unban = function(peer) {
 	// In such a case peer will be removed.
 	if (self.upsert(peer) === false) {
 		self.remove(peer);
-		library.logger.info('Attempt to unban a peer failed and resulted with removal');
+		library.logger.info(
+			'Attempt to unban a peer failed and resulted with removal'
+		);
 	}
-	library.logger.info(`Peer ${peer.string} unbanned successfully and moved to disconnected`);
+	library.logger.info(
+		`Peer ${peer.string} unbanned successfully and moved to disconnected`
+	);
 };
 
 /**
@@ -305,7 +311,8 @@ Peers.prototype.listRandomConnected = function(options) {
 		.map(key => self.peersManager.peers[key])
 		.filter(peer => peer.state === Peer.STATE.CONNECTED);
 	const shuffledPeerList = _.shuffle(peerList);
-	return options.limit ? shuffledPeerList.slice(0, options.limit)
+	return options.limit
+		? shuffledPeerList.slice(0, options.limit)
 		: shuffledPeerList;
 };
 

--- a/logic/peers.js
+++ b/logic/peers.js
@@ -127,7 +127,7 @@ Peers.prototype.ban = function(peer) {
 			err: 'INVALID_PEER',
 			peer: peer.object(),
 		});
-		self.remove(peer);
+		return self.remove(peer);
 	}
 	self.banManager.banTemporarily(peer, self.unban);
 	library.logger.info('Banned peer', peer.string);
@@ -150,7 +150,7 @@ Peers.prototype.unban = function(peer) {
 			err: 'INVALID_PEER',
 			peer: peer.object(),
 		});
-		self.remove(peer);
+		return self.remove(peer);
 	}
 	library.logger.info('Unbanned peer', peer.string);
 	library.logger.debug('Unbanned peer', { peer: peer.object() });

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -478,7 +478,9 @@ Process.prototype.loadBlocksFromPeer = function(peer, cb) {
 				return processBlock(block, err => {
 					// Ban a peer if block validation fails
 					// Invalid peers won't get chosen in the next sync attempt
-					library.logic.peers.ban(peer);
+					if (err) {
+						library.logic.peers.ban(peer);
+					}
 					return eachSeriesCb(err);
 				});
 			},

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -475,7 +475,12 @@ Process.prototype.loadBlocksFromPeer = function(peer, cb) {
 					return setImmediate(eachSeriesCb);
 				}
 				// ...then process block
-				return processBlock(block, eachSeriesCb);
+				return processBlock(block, err => {
+					// Ban a peer if block validation fails
+					// Invalid peers won't get chosen in the next sync attempt
+					library.logic.peers.ban(peer);
+					return eachSeriesCb(err);
+				});
 			},
 			err => setImmediate(seriesCb, err)
 		);

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -678,8 +678,7 @@ __private.loadBlocksFromNetwork = function(cb) {
 								);
 								// Ban a peer if block validation fails
 								// Invalid peers won't get chosen in the next sync attempt
-								peer.state = library.logic.peers.state.BANNED;
-								modules.peers.upsert(peer);
+								library.logic.peers.ban(peer);
 								errorCount += 1;
 							}
 							loaded = lastValidBlock.id === lastBlock.id;

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -676,6 +676,10 @@ __private.loadBlocksFromNetwork = function(cb) {
 								library.logger.error(
 									`Failed to load blocks from: ${peer.string}`
 								);
+								// Ban a peer if block validation fails
+								// Invalid peers won't get chosen in the next sync attempt
+								peer.state = library.logic.peers.state.BANNED;
+								modules.peers.upsert(peer);
 								errorCount += 1;
 							}
 							loaded = lastValidBlock.id === lastBlock.id;

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -676,9 +676,6 @@ __private.loadBlocksFromNetwork = function(cb) {
 								library.logger.error(
 									`Failed to load blocks from: ${peer.string}`
 								);
-								// Ban a peer if block validation fails
-								// Invalid peers won't get chosen in the next sync attempt
-								library.logic.peers.ban(peer);
 								errorCount += 1;
 							}
 							loaded = lastValidBlock.id === lastBlock.id;

--- a/test/common/application.js
+++ b/test/common/application.js
@@ -281,6 +281,9 @@ function __init(initScope, done) {
 									bus(cb) {
 										cb(null, scope.bus);
 									},
+									config(cb) {
+										cb(null, scope.config);
+									},
 									db(cb) {
 										cb(null, scope.db);
 									},
@@ -343,8 +346,9 @@ function __init(initScope, done) {
 									],
 									peers: [
 										'logger',
+										'config',
 										function(scope, cb) {
-											new Peers(scope.logger, cb);
+											new Peers(scope.logger, scope.config, cb);
 										},
 									],
 									multisignature: [

--- a/test/common/modules_loader.js
+++ b/test/common/modules_loader.js
@@ -133,7 +133,7 @@ var modulesLoader = new function() {
 				);
 				break;
 			case 'Peers':
-				new Logic(scope.logger, cb);
+				new Logic(scope.logger, scope.config, cb);
 				break;
 			default:
 				console.info('no Logic case initLogic');

--- a/test/unit/helpers/ban_manager.js
+++ b/test/unit/helpers/ban_manager.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const prefixedPeer = require('../../fixtures/peers').randomNormalizedPeer;
+const Peer = require('../../../logic/peer');
+const BanManager = require('../../../helpers/ban_manager');
+
+let configWithBlackListStub;
+let loggerStub;
+let banManagerInstance;
+const twoMinTimeout = 120000;
+
+describe('BanManager', () => {
+	before(done => {
+		loggerStub = {
+			error: sinonSandbox.stub(),
+			warn: sinonSandbox.stub(),
+			log: sinonSandbox.stub(),
+			debug: sinonSandbox.stub(),
+			trace: sinonSandbox.stub(),
+		};
+		configWithBlackListStub = {
+			peers: {
+				access: {
+					blackList: [],
+				},
+			},
+		};
+		return done();
+	});
+	beforeEach(done => {
+		banManagerInstance = new BanManager(loggerStub, configWithBlackListStub);
+		return done();
+	});
+
+	describe('constructor', () => {
+		it('should have empty bannedPeers map after initialization', () => {
+			return expect(banManagerInstance).to.have.property('bannedPeers').to.be
+				.empty;
+		});
+
+		it('should have logger assigned after initialization', () => {
+			return expect(banManagerInstance)
+				.to.have.property('logger')
+				.equal(loggerStub);
+		});
+
+		it('should have config assigned after initialization', () => {
+			return expect(banManagerInstance)
+				.to.have.property('config')
+				.equal(configWithBlackListStub);
+		});
+	});
+
+	describe('banTemporarily', () => {
+		let validPeer;
+		let onBanFinishedSpy;
+		before(done => {
+			validPeer = new Peer(prefixedPeer);
+			onBanFinishedSpy = sinonSandbox.spy();
+			return done();
+		});
+
+		beforeEach(done => {
+			onBanFinishedSpy.reset();
+			banManagerInstance.bannedPeers = {};
+			banManagerInstance.banTemporarily(validPeer, onBanFinishedSpy);
+			return done();
+		});
+
+		describe('when peer is in config.json blackList', () => {
+			before(done => {
+				configWithBlackListStub.peers.access.blackList = [validPeer.ip];
+				return done();
+			});
+			it('should not add validPeer to bannedPeers map', () => {
+				return expect(banManagerInstance.bannedPeers).not.to.have.property(
+					validPeer.string
+				);
+			});
+		});
+
+		describe('when peer is not in config.json blackList', () => {
+			let clock;
+			before(done => {
+				configWithBlackListStub.peers.access.blackList = [];
+				clock = sinonSandbox.useFakeTimers();
+				return done();
+			});
+			after(done => {
+				clock.restore();
+				return done();
+			});
+
+			describe('when peer was not banned before', () => {
+				it('should add validPeer to bannedPeers map', () => {
+					return expect(banManagerInstance.bannedPeers).to.have.property(
+						validPeer.string
+					);
+				});
+				it('should add an entry to bannedPeers containing validPeer', () => {
+					return expect(banManagerInstance.bannedPeers[validPeer.string])
+						.to.have.property('peer')
+						.equal(validPeer);
+				});
+				it('should add an entry to bannedPeers containing banTimeoutId as a Timeout', () => {
+					return expect(banManagerInstance.bannedPeers[validPeer.string])
+						.to.have.nested.property('banTimeoutId.id')
+						.to.be.a('number');
+				});
+				describe('when 2 min have not passed', () => {
+					beforeEach(done => {
+						clock.tick(twoMinTimeout - 1);
+						return done();
+					});
+					it('should not call onBanFinished', () => {
+						return expect(onBanFinishedSpy).not.to.be.called;
+					});
+				});
+				describe('when 2 min have passed', () => {
+					beforeEach(done => {
+						clock.tick(twoMinTimeout);
+						return done();
+					});
+					it('should call onBanFinished', () => {
+						return expect(onBanFinishedSpy).to.be.called;
+					});
+					it('should call onBanFinished with validPeer', () => {
+						return expect(onBanFinishedSpy).to.be.calledWith(validPeer);
+					});
+					it('should remove entry from bannedPeers', () => {
+						return expect(banManagerInstance.bannedPeers).not.to.have.property(
+							validPeer.string
+						);
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -107,6 +107,8 @@ describe('blocks/process', () => {
 				return 'me';
 			},
 			applyHeaders: peerStub.applyHeaders,
+			ban: sinonSandbox.stub(),
+			unban: sinonSandbox.stub(),
 		};
 
 		transactionStub = {


### PR DESCRIPTION
### What was the problem?
Peers were not banned during the sync process.
### How did I fix it?
Peers are banned temporarily if validation of their blocks fails in the sync process.
### How to test it?
Sync with peers distributing invalid peers. Check if it was banned.
### Review checklist

* The PR solves #2252
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
