### PR TITLE
Add block version exception for devnet-rc2 branch - Closes #2258

### DIFF
--- a/helpers/exceptions.js
+++ b/helpers/exceptions.js
@@ -47,5 +47,7 @@ module.exports = {
 	inertTransactions: [],
 	transactionFee: [],
 	// <version>: { start: <start_height>, end: <end_height> }
-	blockVersions: {},
+	blockVersions: {
+		0: { start: 1, end: 1111 },
+	},
 };

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -456,6 +456,12 @@ describe('blocks/verify', () => {
 	describe('__private.verifyVersion', () => {
 		let verifyVersion;
 
+		before(done => {
+			// Reset exceptions for blocks versions
+			exceptions.blockVersions = {};
+			done();
+		});
+
 		describe('when there are no exceptions for block versions', () => {
 			describe('when block height provided', () => {
 				it('should return no error when block version = 1', () => {


### PR DESCRIPTION
### What was the problem?
Migration is being tested from round 11 with the version being built out of `devnet-development` branch. To validate the block version properly the entry in exceptions needs to be added.
### How did I fix it?
Block version `1` range is added in exceptions.
### How to test it?
Check if blocks after the height 1111 are having version 1 and are getting accepted.
### Review checklist

* The PR solves #2258
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated


