### PR TITLE
Improve process exit - Closes #1788

### DIFF
--- a/app.js
+++ b/app.js
@@ -798,7 +798,7 @@ d.run(() => {
 
 			if (err) {
 				logger.fatal(err);
-				process.emit('cleanup');
+				process.emit('cleanup', err);
 			} else {
 				scope.logger.info('Modules ready and launched');
 			}

--- a/app.js
+++ b/app.js
@@ -806,8 +806,12 @@ d.run(() => {
 	);
 });
 
+// TODO: This should be the only place in the master process where
+// 'uncaughtException' is handled. Right now, one of our dependencies (js-nacl;
+// which is a dependency of lisk-elements) adds its own handler which interferes
+// with our own process exit logic.
 process.on('uncaughtException', err => {
 	// Handle error safely
 	logger.fatal('System error', { message: err.message, stack: err.stack });
-	process.emit('cleanup');
+	process.emit('cleanup', err);
 });

--- a/app.js
+++ b/app.js
@@ -181,7 +181,7 @@ try {
 // Domain error handler
 d.on('error', err => {
 	logger.fatal('Domain master', { message: err.message, stack: err.stack });
-	process.exit(0);
+	process.emit('cleanup', err);
 });
 
 logger.info(`Starting lisk with "${appConfig.network}" genesis block.`);

--- a/app.js
+++ b/app.js
@@ -750,9 +750,14 @@ d.run(() => {
 		},
 		(err, scope) => {
 			// Receives a 'cleanup' signal and cleans all modules
-			process.once('cleanup', error => {
+			process.once('cleanup', (error, code) => {
 				if (error) {
 					logger.fatal(error.toString());
+					if (code === undefined) {
+						code = 1;
+					}
+				} else if (code === undefined || code === null) {
+					code = 0;
 				}
 				logger.info('Cleaning up...');
 				if (scope.socketCluster) {
@@ -774,7 +779,7 @@ d.run(() => {
 						} else {
 							logger.info('Cleaned up successfully');
 						}
-						process.exit(1);
+						process.exit(code);
 					}
 				);
 			});
@@ -783,8 +788,8 @@ d.run(() => {
 				process.emit('cleanup');
 			});
 
-			process.once('exit', () => {
-				process.emit('cleanup');
+			process.once('exit', code => {
+				process.emit('cleanup', null, code);
 			});
 
 			process.once('SIGINT', () => {

--- a/app.js
+++ b/app.js
@@ -764,6 +764,8 @@ d.run(() => {
 					scope.socketCluster.removeAllListeners('fail');
 					scope.socketCluster.destroy();
 				}
+				// Run cleanup operation on each module before shutting down the node;
+				// this includes operations like snapshotting database tables.
 				async.eachSeries(
 					modules,
 					(module, cb) => {

--- a/app.js
+++ b/app.js
@@ -815,3 +815,12 @@ process.on('uncaughtException', err => {
 	logger.fatal('System error', { message: err.message, stack: err.stack });
 	process.emit('cleanup', err);
 });
+
+process.on('unhandledRejection', err => {
+	// Handle unhandledRejection safely
+	logger.fatal('System promise rejection', {
+		message: err.message,
+		stack: err.stack,
+	});
+	process.emit('cleanup', err);
+});

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -637,7 +637,7 @@ __private.snapshotFinished = err => {
 	} else {
 		library.logger.info('Snapshot creation finished');
 	}
-	process.emit('cleanup');
+	process.emit('cleanup', err);
 };
 
 /**

--- a/scripts/console.js
+++ b/scripts/console.js
@@ -70,7 +70,7 @@ application.init(
 process.on('uncaughtException', err => {
 	// Handle error safely
 	console.error('System error', { message: err.message, stack: err.stack });
-	process.emit('cleanup');
+	process.emit('cleanup', err);
 });
 
 process.on('unhandledRejection', (reason, p) => {


### PR DESCRIPTION
### What was the problem?

The 'cleanup' event caused the master process to always exit with code 1.
Sometimes the 'cleanup' event is sometimes triggered intentionally; in those cases, we want to shut down the process with code 0.

### How did I fix it?

If an error is passed to the 'cleanup' event handler, then the exit code will default to 1. Otherwise it will default to 0. Alternatively, a custom error code can be provided explicitly.

This PR narrows down the scope of #1788 to keep things simple - Now we just have 2 distinct error codes. If we end up wanting to add more exit codes in the future (and want to handle them in special ways), then we can raise separate issues for those.

### How to test it?

Test manually.
If you shut down the Lisk node from the command line (I.e. `Ctrl + C`), the exit code (e.g. `$?`) should be 0 (intentional exit). If you trigger a 'cleanup' event and pass an Error as second argument, then the exit code should be 1. If you trigger a 'cleanup' event and pass a custom integer as third argument, then the exit code of the process should be that integer.

### Review checklist

* The PR solves #1788
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
