### PR TITLE
Add sorting to block block loading - Relates #2249

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -580,7 +580,7 @@ __private.validateBlock = (blockToVerify, cb) => {
 			blockToVerify.height
 		}`
 	);
-	library.logger.debug(blockToVerify);
+	library.logger.debug(JSON.stringify(blockToVerify));
 
 	const lastBlock = modules.blocks.lastBlock.get();
 


### PR DESCRIPTION
### What was the problem?
There were no sorting while loading block for verifying 

### How did I fix it?
Add the sorting logic which were used in the load last block. 

### Review checklist

* The PR relates #2249
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
