### PR TITLE
Stringify Block to verify while logging - Relates #2249

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -580,7 +580,7 @@ __private.validateBlock = (blockToVerify, cb) => {
 			blockToVerify.height
 		}`
 	);
-	library.logger.debug(blockToVerify);
+	library.logger.debug(JSON.stringify(blockToVerify));
 
 	const lastBlock = modules.blocks.lastBlock.get();
 


### PR DESCRIPTION
### What was the problem?
Logs of blocks after its validations were not readable.

### Review checklist

* The PR solves #2249
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
