### PR TITLE
Application should exit with status code 1 on any error in domain - Closes #2269

### DIFF
--- a/app.js
+++ b/app.js
@@ -180,7 +180,7 @@ try {
 // Domain error handler
 d.on('error', err => {
 	logger.fatal('Domain master', { message: err.message, stack: err.stack });
-	process.exit(0);
+	process.emit('cleanup', err);
 });
 
 // Run domain

--- a/app.js
+++ b/app.js
@@ -808,3 +808,9 @@ process.on('uncaughtException', err => {
 	logger.fatal('System error', { message: err.message, stack: err.stack });
 	process.emit('cleanup');
 });
+
+process.on('unhandledRejection', err => {
+	// Handle error safely
+	logger.fatal('System error', { message: err.message, stack: err.stack });
+	process.emit('cleanup', err);
+});


### PR DESCRIPTION
### What was the problem?
If `domain` caught any error the application is exit immediately with code `0`

### How did I fix it?
Update the domain error handler to emit graceful cleanup.  

### Review checklist

* The PR solves #2269
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
