### PR TITLE
Update lisk-elements to v1.0.0 - Closes #2283

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"ip": "=1.1.5",
 		"js-yaml": "=3.10.0",
 		"json-refs": "=3.0.3",
-		"lisk-elements": "=1.0.0-beta.4",
+		"lisk-elements": "=1.0.0-rc.1",
 		"lodash": "=4.17.4",
 		"method-override": "=2.3.10",
 		"pg-monitor": "=0.9.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"ip": "=1.1.5",
 		"js-yaml": "=3.10.0",
 		"json-refs": "=3.0.3",
-		"lisk-elements": "=1.0.0-rc.1",
+		"lisk-elements": "=1.0.0",
 		"lodash": "=4.17.4",
 		"method-override": "=2.3.10",
 		"pg-monitor": "=0.9.0",

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -708,14 +708,25 @@ describe('transaction', () => {
 		});
 
 		it('should return error when transaction amount is invalid', done => {
-			var transactionDataClone = _.cloneDeep(transactionData);
-			transactionDataClone.amount = constants.totalAmount + 10;
+			// lisk-elements cannot create a transaction with higher amount than max amount. So, this test needs to use hardcoded transaction object
+			var transaction = {
+				type: 0,
+				amount: '1000000000000000000000000000',
+				senderId: '16313739661670634666L',
+				fee: 10000000,
+				recipientId: '16313739661670634666L',
+				senderPublicKey:
+					'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
+				timestamp: 69548399,
+				asset: {},
+				signature:
+					'd6a9824d7b88bdde4426f3496881e54d42b6b1d1f06e2d11e46b3f1901d2b2b826a992104e618ec62ba01deb1e3b31820eb77bd26aa6d4a972e0bbd2503db60c',
+				id: '16729891751827725251',
+			};
 
-			createAndProcess(transactionDataClone, sender, (err, transaction) => {
-				transactionLogic.verify(transaction, sender, null, null, err => {
-					expect(err).to.include('Invalid transaction amount');
-					done();
-				});
+			transactionLogic.verify(transaction, sender, null, null, err => {
+				expect(err).to.include('Invalid transaction amount');
+				done();
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
Lisk Core v1.0.0 should include the recent release candidate of Lisk Elements.
### How did I fix it?
A version of Lisk Elements is updated v1.0.0
### How to test it?
Validate the library usage:
- Lisk Elements is used across the test suite to create transactions
- Lisk Elements used in `modules/delegates.js` to decrypt delegates passphrases
```
__private.decryptPassphrase = function(encryptedPassphrase, password) {
	return lisk.cryptography.decryptPassphraseWithPassword(
		lisk.cryptography.parseEncryptedPassphrase(encryptedPassphrase),
		password
	);
};
```
### Review checklist

* The PR solves #2283
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
