### PR TITLE
Update preinstall section of README - Closes #2248

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The next section details the prerequisites to install Lisk Core from source usin
 
 * Create a new user
 
-  * Ubuntu/ Debian:
+  * Ubuntu 14|16 / Debian:
 
   ```
   sudo adduser lisk
@@ -36,7 +36,7 @@ The next section details the prerequisites to install Lisk Core from source usin
 
     ```
     sudo apt-get update
-    sudo apt-get install -y python build-essential curl automake autoconf libtool ntp
+    sudo apt-get install -y python build-essential curl automake autoconf libtool
     ```
 
   * MacOS 10.12-10.13 (Sierra/High Sierra):
@@ -101,12 +101,15 @@ The next section details the prerequisites to install Lisk Core from source usin
 
 ### PostgreSQL (version 9.6):
 
-### Ubuntu
+* Ubuntu 14|16 / Debian:
 
-Firstly, download and run the postgres install script:
+Firstly, download and install postgreSQL:
 
 ```
-curl -sL "https://downloads.lisk.io/scripts/setup_postgresql.Linux" | bash -
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+echo "deb http://apt.postgresql.org/pub/repos/apt/ $( lsb_release -cs )-pgdg main" |sudo tee /etc/apt/sources.list.d/pgdg.list
+sudo apt-get update
+sudo apt-get install --assume-yes postgresql-9.6 postgresql-contrib-9.6 libpq-dev
 ```
 
 After installation, you should see the postgres database cluster, by running
@@ -128,15 +131,13 @@ Create a new database user called `lisk` and grant it rights to create databases
   sudo -u postgres createuser --createdb lisk
 ```
 
-Switch to the lisk user and create the databases:
+Create the databases for Testnet and Mainnet:
 
 ```
-  su - lisk
-  createdb lisk_test
-  createdb lisk_main
+  createdb -O lisk lisk_test
+  createdb -O lisk lisk_main
 ```
 
-For the following steps, logout from the lisk user again with `CTRL+D`, and continue with your user with sudo rights.
 Change `'password'` to a secure password of your choice.
 
 ```
@@ -144,11 +145,11 @@ sudo -u postgres psql -d lisk_test -c "alter user lisk with password 'password';
 sudo -u postgres psql -d lisk_main -c "alter user lisk with password 'password';"
 ```
 
-### MacOS
+* MacOS 10.12-10.13 (Sierra/High Sierra):
 
 ```
 brew install postgresql@9.6
-initdb /usr/local/var/postgres -E utf8 --locale=en_US.UTF-8
+initdb /usr/local/var/postgres --encoding utf8 --locale=en_US.UTF-8
 brew services start postgresql@9.6
 createdb lisk_test
 createdb lisk_main

--- a/README.md
+++ b/README.md
@@ -20,13 +20,23 @@ The next section details the prerequisites to install Lisk Core from source usin
 
 ### System Install
 
+* Create a new user
+
+  * Ubuntu/ Debian:
+
+  ```
+  sudo adduser lisk
+  ```
+
+  Note: The lisk user itself does not need any sudo rights to run Lisk Core.
+
 * Tool chain components -- Used for compiling dependencies
 
   * Ubuntu 14|16 / Debian:
 
     ```
     sudo apt-get update
-    sudo apt-get install -y python build-essential curl automake autoconf libtool
+    sudo apt-get install -y python build-essential curl automake autoconf libtool ntp
     ```
 
   * MacOS 10.12-10.13 (Sierra/High Sierra):
@@ -91,22 +101,54 @@ The next section details the prerequisites to install Lisk Core from source usin
 
 ### PostgreSQL (version 9.6):
 
-* Ubuntu 14|16 / Debian:
+### Ubuntu
+
+Firstly, download and run the postgres install script:
 
 ```
 curl -sL "https://downloads.lisk.io/scripts/setup_postgresql.Linux" | bash -
-sudo -u postgres createuser --createdb $USER
-createdb lisk_test
-createdb lisk_main
-sudo -u postgres psql -d lisk_test -c "alter user "$USER" with password 'password';"
-sudo -u postgres psql -d lisk_main -c "alter user "$USER" with password 'password';"
 ```
 
-* MacOS 10.12-10.13 (Sierra/High Sierra):
+After installation, you should see the postgres database cluster, by running
+
+```
+  pg_lsclusters
+```
+
+Drop the existing database cluster, and replace it with a cluster with the locale `en_US.UTF-8`:
+
+```
+  sudo pg_dropcluster --stop 9.6 main
+  sudo pg_createcluster --locale en_US.UTF-8 --start 9.6 main
+```
+
+Create a new database user called `lisk` and grant it rights to create databases:
+
+```
+  sudo -u postgres createuser --createdb lisk
+```
+
+Switch to the lisk user and create the databases:
+
+```
+  su - lisk
+  createdb lisk_test
+  createdb lisk_main
+```
+
+For the following steps, logout from the lisk user again with `CTRL+D`, and continue with your user with sudo rights.
+Change `'password'` to a secure password of your choice.
+
+```
+sudo -u postgres psql -d lisk_test -c "alter user lisk with password 'password';"
+sudo -u postgres psql -d lisk_main -c "alter user lisk with password 'password';"
+```
+
+### MacOS
 
 ```
 brew install postgresql@9.6
-initdb /usr/local/var/postgres -E utf8
+initdb /usr/local/var/postgres -E utf8 --locale=en_US.UTF-8
 brew services start postgresql@9.6
 createdb lisk_test
 createdb lisk_main


### PR DESCRIPTION
### What was the problem?
With new changes of #2250, starting the application will fail if another username than `lisk`is picked during setup.

### How did I fix it?
Updated the README to align with the docs on lisk.io

### How to test it?

### Review checklist

* The PR solves #2248 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
