### PR TITLE
Add height as new sorting param for transaction api endpoint - Closes #2272

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -928,6 +928,8 @@ paths:
             - amount:desc
             - fee:asc
             - fee:desc
+            - height:asc
+            - height:desc
             - type:asc
             - type:desc
             - timestamp:asc


### PR DESCRIPTION
### What was the problem?
sorting transactions by height was not supported

### How did I fix it?
Added 2 new sorting options for API endpoint transactions:
- height:asc
- height:desc

### How to test it?
Make a GET request for transactions 2 times, first specify height:asc as sorting param, second height:desc, and compare results

### Review checklist

* The PR solves #2272
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
