### PR TITLE
Sort transaction by height - Closes #1891

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -928,6 +928,8 @@ paths:
             - amount:desc
             - fee:asc
             - fee:desc
+            - height:asc
+            - height:desc
             - type:asc
             - type:desc
             - timestamp:asc

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -745,6 +745,31 @@ describe('GET /api/transactions', () => {
 						});
 				});
 			});
+			describe('height', () => {
+				it('sorted by height:asc should be ok', () => {
+					return transactionsEndpoint
+						.makeRequest({ sort: 'height:asc', minAmount: 100 }, 200)
+						.then(res => {
+							expect(
+								_(res.body.data)
+									.map('height')
+									.sortNumbers('asc')
+							).to.be.eql(_.map(res.body.data, 'height'));
+						});
+				});
+
+				it('sorted by height:desc should be ok', () => {
+					return transactionsEndpoint
+						.makeRequest({ sort: 'height:desc' }, 200)
+						.then(res => {
+							expect(
+								_(res.body.data)
+									.map('height')
+									.sortNumbers('desc')
+							).to.be.eql(_.map(res.body.data, 'height'));
+						});
+				});
+			});
 
 			it('using sort with any of sort fields should not place NULLs first', () => {
 				var transactionSortFields = [
@@ -794,7 +819,7 @@ describe('GET /api/transactions', () => {
 
 			it('using any other sort field should fail', () => {
 				return transactionsEndpoint
-					.makeRequest({ sort: 'height:asc' }, 400)
+					.makeRequest({ sort: 'recipientId:asc' }, 400)
 					.then(res => {
 						expectSwaggerParamError(res, 'sort');
 					});


### PR DESCRIPTION
### What was the problem?
Sorting transactions by height was not supported

### How did I fix it?
Updated `swagger.yml` and added functional tests

### How to test it?
GET transaction with sort param height:asc
GET transaction with sort param height:desc
Compare results

### Review checklist

* The PR solves #1891
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
