### PR TITLE
Support update_config.js migrations - Closes #2278

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,61 @@ Individual test files can be run using the following command:
 npm run mocha -- path/to/test.js
 ```
 
+## Utility scripts
+
+There are couple of command line scripts that facilitate users of lisk to perform handy operations. All scripts are are located under `./scripts/` directory and can be executed directly by `node scripts/<file_name>`.
+
+#### Generate Config
+
+This script will help you to generate unified version of configuration file for any network. Here is the usage of the script:
+
+```
+Usage: generate_config [options] <network>
+
+Options:
+
+  -h, --help     output usage information
+  -V, --version  output the version number
+```
+
+Argument `network` is required and can by `devnet`, `testnet`, `mainnet` or any other network folder available under `./config` directory.
+
+#### Update Config
+
+This script keep track of all changes introduced in Lisk over time in different versions. If you have one config file in any of specific version and you want to make it compatible with other version of the Lisk, this scripts will do it for you.
+
+```
+Usage: update_config [options] <input_file> <from_version> [to_version]
+
+Options:
+
+-h, --help     output usage information
+-V, --version  output the version number
+--output       Output file path
+--diff         Show only difference from default config file.
+```
+
+As you can see from the usage guide, `input_file` and `from_version` are required. So if you have a config file, you must be aware to which version of Lisk this belongs. You can skip the `to_version` argument and it will apply changes up-to latest version of Lisk. If you don't specify `--output` path the final config json will be printed to console. Option `--diff` is useful if you just want to know what are the changes in your version compared to default config located in `./config/default/config.json`.
+
+#### Console
+
+This script is really useful in development. It will initialize the components of Lisk and load these into ndoejs REPL.
+
+```
+node scripts/console.js
+
+initApplication: Application initialization inside test environment started...
+initApplication: Target database - lisk_dev
+initApplication: Rewired modules available
+initApplication: Fake onBlockchainReady event called
+initApplication: Loading delegates...
+initApplication: Delegates loaded from config file - 101
+initApplication: Done
+lisk-core [lisk_dev] >
+```
+
+Once you get the prompt, you can use `modules`, `helpers`, `logic`, `db` and `config` objects and play with these in REPL.
+
 ## Contributors
 
 https://github.com/LiskHQ/lisk/graphs/contributors

--- a/helpers/json_history.js
+++ b/helpers/json_history.js
@@ -137,9 +137,17 @@ function JSONHistory(title, logger) {
 
 		// Get the version from which to start the migration
 		// Skip the matched version, as json is already in that particular version
-		const startFromVersion =
-			versions.findIndex(version => semver.satisfies(fromVersion, version)) +
-			(includeStart ? 0 : 1);
+		let startFromVersion = versions.findIndex(version =>
+			semver.satisfies(fromVersion, version)
+		);
+
+		if (startFromVersion === -1) {
+			throw new Error(
+				`Can't find supported version to start migration from  version "${fromVersion}"`
+			);
+		}
+
+		startFromVersion += includeStart ? 0 : 1;
 
 		// Apply changes till that version
 		const tillVersion =

--- a/helpers/json_history.js
+++ b/helpers/json_history.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const assert = require('assert');
+const semver = require('semver');
+const async = require('async');
+
+function JSONHistory(title, logger) {
+	const self = this;
+
+	// Title of the json history object
+	self.title = title;
+	self.logger = logger || console;
+
+	// List of versions available
+	const versions = [];
+
+	// List of changes for particular version
+	const changes = [];
+
+	function VersionObject(version) {
+		this.version = version;
+
+		this.change = (title, change) => {
+			assert(title, 'Title for the change is required.');
+			assert(
+				typeof change === 'function',
+				'Callback for the change is required.'
+			);
+			assert(
+				change.length > 0 && change.length < 3,
+				'Callback for the change accepts up-to two arguments.'
+			);
+
+			changes.push({
+				version: this.version,
+				title,
+				change,
+			});
+		};
+	}
+
+	this.version = (version, changes) => {
+		assert(version, 'Invalid version specified.');
+		assert(
+			semver.valid(version) || semver.validRange(version),
+			'Invalid version or version range specified.'
+		);
+		assert(!versions.includes(version), `Version ${version} already declared.`);
+
+		versions.push(version);
+
+		if (changes) {
+			changes.call(self, new VersionObject(version));
+		}
+	};
+
+	const applyChange = (change, data, cb) => {
+		if (change.change.length === 0) {
+			throw new TypeError('There must be one param defined for the change');
+		}
+
+		// Copy the data to avoid changing source
+		data = Object.assign({}, data);
+
+		self.logger.info(`--- ${change.title}`);
+
+		// Its a sync function
+		if (change.change.length === 1) {
+			return setImmediate(cb, null, change.change(data));
+		}
+
+		// It was an async change
+		change.change(data, (error, updatedData) =>
+			setImmediate(cb, error, updatedData)
+		);
+	};
+
+	const applyChangesOfVersion = (versionIndex, data, cb) => {
+		const changeSet = changes.filter(c => c.version === versions[versionIndex]);
+
+		// Copy the data to avoid changing source
+		data = Object.assign({}, data);
+
+		if (changeSet.length === 0) {
+			self.logger.info(
+				`\n\n- No changes for version "${versions[versionIndex]}"`
+			);
+		} else {
+			self.logger.info(
+				`\n\n- Applying changes for version "${versions[versionIndex]}"`
+			);
+		}
+
+		async.eachSeries(
+			changeSet,
+			(change, eachCallback) => {
+				applyChange(change, data, (err, updatedData) => {
+					data = updatedData;
+					return setImmediate(eachCallback, err, data);
+				});
+			},
+			err => setImmediate(cb, err, data)
+		);
+	};
+
+	this.migrate = (json, fromVersion, toVersion, cb) => {
+		let includeStart = false;
+
+		if (toVersion === undefined && cb === undefined) {
+			cb = fromVersion;
+			includeStart = true;
+			fromVersion = versions[0];
+			toVersion = versions[versions.length - 1];
+		}
+
+		if (cb === undefined) {
+			cb = toVersion;
+			toVersion = versions[versions.length - 1];
+		}
+
+		assert(typeof json === 'object', 'Invalid json object to migrate.');
+		if (fromVersion)
+			assert(
+				semver.valid(fromVersion),
+				'Invalid start version specified to migrate.'
+			);
+		if (toVersion)
+			assert(
+				semver.valid(toVersion),
+				'Invalid end version specified to migrate.'
+			);
+		assert(typeof cb === 'function', 'Invalid callback specified to migrate.');
+
+		self.logger.info(
+			`Applying migration of ${self.title} from ${fromVersion} to ${toVersion}`
+		);
+
+		// Get the version from which to start the migration
+		// Skip the matched version, as json is already in that particular version
+		const startFromVersion =
+			versions.findIndex(version => semver.satisfies(fromVersion, version)) +
+			(includeStart ? 0 : 1);
+
+		// Apply changes till that version
+		const tillVersion =
+			versions.findIndex(version => semver.satisfies(toVersion, version)) ||
+			versions.length - 1;
+
+		// Clone the provided json to avoid changes into source
+		let compiledJson = Object.assign({}, json);
+
+		let currentVersionIndex = startFromVersion;
+
+		async.whilst(
+			() => currentVersionIndex <= tillVersion,
+			whileCb => {
+				applyChangesOfVersion(
+					currentVersionIndex,
+					compiledJson,
+					(err, data) => {
+						compiledJson = data;
+						currentVersionIndex += 1;
+						return setImmediate(whileCb, err, data);
+					}
+				);
+			},
+			err => setImmediate(cb, err, compiledJson)
+		);
+	};
+
+	this.getVersions = () => versions;
+	this.getChangeSet = () => changes;
+
+	return self;
+}
+
+module.exports = JSONHistory;

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -183,10 +183,8 @@ history.version('1.0.0-rc.2', version => {
 		}
 	);
 });
-history.version('1.0.0');
-history.version('1.0.1');
-history.version('1.1.x');
-history.version('1.2.x');
+history.version('1.1.0-alpha.0');
+history.version('1.2.0-alpha.0');
 
 const askPassword = (message, cb) => {
 	if (program.password && program.password.trim().length !== 0) {
@@ -211,8 +209,7 @@ const askPassword = (message, cb) => {
 };
 
 if (!toVersion) {
-	const versions = history.getVersions();
-	toVersion = versions[versions.length - 1];
+	toVersion = require('../package.json').version;
 }
 
 // Old config in 1.0.x will be single unified config file.

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -21,119 +21,222 @@
 
 const fs = require('fs');
 const path = require('path');
+const readline = require('readline');
 const program = require('commander');
-const merge = require('lodash/merge');
+const lisk = require('lisk-elements').default;
 const observableDiff = require('deep-diff').observableDiff;
 const applyChange = require('deep-diff').applyChange;
+const JSONHistory = require('../helpers/json_history');
 
 const rootPath = path.resolve(path.dirname(__filename), '../');
 const loadJSONFile = filePath => JSON.parse(fs.readFileSync(filePath), 'utf8');
-let oldConfigPath;
-let newConfigPath;
-
-program
-	.version('0.1.1')
-	.arguments('<old_config_file> <new_config_file>')
-	.action((oldConfig, newConfig) => {
-		oldConfigPath = oldConfig;
-		newConfigPath = newConfig;
-	})
-	.parse(process.argv);
-
-if (!oldConfigPath || !newConfigPath) {
-	console.error('error: no config file provided.');
-	process.exit(1);
-}
-
-console.info('Running config migration from 1.0.x to 1.1.x');
-console.info('Starting configuration migration...');
-
-// Old config in 1.0.x will be single unified config file.
-const oldConfig = loadJSONFile(oldConfigPath);
-
-// Had dedicated ssl config only for API
-// https://github.com/LiskHQ/lisk/issues/2154
-if (oldConfig.ssl) {
-	oldConfig.api.ssl = merge({}, oldConfig.ssl);
-	delete oldConfig.ssl;
-}
-
-// New config in 1.1.x will be partial config other than default/config.json
-const newConfig = loadJSONFile(newConfigPath);
-
 // Now get a unified config.json for 1.1.x version
 const defaultConfig = loadJSONFile(
 	path.resolve(rootPath, 'config/default/config.json')
 );
-const unifiedNewConfig = merge({}, defaultConfig, newConfig);
+let configFilePath;
+let fromVersion;
+let toVersion;
 
-const changesMap = {
-	N: '  Added',
-	E: 'Skipped', // Don't apply changes, preserve user configured value
-	D: 'Deleted',
-	A: 'Skipped', // Updated element of array
-};
+program
+	.version('0.1.1')
+	.arguments('<input_file> <from_version> [to_version]')
+	.option('--output', 'Output file path')
+	.option('--diff', 'Show only difference from default config file.')
+	.action((inputFile, version1, version2) => {
+		fromVersion = version1;
+		toVersion = version2;
+		configFilePath = inputFile;
+	})
+	.parse(process.argv);
 
-const arrayItemChangesMap = {
-	D: 'Addition', // It was added in new config and deleted from old
-};
+const history = new JSONHistory('lisk config file', console);
 
-console.info('\nChanges summary: ');
+history.version('0.9.x');
+history.version('1.0.0-rc.1', version => {
+	version.change('removed version and minVersion', config => {
+		delete config.version;
+		delete config.minVersion;
+		return config;
+	});
+	version.change('renamed port to httpPort', config => {
+		config.httpPort = config.port;
+		delete config.port;
+		return config;
+	});
+	version.change('added new config wsPort', config => {
+		config.wsPort = config.httpPort + 1;
+		return config;
+	});
+	version.change('updated db.poolSize to min and max', config => {
+		config.db.max = config.db.poolSize;
+		config.db.min = 10;
+		return config;
+	});
+	version.change('removed peers.options.limits', config => {
+		delete config.peers.options.limits;
+		return config;
+	});
+	version.change(
+		'renamed transactions.maxTxsPerQueue to transactions.maxTransactionsPerQueue',
+		config => {
+			config.transactions.maxTransactionsPerQueue =
+				config.transactions.maxTxsPerQueue;
+			delete config.transactions.maxTxsPerQueue;
+			return config;
+		}
+	);
+	version.change('removed loading.verifyOnLoading', config => {
+		delete config.loading.verifyOnLoading;
+		return config;
+	});
+	version.change('removed dapp', config => {
+		delete config.dapp;
+		return config;
+	});
+	version.change('updated port to wsPort for peers.list', config => {
+		config.peers.list = config.peers.list.map(p => {
+			p.wsPort = p.port + 1;
+			delete p.port;
+			return p;
+		});
+		return config;
+	});
+	version.change('added db.logFileName for db related logs', config => {
+		config.db.logFileName = config.logFileName;
+		return config;
+	});
+	version.change(
+		'added api.options.cors to manage CORS settings for http API',
+		config => {
+			config.api.options.cors = {
+				origin: '*',
+				methods: ['GET', 'POST', 'PUT'],
+			};
+			return config;
+		}
+	);
+	version.change(
+		'added broadcasts.active=true as boolean value to enable/disable the broadcasting behavior',
+		config => {
+			config.broadcasts.active = true;
+			return config;
+		}
+	);
+	version.change(
+		'convert forging.secret to forging.delegates',
+		(config, cb) => {
+			if (!config.forging.secret || config.forging.secret.length === 0) {
+				console.info('No forging secret. So skipping conversion.');
+				return setImmediate(cb, null, config);
+			}
 
-// Since the structure of both files should be same now
-// We just need to extract the value custom values user had modified
-observableDiff(oldConfig, unifiedNewConfig, d => {
-	switch (d.kind) {
-		case 'N':
-			console.info(
-				`${changesMap[d.kind]}: ${d.path.join('.')} = ${JSON.stringify(d.rhs)}`
+			askPassword(
+				'We found some secrets in your config, if you want to migrate, please enter password with minimum 5 characters (enter to skip): ',
+				(err, password) => {
+					config.forging.delegates = [];
+
+					if (password.trim().length === 0) {
+						delete config.forging.secret;
+
+						return setImmediate(cb, null, config);
+					}
+					if (password.length < 5) {
+						console.error(
+							`error: Password is too short (${
+								password.length
+							} characters), minimum 5 characters.`
+						);
+						process.exit(1);
+					}
+
+					console.info('\nMigrating your secrets...');
+					config.forging.secret.forEach(secret => {
+						console.info('.......');
+						config.forging.delegates.push({
+							encryptedPassphrase: lisk.cryptography.stringifyEncryptedPassphrase(
+								lisk.cryptography.encryptPassphraseWithPassword(
+									secret,
+									password
+								)
+							),
+							publicKey: lisk.cryptography.getPrivateAndPublicKeyFromPassphrase(
+								secret
+							).publicKey,
+						});
+					});
+
+					delete config.forging.secret;
+					return setImmediate(cb, null, config);
+				}
 			);
-			applyChange(oldConfig, unifiedNewConfig, d);
-			break;
+		}
+	);
+});
+history.version('1.0.0-rc.2', version => {
+	version.change(
+		'moved ssl to api.ssl to make SSL as API only config',
+		config => {
+			config.api.ssl = config.ssl;
+			delete config.ssl;
+			return config;
+		}
+	);
+});
+history.version('1.0.0');
+history.version('1.0.1');
+history.version('1.1.x');
+history.version('1.2.x');
 
-		case 'E':
-			console.info(
-				`${changesMap[d.kind]}: ${d.path.join('.')} = ${d.lhs} -> ${d.rhs}`
-			);
-			// Don't apply changes, preserve user configured value
-			// applyChange(oldConfig, unifiedNewConfig, d);
-			break;
-
-		case 'D':
-			console.info(
-				`${changesMap[d.kind]}: ${d.path.join('.')} = ${JSON.stringify(d.lhs)}`
-			);
-			applyChange(oldConfig, unifiedNewConfig, d);
-			break;
-
-		case 'A':
-			console.info(
-				`${changesMap[d.kind]}: ${d.path.join('.')} = ${
-					arrayItemChangesMap[d.item.kind]
-				} -> ${d.item.lhs}`
-			);
-			// Preserve user configured value
-			// applyChange(oldConfig, unifiedNewConfig, d);
-			break;
-
-		default:
-			console.warn(`Unknown change type detected '${d.kind}'`);
+const askPassword = (message, cb) => {
+	if (program.password && program.password.trim().length !== 0) {
+		return setImmediate(cb, null, program.password);
 	}
-});
 
-// Old configuration is up-to-date with new configuration.
-// now we need to extract differences from default config file
-// to write those in network specific directory
-const customConfig = {};
-observableDiff(defaultConfig, oldConfig, d => {
-	applyChange(customConfig, oldConfig, d);
-});
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
 
-console.info(`\nWriting updated configuration to ${newConfigPath}`);
-fs.writeFile(newConfigPath, JSON.stringify(customConfig, null, '\t'), err => {
+	rl.question(message, password => {
+		rl.close();
+		return setImmediate(cb, null, password);
+	});
+	// To Patch the password support
+	rl.stdoutMuted = true;
+	rl._writeToOutput = function _writeToOutput(stringToWrite) {
+		if (rl.stdoutMuted) rl.output.write('*');
+		else rl.output.write(stringToWrite);
+	};
+};
+
+if (!toVersion) {
+	const versions = history.getVersions();
+	toVersion = versions[versions.length - 1];
+}
+
+// Old config in 1.0.x will be single unified config file.
+const configFile = loadJSONFile(configFilePath);
+
+history.migrate(configFile, fromVersion, toVersion, (err, json) => {
 	if (err) {
 		throw err;
+	}
+	let customConfig = {};
+
+	if (program.diff) {
+		observableDiff(defaultConfig, json, d => {
+			applyChange(customConfig, json, d);
+		});
 	} else {
-		console.info('\nConfiguration migration completed.');
+		customConfig = json;
+	}
+
+	if (program.output) {
+		console.info(`\nWriting updated configuration to ${program.output}`);
+		fs.writeFileSync(program.output, JSON.stringify(customConfig, null, '\t'));
+	} else {
+		console.info('\n\n------------ OUTPUT -------------');
+		console.info(JSON.stringify(customConfig, null, '\t'));
 	}
 });

--- a/test/unit/helpers/json_history.js
+++ b/test/unit/helpers/json_history.js
@@ -195,7 +195,6 @@ describe('helpers/JSONHistory', () => {
 					done();
 				});
 			});
-
 			it('should provide migrated data as second argument of the callback', done => {
 				history.migrate({}, (error, data) => {
 					expect(error).to.be.null;
@@ -208,7 +207,6 @@ describe('helpers/JSONHistory', () => {
 					done();
 				});
 			});
-
 			it('should migrate through all versions if not specified start and end version', done => {
 				history.migrate({}, (error, data) => {
 					expect(error).to.be.null;
@@ -240,6 +238,11 @@ describe('helpers/JSONHistory', () => {
 					validMigrationExpectations(history, ['2.0.0', '3.0.0', '4.0.0'], []);
 					done();
 				});
+			});
+			it('should throw error if start version is registered in history', () => {
+				return expect(() => history.migrate({}, '0.0.0', () => {})).to.throw(
+					'Can\'t find supported version to start migration from  version "0.0.0"'
+				);
 			});
 			it('should migrate changes till end version if provided', done => {
 				history.migrate({}, '1.0.0', '3.0.0', (error, data) => {

--- a/test/unit/helpers/json_history.js
+++ b/test/unit/helpers/json_history.js
@@ -1,0 +1,368 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const JSONHistory = require('../../../helpers/json_history.js');
+
+const historyTitle = 'config history';
+let history;
+let loggerStub;
+
+describe('helpers/JSONHistory', () => {
+	beforeEach(() => {
+		loggerStub = {
+			info: sinonSandbox.stub(),
+		};
+		history = new JSONHistory(historyTitle, loggerStub);
+		return history;
+	});
+
+	afterEach(() => {
+		return sinonSandbox.restore();
+	});
+
+	describe('constructor function', () => {
+		it('should be a constructor function', () => {
+			return expect(JSONHistory).to.be.a('function');
+		});
+		it('should accept two arguments', () => {
+			return expect(JSONHistory.length).to.be.eql(2);
+		});
+		it('should return a history object', () => {
+			return expect(history).to.be.an('object');
+		});
+	});
+
+	describe('history object', () => {
+		it('should assign title argument', () => {
+			return expect(history.title).to.be.eql(historyTitle);
+		});
+		it('should assign logger argument', () => {
+			return expect(history.logger).to.be.eql(loggerStub);
+		});
+		it('should expose a function version() accepting 2 arguments', () => {
+			expect(history.version).to.be.a('function');
+			return expect(history.version.length).to.be.eql(2);
+		});
+		it('should expose a function migrate() accepting 4 arguments', () => {
+			expect(history.migrate).to.be.a('function');
+			return expect(history.migrate.length).to.be.eql(4);
+		});
+		it('should expose a function getVersions() accepting 0 arguments', () => {
+			expect(history.getVersions).to.be.a('function');
+			return expect(history.getVersions.length).to.be.eql(0);
+		});
+
+		describe('history.version()', () => {
+			it('should be ok to call without callback', () => {
+				return expect(() => history.version('1.1.0')).to.not.throw();
+			});
+			it('should throw error if called without version name', () => {
+				return expect(() => history.version()).to.throw(
+					'Invalid version specified.'
+				);
+			});
+			it('should throw error if version is not valid semver', () => {
+				return expect(() => history.version('nazar')).to.throw(
+					'Invalid version or version range specified.'
+				);
+			});
+			it('should accept version with support wildcard version (0.9.x)', () => {
+				return expect(() => history.version('0.9.x')).to.not.throw();
+			});
+			it('should accept version with support of range (>=0.9.0 <0.10.0)', () => {
+				return expect(() => history.version('>=0.9.0 <0.10.0')).to.not.throw();
+			});
+			it('should throw error if called with duplicate version', () => {
+				history.version('1.1.0');
+				return expect(() => history.version('1.1.0')).to.throw(
+					'Version 1.1.0 already declared.'
+				);
+			});
+			it('should add version to internal collection of versions', done => {
+				validVersionsExpectations(history, done);
+			});
+			it('should call the callback if given', () => {
+				const spy = sinonSandbox.spy();
+				history.version('1.1.0', spy);
+				return expect(spy).to.be.calledOnce;
+			});
+			it('should pass "version" object to the callback as first argument', () => {
+				const spy = sinonSandbox.spy();
+				history.version('1.1.0', spy);
+				const versionObject = spy.firstCall.args[0];
+				expect(versionObject).to.be.an('object');
+				expect(versionObject.change).to.be.a('function');
+				return expect(versionObject.version).to.be.eql('1.1.0');
+			});
+		});
+
+		describe('history.getVersions()', () => {
+			it('should return list of declared versions', done => {
+				validVersionsExpectations(history, done);
+			});
+		});
+
+		describe('history.getChangeSet()', () => {
+			it('should return list of declared changes', done => {
+				validChangeSetExpectations(history, done);
+			});
+		});
+
+		describe('history.migrate()', () => {
+			beforeEach('prepare history to migrate', done => {
+				history.version('1.0.0', version => {
+					version.change('add 1', config => {
+						config.v1 = '1';
+						return config;
+					});
+				});
+
+				history.version('2.0.0');
+
+				history.version('3.0.0', version => {
+					version.change('add 3', config => {
+						config.v3 = '3';
+						return config;
+					});
+				});
+
+				history.version('4.0.0', version => {
+					version.change('add 4', config => {
+						config.v4 = '4';
+						return config;
+					});
+				});
+
+				done();
+			});
+
+			it('should throw error if called without json', () => {
+				return expect(() => history.migrate()).to.throw(
+					'Invalid json object to migrate.'
+				);
+			});
+			it('should throw error if called without invalid json', () => {
+				return expect(() => history.migrate('string')).to.throw(
+					'Invalid json object to migrate.'
+				);
+			});
+			it('should be ok if called with empty json', () => {
+				return expect(() => history.migrate({}, () => {})).to.not.throw();
+			});
+			it('should throw error if called without invalid start version', () => {
+				return expect(() => history.migrate({}, 'nazar', () => {})).to.throw(
+					'Invalid start version specified to migrate.'
+				);
+			});
+			it('should throw error if called without invalid end version', () => {
+				return expect(() =>
+					history.migrate({}, '1.0.0', 'nazar', () => {})
+				).to.throw('Invalid end version specified to migrate.');
+			});
+			it('should throw error if called without callback', () => {
+				return expect(() => history.migrate({}, '1.0.0', '2.0.0')).to.throw(
+					'Invalid callback specified to migrate.'
+				);
+			});
+			it('should be ok if called without start and end version', () => {
+				return expect(() => history.migrate({}, () => {})).to.not.throw();
+			});
+			it('should be ok if called without end version', () => {
+				return expect(() => history.migrate({}, () => {})).to.not.throw();
+			});
+			it('should provide any error as first argument of the callback', done => {
+				history.version('5.0.0', version => {
+					version.change('make an error here', (config, cb) => {
+						cb('Error occurred during change.');
+					});
+				});
+
+				history.migrate({}, error => {
+					expect(error).to.be.eql('Error occurred during change.');
+					done();
+				});
+			});
+
+			it('should provide migrated data as second argument of the callback', done => {
+				history.migrate({}, (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ v1: '1', v3: '3', v4: '4' });
+					validMigrationExpectations(
+						history,
+						['1.0.0', '3.0.0', '4.0.0'],
+						['2.0.0']
+					);
+					done();
+				});
+			});
+
+			it('should migrate through all versions if not specified start and end version', done => {
+				history.migrate({}, (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ v1: '1', v3: '3', v4: '4' });
+					validMigrationExpectations(
+						history,
+						['1.0.0', '3.0.0', '4.0.0'],
+						['2.0.0']
+					);
+					done();
+				});
+			});
+			it('should migrate till end of versions if not specified end version', done => {
+				history.migrate({}, '1.0.0', (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ v3: '3', v4: '4' });
+					validMigrationExpectations(
+						history,
+						['1.0.0', '3.0.0', '4.0.0'],
+						['2.0.0']
+					);
+					done();
+				});
+			});
+			it('should migrate changes from start version skipping change for that version', done => {
+				history.migrate({}, '2.0.0', (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ v3: '3', v4: '4' });
+					validMigrationExpectations(history, ['2.0.0', '3.0.0', '4.0.0'], []);
+					done();
+				});
+			});
+			it('should migrate changes till end version if provided', done => {
+				history.migrate({}, '1.0.0', '3.0.0', (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ v3: '3' });
+					validMigrationExpectations(history, ['1.0.0', '3.0.0'], ['2.0.0']);
+					done();
+				});
+			});
+		});
+	});
+
+	describe('version object', () => {
+		it('should have a property version assigned as current version', done => {
+			history.version('1.1.0', version => {
+				expect(version.version).to.be.eql('1.1.0');
+				done();
+			});
+		});
+
+		it('should expose a function change() accepting 2 arguments', done => {
+			history.version('1.1.0', version => {
+				expect(version.change).to.be.a('function');
+				expect(version.change.length).to.be.eql(2);
+				done();
+			});
+		});
+
+		describe('version.change()', () => {
+			it('should throw error if called without title', done => {
+				history.version('1.1.0', version => {
+					expect(() => version.change()).to.throw(
+						'Title for the change is required.'
+					);
+					done();
+				});
+			});
+			it('should throw error if called with empty string as title', done => {
+				history.version('1.1.0', version => {
+					expect(() => version.change()).to.throw(
+						'Title for the change is required.'
+					);
+					done();
+				});
+			});
+			it('should throw error if called without callback', done => {
+				history.version('1.1.0', version => {
+					expect(() => version.change('a dummy change')).to.throw(
+						'Callback for the change is required.'
+					);
+					done();
+				});
+			});
+			it('should throw error if called without callback without one argument', done => {
+				history.version('1.1.0', version => {
+					expect(() => version.change('a dummy change', () => {})).to.throw(
+						'Callback for the change accepts up-to two arguments.'
+					);
+					done();
+				});
+			});
+
+			it('should add change to internal collection of changes in right order', done => {
+				validChangeSetExpectations(history, done);
+			});
+		});
+	});
+});
+
+const validMigrationExpectations = (history, versions, skipped) => {
+	expect(loggerStub.info).to.be.calledWith(
+		`Applying migration of ${history.title} from ${versions[0]} to ${
+			versions[versions.length - 1]
+		}`
+	);
+
+	// First version will be skipped
+	versions.splice(0);
+
+	versions.forEach(v => {
+		expect(loggerStub.info).to.be.calledWith(
+			`\n\n- Applying changes for version "${v}"`
+		);
+	});
+	skipped.forEach(v => {
+		expect(loggerStub.info).to.be.calledWith(
+			`\n\n- No changes for version "${v}"`
+		);
+	});
+};
+
+const validVersionsExpectations = (history, cb) => {
+	history.version('1.1.0');
+	history.version('1.2.0');
+	expect(history.getVersions()).to.be.eql(['1.1.0', '1.2.0']);
+	cb();
+};
+
+const validChangeSetExpectations = (history, cb) => {
+	history.version('1.1.0', version => {
+		version.change('dummy change 1', data => data);
+		version.change('dummy change 2', data => data);
+	});
+	history.version('1.2.0', version => {
+		version.change('dummy change 3', data => data);
+		version.change('dummy change 4', data => data);
+	});
+
+	const changeSet = history.getChangeSet();
+
+	expect(changeSet.length).to.be.eql(4);
+	expect(changeSet.map(c => c.title)).to.be.eql([
+		'dummy change 1',
+		'dummy change 2',
+		'dummy change 3',
+		'dummy change 4',
+	]);
+	expect(changeSet.map(c => c.version)).to.be.eql([
+		'1.1.0',
+		'1.1.0',
+		'1.2.0',
+		'1.2.0',
+	]);
+	changeSet.map(c => expect(c.change).to.be.a('function'));
+	cb();
+};


### PR DESCRIPTION
### What was the problem?
Current update config was bounded to one start and one end version. We need flexible approach to migrate config files. 

### How did I fix it?
Added versioning support for config file. 

### How to test it?
`node scripts/update_config.js ../lisk-0.9/config.json 0.9.16 1.2.0`

### Review checklist

* The PR solves #2278
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
