### PR TITLE
Reset forging.delegates on migration of old secrets only - Closes #2311

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -135,7 +135,6 @@ if (oldConfig.forging.secret && oldConfig.forging.secret.length) {
 }
 
 function migrateSecrets(password) {
-	oldConfig.forging.delegates = [];
 	password = password.trim();
 	if (!password) {
 		console.info('\nSkipping the secret migration.');
@@ -153,6 +152,7 @@ function migrateSecrets(password) {
 	}
 
 	console.info('\nMigrating your secrets...');
+	oldConfig.forging.delegates = [];
 	oldConfig.forging.secret.forEach(secret => {
 		console.info('.......');
 		oldConfig.forging.delegates.push({

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -129,8 +129,11 @@ if (oldConfig.forging.secret && oldConfig.forging.secret.length) {
 		migrateSecrets(program.password);
 		copyTheConfigFile();
 	}
-} else {
-	migrateSecrets('');
+} else {		// migration not necessary, initialize key, if not yet exist
+	if (!oldConfig.forging.delegates) {
+		oldConfig.forging.delegates = [];
+	}
+
 	copyTheConfigFile();
 }
 

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -135,6 +135,7 @@ if (oldConfig.forging.secret && oldConfig.forging.secret.length) {
 }
 
 function migrateSecrets(password) {
+	oldConfig.forging.delegates = [];
 	password = password.trim();
 	if (!password) {
 		console.info('\nSkipping the secret migration.');
@@ -152,7 +153,6 @@ function migrateSecrets(password) {
 	}
 
 	console.info('\nMigrating your secrets...');
-	oldConfig.forging.delegates = [];
 	oldConfig.forging.secret.forEach(secret => {
 		console.info('.......');
 		oldConfig.forging.delegates.push({


### PR DESCRIPTION
### What was the problem?
The update script resets the forging.delegates section regardless of migrating old secrets or not. 
It's not possible to prepare the forging.delegates key manually before update to core 1.0.0 (assuming forging.secret is empty)

### How did I fix it?
Reset forging.delegates key only, if there are old secrets to migrate.

This PR fixes #2311 