### PR TITLE
Disable updating system headers while snapshotting - Closes #2261

### DIFF
--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -69,7 +69,8 @@ class Blocks {
 				scope.logger,
 				scope.logic.block,
 				scope.logic.transaction,
-				scope.db
+				scope.db,
+				scope.config
 			),
 			process: new blocksProcess(
 				scope.logger,

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -45,7 +45,7 @@ __private.lastNBlockIds = [];
  * @todo Add description for the class
  */
 class Verify {
-	constructor(logger, block, transaction, db) {
+	constructor(logger, block, transaction, db, config) {
 		library = {
 			logger,
 			db,
@@ -53,6 +53,7 @@ class Verify {
 				block,
 				transaction,
 			},
+			config,
 		};
 		self = this;
 		__private.blockReward = new BlockReward();
@@ -821,7 +822,9 @@ Verify.prototype.processBlock = function(block, broadcast, saveBlock, cb) {
 			// 'false' if block comes from chain synchronisation process
 			updateSystemHeaders(seriesCb) {
 				// Update our own headers: broadhash and height
-				modules.system.update(seriesCb);
+				!library.config.loading.snapshotRound
+					? modules.system.update(seriesCb)
+					: seriesCb();
 			},
 			broadcastHeaders(seriesCb) {
 				// Notify all remote peers about our new headers

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -53,7 +53,11 @@ class Verify {
 				block,
 				transaction,
 			},
-			config,
+			config: {
+				loading: {
+					snapshotRound: config.loading.snapshotRound,
+				},
+			},
 		};
 		self = this;
 		__private.blockReward = new BlockReward();

--- a/test/integration/blocks/verify/verify.js
+++ b/test/integration/blocks/verify/verify.js
@@ -241,7 +241,8 @@ describe('blocks/verify', () => {
 				library.logger,
 				library.logic.block,
 				library.logic.transaction,
-				library.db
+				library.db,
+				library.config
 			);
 			verify.onBind(library.modules);
 			privateFunctions = RewiredVerify.__get__('__private');

--- a/test/unit/modules/blocks.js
+++ b/test/unit/modules/blocks.js
@@ -86,6 +86,7 @@ describe('blocks', () => {
 			genesisBlock: dummyGenesisblock,
 			bus: busStub,
 			balancesSequence: balancesSequenceStub,
+			config: { loading: {} },
 		};
 
 		blocksInstance = new Blocks((err, cbSelf) => {

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -1937,8 +1937,8 @@ describe('blocks/verify', () => {
 			done();
 		});
 
-		describe('system headers', () => {
-			it('should be updated if snapshotting was not activated', done => {
+		describe('system update', () => {
+			it('should be called if snapshotting was not activated', done => {
 				blocksVerifyModule.processBlock(
 					dummyBlock,
 					broadcast,
@@ -1951,7 +1951,7 @@ describe('blocks/verify', () => {
 				);
 			});
 
-			it('should not be updated if snapshotting was activated', done => {
+			it('should not be called if snapshotting was activated', done => {
 				const blocksVerifyModule = new BlocksVerify(
 					loggerStub,
 					logicBlockStub,

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -63,7 +63,9 @@ describe('blocks/verify', () => {
 		};
 
 		configMock = {
-			loading: {},
+			loading: {
+				snapshotRound: null,
+			},
 		};
 
 		blocksVerifyModule = new BlocksVerify(
@@ -137,6 +139,7 @@ describe('blocks/verify', () => {
 			expect(library.logger).to.eql(loggerStub);
 			expect(library.db).to.eql(dbStub);
 			expect(library.logic.block).to.eql(logicBlockStub);
+			expect(library.config).to.eql(configMock);
 			return expect(library.logic.transaction).to.eql(logicTransactionStub);
 		});
 

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -1952,7 +1952,7 @@ describe('blocks/verify', () => {
 			});
 
 			it('should not be updated if snapshotting was activated', done => {
-				blocksVerifyModule = new BlocksVerify(
+				const blocksVerifyModule = new BlocksVerify(
 					loggerStub,
 					logicBlockStub,
 					logicTransactionStub,


### PR DESCRIPTION
### What was the problem?
As @4miners stated here https://github.com/LiskHQ/lisk/pull/2300#issuecomment-412379504: 

> After the change we're always calling modules.system.update from inside Verify.prototype.processBlock. System.prototype.update is calling System.prototype.getBroadhash which is performing database query SELECT * FROM blocks_list ORDER BY b_height DESC LIMIT 5 OFFSET 0 and calculate SHA-256. While both the query (0.5ms) and hash operation are fast - they are executed for every block. Those operations are not needed for snapshotting and will decrease the performance:
6000000 blocks * 0.5 ms = 3000000 ms = 3000 s = 50 minutes.
So change introduced in this PR will make snapshotting process longer by at least 50 minutes (only because of the query). Please consider not executing those when snapshotting.

### How did I fix it?
I disabled updating system headers while snapshotting.

### Review checklist

* The PR resolves #2261 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
