### PR TITLE
Add height range to blockVersions in exceptions (Mainnet) - Closes #2245

### DIFF
--- a/helpers/exceptions.js
+++ b/helpers/exceptions.js
@@ -81,6 +81,6 @@ module.exports = {
 	transactionFee: [],
 	// <version>: { start: <start_height>, end: <end_height> }
 	blockVersions: {
-		0: { start: 1, end: 9000000 },
+		0: { start: 1, end: 6901027 },
 	},
 };


### PR DESCRIPTION
### What was the problem?
As the Mainnet migration block height is announced corresponding block version = 0 needs to be added to make all of the blocks before migration valid.
### How did I fix it?
Block version = 0 is set within the range 1 to 6901027.
### How to test it?

### Review checklist

* The PR solves #2245
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
