### PR TITLE
Use DNS name for seed nodes in config.json - Closes #2320

### DIFF
--- a/config/betanet/config.json
+++ b/config/betanet/config.json
@@ -9,23 +9,23 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "94.237.41.99",
+				"ip": "betanet-seed-01.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "209.50.52.217",
+				"ip": "betanet-seed-02.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "94.237.26.150",
+				"ip": "betanet-seed-03.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "83.136.249.102",
+				"ip": "betanet-seed-04.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "94.237.65.179",
+				"ip": "betanet-seed-05.lisk.io",
 				"wsPort": 5001
 			}
 		]

--- a/config/mainnet/config.json
+++ b/config/mainnet/config.json
@@ -7,43 +7,43 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "83.136.254.92",
+				"ip": "mainnet-seed-01.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "83.136.249.76",
+				"ip": "mainnet-seed-02.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.28.66",
+				"ip": "mainnet-seed-03.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.24.199",
+				"ip": "mainnet-seed-04.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "209.50.49.23",
+				"ip": "mainnet-seed-05.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "209.50.49.40",
+				"ip": "mainnet-seed-06.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.64.70",
+				"ip": "mainnet-seed-07.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.64.73",
+				"ip": "mainnet-seed-08.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.40.140",
+				"ip": "mainnet-seed-09.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.40.141",
+				"ip": "mainnet-seed-10.lisk.io",
 				"wsPort": 8000
 			}
 		]

--- a/config/testnet/config.json
+++ b/config/testnet/config.json
@@ -7,23 +7,23 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "94.237.29.221",
+				"ip": "testnet-seed-01.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "83.136.254.104",
+				"ip": "testnet-seed-02.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "209.50.48.177",
+				"ip": "testnet-seed-03.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "94.237.64.33",
+				"ip": "testnet-seed-04.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "94.237.30.23",
+				"ip": "testnet-seed-05.lisk.io",
 				"wsPort": 7001
 			}
 		]


### PR DESCRIPTION
### What was the problem?

`config.json` used DNS name for seed nodes.

### How did I fix it?

IP addresses were replaced with DNS names.

### How to test it?

Ensure that `config/{main,test}net/config.json` contains DNS names under `.peers.list[].ip`, make sure those resolve (except for betanet which does not exist at the moment) and that there are no duplicates.

### Review checklist

* The PR solves #2320 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
