### PR TITLE
Use DNS name instead of IP addresses for seed nodes in config.json - Closes #2320

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,8 @@
 var path = require('path');
 var fs = require('fs');
 var d = require('domain').create();
+var dns = require('dns');
+var net = require('net');
 var SocketCluster = require('socketcluster');
 var async = require('async');
 var Logger = require('./logger.js');
@@ -188,7 +190,7 @@ d.run(() => {
 	async.auto(
 		{
 			/**
-			 * Attempts to determine nethash from genesis block.
+			 * Prepare the config object.
 			 *
 			 * @func config
 			 * @memberof! app
@@ -199,7 +201,37 @@ d.run(() => {
 				if (!appConfig.nethash) {
 					throw Error('Failed to assign nethash from genesis block');
 				}
-				cb(null, appConfig);
+
+				// In case domain names are used, resolve those to IP addresses.
+				var peerDomainLookupTasks = appConfig.peers.list.map(
+					peer => callback => {
+						if (net.isIPv4(peer.ip)) {
+							return setImmediate(() => {
+								callback(null, peer);
+							});
+						}
+						dns.lookup(peer.ip, { family: 4 }, (err, address) => {
+							if (err) {
+								console.error(
+									`Failed to resolve peer domain name ${
+										peer.ip
+									} to an IP address`
+								);
+								return callback(err, peer);
+							}
+							callback(null, Object.assign({}, peer, { ip: address }));
+						});
+					}
+				);
+
+				async.parallel(peerDomainLookupTasks, (err, results) => {
+					if (err) {
+						cb(err, appConfig);
+						return;
+					}
+					appConfig.peers.list = results;
+					cb(null, appConfig);
+				});
 			},
 
 			logger(cb) {
@@ -415,20 +447,23 @@ d.run(() => {
 				},
 			],
 
-			/**
-			 * Description of the function.
-			 *
-			 * @memberof! app
-			 * @param {function} cb - Callback function
-			 * @todo Add description for the function and its params
-			 */
-			db(cb) {
-				var db = require('./db');
-				db
-					.connect(config.db, dbLogger)
-					.then(db => cb(null, db))
-					.catch(cb);
-			},
+			db: [
+				'config',
+				/**
+				 * Description of the function.
+				 *
+				 * @memberof! app
+				 * @param {function} cb - Callback function
+				 * @todo Add description for the function and its params
+				 */
+				function(scope, cb) {
+					var db = require('./db');
+					db
+						.connect(config.db, dbLogger)
+						.then(db => cb(null, db))
+						.catch(cb);
+				},
+			],
 
 			/**
 			 * Description of the function.

--- a/config/betanet/config.json
+++ b/config/betanet/config.json
@@ -9,23 +9,23 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "94.237.41.99",
+				"ip": "betanet-seed-01.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "209.50.52.217",
+				"ip": "betanet-seed-02.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "94.237.26.150",
+				"ip": "betanet-seed-03.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "83.136.249.102",
+				"ip": "betanet-seed-04.lisk.io",
 				"wsPort": 5001
 			},
 			{
-				"ip": "94.237.65.179",
+				"ip": "betanet-seed-05.lisk.io",
 				"wsPort": 5001
 			}
 		]

--- a/config/mainnet/config.json
+++ b/config/mainnet/config.json
@@ -7,43 +7,43 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "83.136.254.92",
+				"ip": "mainnet-seed-01.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "83.136.249.76",
+				"ip": "mainnet-seed-02.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.28.66",
+				"ip": "mainnet-seed-03.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.24.199",
+				"ip": "mainnet-seed-04.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "209.50.49.23",
+				"ip": "mainnet-seed-05.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "209.50.49.40",
+				"ip": "mainnet-seed-06.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.64.70",
+				"ip": "mainnet-seed-07.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.64.73",
+				"ip": "mainnet-seed-08.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.40.140",
+				"ip": "mainnet-seed-09.lisk.io",
 				"wsPort": 8000
 			},
 			{
-				"ip": "94.237.40.141",
+				"ip": "mainnet-seed-10.lisk.io",
 				"wsPort": 8000
 			}
 		]

--- a/config/testnet/config.json
+++ b/config/testnet/config.json
@@ -7,23 +7,23 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "94.237.29.221",
+				"ip": "testnet-seed-01.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "83.136.254.104",
+				"ip": "testnet-seed-02.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "209.50.48.177",
+				"ip": "testnet-seed-03.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "94.237.64.33",
+				"ip": "testnet-seed-04.lisk.io",
 				"wsPort": 7001
 			},
 			{
-				"ip": "94.237.30.23",
+				"ip": "testnet-seed-05.lisk.io",
 				"wsPort": 7001
 			}
 		]


### PR DESCRIPTION
### What was the problem?

`config.json` did not support domain names for seed nodes.

### How did I fix it?

When the node launches, it preprocesses the peer list from the config file and resolves any domain names into IP addresses before creating the relevant peer objects.

This approach was chosen because the node currently relies on IP addresses in order to uniquely identify peers. To allow a peer to have both an IP address AND a domain name would have complicated things; it's easier to resolve all domains during node startup.

I cherry-picked the commits of @fchavant from https://github.com/LiskHQ/lisk/pull/2322 so we can probably close that other PR.

### How to test it?

- In the peer list in the relevant configuration file, change the ip addresses from `127.0.0.1` to the string `localhost`; then run integration tests.
- Run the node locally using `localhost` instead of `127.0.0.1` as the IP address of a peer in the config file; the node should run without errors.

### Review checklist

* The PR solves #2320
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
