### PR TITLE
Always update version/minVersion to new version in update_config.js

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -51,6 +51,10 @@ console.info('Starting configuration migration...');
 const oldConfig = JSON.parse(fs.readFileSync(oldConfigPath, 'utf8'));
 const newConfig = JSON.parse(fs.readFileSync(newConfigPath, 'utf8'));
 
+// Values to always keep from new config file
+delete oldConfig.version;
+delete oldConfig.minVersion;
+
 // If old release was a 1.0.0-rc.2 release
 if (oldConfig.version === '1.0.0-rc.2') {
 	copyTheConfigFile();
@@ -60,10 +64,6 @@ if (oldConfig.version === '1.0.0-rc.2') {
 
 // If old release was a 1.0.0-rc.1 release
 if (oldConfig.version === '1.0.0-rc.1') {
-	// Values to keep from new config file
-	delete oldConfig.version;
-	delete oldConfig.minVersion;
-
 	// https://github.com/LiskHQ/lisk/issues/2154
 	oldConfig.api.ssl = extend(true, {}, oldConfig.ssl);
 	delete oldConfig.ssl;


### PR DESCRIPTION
### What was the problem?
When upgrading from 1.0.0-rc.2 to 1.0.0-rc.3, the version in config.json stayed as 1.0.0-rc.2. Looks like minVersion is affected as well
### How did I fix it?
Made a slight modification to update_config.js so that version and minVersion are always taken from the new config
### How to test it?
When running 1.0.0-rc.2, upgrade to 1.0.0-rc.3:
- bash installLisk.sh upgrade -r test
### Review checklist
 
* The PR solves #2338

