### PR TITLE
Always update version/minVersion to new version in update_config.js

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -51,6 +51,10 @@ console.info('Starting configuration migration...');
 const oldConfig = JSON.parse(fs.readFileSync(oldConfigPath, 'utf8'));
 const newConfig = JSON.parse(fs.readFileSync(newConfigPath, 'utf8'));
 
+// Values to keep from new config file
+delete oldConfig.version;
+delete oldConfig.minVersion;
+
 // 1.0.1 doesn't add any changes to 1.0.0 config.json
 if (oldConfig.version === '1.0.0') {
 	copyTheConfigFile();
@@ -60,10 +64,6 @@ if (oldConfig.version === '1.0.0') {
 
 newConfig.api.ssl = extend(true, {}, oldConfig.ssl);
 delete oldConfig.ssl;
-
-// Values to keep from new config file
-delete oldConfig.version;
-delete oldConfig.minVersion;
 
 // Rename old port to new wsPort
 oldConfig.httpPort = oldConfig.port;


### PR DESCRIPTION
### What was the problem?
When upgrading from 1.0.0 to 1.0.1, the version in config.json stayed as 1.0.0. Looks like minVersion is affected as well
### How did I fix it?
Made a slight modification to update_config.js so that version and minVersion are always taken from the new config
### How to test it?
When running 1.0.0, upgrade to 1.0.1:
- bash installLisk.sh upgrade -r test
### Review checklist
 
* The PR solves #2340 

