### PR TITLE
Poor performance of GET /api/delegates/[address]/forging_statistics - Closes #2352

### DIFF
--- a/api/controllers/delegates.js
+++ b/api/controllers/delegates.js
@@ -15,7 +15,6 @@
 'use strict';
 
 var _ = require('lodash');
-var Bignum = require('../../helpers/bignum.js');
 var swaggerHelper = require('../../helpers/swagger');
 
 // Private Fields
@@ -126,11 +125,11 @@ DelegatesController.getForgingStatistics = function(context, next) {
 
 	var filters = {
 		address: params.address.value,
-		start: params.fromTimestamp.value || constants.epochTime.getTime(),
-		end: params.toTimestamp.value || Date.now(),
+		start: params.fromTimestamp.value,
+		end: params.toTimestamp.value,
 	};
 
-	modules.blocks.utils.aggregateBlocksReward(filters, (err, reward) => {
+	modules.delegates.shared.getForgingStatistics(filters, (err, reward) => {
 		if (err) {
 			if (err === 'Account not found' || err === 'Account is not a delegate') {
 				return next(
@@ -140,23 +139,19 @@ DelegatesController.getForgingStatistics = function(context, next) {
 			return next(err);
 		}
 
-		var forged = new Bignum(reward.fees)
-			.plus(new Bignum(reward.rewards))
-			.toString();
-		var response = {
+		return next(null, {
 			data: {
 				fees: reward.fees,
 				rewards: reward.rewards,
-				forged,
+				forged: reward.forged,
 				count: reward.count,
 			},
 			meta: {
-				fromTimestamp: filters.start,
-				toTimestamp: filters.end,
+				fromTimestamp: filters.start || constants.epochTime.getTime(),
+				toTimestamp: filters.end || Date.now(),
 			},
 			links: {},
-		};
-		return next(null, response);
+		});
 	});
 };
 

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -24,6 +24,7 @@ const BlockReward = require('../logic/block_reward.js');
 const jobsQueue = require('../helpers/jobs_queue.js');
 const Delegate = require('../logic/delegate.js');
 const slots = require('../helpers/slots.js');
+const bignum = require('../helpers/bignum.js');
 const transactionTypes = require('../helpers/transaction_types.js');
 
 // Private fields
@@ -1076,6 +1077,58 @@ Delegates.prototype.shared = {
 			}
 			return setImmediate(cb, null, delegates);
 		});
+	},
+
+	/**
+	 *
+	 * @param {Object} filters - Filters applied to results
+	 * @param {string} filters.address - Address of the delegate
+	 * @param {string} filters.start - Start time to aggregate
+	 * @param {string} filters.end - End time to aggregate
+	 * @params {function} cb - Callback function
+	 * @param {SetImmediateCallback} cb
+	 */
+	getForgingStatistics(filters, cb) {
+		// If need to aggregate all data then just fetch from the account
+		if (!filters.start && !filters.end) {
+			modules.delegates.getDelegates(
+				{ address: filters.address },
+				['rewards', 'fees', 'producedBlocks'],
+				(err, data) => {
+					if (err) {
+						return setImmediate(cb, err);
+					}
+
+					if (!data) {
+						return setImmediate(cb, 'Account not found');
+					}
+
+					processStatistics({
+						rewards: data[0].rewards,
+						fees: data[0].fees,
+						count: data[0].producedBlocks,
+					});
+				}
+			);
+
+			// If need to aggregate some period of time
+		} else {
+			modules.blocks.utils.aggregateBlocksReward(filters, (err, reward) => {
+				if (err) {
+					return setImmediate(cb, err);
+				}
+
+				processStatistics(reward);
+			});
+		}
+
+		const processStatistics = reward => {
+			reward.forged = new bignum(reward.fees)
+				.plus(new bignum(reward.rewards))
+				.toString();
+
+			return setImmediate(cb, null, reward);
+		};
 	},
 };
 


### PR DESCRIPTION
### What was the problem?
Performance of the endpoint `/api/delegates/[address]/forging_statistics` was slow because of aggregating all data when no time filter is provided. 

### How did I fix it?
When no time filter is provided we get data from mem_accounts instead of aggregating. 

### How to test it?

```
npx mocha test/functional/http/get/delegates.js
```

### Review checklist

* The PR solves #2352
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
