### PR TITLE
Poor performance of GET /api/delegates/[address]/forging_statistics - Closes #2352

### DIFF
--- a/api/controllers/delegates.js
+++ b/api/controllers/delegates.js
@@ -15,7 +15,6 @@
 'use strict';
 
 var _ = require('lodash');
-var Bignum = require('../../helpers/bignum.js');
 var swaggerHelper = require('../../helpers/swagger');
 
 // Private Fields
@@ -126,11 +125,11 @@ DelegatesController.getForgingStatistics = function(context, next) {
 
 	var filters = {
 		address: params.address.value,
-		start: params.fromTimestamp.value || constants.epochTime.getTime(),
-		end: params.toTimestamp.value || Date.now(),
+		start: params.fromTimestamp.value,
+		end: params.toTimestamp.value,
 	};
 
-	modules.blocks.utils.aggregateBlocksReward(filters, (err, reward) => {
+	modules.delegates.shared.getForgingStatistics(filters, (err, reward) => {
 		if (err) {
 			if (err === 'Account not found' || err === 'Account is not a delegate') {
 				return next(
@@ -140,23 +139,19 @@ DelegatesController.getForgingStatistics = function(context, next) {
 			return next(err);
 		}
 
-		var forged = new Bignum(reward.fees)
-			.plus(new Bignum(reward.rewards))
-			.toString();
-		var response = {
+		return next(null, {
 			data: {
 				fees: reward.fees,
 				rewards: reward.rewards,
-				forged,
+				forged: reward.forged,
 				count: reward.count,
 			},
 			meta: {
-				fromTimestamp: filters.start,
-				toTimestamp: filters.end,
+				fromTimestamp: filters.start || constants.epochTime.getTime(),
+				toTimestamp: filters.end || Date.now(),
 			},
 			links: {},
-		};
-		return next(null, response);
+		});
 	});
 };
 


### PR DESCRIPTION
### What was the problem?
Performance of the endpoint `/api/delegates/[address]/forging_statistics` was slow because of aggregating all data when no time filter is provided. 

### How did I fix it?
When no time filter is provided we get data from mem_accounts instead of aggregating. 

### How to test it?

```
npx mocha test/functional/http/get/delegates.js
```

### Review checklist

* The PR solves #2352
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
