### PR TITLE
Poor performance of GET /api/accounts in case of some few parameters - Resolves #2350

### DIFF
--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -254,7 +254,24 @@ Accounts.prototype.shared = {
 	 * @todo Add description for the return value
 	 */
 	getAccounts(filters, cb) {
-		library.logic.account.getAll(filters, (err, accounts) => {
+		const fields = [
+			'address',
+			'publicKey',
+			'secondPublicKey',
+			'secondSignature',
+			'u_secondSignature',
+			'username',
+			'balance',
+			'u_balance',
+			'vote',
+			'rewards',
+			'producedBlocks',
+			'missedBlocks',
+			'rank',
+			'approval',
+			'productivity',
+		];
+		library.logic.account.getAll(filters, fields, (err, accounts) => {
 			if (err) {
 				return setImmediate(cb, err);
 			}


### PR DESCRIPTION
### What was the problem?
The poor performance of `/api/accounts` due to subqueries.
### How did I fix it?
Pass only required fields when getting accounts, so subqueries are not executed.
### How to test it?
Manually.
### Review checklist

* The PR resolves #2350
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
