### PR TITLE
Better regular expression for verifying vote in verify vote - Close #627

### DIFF
--- a/logic/vote.js
+++ b/logic/vote.js
@@ -227,12 +227,8 @@ Vote.prototype.verifyVote = function(vote, cb) {
 		return setImmediate(cb, 'Invalid vote type');
 	}
 
-	if (!/[-+]{1}[0-9a-z]{64}/.test(vote)) {
+	if (!/^[-+]{1}[0-9a-f]{64}$/.test(vote)) {
 		return setImmediate(cb, 'Invalid vote format');
-	}
-
-	if (vote.length !== 65) {
-		return setImmediate(cb, 'Invalid vote length');
 	}
 
 	return setImmediate(cb);

--- a/test/functional/http/post/3.votes.js
+++ b/test/functional/http/post/3.votes.js
@@ -289,7 +289,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 				errorCodes.PROCESSING_ERROR
 			).then(res => {
 				expect(res.body.message).to.be.equal(
-					'Invalid vote at index 0 - Invalid vote length'
+					'Invalid vote at index 0 - Invalid vote format'
 				);
 				badTransactions.push(transaction);
 			});

--- a/test/unit/logic/vote.js
+++ b/test/unit/logic/vote.js
@@ -378,9 +378,36 @@ describe('vote', () => {
 	});
 
 	describe('verifyVote', () => {
-		it('should throw if vote is of invalid length', done => {
+		it('should return error if vote is of invalid length', done => {
 			var invalidVote =
 				'-01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d746';
+			vote.verifyVote(invalidVote, err => {
+				expect(err).to.equal('Invalid vote format');
+				done();
+			});
+		});
+
+		it('should return error if vote contains non-hex value', done => {
+			const invalidVote =
+				'-z1389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d7466';
+			vote.verifyVote(invalidVote, err => {
+				expect(err).to.equal('Invalid vote format');
+				done();
+			});
+		});
+
+		it('should return error if vote length is less than 65', done => {
+			const invalidVote =
+				'-01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d745';
+			vote.verifyVote(invalidVote, err => {
+				expect(err).to.equal('Invalid vote format');
+				done();
+			});
+		});
+
+		it('should return error if vote length is more than 65', done => {
+			const invalidVote =
+				'-01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d74667';
 			vote.verifyVote(invalidVote, err => {
 				expect(err).to.equal('Invalid vote format');
 				done();

--- a/test/unit/logic/vote.js
+++ b/test/unit/logic/vote.js
@@ -378,15 +378,6 @@ describe('vote', () => {
 	});
 
 	describe('verifyVote', () => {
-		it('should return error if vote is of invalid length', done => {
-			var invalidVote =
-				'-01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d746';
-			vote.verifyVote(invalidVote, err => {
-				expect(err).to.equal('Invalid vote format');
-				done();
-			});
-		});
-
 		it('should return error if vote contains non-hex value', done => {
 			const invalidVote =
 				'-z1389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398d7466';


### PR DESCRIPTION
### What was the problem?
Vote regular expression was passing on non-hex vote string.
### How did I fix it?
Updated the regular expression to fail on non-hex vote string.
### How to test it?
Run the unit tests
### Review checklist

* The PR resolves #627 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
