### PR TITLE
Add sort support for username field on api/voters - Closes #2330

### DIFF
--- a/db/sql/voters/get_voters.sql
+++ b/db/sql/voters/get_voters.sql
@@ -19,7 +19,7 @@
   PARAMETERS: ?
 */
 
-SELECT accounts.address, accounts.balance, accounts.username, encode(accounts."publicKey", 'hex') AS "publicKey" FROM mem_accounts2delegates delegates
+SELECT accounts.address, accounts.balance, encode(accounts."publicKey", 'hex') AS "publicKey" FROM mem_accounts2delegates delegates
 INNER JOIN mem_accounts accounts ON delegates."accountId" = accounts.address
 WHERE delegates."dependentId" = ${publicKey}
 ORDER BY "${sortField:raw}" ${sortMethod:raw}

--- a/db/sql/voters/get_voters.sql
+++ b/db/sql/voters/get_voters.sql
@@ -19,7 +19,7 @@
   PARAMETERS: ?
 */
 
-SELECT accounts.address, accounts.balance, encode(accounts."publicKey", 'hex') AS "publicKey" FROM mem_accounts2delegates delegates
+SELECT accounts.address, accounts.balance, accounts.username, encode(accounts."publicKey", 'hex') AS "publicKey" FROM mem_accounts2delegates delegates
 INNER JOIN mem_accounts accounts ON delegates."accountId" = accounts.address
 WHERE delegates."dependentId" = ${publicKey}
 ORDER BY "${sortField:raw}" ${sortMethod:raw}

--- a/modules/voters.js
+++ b/modules/voters.js
@@ -86,7 +86,7 @@ const getVotersForDelegates = function(filters, delegate, cb) {
 
 	let sort = { sortField: 'publicKey', sortMethod: 'ASC' };
 	if (filters.sort) {
-		const allowedSortFields = ['balance', 'publicKey'];
+		const allowedSortFields = ['balance', 'publicKey', 'username'];
 		sort = sortBy.sortBy(filters.sort, {
 			sortFields: allowedSortFields,
 			quoteField: false,

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -765,6 +765,8 @@ paths:
             - publicKey:desc
             - balance:asc
             - balance:desc
+            - username:asc
+            - username:desc
           default: publicKey:asc
       responses:
         200:

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -388,6 +388,50 @@ describe('GET /api/voters', () => {
 							});
 					});
 				});
+
+				describe('username', () => {
+					it('should return voters in ascending order', () => {
+						return votersEndpoint
+							.makeRequest(
+								{
+									sort: 'username:asc',
+									username: validVotedDelegate.delegateName,
+								},
+								200
+							)
+							.then(res => {
+								expectValidVotedDelegateResponse(res);
+								expect(res.body.data.username).to.equal(
+									validVotedDelegate.delegateName
+								);
+								expect(
+									_.map(res.body.data.voters, 'username').sort()
+								).to.to.be.eql(_.map(res.body.data.voters, 'username'));
+							});
+					});
+
+					it('should return voters in descending order', () => {
+						return votersEndpoint
+							.makeRequest(
+								{
+									sort: 'username:desc',
+									username: validVotedDelegate.delegateName,
+								},
+								200
+							)
+							.then(res => {
+								expectValidVotedDelegateResponse(res);
+								expect(res.body.data.username).to.equal(
+									validVotedDelegate.delegateName
+								);
+								expect(
+									_.map(res.body.data.voters, 'username')
+										.sort()
+										.reverse()
+								).to.to.be.eql(_.map(res.body.data.voters, 'username'));
+							});
+					});
+				});
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
The fix we provided with #2346 was not backwards compatible. We had to keep username sort support.
### How did I fix it?
I added sort support for username field as well.
### How to test it?

### Review checklist

* The PR resolves #2330 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
