### PR TITLE
Replace hardcoded values from description of Peer Disconnect network tests - Closes #2333

### DIFF
--- a/test/network/index.js
+++ b/test/network/index.js
@@ -20,8 +20,11 @@ const setup = require('./setup');
 
 const TOTAL_PEERS = Number.parseInt(process.env.TOTAL_PEERS) || 10;
 // Full mesh network with 2 connection for bi-directional communication
-const EXPECTED_OUTOGING_CONNECTIONS = (TOTAL_PEERS - 1) * TOTAL_PEERS * 2;
+const EXPECTED_TOTAL_CONNECTIONS = (TOTAL_PEERS - 1) * TOTAL_PEERS * 2;
 const NUMBER_OF_TRANSACTIONS = process.env.NUMBER_OF_TRANSACTIONS || 1000;
+// 2 connections (1 bidirectional) are established for each node in order to
+// monitor and interact with them as part of the test.
+const NUMBER_OF_MONITORING_CONNECTIONS = TOTAL_PEERS * 2;
 
 describe(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS ports 500[0-9] and HTTP ports 400[0-9] using separate databases`, () => {
 	const wsPorts = [];
@@ -65,13 +68,13 @@ describe(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS p
 		});
 	});
 
-	it(`there should be a maximum ${EXPECTED_OUTOGING_CONNECTIONS} established connections from 500[0-9] ports`, done => {
+	it(`there should be a maximum ${EXPECTED_TOTAL_CONNECTIONS} established connections from 500[0-9] ports`, done => {
 		utils.getEstablishedConnections(wsPorts, (err, numOfConnections) => {
 			if (err) {
 				return done(err);
 			}
-			// It should be less than EXPECTED_OUTOGING_CONNECTIONS, as nodes are just started and establishing the connections
-			if (numOfConnections <= EXPECTED_OUTOGING_CONNECTIONS) {
+			// It should be less than EXPECTED_TOTAL_CONNECTIONS, as nodes are just started and establishing the connections
+			if (numOfConnections <= EXPECTED_TOTAL_CONNECTIONS) {
 				done();
 			} else {
 				done(
@@ -91,8 +94,9 @@ describe(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS p
 			test(
 				configurations,
 				TOTAL_PEERS,
-				EXPECTED_OUTOGING_CONNECTIONS,
-				NUMBER_OF_TRANSACTIONS
+				EXPECTED_TOTAL_CONNECTIONS,
+				NUMBER_OF_TRANSACTIONS,
+				NUMBER_OF_MONITORING_CONNECTIONS
 			);
 		});
 	});

--- a/test/network/scenarios/p2p/peer_disconnect.js
+++ b/test/network/scenarios/p2p/peer_disconnect.js
@@ -150,7 +150,10 @@ module.exports = function(
 									return done(err);
 								}
 
-								if (numOfConnections <= EXPECTED_TOTAL_CONNECTIONS + 18) {
+								if (
+									numOfConnections - NUMBER_OF_MONITORING_CONNECTIONS <=
+									EXPECTED_TOTAL_CONNECTIONS
+								) {
 									done();
 								} else {
 									done(

--- a/test/network/scenarios/p2p/peer_disconnect.js
+++ b/test/network/scenarios/p2p/peer_disconnect.js
@@ -22,8 +22,14 @@ const common = require('../common');
 module.exports = function(
 	configurations,
 	TOTAL_PEERS,
-	EXPECTED_OUTOGING_CONNECTIONS
+	EXPECTED_TOTAL_CONNECTIONS,
+	NUMBER_OF_TRANSACTIONS,
+	NUMBER_OF_MONITORING_CONNECTIONS
 ) {
+	const TOTAL_PEERS_LESS_ONE = TOTAL_PEERS - 1;
+	const EXPECTED_TOTAL_CONNECTIONS_AFTER_REMOVING_PEER =
+		(TOTAL_PEERS_LESS_ONE - 1) * TOTAL_PEERS_LESS_ONE * 2;
+
 	describe('@network : peer Disconnect', () => {
 		const params = {};
 		common.setMonitoringSocketsConnections(params, configurations);
@@ -54,8 +60,7 @@ module.exports = function(
 					}, 2000);
 				});
 
-				it(`peer manager should remove peer from the list and there should be ${EXPECTED_OUTOGING_CONNECTIONS -
-					20} established connections from 500[0-9] ports`, done => {
+				it(`peer manager should remove peer from the list and there should be ${EXPECTED_TOTAL_CONNECTIONS_AFTER_REMOVING_PEER} established connections from 500[0-9] ports`, done => {
 					utils.getEstablishedConnections(
 						Array.from(wsPorts),
 						(err, numOfConnections) => {
@@ -63,7 +68,10 @@ module.exports = function(
 								return done(err);
 							}
 
-							if (numOfConnections <= EXPECTED_OUTOGING_CONNECTIONS - 20) {
+							if (
+								numOfConnections - NUMBER_OF_MONITORING_CONNECTIONS <=
+								EXPECTED_TOTAL_CONNECTIONS_AFTER_REMOVING_PEER
+							) {
 								done();
 							} else {
 								done(
@@ -83,7 +91,7 @@ module.exports = function(
 					}, 2000);
 				});
 
-				it(`there should be ${EXPECTED_OUTOGING_CONNECTIONS} established connections from 500[0-9] ports`, done => {
+				it(`there should be ${EXPECTED_TOTAL_CONNECTIONS} established connections from 500[0-9] ports`, done => {
 					utils.getEstablishedConnections(
 						Array.from(wsPorts),
 						(err, numOfConnections) => {
@@ -91,7 +99,7 @@ module.exports = function(
 								return done(err);
 							}
 
-							if (numOfConnections <= EXPECTED_OUTOGING_CONNECTIONS) {
+							if (numOfConnections <= EXPECTED_TOTAL_CONNECTIONS) {
 								done();
 							} else {
 								done(
@@ -132,8 +140,8 @@ module.exports = function(
 						network.enableForgingForDelegates(params.configurations, done);
 					});
 
-					// The expected connection becomes EXPECTED_OUTOGING_CONNECTIONS + 18 previously held connections
-					it(`there should be ${EXPECTED_OUTOGING_CONNECTIONS +
+					// The expected connection becomes EXPECTED_TOTAL_CONNECTIONS + 18 previously held connections
+					it(`there should be ${EXPECTED_TOTAL_CONNECTIONS +
 						18} established connections from 500[0-9] ports`, done => {
 						utils.getEstablishedConnections(
 							Array.from(wsPorts),
@@ -142,7 +150,7 @@ module.exports = function(
 									return done(err);
 								}
 
-								if (numOfConnections <= EXPECTED_OUTOGING_CONNECTIONS + 18) {
+								if (numOfConnections <= EXPECTED_TOTAL_CONNECTIONS + 18) {
 									done();
 								} else {
 									done(

--- a/test/network/scenarios/p2p/peers_blacklist.js
+++ b/test/network/scenarios/p2p/peers_blacklist.js
@@ -24,10 +24,12 @@ const common = require('../common');
 module.exports = function(
 	configurations,
 	TOTAL_PEERS,
-	EXPECTED_OUTOGING_CONNECTIONS
+	EXPECTED_TOTAL_CONNECTIONS,
+	NUMBER_OF_TRANSACTIONS,
+	NUMBER_OF_MONITORING_CONNECTIONS
 ) {
 	// Full mesh network with 2 connection for bi-directional communication without the blacklisted peer
-	const EXPECTED_OUTOGING_CONNECTIONS_AFTER_BLACKLISTING =
+	const EXPECTED_TOTAL_CONNECTIONS_AFTER_BLACKLISTING =
 		(TOTAL_PEERS - 2) * (TOTAL_PEERS - 1) * 2;
 
 	describe('@network : peer Blacklisted', () => {
@@ -50,7 +52,7 @@ module.exports = function(
 				});
 			});
 
-			it(`there should be ${EXPECTED_OUTOGING_CONNECTIONS} established connections from 500[0-9] ports`, done => {
+			it(`there should be ${EXPECTED_TOTAL_CONNECTIONS} established connections from 500[0-9] ports`, done => {
 				utils.getEstablishedConnections(
 					Array.from(wsPorts),
 					(err, numOfConnections) => {
@@ -58,7 +60,10 @@ module.exports = function(
 							return done(err);
 						}
 
-						if (numOfConnections - 20 <= EXPECTED_OUTOGING_CONNECTIONS) {
+						if (
+							numOfConnections - NUMBER_OF_MONITORING_CONNECTIONS <=
+							EXPECTED_TOTAL_CONNECTIONS
+						) {
 							done();
 						} else {
 							done(
@@ -83,7 +88,7 @@ module.exports = function(
 					}, 8000);
 				});
 
-				it(`there should be ${EXPECTED_OUTOGING_CONNECTIONS_AFTER_BLACKLISTING} established connections from 500[0-9] ports`, done => {
+				it(`there should be ${EXPECTED_TOTAL_CONNECTIONS_AFTER_BLACKLISTING} established connections from 500[0-9] ports`, done => {
 					utils.getEstablishedConnections(
 						Array.from(wsPorts),
 						(err, numOfConnections) => {
@@ -92,8 +97,8 @@ module.exports = function(
 							}
 
 							if (
-								numOfConnections - 20 <=
-								EXPECTED_OUTOGING_CONNECTIONS_AFTER_BLACKLISTING
+								numOfConnections - NUMBER_OF_MONITORING_CONNECTIONS <=
+								EXPECTED_TOTAL_CONNECTIONS_AFTER_BLACKLISTING
 							) {
 								done();
 							} else {
@@ -154,7 +159,7 @@ module.exports = function(
 					}, 8000);
 				});
 
-				it(`there should be ${EXPECTED_OUTOGING_CONNECTIONS} established connections from 500[0-9] ports`, done => {
+				it(`there should be ${EXPECTED_TOTAL_CONNECTIONS} established connections from 500[0-9] ports`, done => {
 					utils.getEstablishedConnections(
 						Array.from(wsPorts),
 						(err, numOfConnections) => {
@@ -162,7 +167,10 @@ module.exports = function(
 								return done(err);
 							}
 
-							if (numOfConnections - 20 <= EXPECTED_OUTOGING_CONNECTIONS) {
+							if (
+								numOfConnections - NUMBER_OF_MONITORING_CONNECTIONS <=
+								EXPECTED_TOTAL_CONNECTIONS
+							) {
 								done();
 							} else {
 								done(


### PR DESCRIPTION
### What was the problem?

Some numbers in the network tests were hardcoded and it wasn't clear what they represented.

### How did I fix it?

Replaced magic numbers with constants and added comments to describe them.

### How to test it?

`grunt mocha:default:network`

### Review checklist

* The PR resolves #2333 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
