### PR TITLE
Expire transaction test is failing randomly - Closes #2377

### DIFF
--- a/test/integration/transactions/expire_transactions.js
+++ b/test/integration/transactions/expire_transactions.js
@@ -207,7 +207,7 @@ describe('expire transactions', () => {
 				memAccountBefore = account;
 				// Transfer balance to multi-signature account
 				// so that multi-signature account can be registered
-				return addTransactionsAndForgePromise(library, [transaction]);
+				return addTransactionsAndForgePromise(library, [transaction], 0);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
Expire transaction test was failing randomly
### How did I fix it?
`addTransactionsAndForge` was not called with `0` timeout, so the transaction was not forged and the test was failing.
### How to test it?
on the local machine run the test 100 times to ensure it never fails
`for i in {1..100}; do ./node_modules/.bin/mocha test/integration/transactions/expire_transactions.js; done`
### Review checklist

* The PR resolves #2377 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
