### PR TITLE
Disable totalAmount verification on Transaction - Closes #2319

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -22,6 +22,7 @@ const Bignum = require('../helpers/bignum.js');
 const slots = require('../helpers/slots.js');
 
 const exceptions = global.exceptions;
+const POSTGRESQL_BIGINT_MAX_VALUE = '9223372036854775807';
 const __private = {};
 
 /**
@@ -633,7 +634,11 @@ class Transaction {
 
 		// Check amount
 		let amount = transaction.amount;
-		if (!amount.isInteger() || amount.lessThan(0)) {
+		if (
+			!amount.isInteger() ||
+			amount.greaterThan(POSTGRESQL_BIGINT_MAX_VALUE) ||
+			amount.lessThan(0)
+		) {
 			return setImmediate(cb, 'Invalid transaction amount');
 		}
 

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -22,7 +22,6 @@ const Bignum = require('../helpers/bignum.js');
 const slots = require('../helpers/slots.js');
 
 const exceptions = global.exceptions;
-const constants = global.constants;
 const __private = {};
 
 /**
@@ -634,11 +633,7 @@ class Transaction {
 
 		// Check amount
 		let amount = transaction.amount;
-		if (
-			amount.lessThan(0) ||
-			amount.greaterThan(constants.totalAmount) ||
-			!amount.isInteger()
-		) {
+		if (!amount.isInteger() || amount.lessThan(0)) {
 			return setImmediate(cb, 'Invalid transaction amount');
 		}
 

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -751,7 +751,7 @@ describe('transaction', () => {
 			});
 		});
 
-		it('should return error when transaction amount is invalid', done => {
+		it('should not return "Invalid transaction amount" error when transaction amount is bigger than total amount of Lisk tokens', done => {
 			// lisk-elements cannot create a transaction with higher amount than max amount. So, this test needs to use hardcoded transaction object
 			var transaction = {
 				type: 0,
@@ -769,7 +769,8 @@ describe('transaction', () => {
 			};
 
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.include('Invalid transaction amount');
+				expect(err).to.not.include('Invalid transaction amount');
+				expect(err).to.include('Account does not have enough LSK:');
 				done();
 			});
 		});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -751,7 +751,7 @@ describe('transaction', () => {
 			});
 		});
 
-		it('should not return "Invalid transaction amount" error when transaction amount is bigger than total amount of Lisk tokens', done => {
+		it("should return error when transaction amount is bigger than postgreSQL's Max BigInt value", done => {
 			// lisk-elements cannot create a transaction with higher amount than max amount. So, this test needs to use hardcoded transaction object
 			var transaction = {
 				type: 0,
@@ -769,8 +769,7 @@ describe('transaction', () => {
 			};
 
 			transactionLogic.verify(transaction, sender, null, null, err => {
-				expect(err).to.not.include('Invalid transaction amount');
-				expect(err).to.include('Account does not have enough LSK:');
+				expect(err).to.include('Invalid transaction amount');
 				done();
 			});
 		});


### PR DESCRIPTION
### What was the problem?
We were validating the transaction amount agains totalAmount constant which is equal to 100 mln LSK. But It is possible for one account to accumulate > 100 mln LSK, especially on test networks.
### How did I fix it?
I disabled the conditional check for totalAmount in transaction logic. Since we already have a check against user balance, we didn't need that.
### How to test it?

### Review checklist

* The PR resolves #2319 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
