### PR TITLE
Fix inconsistent transactions response caused by senderIdOrRecipientId - Closes #2358

### DIFF
--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -104,7 +104,7 @@ __private.list = function(filter, cb) {
 	const where = [];
 	const allowedFieldsMap = {
 		senderIdOrRecipientId:
-			'"t_senderId" = ${senderIdOrRecipientId} OR "t_recipientId" = ${senderIdOrRecipientId}',
+			'("t_senderId" = ${senderIdOrRecipientId} OR "t_recipientId" = ${senderIdOrRecipientId})',
 		id: '"t_id" = ${id}',
 		blockId: '"t_blockId" = ${blockId}',
 		fromHeight: '"b_height" >= ${fromHeight}',


### PR DESCRIPTION
### What was the problem?
API endpoint wasn't respecting minAmount filter
### How did I fix it?
I wrapped the senderIdOrRecipientId condition with parentheses to make `or` condition isolated.
### How to test it?
/api/transactions?senderIdOrRecipientId=`:addressId`&minAmount=1000000000000&sort=amount:asc

`:addressId` is an address which contains transactions with amount lower than 1000000000

### Review checklist

* The PR resolves #2358 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
