### PR TITLE
Update to Node.js version 8.12.0 and npm to version 5.6.0 - Closes #2135

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"url": "https://github.com/LiskHQ/lisk/issues"
 	},
 	"engines": {
-		"node": ">=6.14.1 <=8.11.3",
-		"npm": ">=3.10.10 <=5.6.0"
+		"node": "8.11.3",
+		"npm": "5.6.0"
 	},
 	"main": "app.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"url": "https://github.com/LiskHQ/lisk/issues"
 	},
 	"engines": {
-		"node": "8.11.3",
+		"node": "8.12.0",
 		"npm": "5.6.0"
 	},
 	"main": "app.js",


### PR DESCRIPTION
### What was the problem?
We decided to support one Node version at the time. 1.2.0 Lisk Core version goes with Node `v8.12.0` and npm `v5.6.0`. 

### How did I fix it?
`package.json` is updated.

### Review checklist

* The PR resolves #2135
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
