### PR TITLE
Calculate the correct time interval in aggregateBlocksReward - Closes #2367

### DIFF
--- a/modules/blocks/utils.js
+++ b/modules/blocks/utils.js
@@ -410,12 +410,12 @@ Utils.prototype.aggregateBlocksReward = function(filter, cb) {
 		params.delegates = constants.activeDelegates;
 
 		if (filter.start !== undefined) {
-			params.start = (filter.start - constants.epochTime.getTime()) / 1000;
+			params.start = Math.floor((filter.start - constants.epochTime.getTime()) / 1000);
 			params.start = params.start.toFixed();
 		}
 
 		if (filter.end !== undefined) {
-			params.end = (filter.end - constants.epochTime.getTime()) / 1000;
+			params.end = Math.floor((filter.end - constants.epochTime.getTime()) / 1000);
 			params.end = params.end.toFixed();
 		}
 


### PR DESCRIPTION
There was a rounding error when converting the UNIX timestamps to Lisk timestamps

Example:
Query the forging statistics for the 2017-02-07:
.../api/delegates/15056673209583244182L/forging_statistics?fromTimestamp=1486425600000&toTimestamp=1486511999999

result:
{
meta: {
fromTimestamp: 1486425600000,
toTimestamp: 1486511999999
},
data: {
fees: "187227675",
rewards: "42500000000",
forged: "42687227675",
count: "85"
},
links: { }
}

The result is wrong, because the query includes the data of round 20042 (timestamp 22402800),
which ended at UNIX timestamp 1486512000 and thus outside the requested intervall

The reason is a rounding error when converting the UNIX timestamp to Lisk timestamp:

timeStamp: 1486511999999
Milliseconds since lisk start: 1486511999999-epochtime = 22402799999
Lisk Timestamp: 22402799999 / 1000 = 22402799.999
The Lisk timestamp should be '22402799' and not '22402800' which is the (rounded) result of the toFixed() method !!!

the right result should be:

{
meta: {
fromTimestamp: 1486425600000,
toTimestamp: 1486511999999
},
data: {
fees: "173267279",
rewards: "42000000000",
forged: "42173267279",
count: "84"
},
links: { }
}
