### PR TITLE
Update package jsons - Closes #2411

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -419,6 +419,15 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
 			"integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
 		},
+		"axios": {
+			"version": "0.18.0",
+			"resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+			"requires": {
+				"follow-redirects": "1.5.1",
+				"is-buffer": "1.1.6"
+			}
+		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved":
@@ -429,6 +438,16 @@
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
 				"js-tokens": "3.0.2"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved":
+				"https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "2.5.7",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"backo2": {
@@ -529,6 +548,19 @@
 				"https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
 			"dev": true
+		},
+		"bip39": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
+			"integrity":
+				"sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
+			"requires": {
+				"create-hash": "1.2.0",
+				"pbkdf2": "3.0.16",
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.1",
+				"unorm": "1.4.1"
+			}
 		},
 		"bitcore-lib": {
 			"version": "0.14.0",
@@ -753,8 +785,7 @@
 			"version": "1.3.0-2",
 			"resolved":
 				"https://registry.npmjs.org/browserify-bignum/-/browserify-bignum-1.3.0-2.tgz",
-			"integrity": "sha1-3cO27WB/1slglmlQ4rNaKwxvub8=",
-			"dev": true
+			"integrity": "sha1-3cO27WB/1slglmlQ4rNaKwxvub8="
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -775,6 +806,12 @@
 				"https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
 			"integrity":
 				"sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+		},
+		"buffer-reverse": {
+			"version": "1.0.1",
+			"resolved":
+				"https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+			"integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
 		},
 		"buffer-writer": {
 			"version": "1.0.1",
@@ -1044,6 +1081,17 @@
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
 			"integrity": "sha1-cQGTJkuwXHe4yQ0C9aryIhamZ7I=",
 			"dev": true
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved":
+				"https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity":
+				"sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
 		},
 		"circular-json": {
 			"version": "0.3.3",
@@ -1446,6 +1494,12 @@
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
 			"integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
 		},
+		"core-js": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+			"integrity":
+				"sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved":
@@ -1679,6 +1733,35 @@
 				}
 			}
 		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved":
+				"http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity":
+				"sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"md5.js": "1.3.4",
+				"ripemd160": "2.0.2",
+				"sha.js": "2.4.11"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved":
+				"http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity":
+				"sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
+			}
+		},
 		"cron": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/cron/-/cron-1.2.1.tgz",
@@ -1821,6 +1904,12 @@
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
 			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
+		},
+		"deep-diff": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.1.tgz",
+			"integrity":
+				"sha512-Vkn+eQK6H63gObVi3KWmPMb4RdzMpfdp5t0HNppq8Oc7xbwmvBy5BIHsEYSXOiS9Lr/W+3lF020zyPTsGfea4g=="
 		},
 		"deep-eql": {
 			"version": "2.0.2",
@@ -2042,6 +2131,14 @@
 					"integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
 					"dev": true
 				}
+			}
+		},
+		"ed2curve": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.2.1.tgz",
+			"integrity": "sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=",
+			"requires": {
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"ee-first": {
@@ -3026,7 +3123,6 @@
 			"resolved":
 				"https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
 			"integrity": "sha1-Z6jxT1ofZ/liwsRkaceersCpApE=",
-			"dev": true,
 			"requires": {
 				"debug": "3.1.0"
 			}
@@ -4170,6 +4266,15 @@
 				}
 			}
 		},
+		"hash-base": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -4441,8 +4546,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-			"dev": true
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -5456,6 +5560,31 @@
 				}
 			}
 		},
+		"lisk-elements": {
+			"version": "1.0.0",
+			"resolved":
+				"https://registry.npmjs.org/lisk-elements/-/lisk-elements-1.0.0.tgz",
+			"integrity":
+				"sha512-wD30a1WRXdBLIrXXRLBUHxtR6AIKUQEVRBCWQG4wLtqF5zfGyHQ0d7HAC+kwkECI5en+lwzuI8egovQotMWNMg==",
+			"requires": {
+				"axios": "0.18.0",
+				"babel-runtime": "6.26.0",
+				"bip39": "2.4.0",
+				"browserify-bignum": "1.3.0-2",
+				"buffer-reverse": "1.0.1",
+				"ed2curve": "0.2.1",
+				"tweetnacl": "1.0.0",
+				"varuint-bitcoin": "1.1.0"
+			},
+			"dependencies": {
+				"tweetnacl": {
+					"version": "1.0.0",
+					"resolved":
+						"https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+					"integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+				}
+			}
+		},
 		"listr": {
 			"version": "0.13.0",
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
@@ -5990,6 +6119,15 @@
 				"https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
 			"dev": true
+		},
+		"md5.js": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"requires": {
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
+			}
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -7037,6 +7175,19 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
+		"pbkdf2": {
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+			"integrity":
+				"sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+			"requires": {
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved":
@@ -7576,6 +7727,16 @@
 				}
 			}
 		},
+		"randombytes": {
+			"version": "2.0.6",
+			"resolved":
+				"https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity":
+				"sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"randomstring": {
 			"version": "1.1.5",
 			"resolved":
@@ -7738,6 +7899,13 @@
 				"https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
 			"integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
 		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved":
+				"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity":
+				"sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved":
@@ -7747,6 +7915,13 @@
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
+		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity":
+				"sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -7896,6 +8071,258 @@
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
 			"integrity": "sha1-toYXgqH0di3OQ0Aqcet6KD9EVzw="
 		},
+		"rewire": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
+			"integrity":
+				"sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+			"dev": true,
+			"requires": {
+				"eslint": "4.19.1"
+			},
+			"dependencies": {
+				"ajv-keywords": {
+					"version": "2.1.1",
+					"resolved":
+						"https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+					"dev": true
+				},
+				"ansi-escapes": {
+					"version": "3.1.0",
+					"resolved":
+						"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+					"integrity":
+						"sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved":
+						"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved":
+						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity":
+						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.2"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity":
+						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.5.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved":
+						"https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "2.0.0"
+					}
+				},
+				"eslint": {
+					"version": "4.19.1",
+					"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+					"integrity":
+						"sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "5.5.2",
+						"babel-code-frame": "6.26.0",
+						"chalk": "2.4.1",
+						"concat-stream": "1.6.2",
+						"cross-spawn": "5.1.0",
+						"debug": "3.1.0",
+						"doctrine": "2.1.0",
+						"eslint-scope": "3.7.3",
+						"eslint-visitor-keys": "1.0.0",
+						"espree": "3.5.4",
+						"esquery": "1.0.1",
+						"esutils": "2.0.2",
+						"file-entry-cache": "2.0.0",
+						"functional-red-black-tree": "1.0.1",
+						"glob": "7.1.2",
+						"globals": "11.7.0",
+						"ignore": "3.3.10",
+						"imurmurhash": "0.1.4",
+						"inquirer": "3.3.0",
+						"is-resolvable": "1.1.0",
+						"js-yaml": "3.10.0",
+						"json-stable-stringify-without-jsonify": "1.0.1",
+						"levn": "0.3.0",
+						"lodash": "4.17.4",
+						"minimatch": "3.0.4",
+						"mkdirp": "0.5.1",
+						"natural-compare": "1.4.0",
+						"optionator": "0.8.2",
+						"path-is-inside": "1.0.2",
+						"pluralize": "7.0.0",
+						"progress": "2.0.0",
+						"regexpp": "1.1.0",
+						"require-uncached": "1.0.3",
+						"semver": "5.3.0",
+						"strip-ansi": "4.0.0",
+						"strip-json-comments": "2.0.1",
+						"table": "4.0.2",
+						"text-table": "0.2.0"
+					}
+				},
+				"external-editor": {
+					"version": "2.2.0",
+					"resolved":
+						"http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+					"integrity":
+						"sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"dev": true,
+					"requires": {
+						"chardet": "0.4.2",
+						"iconv-lite": "0.4.19",
+						"tmp": "0.0.33"
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "1.0.5"
+					}
+				},
+				"inquirer": {
+					"version": "3.3.0",
+					"resolved":
+						"https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+					"integrity":
+						"sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.4.1",
+						"cli-cursor": "2.1.0",
+						"cli-width": "2.2.0",
+						"external-editor": "2.2.0",
+						"figures": "2.0.0",
+						"lodash": "4.17.4",
+						"mute-stream": "0.0.7",
+						"run-async": "2.3.0",
+						"rx-lite": "4.0.8",
+						"rx-lite-aggregates": "4.0.8",
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"through": "2.3.8"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved":
+						"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved":
+						"https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"dev": true
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "1.2.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved":
+						"https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
+					"requires": {
+						"onetime": "2.0.1",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved":
+						"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity":
+						"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved":
+						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved":
+						"https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity":
+						"sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				},
+				"table": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+					"integrity":
+						"sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+					"dev": true,
+					"requires": {
+						"ajv": "5.5.2",
+						"ajv-keywords": "2.1.1",
+						"chalk": "2.4.1",
+						"lodash": "4.17.4",
+						"slice-ansi": "1.0.0",
+						"string-width": "2.1.1"
+					}
+				},
+				"tmp": {
+					"version": "0.0.33",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+					"integrity":
+						"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
+					"requires": {
+						"os-tmpdir": "1.0.2"
+					}
+				}
+			}
+		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved":
@@ -7913,6 +8340,16 @@
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 			"requires": {
 				"glob": "7.1.2"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity":
+				"sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"requires": {
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
 			}
 		},
 		"rttc": {
@@ -8173,6 +8610,16 @@
 			"resolved":
 				"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
 			"integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity":
+				"sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
 		},
 		"shallow-clone": {
 			"version": "0.1.2",
@@ -9768,8 +10215,7 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"optional": true
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -9933,8 +10379,7 @@
 		"unorm": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-			"integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
-			"dev": true
+			"integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -10022,6 +10467,16 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
 			"integrity": "sha1-R84j7Y1Ord+p1LjvAHG2zxB418g="
+		},
+		"varuint-bitcoin": {
+			"version": "1.1.0",
+			"resolved":
+				"https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
+			"integrity":
+				"sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
 		},
 		"vary": {
 			"version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "lisk",
-	"version": "1.2.0-alpha.0",
+	"version": "1.1.0-rc.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -8,8 +8,7 @@
 			"version": "2.0.0",
 			"resolved":
 				"https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-			"integrity":
-				"sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
 			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
@@ -18,8 +17,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity":
-				"sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
 			"dev": true
 		},
 		"accepts": {
@@ -34,8 +32,7 @@
 		"acorn": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-			"integrity":
-				"sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+			"integrity": "sha1-8JWCkpdwanyXdpWMCvyJMKm52dg=",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -64,8 +61,7 @@
 			"version": "4.2.1",
 			"resolved":
 				"https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-			"integrity":
-				"sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
 			"dev": true,
 			"requires": {
 				"es6-promisify": "5.0.0"
@@ -158,8 +154,7 @@
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity":
-				"sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
 			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -278,8 +273,7 @@
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity":
-				"sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -297,8 +291,7 @@
 			"version": "1.1.0",
 			"resolved":
 				"https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity":
-				"sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
 			"dev": true
 		},
 		"array-find-index": {
@@ -341,8 +334,7 @@
 			"version": "0.0.7",
 			"resolved":
 				"https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-			"integrity":
-				"sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+			"integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU="
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -371,15 +363,13 @@
 			"version": "1.1.0",
 			"resolved":
 				"https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity":
-				"sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
 			"dev": true
 		},
 		"ast-types": {
 			"version": "0.11.5",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-			"integrity":
-				"sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
+			"integrity": "sha1-mJCCXWYMA8KDOfMV6foKNg4x7Cg=",
 			"dev": true
 		},
 		"async": {
@@ -401,15 +391,13 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity":
-				"sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+			"integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg="
 		},
 		"async-listener": {
 			"version": "0.6.9",
 			"resolved":
 				"https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
-			"integrity":
-				"sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
+			"integrity": "sha1-UbyV5BCVQX8zki+03uTyMrMiZIg=",
 			"dev": true,
 			"requires": {
 				"semver": "5.3.0",
@@ -429,8 +417,7 @@
 		"aws4": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity":
-				"sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+			"integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -444,16 +431,6 @@
 				"js-tokens": "3.0.2"
 			}
 		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
-			}
-		},
 		"backo2": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -462,8 +439,7 @@
 		"bagpipes": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/bagpipes/-/bagpipes-0.1.2.tgz",
-			"integrity":
-				"sha512-+1JbB1W4s46ptVw6mtyxdCH9nLpuRp01qq6JD7Ga/JFQbfrF7u1AGa7N2m0wcqirVUXpFFOjfZ08NDYyZuna4w==",
+			"integrity": "sha1-Ak/qq9z+QLAQUHFlDlRqMnefMPU=",
 			"requires": {
 				"async": "1.5.2",
 				"debug": "2.6.9",
@@ -482,8 +458,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -554,19 +529,6 @@
 				"https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
 			"dev": true
-		},
-		"bip39": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
-			"integrity":
-				"sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
-			"requires": {
-				"create-hash": "1.2.0",
-				"pbkdf2": "3.0.16",
-				"randombytes": "2.0.6",
-				"safe-buffer": "5.1.1",
-				"unorm": "1.4.1"
-			}
 		},
 		"bitcore-lib": {
 			"version": "0.14.0",
@@ -710,8 +672,7 @@
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity":
-				"sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
 		},
 		"body-parser": {
 			"version": "1.18.2",
@@ -734,8 +695,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -765,8 +725,7 @@
 			"version": "1.1.11",
 			"resolved":
 				"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity":
-				"sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -794,7 +753,8 @@
 			"version": "1.3.0-2",
 			"resolved":
 				"https://registry.npmjs.org/browserify-bignum/-/browserify-bignum-1.3.0-2.tgz",
-			"integrity": "sha1-3cO27WB/1slglmlQ4rNaKwxvub8="
+			"integrity": "sha1-3cO27WB/1slglmlQ4rNaKwxvub8=",
+			"dev": true
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -969,8 +929,7 @@
 			"version": "7.1.1",
 			"resolved":
 				"https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-			"integrity":
-				"sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+			"integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
 			"dev": true,
 			"requires": {
 				"check-error": "1.0.2"
@@ -998,8 +957,7 @@
 		"chance": {
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/chance/-/chance-1.0.16.tgz",
-			"integrity":
-				"sha512-2bgDHH5bVfAXH05SPtjqrsASzZ7h90yCuYT2z4mkYpxxYvJXiIydBFzVieVHZx7wLH1Ag2Azaaej2/zA1XUrNQ=="
+			"integrity": "sha1-vWGRJxawAQw9yo45SKlg78qnuxs="
 		},
 		"change-case": {
 			"version": "3.0.1",
@@ -1084,27 +1042,14 @@
 		"ci-info": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity":
-				"sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+			"integrity": "sha1-cQGTJkuwXHe4yQ0C9aryIhamZ7I=",
 			"dev": true
-		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved":
-				"https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity":
-				"sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
-			}
 		},
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved":
 				"https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity":
-				"sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
 			"dev": true
 		},
 		"cli-color": {
@@ -1237,8 +1182,7 @@
 		"co-mocha": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/co-mocha/-/co-mocha-1.2.1.tgz",
-			"integrity":
-				"sha512-hlgDSWGXG1PuXiBTWUi+9ewhy0gII2hbNpS4lE0Esyr/eJlYx2xuIVV8ufEYxcBCzYOqiwcEZ7ck1CidWGNWkA==",
+			"integrity": "sha1-FFuZfVis1WYWs95Vf/JN89fNY7o=",
 			"dev": true,
 			"requires": {
 				"co": "4.6.0",
@@ -1262,8 +1206,7 @@
 			"version": "1.9.2",
 			"resolved":
 				"https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-			"integrity":
-				"sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"integrity": "sha1-SYgbj7pn3xKpa98/VsCqueeRMUc=",
 			"dev": true,
 			"requires": {
 				"color-name": "1.1.1"
@@ -1392,8 +1335,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -1410,8 +1352,7 @@
 			"version": "1.6.2",
 			"resolved":
 				"https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity":
-				"sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
 			"requires": {
 				"buffer-from": "1.1.0",
 				"inherits": "2.0.3",
@@ -1432,8 +1373,7 @@
 			"version": "3.1.2",
 			"resolved":
 				"https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-			"integrity":
-				"sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+			"integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
 			"dev": true,
 			"requires": {
 				"dot-prop": "4.2.0",
@@ -1471,15 +1411,13 @@
 			"version": "1.0.4",
 			"resolved":
 				"https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity":
-				"sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+			"integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
 		},
 		"continuation-local-storage": {
 			"version": "3.2.1",
 			"resolved":
 				"https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-			"integrity":
-				"sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+			"integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
 			"dev": true,
 			"requires": {
 				"async-listener": "0.6.9",
@@ -1506,14 +1444,7 @@
 		"cookiejar": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity":
-				"sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity":
-				"sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1540,8 +1471,7 @@
 			"version": "4.0.0",
 			"resolved":
 				"https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-			"integrity":
-				"sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+			"integrity": "sha1-dgORVJWAu9LfHlYrwXexPCkJctw=",
 			"dev": true,
 			"requires": {
 				"is-directory": "0.3.1",
@@ -1695,8 +1625,7 @@
 					"version": "2.3.4",
 					"resolved":
 						"https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity":
-						"sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
 					"dev": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -1748,35 +1677,6 @@
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 					"dev": true
 				}
-			}
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity":
-				"sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"md5.js": "1.3.4",
-				"ripemd160": "2.0.2",
-				"sha.js": "2.4.11"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved":
-				"https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity":
-				"sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.2.0",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.2",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.11"
 			}
 		},
 		"cron": {
@@ -1881,15 +1781,13 @@
 			"version": "1.2.0",
 			"resolved":
 				"https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-			"integrity":
-				"sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+			"integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU=",
 			"dev": true
 		},
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity":
-				"sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+			"integrity": "sha1-EuYJzcuTUScxHQTTMzTilgoqVOY=",
 			"dev": true
 		},
 		"dateformat": {
@@ -1906,8 +1804,7 @@
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity":
-				"sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1959,8 +1856,7 @@
 			"version": "0.0.1",
 			"resolved":
 				"https://registry.npmjs.org/deep-metrics/-/deep-metrics-0.0.1.tgz",
-			"integrity":
-				"sha512-732WmZgCWxOkf4QBvrCjPPuT6wTEzaGye/4JqYsU/sO0J53UNX4PBwK0JV262BZ5cxgLmKhU+NlrtKdPDgybkg==",
+			"integrity": "sha1-isMzMZXMXsoFmyJOscph/EzaUP0=",
 			"dev": true,
 			"requires": {
 				"semver": "5.3.0"
@@ -2070,15 +1966,13 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity":
-				"sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
 			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity":
-				"sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
@@ -2095,8 +1989,7 @@
 		"dot-prop": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-			"integrity":
-				"sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
 			"dev": true,
 			"requires": {
 				"is-obj": "1.0.1"
@@ -2111,8 +2004,7 @@
 		"drange": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/drange/-/drange-1.0.2.tgz",
-			"integrity":
-				"sha512-bve7maXvfKW+vcsRpP8gzEDzkTg8O6AoCGvi/52pnllzhl/nmex8XLrHOUEQ42Z8GshcyftvG+E4s5vcd/qo0Q=="
+			"integrity": "sha1-pzkK1Yacb2nqvcQuCltRa9EAlm4="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
@@ -2135,8 +2027,7 @@
 		"ecstatic": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.2.1.tgz",
-			"integrity":
-				"sha512-BAdHx9LOCG1fwxY8MIydUBskl8UUQrYeC3WE14FA1DPlBzqoG1aOgEkypcSpmiiel8RAj8gW1s40RrclfrpGUg==",
+			"integrity": "sha1-EZanTWPXHSjeqAftK2GDBiZxogY=",
 			"dev": true,
 			"requires": {
 				"he": "1.1.1",
@@ -2148,18 +2039,9 @@
 				"mime": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity":
-						"sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
 					"dev": true
 				}
-			}
-		},
-		"ed2curve": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.2.1.tgz",
-			"integrity": "sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=",
-			"requires": {
-				"tweetnacl": "0.14.5"
 			}
 		},
 		"ee-first": {
@@ -2183,8 +2065,7 @@
 			"version": "2.0.4",
 			"resolved":
 				"https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-			"integrity":
-				"sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+			"integrity": "sha1-uN+qXQ2uKPGwPJWIHZBNTkC/5+0=",
 			"dev": true
 		},
 		"emitter-listener": {
@@ -2206,8 +2087,7 @@
 			"version": "1.4.1",
 			"resolved":
 				"https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity":
-				"sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
 			"dev": true,
 			"requires": {
 				"once": "1.4.0"
@@ -2216,8 +2096,7 @@
 		"engine.io": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
-			"integrity":
-				"sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
+			"integrity": "sha1-Dn751pDrCzVZfx1K0Comyi26OEU=",
 			"requires": {
 				"accepts": "1.3.5",
 				"base64id": "1.0.0",
@@ -2232,8 +2111,7 @@
 			"version": "3.1.6",
 			"resolved":
 				"https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-			"integrity":
-				"sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+			"integrity": "sha1-W96xMPi5SlCsXL63JYPnpKBj3f0=",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"component-inherit": "0.0.3",
@@ -2252,8 +2130,7 @@
 			"version": "2.1.2",
 			"resolved":
 				"https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-			"integrity":
-				"sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+			"integrity": "sha1-TA9M/3mq7su9z96maoI8YIVAkZY=",
 			"requires": {
 				"after": "0.8.2",
 				"arraybuffer.slice": "0.0.7",
@@ -2265,8 +2142,7 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity":
-				"sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
 			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
@@ -2275,8 +2151,7 @@
 		"es5-ext": {
 			"version": "0.10.45",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-			"integrity":
-				"sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+			"integrity": "sha1-C/33tHPaWRnVrfO9Jc63VPzMNlM=",
 			"requires": {
 				"es6-iterator": "2.0.3",
 				"es6-symbol": "3.1.1",
@@ -2298,8 +2173,7 @@
 			"version": "4.2.4",
 			"resolved":
 				"https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-			"integrity":
-				"sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+			"integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
 			"dev": true
 		},
 		"es6-promisify": {
@@ -2384,8 +2258,7 @@
 		"eslint": {
 			"version": "4.16.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
-			"integrity":
-				"sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
+			"integrity": "sha1-k0ranphxXh17v9b28FGe0vqzXME=",
 			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
@@ -2431,8 +2304,7 @@
 					"version": "3.1.0",
 					"resolved":
 						"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-					"integrity":
-						"sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+					"integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA=",
 					"dev": true
 				},
 				"ansi-regex": {
@@ -2446,8 +2318,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -2456,8 +2327,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -2479,8 +2349,7 @@
 					"version": "2.2.0",
 					"resolved":
 						"https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity":
-						"sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
 					"dev": true,
 					"requires": {
 						"chardet": "0.4.2",
@@ -2501,8 +2370,7 @@
 					"version": "3.3.0",
 					"resolved":
 						"https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity":
-						"sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "3.1.0",
@@ -2559,8 +2427,7 @@
 					"version": "2.1.1",
 					"resolved":
 						"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity":
-						"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
@@ -2581,8 +2448,7 @@
 					"version": "5.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
@@ -2591,8 +2457,7 @@
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity":
-						"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 					"dev": true,
 					"requires": {
 						"os-tmpdir": "1.0.2"
@@ -2604,8 +2469,7 @@
 			"version": "12.1.0",
 			"resolved":
 				"https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
-			"integrity":
-				"sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+			"integrity": "sha1-OGRB5UoSzNlXsKklZKS6/r10eUQ=",
 			"dev": true,
 			"requires": {
 				"eslint-restricted-globals": "0.1.1"
@@ -2622,8 +2486,7 @@
 			"version": "0.3.2",
 			"resolved":
 				"https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-			"integrity":
-				"sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -2633,8 +2496,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2656,8 +2518,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2669,8 +2530,7 @@
 			"version": "2.8.0",
 			"resolved":
 				"https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-			"integrity":
-				"sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+			"integrity": "sha1-+htu8x/LPFAcCYWcG4bx/FuYaJQ=",
 			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1",
@@ -2688,8 +2548,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2729,8 +2588,7 @@
 			"version": "3.7.3",
 			"resolved":
 				"https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-			"integrity":
-				"sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+			"integrity": "sha1-u1ByANPRf2AkdjYWC0gmKEsQhTU=",
 			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
@@ -2741,15 +2599,13 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity":
-				"sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
 			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity":
-				"sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
 			"dev": true,
 			"requires": {
 				"acorn": "5.7.1",
@@ -2759,14 +2615,12 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity":
-				"sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
 		},
 		"esquery": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity":
-				"sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
 			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
@@ -2775,8 +2629,7 @@
 		"esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity":
-				"sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
 			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
@@ -2821,8 +2674,7 @@
 			"version": "3.1.0",
 			"resolved":
 				"https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity":
-				"sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+			"integrity": "sha1-CQtNbNvWRe0Qv3UNS1QHlC17oWM=",
 			"dev": true
 		},
 		"execa": {
@@ -2917,8 +2769,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3047,8 +2898,7 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity":
-				"sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
 			"dev": true
 		},
 		"filename-regex": {
@@ -3062,8 +2912,7 @@
 			"version": "2.2.4",
 			"resolved":
 				"https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity":
-				"sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
 			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -3091,8 +2940,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3177,8 +3025,7 @@
 			"version": "1.5.1",
 			"resolved":
 				"https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-			"integrity":
-				"sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+			"integrity": "sha1-Z6jxT1ofZ/liwsRkaceersCpApE=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0"
@@ -3228,8 +3075,7 @@
 			"version": "1.2.1",
 			"resolved":
 				"https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-			"integrity":
-				"sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+			"integrity": "sha1-cPt8oCkO5v+WEJBBX0s989IIJlk="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -3244,8 +3090,7 @@
 		"fs-extra": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-			"integrity":
-				"sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+			"integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"jsonfile": "4.0.0",
@@ -3261,8 +3106,7 @@
 		"fsevents": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity":
-				"sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"integrity": "sha1-9B3LGvJYKvNpLaNvxVy9jhBBxCY=",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -3830,8 +3674,7 @@
 			"version": "1.1.1",
 			"resolved":
 				"https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity":
-				"sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
 			"dev": true
 		},
 		"functional-red-black-tree": {
@@ -3869,8 +3712,7 @@
 			"version": "2.0.1",
 			"resolved":
 				"https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-			"integrity":
-				"sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+			"integrity": "sha1-XErYfyg0xLm06EVJ3B4GUPs4wks=",
 			"dev": true
 		},
 		"get-stdin": {
@@ -3889,8 +3731,7 @@
 		"get-uri": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.2.tgz",
-			"integrity":
-				"sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
+			"integrity": "sha1-XHlecTJvbKEoby/IJXXNK6sq9Xg=",
 			"dev": true,
 			"requires": {
 				"data-uri-to-buffer": "1.2.0",
@@ -3904,8 +3745,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -3929,16 +3769,14 @@
 		},
 		"gkt": {
 			"version": "https://tgz.pm2.io/gkt-1.0.0.tgz",
-			"integrity":
-				"sha512-zr6QQnzLt3Ja0t0XI8gws2kn7zV2p0l/D3kreNvS6hFZhVU5g+uY/30l42jbgt0XGcNBEmBDGJR71J692V92tA==",
+			"integrity": "sha1-QFUCsAfzGcP0cXXER0UnMA8qta0=",
 			"dev": true,
 			"optional": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity":
-				"sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -4007,8 +3845,7 @@
 		"globals": {
 			"version": "11.7.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-			"integrity":
-				"sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+			"integrity": "sha1-pYP6pDBVsayncZFL9oJY4vwSVnM=",
 			"dev": true
 		},
 		"globby": {
@@ -4040,8 +3877,7 @@
 		"graphlib": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-			"integrity":
-				"sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+			"integrity": "sha1-av4a/MUUhVXseZ5JkFZ5W9aTjIc=",
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -4049,8 +3885,7 @@
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity":
-				"sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
 			"dev": true
 		},
 		"grunt": {
@@ -4152,8 +3987,7 @@
 			"version": "1.0.2",
 			"resolved":
 				"https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
-			"integrity":
-				"sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
+			"integrity": "sha1-fXRAQmrOd7IG50+ZPjMuKhWjkE4=",
 			"dev": true,
 			"requires": {
 				"colors": "1.1.2",
@@ -4165,8 +3999,7 @@
 				"lodash": {
 					"version": "4.17.10",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity":
-						"sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
 					"dev": true
 				}
 			}
@@ -4279,8 +4112,7 @@
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity":
-				"sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
 			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
@@ -4298,8 +4130,7 @@
 			"version": "1.0.3",
 			"resolved":
 				"https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-			"integrity":
-				"sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+			"integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
 			"requires": {
 				"isarray": "2.0.1"
 			},
@@ -4337,15 +4168,6 @@
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
 					"dev": true
 				}
-			}
-		},
-		"hash-base": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
 			}
 		},
 		"hawk": {
@@ -4392,8 +4214,7 @@
 			"version": "2.7.1",
 			"resolved":
 				"https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity":
-				"sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
 			"dev": true
 		},
 		"http-errors": {
@@ -4412,8 +4233,7 @@
 			"version": "1.17.0",
 			"resolved":
 				"https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-			"integrity":
-				"sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+			"integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
 			"dev": true,
 			"requires": {
 				"eventemitter3": "3.1.0",
@@ -4425,8 +4245,7 @@
 			"version": "2.1.0",
 			"resolved":
 				"https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-			"integrity":
-				"sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
 			"dev": true,
 			"requires": {
 				"agent-base": "4.2.1",
@@ -4437,8 +4256,7 @@
 			"version": "0.11.1",
 			"resolved":
 				"https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-			"integrity":
-				"sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
+			"integrity": "sha1-IwKlam/+9/mr6gFH2Dil6ba2p5s=",
 			"dev": true,
 			"requires": {
 				"colors": "1.0.3",
@@ -4474,8 +4292,7 @@
 			"version": "2.2.1",
 			"resolved":
 				"https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity":
-				"sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
 			"dev": true,
 			"requires": {
 				"agent-base": "4.2.1",
@@ -4485,8 +4302,7 @@
 		"husky": {
 			"version": "0.14.3",
 			"resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-			"integrity":
-				"sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+			"integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
 			"dev": true,
 			"requires": {
 				"is-ci": "1.1.0",
@@ -4507,14 +4323,12 @@
 			"version": "0.4.19",
 			"resolved":
 				"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity":
-				"sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
 		},
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity":
-				"sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
 			"dev": true
 		},
 		"imurmurhash": {
@@ -4556,8 +4370,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity":
-				"sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
 		},
 		"inquirer": {
 			"version": "1.1.3",
@@ -4628,8 +4441,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity":
-				"sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
 			"dev": true
 		},
 		"is-builtin-module": {
@@ -4645,8 +4457,7 @@
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity":
-				"sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
 			"dev": true,
 			"requires": {
 				"ci-info": "1.1.3"
@@ -4737,16 +4548,14 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity":
-				"sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+			"integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
 			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.17.2",
 			"resolved":
 				"https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-			"integrity":
-				"sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+			"integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
 			"dev": true,
 			"requires": {
 				"generate-function": "2.0.0",
@@ -4792,8 +4601,7 @@
 			"version": "1.0.1",
 			"resolved":
 				"https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity":
-				"sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
 			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
@@ -4813,8 +4621,7 @@
 			"version": "2.0.4",
 			"resolved":
 				"https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity":
-				"sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
@@ -4866,8 +4673,7 @@
 			"version": "1.1.0",
 			"resolved":
 				"https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity":
-				"sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
 			"dev": true
 		},
 		"is-stream": {
@@ -5119,16 +4925,14 @@
 			"version": "21.2.0",
 			"resolved":
 				"https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-			"integrity":
-				"sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+			"integrity": "sha1-9jdqudtLYNgeOfMHScbEZvQNSiM=",
 			"dev": true
 		},
 		"jest-validate": {
 			"version": "21.2.1",
 			"resolved":
 				"https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-			"integrity":
-				"sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+			"integrity": "sha1-zAy8plPNVJN7pPKhEXlndFMN08c=",
 			"dev": true,
 			"requires": {
 				"chalk": "2.4.1",
@@ -5141,8 +4945,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -5151,8 +4954,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -5164,8 +4966,7 @@
 					"version": "5.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
@@ -5178,10 +4979,6 @@
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.6.tgz",
 			"integrity":
 				"sha512-O9SR2NVICx6rCqh1qsU91QZ5IoNa+2T1ROJ0OQlfvATKGmnjsAvg3r0E5ufPZ4a95jdKTPXhFWiE/sOZ7a5Rtg=="
-		},
-		"js-nacl": {
-			"version":
-				"github:LiskHQ/js-nacl#6dc1417057cd81381d332b370e82ceab1f2416af"
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -5198,8 +4995,7 @@
 		"js-yaml": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity":
-				"sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.1"
@@ -5315,15 +5111,13 @@
 			"version": "1.0.2",
 			"resolved":
 				"https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity":
-				"sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
 			"dev": true
 		},
 		"json-refs": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.3.tgz",
-			"integrity":
-				"sha512-nJUbEsfzqGz4dJCcLh0tyN8yqB4dupdodH07IgyIgLtagIP4lElad10ABrwrcaOB3OKJDCkRUZXpPaRSLLun+A==",
+			"integrity": "sha1-xbjcQxVeGL1cWhv+ECMox+q0+Bk=",
 			"requires": {
 				"commander": "2.11.0",
 				"graphlib": "2.1.5",
@@ -5339,8 +5133,7 @@
 					"version": "2.11.0",
 					"resolved":
 						"https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity":
-						"sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM="
 				}
 			}
 		},
@@ -5418,8 +5211,7 @@
 			"version": "8.3.0",
 			"resolved":
 				"https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
-			"integrity":
-				"sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+			"integrity": "sha1-BWyQ7ummXtbmxy3bCh0yUQmq9kM=",
 			"requires": {
 				"jws": "3.1.5",
 				"lodash.includes": "4.3.0",
@@ -5435,8 +5227,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity":
-						"sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
 				}
 			}
 		},
@@ -5460,15 +5251,13 @@
 			"version": "1.1.27",
 			"resolved":
 				"https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity":
-				"sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
 			"dev": true
 		},
 		"jwa": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-			"integrity":
-				"sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+			"integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
 			"requires": {
 				"buffer-equal-constant-time": "1.0.1",
 				"ecdsa-sig-formatter": "1.0.10",
@@ -5478,8 +5267,7 @@
 		"jws": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-			"integrity":
-				"sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+			"integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
 			"requires": {
 				"jwa": "1.1.6",
 				"safe-buffer": "5.1.1"
@@ -5597,8 +5385,7 @@
 			"version": "6.1.0",
 			"resolved":
 				"https://registry.npmjs.org/lint-staged/-/lint-staged-6.1.0.tgz",
-			"integrity":
-				"sha512-RMB6BUd2bEKaPnj06F7j8RRB8OHM+UP4fQS2LT8lF+X9BjSaezw1oVB5hc4elLhYvzlFCkhAaatzYz+x53YHgw==",
+			"integrity": "sha1-KPYAwQpsvSSc6wAxGKFVLlNUSpM=",
 			"dev": true,
 			"requires": {
 				"app-root-path": "2.1.0",
@@ -5627,8 +5414,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -5637,8 +5423,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -5650,8 +5435,7 @@
 					"version": "2.16.0",
 					"resolved":
 						"https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-					"integrity":
-						"sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+					"integrity": "sha1-8WOQWTmWzrTz7rAgsx14Uo9/ilA=",
 					"dev": true
 				},
 				"pify": {
@@ -5664,28 +5448,12 @@
 					"version": "5.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
 				}
-			}
-		},
-		"lisk-elements": {
-			"version": "1.0.0-beta.4",
-			"resolved":
-				"https://registry.npmjs.org/lisk-elements/-/lisk-elements-1.0.0-beta.4.tgz",
-			"integrity": "sha1-EYKUxQJ2FolCW4Crq3uZGDhcA3c=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"bip39": "2.4.0",
-				"browserify-bignum": "1.3.0-2",
-				"ed2curve": "0.2.1",
-				"js-nacl":
-					"github:LiskHQ/js-nacl#6dc1417057cd81381d332b370e82ceab1f2416af",
-				"popsicle": "9.1.0"
 			}
 		},
 		"listr": {
@@ -5912,8 +5680,7 @@
 			"version": "4.6.1",
 			"resolved":
 				"https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity":
-				"sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+			"integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ=",
 			"dev": true
 		},
 		"lodash.once": {
@@ -5940,8 +5707,7 @@
 			"version": "2.2.0",
 			"resolved":
 				"https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity":
-				"sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
 			"dev": true,
 			"requires": {
 				"chalk": "2.4.1"
@@ -5951,8 +5717,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -5961,8 +5726,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -5974,8 +5738,7 @@
 					"version": "5.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
@@ -5997,8 +5760,7 @@
 		"lolex": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
-			"integrity":
-				"sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+			"integrity": "sha1-5AqMTR8UtTaqA+QqU3x6268MIL4=",
 			"dev": true
 		},
 		"long": {
@@ -6041,8 +5803,7 @@
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity":
-				"sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
 			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
@@ -6073,8 +5834,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -6118,8 +5878,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -6173,15 +5932,13 @@
 			"version": "1.1.0",
 			"resolved":
 				"https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-			"integrity":
-				"sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
+			"integrity": "sha1-gxlF4pNltHCqhySwqzbI+JWdEPs=",
 			"dev": true
 		},
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity":
-				"sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
 			"dev": true,
 			"requires": {
 				"pify": "3.0.0"
@@ -6199,8 +5956,7 @@
 			"version": "1.3.4",
 			"resolved":
 				"https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-			"integrity":
-				"sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
+			"integrity": "sha1-GZeO1XX56VRdL/jBPjO10Ypn1TU="
 		},
 		"make-error-cause": {
 			"version": "1.2.2",
@@ -6225,8 +5981,7 @@
 		"marked": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity":
-				"sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+			"integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A=",
 			"dev": true
 		},
 		"math-random": {
@@ -6235,15 +5990,6 @@
 				"https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
 			"dev": true
-		},
-		"md5.js": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
-			}
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -6254,8 +6000,7 @@
 		"memoizee": {
 			"version": "0.4.12",
 			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.12.tgz",
-			"integrity":
-				"sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
+			"integrity": "sha1-eA6ZohnFDFSb5tD8YXZQgJdcWPs=",
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.45",
@@ -6367,8 +6112,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -6433,8 +6177,7 @@
 		"mime": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity":
-				"sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+			"integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
 		},
 		"mime-db": {
 			"version": "1.33.0",
@@ -6455,15 +6198,13 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity":
-				"sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
 			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity":
-				"sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -6511,8 +6252,7 @@
 		"mocha": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-			"integrity":
-				"sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+			"integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
 			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
@@ -6531,8 +6271,7 @@
 					"version": "2.11.0",
 					"resolved":
 						"https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity":
-						"sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
 					"dev": true
 				},
 				"has-flag": {
@@ -6546,8 +6285,7 @@
 					"version": "4.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-					"integrity":
-						"sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
 					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
@@ -6565,8 +6303,7 @@
 			"version": "0.5.21",
 			"resolved":
 				"https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
-			"integrity":
-				"sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+			"integrity": "sha1-PLokfYRJIXTb9x3iqYSPoTIHuEU=",
 			"dev": true,
 			"requires": {
 				"moment": "2.19.3"
@@ -6580,8 +6317,7 @@
 		"multer": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/multer/-/multer-1.3.1.tgz",
-			"integrity":
-				"sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
+			"integrity": "sha1-w/s7NfUMfu/oc1MvkNPd4Czm4EA=",
 			"requires": {
 				"append-field": "0.1.0",
 				"busboy": "0.2.14",
@@ -6615,8 +6351,7 @@
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity":
-				"sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+			"integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8="
 		},
 		"native-promise-only": {
 			"version": "0.8.1",
@@ -6634,8 +6369,7 @@
 		"ncom": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ncom/-/ncom-1.0.1.tgz",
-			"integrity":
-				"sha512-g7/hfG/yYNoi4GMwiyW1F17KFcDhgQ7YLOe+889sfaS+D4G9qcpLvtQu7FY5diDa6K+mLNU7tdhy5KD5t68ByQ==",
+			"integrity": "sha1-HFyvJceCEznW3zeI7BVlTPXOEnI=",
 			"requires": {
 				"sc-formatter": "3.0.2"
 			}
@@ -6643,8 +6377,7 @@
 		"nconf": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-			"integrity":
-				"sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+			"integrity": "sha1-2hKF7pXQqSLKbO51rc+GH0ggWtI=",
 			"dev": true,
 			"requires": {
 				"async": "1.5.2",
@@ -6697,8 +6430,7 @@
 		"needle": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
-			"integrity":
-				"sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
+			"integrity": "sha1-teMlvTqujCZ4kC+ilvcpRV0dOn0=",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -6709,8 +6441,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -6744,8 +6475,7 @@
 		"nise": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-			"integrity":
-				"sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+			"integrity": "sha1-qaOADjmUmUr55FIzPVSdYPcrjow=",
 			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
@@ -6776,8 +6506,7 @@
 		"no-case": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity":
-				"sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
 			"requires": {
 				"lower-case": "1.1.4"
 			}
@@ -6799,8 +6528,7 @@
 			"version": "1.7.0",
 			"resolved":
 				"https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.7.0.tgz",
-			"integrity":
-				"sha512-AX1jGG87itK38N9UZif1CFYjJDibCOj07d0YGpUsxzglVWJjyJ3R7fxtuK7l6RVCKZteLiQyaTo9UR8rIEESgw==",
+			"integrity": "sha1-0lIZHXrciN2XK3MaLteB2V5y1ss=",
 			"dev": true,
 			"requires": {
 				"accepts": "1.3.5",
@@ -6828,8 +6556,7 @@
 			"version": "2.4.0",
 			"resolved":
 				"https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity":
-				"sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.7.1",
@@ -6848,8 +6575,7 @@
 		"npm-path": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
-			"integrity":
-				"sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+			"integrity": "sha1-xkE0el/51qCeTZvOVYDE9QUnjmQ=",
 			"dev": true,
 			"requires": {
 				"which": "1.3.1"
@@ -6964,8 +6690,7 @@
 		"opn": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-			"integrity":
-				"sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+			"integrity": "sha1-ZIcVZchjh18FLP31PT48ta21Oxw=",
 			"dev": true,
 			"requires": {
 				"is-wsl": "1.1.0"
@@ -7068,8 +6793,7 @@
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity":
-				"sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
 			"dev": true,
 			"requires": {
 				"p-try": "1.0.0"
@@ -7087,8 +6811,7 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity":
-				"sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
 			"dev": true
 		},
 		"p-try": {
@@ -7101,8 +6824,7 @@
 			"version": "2.0.2",
 			"resolved":
 				"https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
-			"integrity":
-				"sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+			"integrity": "sha1-kNn2cwqw9NJgfc3NTT1kGqJsOJY=",
 			"dev": true,
 			"requires": {
 				"agent-base": "4.2.1",
@@ -7133,8 +6855,7 @@
 			"version": "3.0.0",
 			"resolved":
 				"https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-			"integrity":
-				"sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+			"integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
 			"dev": true,
 			"requires": {
 				"co": "4.6.0",
@@ -7282,8 +7003,7 @@
 			"version": "1.0.4",
 			"resolved":
 				"https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
-			"integrity":
-				"sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
+			"integrity": "sha1-EH3IsbfA9qihjndJva9GomwtmLQ=",
 			"requires": {
 				"native-promise-only": "0.8.1",
 				"superagent": "3.8.3"
@@ -7317,19 +7037,6 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
-		"pbkdf2": {
-			"version": "3.0.16",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
-			"integrity":
-				"sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
-			"requires": {
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"ripemd160": "2.0.2",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.11"
-			}
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved":
@@ -7339,8 +7046,7 @@
 		"pg": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
-			"integrity":
-				"sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
+			"integrity": "sha1-80Ecjd+faSMi/gXnAXoYiOR/ePE=",
 			"requires": {
 				"buffer-writer": "1.0.1",
 				"js-string-escape": "1.0.1",
@@ -7368,15 +7074,13 @@
 		"pg-minify": {
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.5.4.tgz",
-			"integrity":
-				"sha512-GHB2v4OiMHDgwiHH86ZWNfvgEPVijrnfuWLQocseX6Zlf30k+x0imA65zBy4skIpEwfBBEplIEEKP4n3q9KkVA=="
+			"integrity": "sha1-idUmHKz9RN15J/oFIiKkBOmyo8k="
 		},
 		"pg-monitor": {
 			"version": "0.9.0",
 			"resolved":
 				"https://registry.npmjs.org/pg-monitor/-/pg-monitor-0.9.0.tgz",
-			"integrity":
-				"sha512-oJD1e4hiU1sBLaEt1sRtNXwqh+th5NpMG4EszBJID5PDi8Ol4KeyUzf9tr4bBOowt7OvOh4YeA8j/OAD4GpVvw==",
+			"integrity": "sha1-rgIYUNJF9tJUkAKxzxBEFPUns/Y=",
 			"requires": {
 				"cli-color": "1.2.0"
 			}
@@ -7390,8 +7094,7 @@
 			"version": "8.2.1",
 			"resolved":
 				"https://registry.npmjs.org/pg-promise/-/pg-promise-8.2.1.tgz",
-			"integrity":
-				"sha512-7Ao57+0MUOAOMeA4vHj7vcnVYUY6Mx4VgtQtrEzym0c7QBKDcVmYwy4goeQcTUexY/fthFLv+WBc6SNC30hD5A==",
+			"integrity": "sha1-rxH0AJqNnQ4NN9KRWl5+D2aGWDg=",
 			"requires": {
 				"manakin": "0.5.1",
 				"pg": "7.4.1",
@@ -7421,8 +7124,7 @@
 		"pidusage": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
-			"integrity":
-				"sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg==",
+			"integrity": "sha1-Ze6WrOTgikzT+SQJlshbNnFx7pI=",
 			"dev": true
 		},
 		"pify": {
@@ -7468,8 +7170,7 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity":
-				"sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
 			"dev": true
 		},
 		"pm2": {
@@ -7515,8 +7216,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7612,8 +7312,7 @@
 		"pmx": {
 			"version": "1.6.7",
 			"resolved": "https://registry.npmjs.org/pmx/-/pmx-1.6.7.tgz",
-			"integrity":
-				"sha512-CoyZD1EWj/fvpuEPnndB11s5onzN5p/0bxGsBuwbyb8uFtg3lMxXys1pXs88gReiRnMSYCSt25J3GCc6AnxoFQ==",
+			"integrity": "sha1-sPyAYbyDQ6QGnRjk7k8DHeCviQo=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -7655,8 +7354,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7686,8 +7384,7 @@
 			"version": "1.1.2",
 			"resolved":
 				"https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
-			"integrity":
-				"sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+			"integrity": "sha1-v3H/kCY18hyyQaAT/EIdgdHbFak=",
 			"requires": {
 				"xtend": "4.0.1"
 			}
@@ -7708,16 +7405,14 @@
 		"prettier": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-			"integrity":
-				"sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+			"integrity": "sha1-Gvg1bRhCJ2qZpbVSnILdnprTzJM=",
 			"dev": true
 		},
 		"pretty-format": {
 			"version": "21.2.1",
 			"resolved":
 				"https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-			"integrity":
-				"sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+			"integrity": "sha1-rlQH888hBmzQEaobpfzntqLt2zY=",
 			"dev": true,
 			"requires": {
 				"ansi-regex": "3.0.0",
@@ -7735,8 +7430,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -7754,8 +7448,7 @@
 			"version": "2.0.0",
 			"resolved":
 				"https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity":
-				"sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
 		},
 		"progress": {
 			"version": "2.0.0",
@@ -7766,8 +7459,7 @@
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity":
-				"sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
 			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
@@ -7818,14 +7510,12 @@
 		"psl": {
 			"version": "1.1.28",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-			"integrity":
-				"sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
+			"integrity": "sha1-T7bOsIoeIhTU/U3gyiLa4TdAvHs="
 		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity":
-				"sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -7836,8 +7526,7 @@
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity":
-				"sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -7854,8 +7543,7 @@
 		"randexp": {
 			"version": "0.4.9",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
-			"integrity":
-				"sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
+			"integrity": "sha1-MnMmNY4ZDGhcIGnh+bRcUZDFF7I=",
 			"requires": {
 				"drange": "1.0.2",
 				"ret": "0.2.2"
@@ -7865,8 +7553,7 @@
 			"version": "3.0.0",
 			"resolved":
 				"https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity":
-				"sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+			"integrity": "sha1-01SQAw6091eN4pLObfsEqRoSiSM=",
 			"dev": true,
 			"requires": {
 				"is-number": "4.0.0",
@@ -7878,27 +7565,15 @@
 					"version": "4.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity":
-						"sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
-			}
-		},
-		"randombytes": {
-			"version": "2.0.6",
-			"resolved":
-				"https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity":
-				"sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-			"requires": {
-				"safe-buffer": "5.1.1"
 			}
 		},
 		"randomstring": {
@@ -7989,8 +7664,7 @@
 			"version": "2.3.6",
 			"resolved":
 				"https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity":
-				"sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -8026,8 +7700,7 @@
 			"version": "2.2.2",
 			"resolved":
 				"https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-			"integrity":
-				"sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+			"integrity": "sha1-mUb7MnThYo3m42svZxSVO0hFCU8=",
 			"dev": true,
 			"requires": {
 				"minimatch": "3.0.4"
@@ -8057,8 +7730,7 @@
 			"version": "1.3.5",
 			"resolved":
 				"https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
-			"integrity":
-				"sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA=="
+			"integrity": "sha1-RJWIlBTx6IYmEYCxRC5ylWAtg6I="
 		},
 		"redis-parser": {
 			"version": "2.6.0",
@@ -8066,19 +7738,11 @@
 				"https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
 			"integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
 		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved":
-				"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity":
-				"sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved":
 				"https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity":
-				"sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
 			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -8117,8 +7781,7 @@
 		"request": {
 			"version": "2.87.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity":
-				"sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.7.0",
@@ -8152,8 +7815,7 @@
 					"version": "2.3.4",
 					"resolved":
 						"https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity":
-						"sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
 					"requires": {
 						"punycode": "1.4.1"
 					}
@@ -8164,8 +7826,7 @@
 			"version": "2.0.2",
 			"resolved":
 				"https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity":
-				"sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
 			"dev": true
 		},
 		"require-uncached": {
@@ -8207,8 +7868,7 @@
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity":
-				"sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
 			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
@@ -8234,14 +7894,7 @@
 		"ret": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-			"integrity":
-				"sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
-		},
-		"rewire": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
-			"integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
-			"dev": true
+			"integrity": "sha1-toYXgqH0di3OQ0Aqcet6KD9EVzw="
 		},
 		"right-align": {
 			"version": "0.1.3",
@@ -8260,16 +7913,6 @@
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 			"requires": {
 				"glob": "7.1.2"
-			}
-		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity":
-				"sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
 			}
 		},
 		"rttc": {
@@ -8319,8 +7962,7 @@
 		"rxjs": {
 			"version": "5.5.11",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-			"integrity":
-				"sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+			"integrity": "sha1-9zMCfKQ+O+xrmURzvkq5itQ87Yc=",
 			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.1"
@@ -8339,35 +7981,30 @@
 			"version": "5.1.1",
 			"resolved":
 				"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity":
-				"sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved":
 				"https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity":
-				"sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity":
-				"sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
 			"dev": true
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity":
-				"sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
 			"dev": true
 		},
 		"sc-auth": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/sc-auth/-/sc-auth-5.0.1.tgz",
-			"integrity":
-				"sha512-UgTdvJZS17wkLfNNwj8/uObfACUiGPc5Jl2VmTPpwipasj1kO1Sr64VVhCBUz38j+f/9rBCKlzxCTwljxgX95Q==",
+			"integrity": "sha1-5vBPt0fZyZMak/EVf9JsNklg9xs=",
 			"requires": {
 				"jsonwebtoken": "8.3.0",
 				"sc-errors": "1.4.0"
@@ -8376,8 +8013,7 @@
 		"sc-broker": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/sc-broker/-/sc-broker-5.1.3.tgz",
-			"integrity":
-				"sha512-5mWOGPrh+HokIPVRPESnbvHNGbsgmhiu8LVQIxkA/gNkLUGRJIYudXLekWufqOtbmheCI91z3VAacmDsB/LzYQ==",
+			"integrity": "sha1-2caDgNZTYR87fNDQ6bqC3sZ8TGM=",
 			"requires": {
 				"expirymanager": "0.9.3",
 				"fleximap": "0.9.10",
@@ -8389,8 +8025,7 @@
 				"uuid": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-					"integrity":
-						"sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+					"integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
 				}
 			}
 		},
@@ -8398,8 +8033,7 @@
 			"version": "6.1.5",
 			"resolved":
 				"https://registry.npmjs.org/sc-broker-cluster/-/sc-broker-cluster-6.1.5.tgz",
-			"integrity":
-				"sha512-9plfm1TSBWO+9oSvUXCFl9wT1fJjNwl5H22alnTIloXzxDYVqvN0kaPn3WWJOP4tZUdeXKWKQlENAYE+5F9L7A==",
+			"integrity": "sha1-ttG2NWUOPm5eWJ8w7VRJeo9avDQ=",
 			"requires": {
 				"async": "2.0.0",
 				"sc-broker": "5.1.3",
@@ -8422,8 +8056,7 @@
 			"version": "1.2.0",
 			"resolved":
 				"https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
-			"integrity":
-				"sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
+			"integrity": "sha1-2SCfOpHj+mlMZrARzlXErYwwh9k=",
 			"requires": {
 				"component-emitter": "1.2.1"
 			}
@@ -8431,15 +8064,13 @@
 		"sc-errors": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.0.tgz",
-			"integrity":
-				"sha512-h+jRWx/xRJmkPFDd0IltoTl/QJ6hAr5Y+3ZVeBQRLuWZKe+dHdf2uVwFp2OYqlLQ7GHht4y9eXG2zOf2Ik6PTw=="
+			"integrity": "sha1-JUWY5W1EoCYBHNCdrNkNy4ewaI0="
 		},
 		"sc-formatter": {
 			"version": "3.0.2",
 			"resolved":
 				"https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
-			"integrity":
-				"sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A=="
+			"integrity": "sha1-mr2xTnGHPOcVdxTTACR3u9szxOY="
 		},
 		"sc-hasher": {
 			"version": "1.0.0",
@@ -8450,8 +8081,7 @@
 			"version": "2.1.2",
 			"resolved":
 				"https://registry.npmjs.org/sc-simple-broker/-/sc-simple-broker-2.1.2.tgz",
-			"integrity":
-				"sha512-8hbr47jLhrMecShZi6lunEeUPySkuLHlpg6G7g5jbBJQRrBiFiTuQdwk7KpMwAjLBh1qfaoku9Z+yWieOd5oLA==",
+			"integrity": "sha1-C+wdP/kruehvxXxRRwoIirEgkH8=",
 			"requires": {
 				"sc-channel": "1.2.0"
 			}
@@ -8459,8 +8089,7 @@
 		"sc-uws": {
 			"version": "10.148.1",
 			"resolved": "https://registry.npmjs.org/sc-uws/-/sc-uws-10.148.1.tgz",
-			"integrity":
-				"sha512-frMMhWhapvVLknOjyZJ+T1GMPgE6KJp2rIcTNhVj+Hyj827m3rmAnI0aHZcWmlNlyPEr95PA9Sm9A5RuD0fD4g=="
+			"integrity": "sha1-0Ds/+ETDurFcGtWcKlKaN3gXcE8="
 		},
 		"secure-keys": {
 			"version": "1.0.0",
@@ -8497,8 +8126,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -8544,18 +8172,7 @@
 			"version": "1.1.0",
 			"resolved":
 				"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity":
-				"sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity":
-				"sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
-			}
+			"integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
 		},
 		"shallow-clone": {
 			"version": "0.1.2",
@@ -8619,8 +8236,7 @@
 		"shimmer": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity":
-				"sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag==",
+			"integrity": "sha1-+Wb3VVeJdj502IQRk2haXnhzZmU=",
 			"dev": true
 		},
 		"signal-exit": {
@@ -8633,8 +8249,7 @@
 		"sinon": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-3.2.1.tgz",
-			"integrity":
-				"sha512-KY3OLOWpek/I4NGAMHetuutVgS2aRgMR5g5/1LSYvPJ3qo2BopIvk3esFztPxF40RWf/NNNJzdFPriSkXUVK3A==",
+			"integrity": "sha1-2K2r2QBzD9SXeIoCcEnGSwi+kcI=",
 			"dev": true,
 			"requires": {
 				"diff": "3.3.1",
@@ -8670,8 +8285,7 @@
 			"version": "2.14.0",
 			"resolved":
 				"https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity":
-				"sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"integrity": "sha1-2n3UzIPNaiYLZ8yg96n9riahIF0=",
 			"dev": true
 		},
 		"slash": {
@@ -8683,8 +8297,7 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-			"integrity":
-				"sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
 			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
@@ -8770,8 +8383,7 @@
 					"version": "3.1.0",
 					"resolved":
 						"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-					"integrity":
-						"sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+					"integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA=",
 					"dev": true
 				},
 				"ansi-regex": {
@@ -8785,8 +8397,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -8795,8 +8406,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -8818,8 +8428,7 @@
 					"version": "2.2.0",
 					"resolved":
 						"https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity":
-						"sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
 					"dev": true,
 					"requires": {
 						"chardet": "0.4.2",
@@ -8840,8 +8449,7 @@
 					"version": "3.3.0",
 					"resolved":
 						"https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity":
-						"sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "3.1.0",
@@ -8870,8 +8478,7 @@
 				"lodash": {
 					"version": "4.17.10",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity":
-						"sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
 					"dev": true
 				},
 				"mute-stream": {
@@ -8904,16 +8511,14 @@
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity":
-						"sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved":
 						"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity":
-						"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
@@ -8934,8 +8539,7 @@
 					"version": "5.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
@@ -8944,8 +8548,7 @@
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity":
-						"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 					"dev": true,
 					"requires": {
 						"os-tmpdir": "1.0.2"
@@ -8957,8 +8560,7 @@
 			"version": "2.1.0",
 			"resolved":
 				"https://registry.npmjs.org/snyk-config/-/snyk-config-2.1.0.tgz",
-			"integrity":
-				"sha512-D1Xz1pZa9lwA9AHogmAigyJGo/iuEGH+rcPB77mFsneVfnuiK9c6IjnsHbEBUf1cePtZvWdGBjs6e75Cvc2AMg==",
+			"integrity": "sha1-S9qa0t9v95QTrXomOrcgo/hRv5M=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -8969,8 +8571,7 @@
 			"version": "1.10.3",
 			"resolved":
 				"https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.10.3.tgz",
-			"integrity":
-				"sha512-nIw6zS705SiQLEhBwoO2qsJ3lVN1DZ48tyMgqhlr5f5GuOrwUJ0ivUK5HQUI79xA6pF7tU18495OlbsKuEHUOw==",
+			"integrity": "sha1-KsLwWrgh4SKl4YUSQNPAIbu4Ij8=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -8984,8 +8585,7 @@
 			"version": "1.5.1",
 			"resolved":
 				"https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.5.1.tgz",
-			"integrity":
-				"sha512-8OPJOT05Z/UL5fFSXV6b/A6KjlS1Ahr2gpup1bhXtAGXlUUPyWidqkCIER9fexDXqYWgAoDAdn9YHIvmL/5bfw==",
+			"integrity": "sha1-IgAW8txR4fX+jv5JYEkDmtPwMBA=",
 			"dev": true,
 			"requires": {
 				"graphlib": "2.1.5",
@@ -8996,8 +8596,7 @@
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity":
-						"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 					"dev": true,
 					"requires": {
 						"os-tmpdir": "1.0.2"
@@ -9009,8 +8608,7 @@
 			"version": "1.3.0",
 			"resolved":
 				"https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.3.0.tgz",
-			"integrity":
-				"sha512-rKZcPwbDM9zk3pFcO0w77MIKOZTkk5ZBVBkBlTlUiFg+eNOKqPTmw2hBGF5NB4ASQmMnx3uB1C8+hrQ405CthA==",
+			"integrity": "sha1-eliRVYJexhPiTMK88Nc4Q4+wYhY=",
 			"dev": true,
 			"requires": {
 				"clone-deep": "0.3.0"
@@ -9020,8 +8618,7 @@
 			"version": "1.8.2",
 			"resolved":
 				"https://registry.npmjs.org/snyk-module/-/snyk-module-1.8.2.tgz",
-			"integrity":
-				"sha512-XqhdbZ/CUuJ5gSaYdYfapLqx9qm2Mp6nyRMBCLXe9tJSiohOJsc9fQuUDbdOiRCqpA4BD6WLl+qlwOJmJoszBg==",
+			"integrity": "sha1-vTwRtGqQuMywoEoYs4ex0OWxApE=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -9032,8 +8629,7 @@
 			"version": "1.2.0",
 			"resolved":
 				"https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.0.tgz",
-			"integrity":
-				"sha512-ieTWhn1MB88gEQ6nUtGCeUKQ6Xoxm+u+QmD9u3zfP1QS5ep9fWt3YYDUQjgUiDTJJy7QyVQdZ/fsz3RECnOA7w==",
+			"integrity": "sha1-4jxg41RXzlom/UJS3fEg29fp7yo=",
 			"dev": true
 		},
 		"snyk-nuget-plugin": {
@@ -9054,8 +8650,7 @@
 				"lodash": {
 					"version": "4.17.10",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity":
-						"sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
 					"dev": true
 				}
 			}
@@ -9064,8 +8659,7 @@
 			"version": "1.5.1",
 			"resolved":
 				"https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.5.1.tgz",
-			"integrity":
-				"sha512-g5QSHBsRJ2O4cNxKC4zlWwnQYiSgQ77Y6QgGmo3ihPX3VLZrc1amaZIpPsNe1jwXirnGj2rvR5Xw+jDjbzvHFw==",
+			"integrity": "sha1-N4XuRfXgA5GavEdqEJrU80+r5jE=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -9076,8 +8670,7 @@
 				"lodash": {
 					"version": "4.17.10",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity":
-						"sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
 					"dev": true
 				}
 			}
@@ -9086,8 +8679,7 @@
 			"version": "1.12.0",
 			"resolved":
 				"https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.12.0.tgz",
-			"integrity":
-				"sha512-CEioNnDzccHyid7UIVl3bJ1dnG4co4ofI+KxuC1mo0IUXy64gxnBTeVoZF5gVLWbAyxGxSeW8f0+8GmWMHVb7w==",
+			"integrity": "sha1-UWfLxKKLIEa4IjT4ZuSe5P6h9So=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -9104,8 +8696,7 @@
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity":
-						"sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
 					"dev": true
 				}
 			}
@@ -9114,8 +8705,7 @@
 			"version": "1.6.1",
 			"resolved":
 				"https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.6.1.tgz",
-			"integrity":
-				"sha512-6zr5jAB3p/bwMZQxZpdj+aPmioTgHB4DI6JMLInhZupss0x8Ome5YqzVzBbOvUKNrc3KaLtjGrJWcAuxDL6M/g==",
+			"integrity": "sha1-6zGUs3tHEO3r7jQGoq3qSgFZ6J8=",
 			"dev": true,
 			"requires": {
 				"tmp": "0.0.33"
@@ -9124,8 +8714,7 @@
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity":
-						"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 					"dev": true,
 					"requires": {
 						"os-tmpdir": "1.0.2"
@@ -9137,8 +8726,7 @@
 			"version": "1.0.1",
 			"resolved":
 				"https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.1.tgz",
-			"integrity":
-				"sha512-7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==",
+			"integrity": "sha1-6qSidc9+K1efGNpbGI/mAbju2as=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0",
@@ -9149,8 +8737,7 @@
 			"version": "3.1.0",
 			"resolved":
 				"https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-3.1.0.tgz",
-			"integrity":
-				"sha512-YVAelR+dTpqLgfk6lf6WgOlw+MGmGI0r3/Dny8tUbJJ9uVTHTRAOdZCbUyTFqJG7oEmEZxUwmfjqgAuniYwx8Q==",
+			"integrity": "sha1-ciqXV3lLXg+0A2h0RZr6OYR7Yuw=",
 			"dev": true,
 			"requires": {
 				"ansicolors": "0.3.2",
@@ -9173,8 +8760,7 @@
 			"version": "1.3.0",
 			"resolved":
 				"https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.3.0.tgz",
-			"integrity":
-				"sha512-SRxPB16392dvN3Qv2RfUcHe0XETLWx2kNIOuoNXvc2Gl6DuPW+X+meDJY7xC/yQhU7bSPPKoM2B7awYaj9i2Bg==",
+			"integrity": "sha1-gewOj8vxsyYaGW44fz0IrbPPS2Y=",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9"
@@ -9183,8 +8769,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -9230,8 +8815,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -9268,8 +8852,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -9280,8 +8863,7 @@
 			"version": "3.1.3",
 			"resolved":
 				"https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-			"integrity":
-				"sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
+			"integrity": "sha1-7S2l7nnxCVUDbj2kE7/X8eTYbI4=",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"debug": "3.1.0",
@@ -9300,8 +8882,7 @@
 			"version": "11.4.1",
 			"resolved":
 				"https://registry.npmjs.org/socketcluster/-/socketcluster-11.4.1.tgz",
-			"integrity":
-				"sha512-RywDx9fExY5AAOk9UU+BzRdsy3Ok+d2oxz4Os7585pz8RCfnDCiAd10hbDorNMNY7Kbn93mHDVURn+TC7P2hHQ==",
+			"integrity": "sha1-Hm7QqIoM6+Tyop1ZHUdEizaei/E=",
 			"requires": {
 				"async": "2.3.0",
 				"fs-extra": "2.0.0",
@@ -9348,8 +8929,7 @@
 			"version": "11.2.0",
 			"resolved":
 				"https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-11.2.0.tgz",
-			"integrity":
-				"sha512-6yRBmS5aGWwZzCxvIU5tfTvFRUcJmQ9Mfh9vi07TDda7+h5OQ77ZHFYqzfjVQvEjaZm5D1Ja/tgPd04MkpPIwA==",
+			"integrity": "sha1-Axl+TWh7VdkCrbb4VJKOcG+jLO8=",
 			"requires": {
 				"base-64": "0.1.0",
 				"clone": "2.1.1",
@@ -9371,8 +8951,7 @@
 				"ws": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
-					"integrity":
-						"sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
+					"integrity": "sha1-HUNwRolxGsGUL9Lyg+OPglxLi5U=",
 					"requires": {
 						"async-limiter": "1.0.0"
 					}
@@ -9383,8 +8962,7 @@
 			"version": "11.2.1",
 			"resolved":
 				"https://registry.npmjs.org/socketcluster-server/-/socketcluster-server-11.2.1.tgz",
-			"integrity":
-				"sha512-ry/RLnpN2P0JuzlPufZuHoMGUufFwTlJhCT96klOMzDKL650NlzxN8B9k5ArkATIQ/rT1r/LVBBfdXTJFIYHIA==",
+			"integrity": "sha1-JkuzIL+neU+fuNrZ0lvIlw6j8BI=",
 			"requires": {
 				"async": "2.3.0",
 				"base64id": "1.0.0",
@@ -9410,8 +8988,7 @@
 				"ws": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
-					"integrity":
-						"sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
+					"integrity": "sha1-HUNwRolxGsGUL9Lyg+OPglxLi5U=",
 					"requires": {
 						"async-limiter": "1.0.0"
 					}
@@ -9462,8 +9039,11 @@
 			}
 		},
 		"sodium-native": {
-			"version":
-				"github:LiskHQ/sodium-native#dd0319f679cc5b4821c9c409fa02884a2c80938e",
+			"version": "2.2.1",
+			"resolved":
+				"https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
+			"integrity":
+				"sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
 			"requires": {
 				"ini": "1.3.5",
 				"nan": "2.10.0",
@@ -9485,8 +9065,7 @@
 			"version": "0.4.18",
 			"resolved":
 				"https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-			"integrity":
-				"sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
 			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
@@ -9515,8 +9094,7 @@
 			"version": "3.0.0",
 			"resolved":
 				"https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity":
-				"sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "3.0.0",
@@ -9527,16 +9105,14 @@
 			"version": "2.1.0",
 			"resolved":
 				"https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity":
-				"sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
 			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved":
 				"https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity":
-				"sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "2.1.0",
@@ -9547,21 +9123,18 @@
 			"version": "3.0.0",
 			"resolved":
 				"https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity":
-				"sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc=",
 			"dev": true
 		},
 		"spex": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/spex/-/spex-2.0.2.tgz",
-			"integrity":
-				"sha512-LU6TS3qTEpRth+FnNs/fIWEmridYN7JmaN2k1Jk31XVC4ex7+wYxiHMnKguRxS7oKjbOFl4H6seeWNDFFgkVRg=="
+			"integrity": "sha1-6MjWM6TGevZC3e1wHsI1DJ3pZKA="
 		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity":
-				"sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
 			"requires": {
 				"through": "2.3.8"
 			}
@@ -9649,8 +9222,7 @@
 			"version": "1.1.1",
 			"resolved":
 				"https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity":
-				"sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -9659,8 +9231,7 @@
 			"version": "3.2.2",
 			"resolved":
 				"https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
-			"integrity":
-				"sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+			"integrity": "sha1-mFMFLlqI+2BaRM0nRFqiV61/+80=",
 			"dev": true,
 			"requires": {
 				"get-own-enumerable-property-symbols": "2.0.1",
@@ -9672,8 +9243,7 @@
 			"version": "0.0.6",
 			"resolved":
 				"https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity":
-				"sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+			"integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
 			"dev": true
 		},
 		"strip-ansi": {
@@ -9718,8 +9288,7 @@
 			"version": "3.8.3",
 			"resolved":
 				"https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-			"integrity":
-				"sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+			"integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
 			"requires": {
 				"component-emitter": "1.2.1",
 				"cookiejar": "2.1.2",
@@ -9753,8 +9322,7 @@
 			"version": "1.0.4",
 			"resolved":
 				"https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.4.tgz",
-			"integrity":
-				"sha512-xrKFLbrZ6VxRsg+M3uJozJtsEpNI/aPfZsOkoEjXw8vhAqdMIqwTYGj1f4dmUgvJvCdZhV5iArgtqXgs403ltg=="
+			"integrity": "sha1-LFuET0oiqy9edz+YGTwo44axw34="
 		},
 		"swagger-node-runner": {
 			"version": "0.7.3",
@@ -9785,8 +9353,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -9834,8 +9401,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -9897,8 +9463,7 @@
 		"table": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-			"integrity":
-				"sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+			"integrity": "sha1-ALXitgLxeUuayvnKkIp2OGp4E7w=",
 			"dev": true,
 			"requires": {
 				"ajv": "6.5.2",
@@ -9912,8 +9477,7 @@
 				"ajv": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-					"integrity":
-						"sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+					"integrity": "sha1-Z4SV+bgvfMpr4kjdkvWb/14fQ2A=",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "2.0.1",
@@ -9933,8 +9497,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "1.9.2"
@@ -9943,8 +9506,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
@@ -9970,16 +9532,14 @@
 					"version": "0.4.1",
 					"resolved":
 						"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity":
-						"sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved":
 						"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity":
-						"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
@@ -10000,8 +9560,7 @@
 					"version": "5.4.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
 					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
@@ -10010,8 +9569,7 @@
 				"uri-js": {
 					"version": "4.2.2",
 					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-					"integrity":
-						"sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+					"integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
 					"dev": true,
 					"requires": {
 						"punycode": "2.1.1"
@@ -10120,8 +9678,7 @@
 			"version": "0.1.5",
 			"resolved":
 				"https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
-			"integrity":
-				"sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
+			"integrity": "sha1-dxR91OdrZgwqu4eF25ZXTLvRKSI=",
 			"requires": {
 				"es5-ext": "0.10.45",
 				"next-tick": "1.0.0"
@@ -10159,16 +9716,14 @@
 		"toml": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-			"integrity":
-				"sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
+			"integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs=",
 			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
 			"resolved":
 				"https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity":
-				"sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
 			"requires": {
 				"psl": "1.1.28",
 				"punycode": "1.4.1"
@@ -10213,7 +9768,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -10229,15 +9785,13 @@
 			"version": "4.0.8",
 			"resolved":
 				"https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity":
-				"sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
 			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity":
-				"sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "2.1.18"
@@ -10288,8 +9842,7 @@
 		"ultron": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-			"integrity":
-				"sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+			"integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
 		},
 		"undefsafe": {
 			"version": "2.0.2",
@@ -10303,8 +9856,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -10376,13 +9928,13 @@
 			"version": "0.1.2",
 			"resolved":
 				"https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity":
-				"sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+			"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
 		},
 		"unorm": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-			"integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
+			"integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -10421,8 +9973,7 @@
 		"util": {
 			"version": "0.10.4",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity":
-				"sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"integrity": "sha1-OqASW/5mikZy3liFfTrOJ+y3aQE=",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
@@ -10443,14 +9994,12 @@
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity":
-				"sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+			"integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
 		},
 		"uws": {
 			"version": "9.14.0",
 			"resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
-			"integrity":
-				"sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
+			"integrity": "sha1-+sg4a+/DOno3BcvVjcR7Qwyk3ZU=",
 			"optional": true
 		},
 		"valid-url": {
@@ -10462,8 +10011,7 @@
 			"version": "3.0.3",
 			"resolved":
 				"https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity":
-				"sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
 			"dev": true,
 			"requires": {
 				"spdx-correct": "3.0.0",
@@ -10529,8 +10077,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -10550,8 +10097,7 @@
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity":
-				"sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
 			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
@@ -10609,8 +10155,7 @@
 			"version": "2.3.0",
 			"resolved":
 				"https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity":
-				"sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -10621,8 +10166,7 @@
 		"ws": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-			"integrity":
-				"sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+			"integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
 			"requires": {
 				"async-limiter": "1.0.0",
 				"safe-buffer": "5.1.1",
@@ -10639,8 +10183,7 @@
 		"xml2js": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity":
-				"sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
 			"dev": true,
 			"requires": {
 				"sax": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"socket.io": "=2.0.3",
 		"socketcluster": "=11.4.1",
 		"socketcluster-client": "=11.2.0",
-		"sodium-native": "LiskHQ/sodium-native#dd0319f",
+		"sodium-native": "=2.2.1",
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",
 		"sway": "=1.0.0",


### PR DESCRIPTION
### What was the problem?
We are having `package-lock.json` from 1.2.0, so we don't need to reference our fork version of `sodium-native` anymore.

### How did I fix it?
Change to npm version of sodium native in the `package.json` and update `package-lock.json`.

### Review checklist

* The PR resolves #2411
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
