### PR TITLE
Wrong block height for block version 0 for testnet - Closes #2433

### DIFF
--- a/config/testnet/exceptions.js
+++ b/config/testnet/exceptions.js
@@ -46,6 +46,6 @@ module.exports = {
 	},
 	// <version>: { start: <start_height>, end: <end_height> }
 	blockVersions: {
-		0: { start: 1, end: 5594491 },
+		0: { start: 1, end: 5932033 },
 	},
 };


### PR DESCRIPTION
### What was the problem?
Wrong block height for block version in testnet.

### How did I fix it?
Updated the block height. 

### Review checklist

* The PR resolves #2433
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
