### PR TITLE
Patching system headers should be logged as debug - Closes #2439

### DIFF
--- a/helpers/patches.js
+++ b/helpers/patches.js
@@ -46,7 +46,7 @@ const Patches = {
 			const isSeedPeer = !isPeerVersionDefined;
 
 			if ((isSeedPeer || isPeerInPreReleaseRange) && headers.version) {
-				logger.info('Patching SystemHeaders.versionForPreRelease', forVersion);
+				logger.debug('Patching SystemHeaders.versionForPreRelease', forVersion);
 				logger.debug(`Before patching version: ${headersData.version}`);
 
 				const versionComponents = semver.parse(headersData.version);


### PR DESCRIPTION
### What was the problem?
System header patching was logged on info level. Causing a lot of redundant log entries. 

### How did I fix it?
Changed it to debug level. 


### Review checklist

* The PR resolves #2439
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
