### PR TITLE
Vote verify function should call waterfall callback instead of main callback - Closes #2450

### DIFF
--- a/logic/vote.js
+++ b/logic/vote.js
@@ -145,7 +145,7 @@ Vote.prototype.verify = function(transaction, sender, cb, tx) {
 			waterCb => {
 				const amount = new Bignum(transaction.amount);
 				if (amount.greaterThan(0)) {
-					return setImmediate(cb, 'Invalid transaction amount');
+					return setImmediate(waterCb, 'Invalid transaction amount');
 				}
 
 				if (transaction.recipientId !== transaction.senderId) {


### PR DESCRIPTION
### What was the problem?
A wrong callback was being called inside `Vote.verify` function.
### How did I fix it?
`waterCb` is being called instead of `cb`, which is a global callback of `Vote.verify` function,
### Review checklist

* The PR resolves #2450
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
