### PR TITLE
Add comments to SYNC_MODES in Network tests - Closes #2335

### DIFF
--- a/test/network/setup/config.js
+++ b/test/network/setup/config.js
@@ -17,6 +17,17 @@
 const fs = require('fs');
 const utils = require('../utils');
 
+/**
+ * SYNC_MODES allow us to choose the network topology to use when
+ * executing network tests.
+ * Nodes in the network can form a sparse graph, a dense graph or
+ * a complete graph.
+ *
+ * The supported SYNC_MODES are:
+ * - RANDOM: Each node will connect to random peers in the group.
+ * - ALL_TO_FIRST: Each node will connect to the first peer in the group.
+ * - ALL_TO_GROUP: Each node will connect to every other node in the group.
+ */
 const SYNC_MODES = {
 	RANDOM: 0,
 	ALL_TO_FIRST: 1,


### PR DESCRIPTION
### What was the problem?

There was no explanation about SYNC_MODES in network tests.

### How did I fix it?

Added comments which explain the purpose of SYNC_MODES and the different options that can be chosen.

### How to test it?

See the code changes in `test/network/setup/config.js`

### Review checklist

* The PR resolves #2335
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
