### PR TITLE
Update script adds null value to api whitelist array - Closes #2459

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ pm2 stop lisk
    * Network specific configuration file
    * Custom configuration file (if specified by user)
    * Command line configurations, specified as command `flags` or `env` variables
-8. If you override any config option of type array, it will completely override. e.g. If you specify one peer at `peers.list` in your custom config file, it will replaces every default peer for the network.
-9. For development purposes use `devnet` as network option, others network are specific to public lisk networks.
+8. Any config option of array type gets completely overridden. If you specify one peer at `peers.list` in your custom config file, it will replace every default peer for the network.
+9. For development use `devnet` as the network option.
 
 ### Command Line Options
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ pm2 stop lisk
    * Network specific configuration file
    * Custom configuration file (if specified by user)
    * Command line configurations, specified as command `flags` or `env` variables
-8. Please remember the fact that if you override an array type config value, it will completely override. e.g. If you specify one peer at `peers.list` in your custom config file, it will replaces every default peer for the network.
+8. If you override any config option of type array, it will completely override. e.g. If you specify one peer at `peers.list` in your custom config file, it will replaces every default peer for the network.
 9. For development purposes use `devnet` as network option, others network are specific to public lisk networks.
 
 ### Command Line Options

--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ pm2 stop lisk
    * Network specific configuration file
    * Custom configuration file (if specified by user)
    * Command line configurations, specified as command `flags` or `env` variables
-8. For development purposes use `devnet` as network option, others network are specific to public lisk networks.
+8. Please remember the fact that if you override an array type config value, it will completely override. e.g. If you specify one peer at `peers.list` in your custom config file, it will replaces every default peer for the network.
+9. For development purposes use `devnet` as network option, others network are specific to public lisk networks.
 
 ### Command Line Options
 


### PR DESCRIPTION
### What was the problem?
The update script was extracting only the difference between two config files. So if there is change of any item in array type config attribute, it was extracting the attribute only at that index and setting every other index value to null. 

### How did I fix it?

We simply preserved what is available in old config file.

### Review checklist

* The PR resolves #2459
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
