### PR TITLE
Allow block to be backward compatible with 1.0.x node while broadcasting - Closes #2464

### DIFF
--- a/modules/transport.js
+++ b/modules/transport.js
@@ -443,15 +443,15 @@ Transport.prototype.onBroadcastBlock = function(block, broadcast) {
 	}
 
 	if (block.totalAmount) {
-		block.totalAmount = block.totalAmount.toString();
+		block.totalAmount = block.totalAmount.toNumber();
 	}
 
 	if (block.totalFee) {
-		block.totalFee = block.totalFee.toString();
+		block.totalFee = block.totalFee.toNumber();
 	}
 
 	if (block.reward) {
-		block.reward = block.reward.toString();
+		block.reward = block.reward.toNumber();
 	}
 	// Perform actual broadcast operation
 	__private.broadcaster.broadcast(

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -18,6 +18,7 @@
 var rewire = require('rewire');
 var chai = require('chai');
 var randomstring = require('randomstring');
+var Bignum = require('../../../helpers/bignum.js');
 var swaggerHelper = require('../../../helpers/swagger');
 var WSServer = require('../../common/ws/server_master');
 var generateRandomActivePeer = require('../../fixtures/peers')
@@ -1449,9 +1450,9 @@ describe('transport', () => {
 						generatorPublicKey:
 							'968ba2fa993ea9dc27ed740da0daf49eddd740dbd7cb1cb4fc5db3a20baf341b',
 						numberOfTransactions: 15,
-						totalAmount: '150000000',
-						totalFee: '15000000',
-						reward: '50000000',
+						totalAmount: new Bignum('150000000'),
+						totalFee: new Bignum('15000000'),
+						reward: new Bignum('50000000'),
 						totalForged: '65000000',
 					};
 					__private.broadcaster = {


### PR DESCRIPTION
### What was the problem?
Blocks were not backward compatible with `1.0.0-x` nodes due to the changes implemented in #2187 
### How did I fix it?
Convert `totalAmount`, `totalFee`, `reward` from `string` to `number`
### How to test it?

### Review checklist

* The PR resolves #2464 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
