### PR TITLE
Improve example for unconfirmedBalance - Closes #2477

### DIFF
--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -2566,7 +2566,7 @@ definitions:
         description: The current balance of the account in Beddows.
       unconfirmedBalance:
         type: string
-        example: 0
+        example: 1081560729258
         description: |
           The current unconfirmed balance of the account in Beddows.
           Includes unconfirmed transactions.
@@ -2609,7 +2609,7 @@ definitions:
         description: The current balance of the account in Beddows.
       unconfirmedBalance:
         type: string
-        example: 0
+        example: 1081560729258
         description: |
           The current unconfirmed balance of the account in Beddows.
           Includes unconfirmed transactions.


### PR DESCRIPTION
### What was the problem?
The example value for unconfirmedBalance was confusing.

### How did I fix it?
Changed the confusing example value `0`to the same value as the example for `balance`, which makes more sense as unconfirmed balance = confirmed balance + balance of pending transactions.

### Review checklist

* The PR resolves #2477 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
