### PR TITLE
Make rewards and offset uppercase for mainnet constants - Closes #2481

### DIFF
--- a/config/mainnet/constants.js
+++ b/config/mainnet/constants.js
@@ -15,7 +15,7 @@
 'use strict';
 
 module.exports = {
-	rewards: {
-		offset: 1451520,
+	REWARDS: {
+		OFFSET: 1451520,
 	},
 };


### PR DESCRIPTION
### What was the problem?
Properties `rewards` and `offset` were lowercase in mainnet constants.
### How did I fix it?
Change `rewards` and `offset` to uppercase in mainnet constants.
### How to test it?
Manually.
### Review checklist

* The PR resolves #2481
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
