### PR TITLE
Failed to validate transaction schema - Closes #2490

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1125,13 +1125,9 @@ class Transaction {
 			}
 		}
 
-		if (transaction.amount) {
-			transaction.amount = new Bignum(transaction.amount);
-		}
+		transaction.amount = new Bignum(transaction.amount || 0);
 
-		if (transaction.fee) {
-			transaction.fee = new Bignum(transaction.fee);
-		}
+		transaction.fee = new Bignum(transaction.fee || 0);
 
 		const report = this.scope.schema.validate(
 			transaction,

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -1158,6 +1158,16 @@ describe('transaction', () => {
 				transactionLogic.objectNormalize(transaction);
 			}).to.throw();
 		});
+
+		it('should not throw error when transaction amount and fee is zero(integer)', () => {
+			var transaction = _.cloneDeep(validTransaction);
+			transaction.amount = 0;
+			transaction.fee = 0;
+
+			return expect(() => {
+				transactionLogic.objectNormalize(transaction);
+			}).to.not.throw();
+		});
 	});
 
 	describe('dbRead', () => {

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -1124,11 +1124,31 @@ describe('transaction', () => {
 
 		it('should remove keys with null or undefined attribute', () => {
 			var transaction = _.cloneDeep(validTransaction);
-			transaction.amount = null;
+			transaction.recipientId = null;
 
 			return expect(
 				_.keys(transactionLogic.objectNormalize(transaction))
-			).to.not.include('amount');
+			).to.not.include('recipientId');
+		});
+
+		it('should convert amount and fee to bignumber when values are null', () => {
+			var transaction = _.cloneDeep(validTransaction);
+			transaction.amount = null;
+			transaction.fee = null;
+
+			const { amount, fee } = transactionLogic.objectNormalize(transaction);
+			expect(amount).to.be.an.instanceOf(Bignum);
+			return expect(fee).to.be.an.instanceOf(Bignum);
+		});
+
+		it('should convert amount and fee to bignumber when values are undefined', () => {
+			var transaction = _.cloneDeep(validTransaction);
+			transaction.amount = undefined;
+			transaction.fee = undefined;
+
+			const { amount, fee } = transactionLogic.objectNormalize(transaction);
+			expect(amount).to.be.an.instanceOf(Bignum);
+			return expect(fee).to.be.an.instanceOf(Bignum);
 		});
 
 		it('should not remove any keys with valid entries', () => {
@@ -1164,9 +1184,13 @@ describe('transaction', () => {
 			transaction.amount = 0;
 			transaction.fee = 0;
 
-			return expect(() => {
+			expect(() => {
 				transactionLogic.objectNormalize(transaction);
 			}).to.not.throw();
+
+			const { amount, fee } = transactionLogic.objectNormalize(transaction);
+			expect(amount).to.be.an.instanceOf(Bignum);
+			return expect(fee).to.be.an.instanceOf(Bignum);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
When a `1.0.x` node broadcast transaction or block with the amount and fee being `0` then `1.1.x` node not converting the amount and fee to `bignum`, this was leading into transaction normalization failure and forks.
### How did I fix it?
Convert the transaction amount and fee to `bignumber` instance regardless of the value, meaning when a transaction is received and called with `objectNormalize` the `amount` and `fee` are converted to `bignumber` instance and also default `0` value for `null` or `undefined` values.
### How to test it?
Run unit test `test/unit/logic/transaction.js`
### Review checklist

* The PR resolves #2490 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
