### PR TITLE
"Error writing cache count for transactions - Cache Disabled" when /api/node/status is called - Closes 2482

### DIFF
--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -873,7 +873,7 @@ Transactions.prototype.shared = {
 						},
 						err => {
 							if (err) {
-								library.logger.error(
+								library.logger.warn(
 									'Error writing cache count for transactions',
 									err
 								);

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -874,7 +874,7 @@ Transactions.prototype.shared = {
 						err => {
 							if (err) {
 								library.logger.warn(
-									'Error writing cache count for transactions',
+									'Not writing cache count for transactions',
 									err
 								);
 							}

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -873,10 +873,7 @@ Transactions.prototype.shared = {
 						},
 						err => {
 							if (err) {
-								library.logger.warn(
-									'Unable to write cache count for transactions',
-									err
-								);
+								library.logger.warn("Transaction count wasn't cached", err);
 							}
 
 							return setImmediate(waterCb, null, dbCount);

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -874,7 +874,7 @@ Transactions.prototype.shared = {
 						err => {
 							if (err) {
 								library.logger.warn(
-									'Not writing cache count for transactions',
+									'Unable to write cache count for transactions',
 									err
 								);
 							}


### PR DESCRIPTION
### What was the problem?

No errors in the log when /api/node/status is called

### How did I fix it?

Changed log level from error to warning

### How to test it?

run testnet then `curl -X GET http://localhost:7000/api/node/status`

### Review checklist

* The PR resolves #2482
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
