### PR TITLE
Add support of LISK_NETWORK variable for configuration migration - Closes #2497

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ Options:
 
 -h, --help     output usage information
 -V, --version  output the version number
+--network      Specify the network or use LISK_NETWORK
 --output       Output file path
---diff         Show only difference from default config file.
 ```
 
-As you can see from the usage guide, `input_file` and `from_version` are required. So if you have a config file, you must be aware to which version of Lisk this belongs. You can skip the `to_version` argument and it will apply changes up-to latest version of Lisk. If you don't specify `--output` path the final config json will be printed to console. Option `--diff` is useful if you just want to know what are the changes in your version compared to default config located in `./config/default/config.json`.
+As you can see from the usage guide, `input_file` and `from_version` are required. So if you have a config file, you must be aware to which version of Lisk this belongs. You can skip the `to_version` argument and it will apply changes up-to latest version of Lisk. If you don't specify `--output` path the final config json will be printed to stdout. If you don't specify specify `--network` script will look to load it from `LISK_NETWORK` env variable.
 
 #### Console
 

--- a/README.md
+++ b/README.md
@@ -454,10 +454,10 @@ Usage: update_config [options] <input_file> <from_version> [to_version]
 
 Options:
 
--h, --help     output usage information
--V, --version  output the version number
---network      Specify the network or use LISK_NETWORK
---output       Output file path
+-h, --help               output usage information
+-V, --version            output the version number
+-n, --network [network]  Specify the network or use LISK_NETWORK
+-o, --output [output]    Output file path
 ```
 
 As you can see from the usage guide, `input_file` and `from_version` are required. So if you have a config file, you must be aware to which version of Lisk this belongs. You can skip the `to_version` argument and it will apply changes up-to latest version of Lisk. If you don't specify `--output` path the final config json will be printed to stdout. If you don't specify specify `--network` script will look to load it from `LISK_NETWORK` env variable.

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Options:
 -h, --help               output usage information
 -V, --version            output the version number
 -c, --config [config]    custom config file
--n, --network [network]  Specify the network or use LISK_NETWORK
+-n, --network [network]  specify the network or use LISK_NETWORK
 ```
 
 Argument `network` is required and can by `devnet`, `testnet`, `mainnet` or any other network folder available under `./config` directory.

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Options:
 
 -h, --help               output usage information
 -V, --version            output the version number
--c, --config [config]    Custom config file
+-c, --config [config]    custom config file
 -n, --network [network]  Specify the network or use LISK_NETWORK
 ```
 

--- a/README.md
+++ b/README.md
@@ -435,12 +435,14 @@ There are couple of command line scripts that facilitate users of lisk to perfor
 This script will help you to generate unified version of configuration file for any network. Here is the usage of the script:
 
 ```
-Usage: generate_config [options] <network>
+Usage: generate_config [options]
 
 Options:
 
-  -h, --help     output usage information
-  -V, --version  output the version number
+-h, --help               output usage information
+-V, --version            output the version number
+-c, --config [config]    Custom config file
+-n, --network [network]  Specify the network or use LISK_NETWORK
 ```
 
 Argument `network` is required and can by `devnet`, `testnet`, `mainnet` or any other network folder available under `./config` directory.

--- a/README.md
+++ b/README.md
@@ -458,8 +458,8 @@ Options:
 
 -h, --help               output usage information
 -V, --version            output the version number
--n, --network [network]  Specify the network or use LISK_NETWORK
--o, --output [output]    Output file path
+-n, --network [network]  specify the network or use LISK_NETWORK
+-o, --output [output]    output file path
 ```
 
 As you can see from the usage guide, `input_file` and` from_version` are required. If you skip `to_version` argument changes in config.json will be applied up to the latest version of Lisk Core. If you do not specify `--output` path the final config.json will be printed to stdout. If you do not specify `--network` argument you will have to load it from` LISK_NETWORK` env variable.

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Options:
 -o, --output [output]    Output file path
 ```
 
-As you can see from the usage guide, `input_file` and `from_version` are required. So if you have a config file, you must be aware to which version of Lisk this belongs. You can skip the `to_version` argument and it will apply changes up-to latest version of Lisk. If you don't specify `--output` path the final config json will be printed to stdout. If you don't specify specify `--network` script will look to load it from `LISK_NETWORK` env variable.
+As you can see from the usage guide, `input_file` and` from_version` are required. If you skip `to_version` argument changes in config.json will be applied up to the latest version of Lisk Core. If you do not specify `--output` path the final config.json will be printed to stdout. If you do not specify `--network` argument you will have to load it from` LISK_NETWORK` env variable.
 
 #### Console
 

--- a/helpers/json_history.js
+++ b/helpers/json_history.js
@@ -137,9 +137,9 @@ function JSONHistory(title, logger) {
 
 		// Get the version from which to start the migration
 		// Skip the matched version, as json is already in that particular version
-		let startFromVersion = versions.findIndex(version =>
-			semver.satisfies(fromVersion, version)
-		);
+		// Used ltr to to match the range versions e.g. 1.1.x
+		let startFromVersion =
+			versions.findIndex(version => semver.ltr(fromVersion, version)) - 1;
 
 		if (startFromVersion === -1) {
 			throw new Error(
@@ -150,9 +150,14 @@ function JSONHistory(title, logger) {
 		startFromVersion += includeStart ? 0 : 1;
 
 		// Apply changes till that version
-		const tillVersion =
-			versions.findIndex(version => semver.satisfies(toVersion, version)) ||
-			versions.length - 1;
+		// Used ltr to to match the range versions e.g. 1.1.x
+		let tillVersion =
+			versions.findIndex(version => semver.ltr(toVersion, version)) - 1;
+
+		// If no matching version found then migrate till last version in the list
+		if (tillVersion < 0) {
+			tillVersion = versions.length - 1;
+		}
 
 		// Clone the provided json to avoid changes into source
 		let compiledJson = Object.assign({}, json);

--- a/scripts/generate_config.js
+++ b/scripts/generate_config.js
@@ -20,37 +20,35 @@
  */
 
 const fs = require('fs');
-const path = require('path');
 const program = require('commander');
 const merge = require('lodash/merge');
 
-const rootPath = path.resolve(path.dirname(__filename), '../');
-let networkName;
+const loadJSONFile = filePath => JSON.parse(fs.readFileSync(filePath), 'utf8');
+const loadJSONFileIfExists = filePath => {
+	if (fs.existsSync(filePath)) {
+		return JSON.parse(fs.readFileSync(filePath), 'utf8');
+	}
+	return {};
+};
 
 program
 	.version('0.1.1')
-	.arguments(
-		'<network>',
-		'Network name for which to generate the configuration'
-	)
-	.action(network => {
-		networkName = network;
-	})
+	.option('-c, --config [config]', 'Custom config file')
+	.option('-n, --network [network]', 'Specify the network or use LISK_NETWORK')
 	.parse(process.argv);
 
-if (!networkName) {
-	console.error('error: no network name is provided.');
-	process.exit(1);
-}
+const networkName = program.network || process.env.LISK_NETWORK;
 
-function loadFile(fileName) {
-	return JSON.parse(fs.readFileSync(path.resolve(rootPath, fileName)));
+if (!networkName) {
+	console.error('error: no network name is provided');
+	process.exit(1);
 }
 
 const config = merge(
 	{},
-	loadFile('config/default/config.json'),
-	loadFile(`./config/${networkName}/config.json`)
+	loadJSONFile('config/default/config.json'),
+	loadJSONFile(`./config/${networkName}/config.json`),
+	loadJSONFileIfExists(program.config)
 );
 
 console.info(JSON.stringify(config, null, '\t'));

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -54,6 +54,16 @@ program
 	})
 	.parse(process.argv);
 
+if (typeof configFilePath === 'undefined') {
+	console.error('No input file is provided.');
+	process.exit(1);
+}
+
+if (typeof fromVersion === 'undefined') {
+	console.error('No start version is provided');
+	process.exit(1);
+}
+
 const defaultConfig = loadJSONFile(
 	path.resolve(rootPath, 'config/default/config.json')
 );

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -183,8 +183,16 @@ history.version('1.0.0-rc.2', version => {
 		}
 	);
 });
-history.version('1.1.0-alpha.0');
-history.version('1.2.0-alpha.0');
+history.version('1.0.0-rc.3');
+history.version('1.0.0-rc.4');
+history.version('1.0.0-rc.5');
+history.version('1.0.0');
+history.version('1.1.0-rc.x');
+history.version('1.1.0');
+history.version('1.1.1-rc.x');
+history.version('1.1.1');
+history.version('1.2.0-rc.x');
+history.version('1.2.0');
 
 const askPassword = (message, cb) => {
 	if (program.password && program.password.trim().length !== 0) {

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -45,8 +45,8 @@ let toVersion;
 program
 	.version('0.1.1')
 	.arguments('<input_file> <from_version> [to_version]')
-	.option('--network', 'Specify the network or use LISK_NETWORK')
-	.option('--output', 'Output file path')
+	.option('-n, --network [network]', 'Specify the network or use LISK_NETWORK')
+	.option('-o, --output [output]', 'Output file path')
 	.action((inputFile, version1, version2) => {
 		fromVersion = version1;
 		toVersion = version2;


### PR DESCRIPTION
### What was the problem?
`LISK_NETWORK ` was not supported for 1.2.0 configuration migration model

### How did I fix it?
Updated the script for configuration 

### Review checklist

* The PR resolves #2497
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
