### PR TITLE
Fix public key size generation for tests - Closes #2510

### DIFF
--- a/test/fixtures/accounts.js
+++ b/test/fixtures/accounts.js
@@ -119,7 +119,7 @@ const Account = stampit({
 		this.publicKey =
 			publicKey ||
 			randomstring
-				.generate({ charset: '0123456789ABCDE', length: 64 })
+				.generate({ charset: '0123456789ABCDEF', length: 64 })
 				.toLowerCase();
 
 		this.vote = randomstring.generate({ charset: '123456789', length: 5 });

--- a/test/fixtures/accounts.js
+++ b/test/fixtures/accounts.js
@@ -119,7 +119,7 @@ const Account = stampit({
 		this.publicKey =
 			publicKey ||
 			randomstring
-				.generate({ charset: '0123456789ABCDE', length: 32 })
+				.generate({ charset: '0123456789ABCDE', length: 64 })
 				.toLowerCase();
 
 		this.vote = randomstring.generate({ charset: '123456789', length: 5 });


### PR DESCRIPTION
### What was the problem?
In our test suite, Account fixture was generate public keys 32 chars long.

### How did I fix it?
Changed it to 64 chars instead

### How to test it?
Run the tests

### Review checklist

* The PR resolves #2510 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
