### PR TITLE
Multi-signature transaction process after long delay - Closes #2489

### DIFF
--- a/logic/broadcaster.js
+++ b/logic/broadcaster.js
@@ -249,7 +249,7 @@ __private.filterQueue = function(cb) {
 					// err = null, isConfirmed = true => return false
 					// In case transaction doesn't exists in "trs" table:
 					// err = null, isConfirmed = false => return true
-					(err, isConfirmed) => !err && !isConfirmed
+					(err, isConfirmed) => filterCb(null, !err && !isConfirmed)
 				);
 			}
 			return setImmediate(filterCb, null, true);

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -279,7 +279,8 @@ class Transaction {
 	/**
 	 * Returns true if a transaction was confirmed.
 	 *
-	 * @param {transaction} transaction
+	 * @param {Object} transaction
+	 * @param {string} transaction.id - only transaction id is necessary here
 	 * @param {function} cb
 	 * @returns {SetImmediate} error, isConfirmed
 	 * @todo Add description for the params


### PR DESCRIPTION
### What was the problem?
Signatures were not being broadcasted due to changed behaviour of `checkConfirmed` function introduced in 1.2.0. The function is checking now if the property "id" exists on a passed parameter: 
```
checkConfirmed(transaction, cb) {
		if (!transaction || !transaction.id) {
			return setImmediate(cb, 'Invalid transaction id', false);
		}
```
Broadcaster though was calling the `checkConfirmed` function with both transactions and signatures (which don't have "id" property, but "transactionId" of the corresponding transaction to sign (https://github.com/LiskHQ/lisk/compare/1.2.0...2489-multisignature_broadcaster_fix?expand=1#diff-9e4ef2f035528df11706d74e5683125dL228)
### How did I fix it?
To decide, wheter to broadcast a signature or not, I am passing the `transactionId` to verify if a corresponding transaction exists in a transaction pool or is not being confirmed: https://github.com/LiskHQ/lisk/compare/1.2.0...2489-multisignature_broadcaster_fix?expand=1#diff-9e4ef2f035528df11706d74e5683125dR258

### How to test it?
Run Multisignature stress tests. Confirm that signatures are being propagated across the nodes.
### Review checklist

* The PR resolves #2489
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
