### PR TITLE
Update docker specific version of wait-for-it script - Closes #2528

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN npm install
 FROM node:8
 
 ENV NODE_ENV=production
+ENV WFI_COMMIT=e34c502a3efe0e8b8166ea6148d55b73da5c8401
 ENV WFI_SHA=0f75de5c9d9c37a933bb9744ffd710750d5773892930cfe40509fa505788835c
 
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >/etc/apt/sources.list.d/backports.list && \
@@ -33,7 +34,7 @@ RUN rm -rf /home/lisk/lisk/.git && \
     mkdir -p /home/lisk/lisk/logs && \
     chown lisk:lisk /home/lisk/lisk/logs
 
-ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /home/lisk/wait-for-it.sh
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/${WFI_COMMIT}/wait-for-it.sh /home/lisk/wait-for-it.sh
 RUN if [ x"$( sha256sum /home/lisk/wait-for-it.sh |awk '{print $1}' )" = x"${WFI_SHA}" ]; then \
       chmod 0755 /home/lisk/wait-for-it.sh; \
     else \


### PR DESCRIPTION
### What was the problem?
The checksum verification for wait-for-it.sh fails as there are new commits and checksum changed.
### How did I fix it?
Using a specific version of wait-for-it.sh to avoid checksum verification failure due to new updates.
### How to test it?
Check out 1.2.0 branch and Run docker `build -t lisk/core .`
### Review checklist

* The PR resolves #2528 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
