### PR TITLE
Wrong error message "API access denied" - Closes #2514

### DIFF
--- a/helpers/http_api.js
+++ b/helpers/http_api.js
@@ -138,22 +138,18 @@ var middleware = {
 	 */
 	applyAPIAccessRules(config, req, res, next) {
 		if (!config.api.enabled) {
-			res
-				.status(apiCodes.INTERNAL_SERVER_ERROR)
-				.send({
-					message: 'API access disabled',
-					errors: ['API is not enabled in this node.'],
-				});
+			res.status(apiCodes.FORBIDDEN).send({
+				message: 'API access disabled',
+				errors: ['API is not enabled in this node.'],
+			});
 		} else if (
 			!config.api.access.public &&
 			!checkIpInList(config.api.access.whiteList, req.ip)
 		) {
-			res
-				.status(apiCodes.FORBIDDEN)
-				.send({
-					message: 'API access denied',
-					errors: ['API access blocked.'],
-				});
+			res.status(apiCodes.FORBIDDEN).send({
+				message: 'API access denied',
+				errors: ['API access blocked.'],
+			});
 		} else {
 			next();
 		}

--- a/helpers/http_api.js
+++ b/helpers/http_api.js
@@ -152,7 +152,7 @@ var middleware = {
 				.status(apiCodes.FORBIDDEN)
 				.send({
 					message: 'API access denied',
-					errors: ['API is not public in this node'],
+					errors: ['API access blocked.'],
 				});
 		} else {
 			next();

--- a/helpers/http_api.js
+++ b/helpers/http_api.js
@@ -140,14 +140,20 @@ var middleware = {
 		if (!config.api.enabled) {
 			res
 				.status(apiCodes.INTERNAL_SERVER_ERROR)
-				.send({ success: false, error: 'API access disabled' });
+				.send({
+					message: 'API access disabled',
+					errors: ['API is not enabled in this node.'],
+				});
 		} else if (
 			!config.api.access.public &&
 			!checkIpInList(config.api.access.whiteList, req.ip)
 		) {
 			res
 				.status(apiCodes.FORBIDDEN)
-				.send({ success: false, error: 'API access denied' });
+				.send({
+					message: 'API access denied',
+					errors: ['API is not public in this node'],
+				});
 		} else {
 			next();
 		}

--- a/test/unit/helpers/http_api.js
+++ b/test/unit/helpers/http_api.js
@@ -243,7 +243,7 @@ describe('httpApi', () => {
 				);
 
 				expect(validNextSpy).to.be.not.called;
-				expect(resMock.status).to.be.calledWith(apiCodes.INTERNAL_SERVER_ERROR);
+				expect(resMock.status.calledWith(apiCodes.FORBIDDEN)).to.be.true;
 				expect(resMock.send).to.be.calledWith({
 					message: 'API access disabled',
 					errors: ['API is not enabled in this node.'],
@@ -308,7 +308,7 @@ describe('httpApi', () => {
 					'192.168.99.101'
 				);
 				expect(validNextSpy).to.be.not.called;
-				expect(resMock.status).to.be.calledWith(apiCodes.FORBIDDEN);
+				expect(resMock.status.calledWith(apiCodes.FORBIDDEN)).to.be.true;
 				expect(resMock.send).to.be.calledWith({
 					message: 'API access denied',
 					errors: ['API access blocked.'],

--- a/test/unit/helpers/http_api.js
+++ b/test/unit/helpers/http_api.js
@@ -245,8 +245,8 @@ describe('httpApi', () => {
 				expect(validNextSpy).to.be.not.called;
 				expect(resMock.status).to.be.calledWith(apiCodes.INTERNAL_SERVER_ERROR);
 				expect(resMock.send).to.be.calledWith({
-					success: false,
-					error: 'API access disabled',
+					message: 'API access disabled',
+					errors: ['API is not enabled in this node.'],
 				});
 				done();
 			});
@@ -310,8 +310,8 @@ describe('httpApi', () => {
 				expect(validNextSpy).to.be.not.called;
 				expect(resMock.status).to.be.calledWith(apiCodes.FORBIDDEN);
 				expect(resMock.send).to.be.calledWith({
-					success: false,
-					error: 'API access denied',
+					message: 'API access denied',
+					errors: ['API is not public in this node'],
 				});
 				done();
 			});

--- a/test/unit/helpers/http_api.js
+++ b/test/unit/helpers/http_api.js
@@ -311,7 +311,7 @@ describe('httpApi', () => {
 				expect(resMock.status).to.be.calledWith(apiCodes.FORBIDDEN);
 				expect(resMock.send).to.be.calledWith({
 					message: 'API access denied',
-					errors: ['API is not public in this node'],
+					errors: ['API access blocked.'],
 				});
 				done();
 			});


### PR DESCRIPTION
### What was the problem?

applyAPIAccessRules() middleware was using error messages that do not match swagger ones.

### How did I fix it?

By changing the messages in the middleware to use the same schema as swagger ones. 

### How to test it?

Two cases for testing: 

1. Edit `config/default/config.json` and set `api.enabled` to `false` start the node and make a request you should get the new error message.
2. Edit  `config/devnet/config.json` and set `api.access` to `{"public": "false", "whiteList": ["127.2.2.1"]}` (you have to use an IP address that is not associated to the host making the request!) start the node and make a request you should get the new error message.

### Review checklist

* The PR resolves #2514
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
