### PR TITLE
Update config fails to migrate from 1.2.1 to 1.3.0 - Closes #2542

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "lisk",
-	"version": "1.3.0-alpha.1",
+	"version": "1.3.0-alpha.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -27,8 +27,7 @@
 		"@pm2/agent": {
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.16.tgz",
-			"integrity":
-				"sha512-8oDUY0N21LFULtr9G0/u4vyIRtG2UM9dvEmrDV6h3iqP/7ykqnJ9JnB3MOsMEL6+EsA0Mwf2A4QbHvItwO3mzQ==",
+			"integrity": "sha1-DS/L+hXNaCQkQJtLZ2XJuPcS3eQ=",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.0",
@@ -45,8 +44,7 @@
 				"async": {
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity":
-						"sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
@@ -68,15 +66,13 @@
 				"semver": {
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity":
-						"sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
 					"dev": true
 				},
 				"ws": {
 					"version": "5.2.2",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-					"integrity":
-						"sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
 					"dev": true,
 					"requires": {
 						"async-limiter": "~1.0.0"
@@ -88,8 +84,7 @@
 			"version": "1.0.7",
 			"resolved":
 				"https://registry.npmjs.org/@pm2/agent-node/-/agent-node-1.0.7.tgz",
-			"integrity":
-				"sha512-09m5zCJM9lpdA4MjHS+nahEVf+bjdvj5OepqiQiLxh+Jz1L5VSFmXyT9tUszanhJg3AajRfNKup1ASNtzVnPMg==",
+			"integrity": "sha1-Lw4SuInE1HMfXR4OlooL1T7bPCg=",
 			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
@@ -107,8 +102,7 @@
 				"ws": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
-					"integrity":
-						"sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
+					"integrity": "sha1-EZqdv5LFThkOwY0Q6HHVXJXPk3M=",
 					"dev": true,
 					"requires": {
 						"async-limiter": "~1.0.0"
@@ -119,8 +113,7 @@
 		"@pm2/io": {
 			"version": "2.4.5",
 			"resolved": "https://registry.npmjs.org/@pm2/io/-/io-2.4.5.tgz",
-			"integrity":
-				"sha512-+JPRL7T/5uoLzUnYV5SlrU1jWNOVfSRBeX386cx68EpotWRH0qS9HjGwh+DjBTeMRdvI9aVyhiBYqqRq8Lb6eg==",
+			"integrity": "sha1-F5cdoi/3Ft7Uo9teA3La9cHi+FE=",
 			"dev": true,
 			"requires": {
 				"@pm2/agent-node": "^1.0.6",
@@ -139,8 +132,7 @@
 				"async": {
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity":
-						"sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
@@ -149,8 +141,7 @@
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity":
-						"sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
 					"dev": true
 				}
 			}
@@ -182,8 +173,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -201,7 +191,7 @@
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
 			"resolved":
-				"http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+				"https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity":
 				"sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
 			"dev": true,
@@ -363,8 +353,7 @@
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity":
-				"sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
 			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
@@ -639,8 +628,7 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity":
-				"sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
 			"dev": true
 		},
 		"aws-sign2": {
@@ -735,8 +723,7 @@
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity":
-				"sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
 			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
@@ -762,8 +749,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -773,8 +759,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -784,8 +769,7 @@
 					"version": "1.0.2",
 					"resolved":
 						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -796,8 +780,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
 			}
@@ -853,8 +836,7 @@
 			"version": "1.12.0",
 			"resolved":
 				"https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity":
-				"sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+			"integrity": "sha1-wteA9T1Fu6gxeokC1M7q86Y4WxQ=",
 			"dev": true
 		},
 		"bip39": {
@@ -983,8 +965,7 @@
 		"braces": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity":
-				"sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
 			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
@@ -1115,8 +1096,7 @@
 			"version": "1.0.1",
 			"resolved":
 				"https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity":
-				"sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
 			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
@@ -1308,8 +1288,7 @@
 		"chokidar": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-			"integrity":
-				"sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"integrity": "sha1-NW/04rDo5D4yLRijckYLvPOszSY=",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
@@ -1350,8 +1329,7 @@
 			"version": "1.0.4",
 			"resolved":
 				"https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity":
-				"sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -1374,8 +1352,7 @@
 			"version": "0.3.6",
 			"resolved":
 				"https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity":
-				"sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
@@ -1429,8 +1406,7 @@
 			"version": "1.0.1",
 			"resolved":
 				"https://registry.npmjs.org/cli-table-redemption/-/cli-table-redemption-1.0.1.tgz",
-			"integrity":
-				"sha512-SjVCciRyx01I4azo2K2rcc0NP/wOceXGzG1ZpYkEulbbIxDA/5YWv0oxG2HtQ4v8zPC6bgbRI7SbNaTZCxMNkg==",
+			"integrity": "sha1-A1nYw033SYACnXbf8HGgWhJ8T90=",
 			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3"
@@ -1867,8 +1843,7 @@
 		"coveralls": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
-			"integrity":
-				"sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+			"integrity": "sha1-9aC82Qyk5k4Ii3EPqN2mQK6kiE8=",
 			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
@@ -1882,8 +1857,7 @@
 				"js-yaml": {
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-					"integrity":
-						"sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
 					"dev": true,
 					"requires": {
 						"argparse": "^1.0.7",
@@ -1935,8 +1909,7 @@
 			"version": "1.2.0",
 			"resolved":
 				"https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity":
-				"sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -1949,8 +1922,7 @@
 			"version": "1.1.7",
 			"resolved":
 				"https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity":
-				"sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -1986,8 +1958,7 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-			"dev": true
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 		},
 		"csv": {
 			"version": "1.1.1",
@@ -2150,8 +2121,7 @@
 			"version": "0.0.2",
 			"resolved":
 				"https://registry.npmjs.org/deep-metrics/-/deep-metrics-0.0.2.tgz",
-			"integrity":
-				"sha512-2b4DO8YcPWSHrZ7XW9YjjJajmflw2EhKUMmeriZmGYsC8XvCWIyztsEjCQ3f5kIQO+ItzBK7BqVjSWlFZQtONQ==",
+			"integrity": "sha1-GAkA3qgqLEuXa+K3aEkUdI9aCTE=",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -2160,8 +2130,7 @@
 		"deepmerge": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
-			"integrity":
-				"sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w==",
+			"integrity": "sha1-6GK05F6gVVByv1Hn/Q2YRRcK52g=",
 			"dev": true
 		},
 		"defaults": {
@@ -2176,8 +2145,7 @@
 			"version": "2.0.2",
 			"resolved":
 				"https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity":
-				"sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
 			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
@@ -2188,8 +2156,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2199,8 +2166,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2210,8 +2176,7 @@
 					"version": "1.0.2",
 					"resolved":
 						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -2222,8 +2187,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
 			}
@@ -2276,7 +2240,7 @@
 		},
 		"deref": {
 			"version": "0.6.4",
-			"resolved": "http://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
+			"resolved": "https://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
 			"integrity": "sha1-vVqW1F2+0wEbuBvfaN31S+jhvU4=",
 			"requires": {
 				"deep-extend": "^0.4.0"
@@ -2365,8 +2329,7 @@
 		"drange": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
-			"integrity":
-				"sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
+			"integrity": "sha1-sq7Owqq4L87xHbvXueMrg/j2wLg="
 		},
 		"ebnf-parser": {
 			"version": "0.1.10",
@@ -2451,8 +2414,7 @@
 			"version": "1.1.2",
 			"resolved":
 				"https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-			"integrity":
-				"sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+			"integrity": "sha1-VrFA6PaZI3Wz18ssqxzHQy2WMug=",
 			"dev": true,
 			"requires": {
 				"shimmer": "^1.2.0"
@@ -3069,8 +3031,7 @@
 			"version": "1.2.2",
 			"resolved":
 				"https://registry.npmjs.org/event-loop-inspector/-/event-loop-inspector-1.2.2.tgz",
-			"integrity":
-				"sha512-v7OqIPmO0jqpmSH4Uc6IrY/H6lOidYzrXHE8vPHLDDOfV1Pw+yu+KEIE/AWnoFheWYlunZbxzKpZBAezVlrU9g==",
+			"integrity": "sha1-5W7XP1CosLkZPMNr6Hf+oYZBrOs=",
 			"dev": true
 		},
 		"eventemitter2": {
@@ -3133,8 +3094,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -3263,8 +3223,7 @@
 					"version": "1.0.1",
 					"resolved":
 						"https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity":
-						"sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -3286,8 +3245,7 @@
 		"extglob": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-			"integrity":
-				"sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
 			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
@@ -3324,8 +3282,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -3335,8 +3292,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -3346,8 +3302,7 @@
 					"version": "1.0.2",
 					"resolved":
 						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -3358,8 +3313,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
 			}
@@ -4316,8 +4270,7 @@
 		},
 		"gkt": {
 			"version": "https://tgz.pm2.io/gkt-1.0.0.tgz",
-			"integrity":
-				"sha512-zr6QQnzLt3Ja0t0XI8gws2kn7zV2p0l/D3kreNvS6hFZhVU5g+uY/30l42jbgt0XGcNBEmBDGJR71J692V92tA==",
+			"integrity": "sha1-QFUCsAfzGcP0cXXER0UnMA8qta0=",
 			"dev": true,
 			"optional": true
 		},
@@ -4409,8 +4362,7 @@
 		"grunt": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
-			"integrity":
-				"sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+			"integrity": "sha1-s8mSYMUdG0KDV2bnllJ7YPe7o3Q=",
 			"dev": true,
 			"requires": {
 				"coffeescript": "~1.10.0",
@@ -4484,8 +4436,7 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity":
-						"sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
 					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -4504,16 +4455,14 @@
 			"version": "1.1.1",
 			"resolved":
 				"https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
-			"integrity":
-				"sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+			"integrity": "sha1-bMCIEHvQIZ3F0+V9kZI/RpBZgE0=",
 			"dev": true
 		},
 		"grunt-legacy-log": {
 			"version": "2.0.0",
 			"resolved":
 				"https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
-			"integrity":
-				"sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
+			"integrity": "sha1-yM0sbIGkRlubvy2HTZY/73pZ/7k=",
 			"dev": true,
 			"requires": {
 				"colors": "~1.1.2",
@@ -4526,8 +4475,7 @@
 			"version": "2.0.1",
 			"resolved":
 				"https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
-			"integrity":
-				"sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
+			"integrity": "sha1-0vRCx8AVAGXZAEsI/XQQ03UZGU4=",
 			"dev": true,
 			"requires": {
 				"chalk": "~2.4.1",
@@ -4538,8 +4486,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -4548,8 +4495,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -4561,8 +4507,7 @@
 					"version": "5.5.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity":
-						"sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -4574,8 +4519,7 @@
 			"version": "1.1.1",
 			"resolved":
 				"https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
-			"integrity":
-				"sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
+			"integrity": "sha1-4QYk58hgNOW4cMioYWdD8KCEXkI=",
 			"dev": true,
 			"requires": {
 				"async": "~1.5.2",
@@ -5055,8 +4999,7 @@
 			"version": "0.1.6",
 			"resolved":
 				"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity":
-				"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
 			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
@@ -5067,8 +5010,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity":
-						"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
 					"dev": true
 				}
 			}
@@ -5261,8 +5203,7 @@
 			"version": "1.0.2",
 			"resolved":
 				"https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity":
-				"sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
 			"dev": true
 		},
 		"is-wsl": {
@@ -5589,8 +5530,7 @@
 		"js-base64": {
 			"version": "2.4.9",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-			"integrity":
-				"sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
+			"integrity": "sha1-dIkR+wT0imDEdxs3XKxFqA3xHAM="
 		},
 		"js-git": {
 			"version": "0.7.8",
@@ -5743,8 +5683,7 @@
 		"json-refs": {
 			"version": "3.0.12",
 			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.12.tgz",
-			"integrity":
-				"sha512-6RbO1Y3e0Hty/tEpXtQG6jUx7g1G8e39GIOuPugobPC8BX1gZ0OGZQpBn1FLWGkuWF35GRGADvhwdEIFpwIjyA==",
+			"integrity": "sha1-lJQ1lol0vMn0tRWpcDaqkScA0Gc=",
 			"requires": {
 				"commander": "~2.11.0",
 				"graphlib": "^2.1.1",
@@ -5774,7 +5713,7 @@
 		"json-schema-faker": {
 			"version": "0.2.16",
 			"resolved":
-				"http://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.2.16.tgz",
+				"https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.2.16.tgz",
 			"integrity": "sha1-UdPKSJVdj+c09ZHXR7ckU75aePI=",
 			"requires": {
 				"chance": "~1.0.1",
@@ -5785,7 +5724,7 @@
 			"dependencies": {
 				"faker": {
 					"version": "3.1.0",
-					"resolved": "http://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
 					"integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8="
 				}
 			}
@@ -5794,8 +5733,7 @@
 			"version": "5.1.3",
 			"resolved":
 				"https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
-			"integrity":
-				"sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
+			"integrity": "sha1-+GxYaPQImOaRaeG7yFRyWk/Q4a0=",
 			"requires": {
 				"call-me-maybe": "^1.0.1",
 				"debug": "^3.1.0",
@@ -5806,8 +5744,7 @@
 				"js-yaml": {
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-					"integrity":
-						"sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -6145,8 +6082,7 @@
 			"version": "1.0.0",
 			"resolved":
 				"https://registry.npmjs.org/lisk-elements/-/lisk-elements-1.0.0.tgz",
-			"integrity":
-				"sha512-wD30a1WRXdBLIrXXRLBUHxtR6AIKUQEVRBCWQG4wLtqF5zfGyHQ0d7HAC+kwkECI5en+lwzuI8egovQotMWNMg==",
+			"integrity": "sha1-kHx/r+BD2fCvy1Y9o5sCLRjfS84=",
 			"requires": {
 				"axios": "=0.18.0",
 				"babel-runtime": "=6.26.0",
@@ -6177,8 +6113,7 @@
 				"debug": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.0.1.tgz",
-					"integrity":
-						"sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==",
+					"integrity": "sha1-+bs21Dm40fDdUtj7a0bk67jBzVs=",
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -6186,8 +6121,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity":
-						"sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
 				}
 			}
 		},
@@ -6320,8 +6254,7 @@
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity":
-				"sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -6458,8 +6391,7 @@
 			"version": "1.2.7",
 			"resolved":
 				"https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity":
-				"sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -6918,8 +6850,7 @@
 			"version": "3.1.10",
 			"resolved":
 				"https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity":
-				"sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -6940,8 +6871,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
 			}
@@ -6993,8 +6923,7 @@
 			"version": "1.3.1",
 			"resolved":
 				"https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity":
-				"sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -7005,8 +6934,7 @@
 					"version": "1.0.1",
 					"resolved":
 						"https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity":
-						"sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -7162,8 +7090,7 @@
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity":
-				"sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -7182,8 +7109,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
 			}
@@ -7309,8 +7235,7 @@
 		"newrelic": {
 			"version": "4.8.1",
 			"resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.8.1.tgz",
-			"integrity":
-				"sha512-IKOpXM3BRxUrzxcsBagJsMOIYJr/VsScubHXMRTAesFM7ljdGcBE2arEXy/crgiZWyl0GKKmbVZLsO3M9ZsByg==",
+			"integrity": "sha1-tg7V4BBvf7hOT6DaOFFMWPGdmbY=",
 			"requires": {
 				"@newrelic/koa": "^1.0.0",
 				"@newrelic/native-metrics": "^3.0.0",
@@ -7594,14 +7519,13 @@
 		},
 		"onetime": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 		},
 		"ono": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.10.tgz",
-			"integrity":
-				"sha512-4Xz4hlbq7MzV0I3vKfZwRvyj8tCbXODqBNzFqtkjP+KTV93zzDRju8kw1qnf6P5kcZ2+xlIq6wSCqA+euSKxhA==",
+			"integrity": "sha1-9/nG0bdicKSZ2GZMladA1EF1E0w=",
 			"requires": {
 				"format-util": "^1.0.3"
 			}
@@ -7921,8 +7845,7 @@
 			"version": "1.0.9",
 			"resolved":
 				"https://registry.npmjs.org/path-loader/-/path-loader-1.0.9.tgz",
-			"integrity":
-				"sha512-pD37gArtr+/72Tst9oJoDB9k7gB9A09Efj7yyBi5HDUqaxqULXBWW8Rnw2TfNF+3sN7QZv0ZNdW1Qx2pFGW5Jg==",
+			"integrity": "sha1-TyBK2hpHfbKlcvzjggKcPyTcUjc=",
 			"requires": {
 				"native-promise-only": "^0.8.1",
 				"superagent": "^3.8.3"
@@ -8060,8 +7983,7 @@
 		"pidusage": {
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.17.tgz",
-			"integrity":
-				"sha512-N8X5v18rBmlBoArfS83vrnD0gIFyZkXEo7a5pAS2aT0i2OLVymFb2AzVg+v8l/QcXnE1JwZcaXR8daJcoJqtjw==",
+			"integrity": "sha1-a0orSgkCbw6YKPflYng35MBnJYE=",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2"
@@ -8071,8 +7993,7 @@
 					"version": "5.1.2",
 					"resolved":
 						"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity":
-						"sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
 					"dev": true
 				}
 			}
@@ -8127,8 +8048,7 @@
 		"pm2": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/pm2/-/pm2-3.2.2.tgz",
-			"integrity":
-				"sha512-Un3S5hirVHy48Pqrxgrqt6deLWf2E9pVeKwFCG0zbldyq415D3QW69KG+p1Rc2S36nuW2QEHoQyoTNai7rJz5Q==",
+			"integrity": "sha1-3d6QOX1gVP65KlEjDDrg8ePZ8sE=",
 			"dev": true,
 			"requires": {
 				"@pm2/agent": "^0.5.11",
@@ -8169,8 +8089,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -8179,8 +8098,7 @@
 				"async": {
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity":
-						"sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
@@ -8189,8 +8107,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -8222,8 +8139,7 @@
 				"semver": {
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity":
-						"sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
 					"dev": true
 				},
 				"sprintf-js": {
@@ -8237,8 +8153,7 @@
 					"version": "5.5.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity":
-						"sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -8249,8 +8164,7 @@
 		"pm2-axon": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-3.3.0.tgz",
-			"integrity":
-				"sha512-dAFlFYRuFbFjX7oAk41zT+dx86EuaFX/TgOp5QpUKRKwxb946IM6ydnoH5sSTkdI2pHSVZ+3Am8n/l0ocr7jdQ==",
+			"integrity": "sha1-qbrf244IP71dfSQxe0oh63CPBzU=",
 			"dev": true,
 			"requires": {
 				"amp": "~0.3.1",
@@ -8263,8 +8177,7 @@
 			"version": "0.5.1",
 			"resolved":
 				"https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.5.1.tgz",
-			"integrity":
-				"sha512-hT8gN3/j05895QLXpwg+Ws8PjO4AVID6Uf9StWpud9HB2homjc1KKCcI0vg9BNOt56FmrqKDT1NQgheIz35+sA==",
+			"integrity": "sha1-rTxDxDgRxx8T5e7ighGU0DzrA/4=",
 			"dev": true,
 			"requires": {
 				"debug": "^3.0"
@@ -8274,8 +8187,7 @@
 			"version": "0.3.10",
 			"resolved":
 				"https://registry.npmjs.org/pm2-deploy/-/pm2-deploy-0.3.10.tgz",
-			"integrity":
-				"sha512-WagPKsX+LDCe8wLCL5nzu8RQvVUQ5GlFdJRVYCL0ogFnHfYRym91qNU4PkNSWSq11pdvG8la7DTjdW6FWXc8lw==",
+			"integrity": "sha1-W2aJ342yOQWJJEt8FcVjvUZwk/Y=",
 			"dev": true,
 			"requires": {
 				"async": "^2.6",
@@ -8285,8 +8197,7 @@
 				"async": {
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity":
-						"sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
@@ -8555,8 +8466,7 @@
 			"version": "2.0.6",
 			"resolved":
 				"https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-			"integrity":
-				"sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8673,8 +8583,7 @@
 		"readdirp": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity":
-				"sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
@@ -8745,8 +8654,7 @@
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity":
-				"sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
@@ -8756,8 +8664,7 @@
 		"regexpp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-			"integrity":
-				"sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"integrity": "sha1-DjUW3Qt5BPQT0tQZPc5GGMOmias=",
 			"dev": true
 		},
 		"remove-trailing-separator": {
@@ -8771,8 +8678,7 @@
 			"version": "1.1.3",
 			"resolved":
 				"https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity":
-				"sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
 			"dev": true
 		},
 		"repeat-string": {
@@ -8924,8 +8830,7 @@
 		"rewire": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
-			"integrity":
-				"sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+			"integrity": "sha1-uhEA1ACp2nWf5Zn8bgIz8Iee1to=",
 			"dev": true,
 			"requires": {
 				"eslint": "^4.19.1"
@@ -8942,8 +8847,7 @@
 					"version": "3.1.0",
 					"resolved":
 						"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-					"integrity":
-						"sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+					"integrity": "sha1-9zIHu4EgfXX9bIPxJa8m7qN4yjA=",
 					"dev": true
 				},
 				"ansi-regex": {
@@ -8957,8 +8861,7 @@
 					"version": "3.2.1",
 					"resolved":
 						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -8967,8 +8870,7 @@
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity":
-						"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -8989,8 +8891,7 @@
 				"eslint": {
 					"version": "4.19.1",
 					"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-					"integrity":
-						"sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+					"integrity": "sha1-MtHWU+HZBAiFS/spbwdux+GGowA=",
 					"dev": true,
 					"requires": {
 						"ajv": "^5.3.0",
@@ -9037,8 +8938,7 @@
 					"version": "2.2.0",
 					"resolved":
 						"https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity":
-						"sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
 					"dev": true,
 					"requires": {
 						"chardet": "^0.4.0",
@@ -9059,8 +8959,7 @@
 					"version": "3.3.0",
 					"resolved":
 						"https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity":
-						"sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -9117,8 +9016,7 @@
 					"version": "2.1.1",
 					"resolved":
 						"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity":
-						"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -9139,8 +9037,7 @@
 					"version": "5.5.0",
 					"resolved":
 						"https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity":
-						"sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -9149,8 +9046,7 @@
 				"table": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-					"integrity":
-						"sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+					"integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
 					"dev": true,
 					"requires": {
 						"ajv": "^5.2.3",
@@ -9164,8 +9060,7 @@
 				"tmp": {
 					"version": "0.0.33",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity":
-						"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.2"
@@ -9484,8 +9379,7 @@
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity":
-				"sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -9516,8 +9410,7 @@
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity":
-				"sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -9574,8 +9467,7 @@
 		"shelljs": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-			"integrity":
-				"sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+			"integrity": "sha1-NFt993Y/TCNA1YSrtTLF91LKnjU=",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
@@ -9686,8 +9578,7 @@
 			"version": "0.8.2",
 			"resolved":
 				"https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity":
-				"sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
 			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
@@ -9703,8 +9594,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -9743,8 +9633,7 @@
 			"version": "2.1.1",
 			"resolved":
 				"https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity":
-				"sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
 			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
@@ -9766,8 +9655,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -9777,8 +9665,7 @@
 					"version": "1.0.0",
 					"resolved":
 						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -9788,8 +9675,7 @@
 					"version": "1.0.2",
 					"resolved":
 						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -9800,8 +9686,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"dev": true
 				}
 			}
@@ -9810,8 +9695,7 @@
 			"version": "3.0.1",
 			"resolved":
 				"https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity":
-				"sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
@@ -10578,8 +10462,7 @@
 			"version": "0.5.2",
 			"resolved":
 				"https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity":
-				"sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
 			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
@@ -10593,8 +10476,7 @@
 			"version": "0.5.9",
 			"resolved":
 				"https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-			"integrity":
-				"sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+			"integrity": "sha1-QbyVOyU0Jn6i1gW8z6e/oxEc7V8=",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -10605,8 +10487,7 @@
 					"version": "0.6.1",
 					"resolved":
 						"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity":
-						"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				}
 			}
@@ -10687,8 +10568,7 @@
 			"version": "3.1.0",
 			"resolved":
 				"https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity":
-				"sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
@@ -10733,8 +10613,7 @@
 			"version": "2.0.0",
 			"resolved":
 				"https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
-			"integrity":
-				"sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
+			"integrity": "sha1-DoIfiSaEfe97S1DNpdVcBKmxOGQ=",
 			"requires": {
 				"escodegen": "^1.8.1"
 			}
@@ -10906,8 +10785,7 @@
 			"version": "1.0.6",
 			"resolved":
 				"https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.6.tgz",
-			"integrity":
-				"sha512-21HVj5jwEjhTMBPBtJDNINItT5RrehikrlKBphnivELUn66RdVo8yQm/sKpZrUYSbr0ncueQx7vDEEHjl27yTg=="
+			"integrity": "sha1-uRwuT3+eXixM07KFuL4GynazzGo="
 		},
 		"swagger-node-runner": {
 			"version": "0.7.3",
@@ -11025,8 +10903,7 @@
 		"sway": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/sway/-/sway-2.0.5.tgz",
-			"integrity":
-				"sha512-F7Y+IiVXAtBgUxlbEKuL5WUVaoriWEvYKXwE5XF+44ZKVY2ZGw4gOLqQFZvGqwQAODoqDVU8ENKKgO+u+S0DzQ==",
+			"integrity": "sha1-2wFn6HBMbcd8SaD64cZU/53MUR4=",
 			"requires": {
 				"debug": "^3.1.0",
 				"faker": "^4.1.0",
@@ -11046,14 +10923,12 @@
 					"version": "0.6.0",
 					"resolved":
 						"https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-					"integrity":
-						"sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+					"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
 				},
 				"deref": {
 					"version": "0.7.6",
 					"resolved": "https://registry.npmjs.org/deref/-/deref-0.7.6.tgz",
-					"integrity":
-						"sha512-8en95BZvFIHY+G4bnW1292qFfubV7NSogpoBNJFCbbSPEvRGKkOfMRgVhl3AtXSdxpRQ6WMuZhMVIlpFVBB3AA==",
+					"integrity": "sha1-CglIHJz/+gv3H1VoHkiaWQaYiC8=",
 					"requires": {
 						"deep-extend": "^0.6.0"
 					}
@@ -11066,8 +10941,7 @@
 				"js-yaml": {
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-					"integrity":
-						"sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -11100,15 +10974,13 @@
 					"version": "10.8.0",
 					"resolved":
 						"https://registry.npmjs.org/validator/-/validator-10.8.0.tgz",
-					"integrity":
-						"sha512-mXqMxfCh5NLsVgYVKl9WvnHNDPCcbNppHSPPowu0VjtSsGWVY+z8hJF44edLR1nbLNzi3jYoYsIl8KZpioIk6g=="
+					"integrity": "sha1-issVpcOUEcvI7yvgyYwlFNpEEKc="
 				},
 				"z-schema": {
 					"version": "3.24.1",
 					"resolved":
 						"https://registry.npmjs.org/z-schema/-/z-schema-3.24.1.tgz",
-					"integrity":
-						"sha512-2eR8eq/v1coNqyBc5HzswEcoLbw+S33RMnR326uiuOIr97ve5vwPNMDrKS1IRCB12bZ3a8BrfGxrRwuSXUyPvw==",
+					"integrity": "sha1-B6NkPI4GHsGvMugjyfnl5eVuPI0=",
 					"requires": {
 						"commander": "^2.7.1",
 						"core-js": "^2.5.7",
@@ -11317,8 +11189,7 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"tempfile": {
 			"version": "2.0.0",
@@ -11328,6 +11199,16 @@
 			"requires": {
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
+			}
+		},
+		"tempy": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+			"integrity":
+				"sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+			"requires": {
+				"temp-dir": "^1.0.0",
+				"unique-string": "^1.0.0"
 			}
 		},
 		"text-encoding": {
@@ -11411,8 +11292,7 @@
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity":
-				"sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
 			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
@@ -11480,8 +11360,7 @@
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity":
-				"sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -11629,8 +11508,7 @@
 			"version": "3.3.5",
 			"resolved":
 				"https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
-			"integrity":
-				"sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+			"integrity": "sha1-/CrSVbi9MJ4jnLxYFv0jqbfqQCM=",
 			"dev": true,
 			"requires": {
 				"sprintf-js": "^1.0.3",
@@ -11697,7 +11575,6 @@
 			"resolved":
 				"https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-			"dev": true,
 			"requires": {
 				"crypto-random-string": "^1.0.0"
 			}
@@ -11766,8 +11643,7 @@
 		"upath": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity":
-				"sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"integrity": "sha1-NSVll+RqWB20eT0M5H+prr/J+r0=",
 			"dev": true
 		},
 		"upper-case": {
@@ -11808,8 +11684,7 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity":
-				"sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
 			"dev": true
 		},
 		"util": {
@@ -11851,8 +11726,7 @@
 			"version": "2.0.2",
 			"resolved":
 				"https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity":
-				"sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
+			"integrity": "sha1-pCiyi7JnkHNMT8i8n6EG/M6/amw=",
 			"dev": true
 		},
 		"valid-url": {
@@ -11881,8 +11755,7 @@
 			"version": "1.1.0",
 			"resolved":
 				"https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-			"integrity":
-				"sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+			"integrity": "sha1-ejQ/UFN2B69qMFkxK5eCoXCJRUA=",
 			"requires": {
 				"safe-buffer": "^5.1.1"
 			}
@@ -11905,8 +11778,7 @@
 		"vizion": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/vizion/-/vizion-2.0.2.tgz",
-			"integrity":
-				"sha512-UGDB/UdC1iyPkwyQaI9AFMwKcluQyD4FleEXObrlu254MEf16MV8l+AZdpFErY/iVKZVWlQ+OgJlVVJIdeMUYg==",
+			"integrity": "sha1-/MJj9BpFQ7ArZVwbbE/xQGcm0vo=",
 			"dev": true,
 			"requires": {
 				"async": "2.6.1",
@@ -11922,8 +11794,7 @@
 				"async": {
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-					"integrity":
-						"sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
 					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
@@ -12109,8 +11980,7 @@
 		"yamljs": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-			"integrity":
-				"sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+			"integrity": "sha1-3AYL8mdEezn3ME6bK/votafdsDs=",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"strftime": "=0.10.0",
 		"swagger-node-runner": "=0.7.3",
 		"sway": "=2.0.5",
+		"tempy": "=0.2.1",
 		"valid-url": "=1.0.9",
 		"wamp-socket-cluster": "=2.0.0-beta.4",
 		"z-schema": "=3.18.2"

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -206,10 +206,6 @@ history.version('1.0.0-rc.2', version => {
 		}
 	);
 });
-history.version('1.0.0-rc.3');
-history.version('1.0.0-rc.4');
-history.version('1.0.0-rc.5');
-history.version('1.0.0');
 history.version('1.1.0-rc.0', version => {
 	version.change('removed version and minVersion', config => {
 		delete config.version;
@@ -221,9 +217,6 @@ history.version('1.1.0-rc.0', version => {
 		return config;
 	});
 });
-history.version('1.1.0');
-history.version('1.1.1-rc.x');
-history.version('1.1.1');
 history.version('1.2.0-rc.x', version => {
 	version.change('remove malformed peer list items', config => {
 		config.peers.list = config.peers.list.filter(
@@ -232,9 +225,6 @@ history.version('1.2.0-rc.x', version => {
 		return config;
 	});
 });
-history.version('1.2.0');
-history.version('1.2.1');
-history.version('1.2.1-rc.x');
 
 const askPassword = (message, cb) => {
 	if (program.password && program.password.trim().length !== 0) {

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -292,7 +292,7 @@ history.migrate(
 		});
 
 		if (program.output) {
-			console.info(`\nWriting updated configuration to ${program.output}`);
+			console.info(`\nWriting configuration to ${program.output}`);
 			fs.writeFileSync(
 				program.output,
 				JSON.stringify(customConfig, null, '\t')

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -25,8 +25,11 @@ const readline = require('readline');
 const _ = require('lodash');
 const program = require('commander');
 const lisk = require('lisk-elements').default;
+const tempy = require('tempy');
 const { observableDiff, applyChange } = require('deep-diff');
 const JSONHistory = require('../helpers/json_history');
+const AppConfig = require('../helpers/config');
+const packageJSON = require('../package.json');
 
 const rootPath = path.resolve(path.dirname(__filename), '../');
 const loadJSONFile = filePath => JSON.parse(fs.readFileSync(filePath), 'utf8');
@@ -63,15 +66,19 @@ if (typeof fromVersion === 'undefined') {
 	process.exit(1);
 }
 
+const network = program.network || process.env.LISK_NETWORK;
+
+if (typeof network === 'undefined') {
+	console.error('No network is provided');
+	process.exit(1);
+}
+
 const defaultConfig = loadJSONFile(
 	path.resolve(rootPath, 'config/default/config.json')
 );
 
 const networkConfig = loadJSONFileIfExists(
-	path.resolve(
-		rootPath,
-		`config/${program.network || process.env.LISK_NETWORK}/config.json`
-	)
+	path.resolve(rootPath, `config/${network}/config.json`)
 );
 
 const unifiedNewConfig = _.merge({}, defaultConfig, networkConfig);
@@ -249,7 +256,7 @@ const askPassword = (message, cb) => {
 };
 
 if (!toVersion) {
-	toVersion = require('../package.json').version;
+	toVersion = packageJSON.version;
 }
 
 history.migrate(
@@ -291,8 +298,21 @@ history.migrate(
 			applyChange(customConfig, json, d);
 		});
 
+		const tempFilePath = tempy.file();
+
+		console.info('\nWriting configuration file temporarily for validation.');
+		console.info(tempFilePath);
+		fs.writeFileSync(tempFilePath, JSON.stringify(customConfig, null, '\t'));
+
+		console.info('\nValidating the configuration file');
+		// Set the env variables to validate against correct network and config file
+		process.env.LISK_NETWORK = network;
+		process.env.LISK_CONFIG_FILE = tempFilePath;
+		AppConfig(packageJSON, false);
+		console.info('Validation finished successfully.');
+
 		if (program.output) {
-			console.info(`\nWriting configuration to ${program.output}`);
+			console.info(`\nWriting configuration file to ${program.output}`);
 			fs.writeFileSync(
 				program.output,
 				JSON.stringify(customConfig, null, '\t')

--- a/test/unit/helpers/json_history.js
+++ b/test/unit/helpers/json_history.js
@@ -167,6 +167,21 @@ describe('helpers/JSONHistory', () => {
 					'Invalid start version specified to migrate.'
 				);
 			});
+			it('should return same config if called with valid non-existing start version', done => {
+				history.migrate({ config: 1 }, '5.0.0', (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ config: 1 });
+					done();
+				});
+			});
+			it('should print the message if called with valid non-existing start version', done => {
+				history.migrate({ config: 1 }, '5.0.0', () => {
+					expect(loggerStub.info).to.be.calledWithExactly(
+						'No migration found applicable from version "5.0.0"'
+					);
+					done();
+				});
+			});
 			it('should throw error if called without invalid end version', () => {
 				return expect(() =>
 					history.migrate({}, '1.0.0', 'nazar', () => {})
@@ -219,6 +234,18 @@ describe('helpers/JSONHistory', () => {
 					done();
 				});
 			});
+			it('should migrate through excluding start if only start version specified', done => {
+				history.migrate({}, '1.0.0', (error, data) => {
+					expect(error).to.be.null;
+					expect(data).to.be.eql({ v3: '3', v4: '4' });
+					validMigrationExpectations(
+						history,
+						['1.0.0', '3.0.0', '4.0.0'],
+						['2.0.0']
+					);
+					done();
+				});
+			});
 			it('should migrate till end of versions if not specified end version', done => {
 				history.migrate({}, '1.0.0', (error, data) => {
 					expect(error).to.be.null;
@@ -238,11 +265,6 @@ describe('helpers/JSONHistory', () => {
 					validMigrationExpectations(history, ['2.0.0', '3.0.0', '4.0.0'], []);
 					done();
 				});
-			});
-			it('should throw error if start version is registered in history', () => {
-				return expect(() => history.migrate({}, '0.0.0', () => {})).to.throw(
-					'Can\'t find supported version to start migration from  version "0.0.0"'
-				);
 			});
 			it('should migrate changes till end version if provided', done => {
 				history.migrate({}, '1.0.0', '3.0.0', (error, data) => {


### PR DESCRIPTION
### What was the problem?

It was required to register every version with in the migration script before releasing. 

### How did I fix it?

Removed the dependency of version registration.  
- If no version specified now, it will migrate from beginning till end. 
- If start version provided and not available it will return same configuration 

### How to test it?
```
echo "{}" > config.json
node scripts/update_config.js ./config.json -n testnet -o config.json 1.2.1 1.3.0-alpha.3
```

### Review checklist

* The PR resolves #2542
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
