### PR TITLE
Refactor eslint-disable comments - Closes #2447

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -150,7 +150,7 @@ class Transaction {
 	 * @returns {!Array} Contents as an ArrayBuffer
 	 * @todo Add description for the params
 	 */
-	/* eslint-disable class-methods-use-this */
+
 	getBytes(transaction, skipSignature, skipSecondSignature) {
 		if (!__private.types[transaction.type]) {
 			throw `Unknown transaction type ${transaction.type}`;
@@ -257,6 +257,7 @@ class Transaction {
 
 		return __private.types[transaction.type].ready(transaction, sender);
 	}
+	/* eslint-enable class-methods-use-this */
 
 	/**
 	 * Counts transactions from `trs` table by id.
@@ -1199,6 +1200,7 @@ class Transaction {
 	 * @returns {null|transaction}
 	 * @todo Add description for the params
 	 */
+
 	/* eslint-disable class-methods-use-this */
 	dbRead(raw) {
 		if (!raw.t_id) {
@@ -1237,6 +1239,7 @@ class Transaction {
 
 		return transaction;
 	}
+	/* eslint-enable class-methods-use-this */
 }
 
 // TODO: The below functions should be converted into static functions,

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -64,6 +64,7 @@ class Vote {
 	 * @returns {SetImmediate} error
 	 * @todo Add description for the params
 	 */
+
 	/* eslint-disable class-methods-use-this */
 	undoConfirmed(transaction, block, sender, cb, tx) {
 		if (transaction.asset.votes === null) {
@@ -82,6 +83,7 @@ class Vote {
 			tx
 		);
 	}
+	/* eslint-enable class-methods-use-this */
 
 	/**
 	 * Calls Diff.reverse to change asset.votes signs and merges account to
@@ -108,6 +110,7 @@ class Vote {
 			tx
 		);
 	}
+	/* eslint-enable class-methods-use-this */
 }
 
 // TODO: The below functions should be converted into static functions,

--- a/test/common/integration/sql/queriesHelper.js
+++ b/test/common/integration/sql/queriesHelper.js
@@ -11,7 +11,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-/* eslint-disable class-methods-use-this */
 
 'use strict';
 
@@ -35,6 +34,7 @@ class Queries {
 		self = this;
 	}
 
+	/* eslint-disable class-methods-use-this */
 	validateAccountsBalances() {
 		return self.db.query(self.validateAccountsBalancesQuery);
 	}
@@ -117,6 +117,7 @@ class Queries {
 			'SELECT "dependentId", ARRAY_AGG("accountId") FROM mem_accounts2delegates GROUP BY "dependentId"'
 		);
 	}
+	/* eslint-enable class-methods-use-this */
 }
 
 module.exports = Queries;

--- a/test/functional/functional.js
+++ b/test/functional/functional.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-top-level-hooks */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,7 @@
 
 'use strict';
 
+// eslint-disable-next-line mocha/no-top-level-hooks
 before(done => {
 	// Retry 20 times with 3 second gap
 	require('../common/utils/wait_for').blockchainReady(

--- a/test/functional/http/get/node/node.js
+++ b/test/functional/http/get/node/node.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -112,8 +111,10 @@ describe('GET /node', () => {
 		describe('GET /forging', () => {
 			var forgingEndpoint = new swaggerEndpoint('GET /node/status/forging');
 
+			/* eslint-disable mocha/no-pending-tests */
 			// TODO: Find a library for supertest to make request from a proxy server
 			it('called from unauthorized IP should fail');
+			/* eslint-enable mocha/no-pending-tests */
 
 			it('using no params should return full list of internal forgers', () => {
 				return forgingEndpoint.makeRequest({}, 200).then(res => {

--- a/test/functional/http/get/node/transactions_unconfirmed.js
+++ b/test/functional/http/get/node/transactions_unconfirmed.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -1010,12 +1010,13 @@ describe('GET /api/transactions', () => {
 				});
 			});
 		});
-		/* eslint-disable mocha/no-skipped-tests */
+
 		/**
 		 * This tests will fail because type 6 and type 7 transactions got disabled in Lisk Core v1.0
 		 * You can make it pass locally, by changing the value for disableDappTransfer
 		 * in config/default/exceptions to a value bigger than 0
 		 * */
+		/* eslint-disable mocha/no-skipped-tests */
 		describe.skip('assets', () => {
 			before(() => {
 				return sendTransactionPromise(transaction4) // send type 0 transaction
@@ -1079,5 +1080,6 @@ describe('GET /api/transactions', () => {
 					});
 			});
 		});
+		/* eslint-enable mocha/no-skipped-tests */
 	});
 });

--- a/test/functional/http/post/6.dapps.in_transfer.js
+++ b/test/functional/http/post/6.dapps.in_transfer.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -94,6 +93,8 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 				return waitFor.confirmations(transactionsToWaitFor);
 			});
 	});
+
+	/* eslint-disable mocha/no-skipped-tests */
 
 	describe.skip('schema validations', () => {
 		common.invalidAssets('inTransfer', badTransactions);
@@ -389,6 +390,8 @@ describe('POST /api/transactions (type 6) inTransfer dapp', () => {
 	describe.skip('confirmation', () => {
 		phases.confirmation(goodTransactions, badTransactions);
 	});
+
+	/* eslint-enable mocha/no-skipped-tests */
 
 	describe('check frozen type', () => {
 		it('transaction should be rejected', () => {

--- a/test/functional/http/post/7.dapps.out_transfer.js
+++ b/test/functional/http/post/7.dapps.out_transfer.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -96,6 +95,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', () => {
 			});
 	});
 
+	/* eslint-disable mocha/no-skipped-tests */
 	describe.skip('schema validations', () => {
 		common.invalidAssets('outTransfer', badTransactions);
 
@@ -674,6 +674,7 @@ describe('POST /api/transactions (type 7) outTransfer dapp', () => {
 	describe.skip('confirmation', () => {
 		phases.confirmation(goodTransactions, badTransactions);
 	});
+	/* eslint-enable mocha/no-skipped-tests */
 
 	describe('check frozen type', () => {
 		it('transaction should be rejected', () => {

--- a/test/functional/http/put/node.js
+++ b/test/functional/http/put/node.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -53,8 +52,10 @@ describe('PUT /node/status/forging', () => {
 			});
 	});
 
+	/* eslint-disable mocha/no-pending-tests */
 	// TODO: Find a library for supertest to make request from a proxy server
 	it('called from unauthorized IP should fail');
+	/* eslint-enable mocha/no-pending-tests */
 
 	it('using no params should fail', () => {
 		return updateForgingEndpoint.makeRequest({ data: {} }, 400).then(res => {

--- a/test/functional/ws/transport/transport.js
+++ b/test/functional/ws/transport/transport.js
@@ -184,6 +184,7 @@ describe('RPC', () => {
 
 		it('asking for a list multiple times should be ok', done => {
 			var successfulAsks = 0;
+
 			/* eslint-disable no-loop-func */
 			for (var i = 0; i < 100; i += 1) {
 				connectedPeer.rpc.list((err, result) => {
@@ -197,6 +198,7 @@ describe('RPC', () => {
 					}
 				});
 			}
+			/* eslint-enable no-loop-func */
 		});
 	});
 

--- a/test/integration/blocks/chain/apply_block.js
+++ b/test/integration/blocks/chain/apply_block.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/integration/blocks/chain/delete_last_block_accounts.js
+++ b/test/integration/blocks/chain/delete_last_block_accounts.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -750,6 +749,7 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 					});
 				});
 
+				/* eslint-disable mocha/no-skipped-tests */
 				describe.skip('(type 6) inTransfer dapp', () => {
 					it('should validate account data from sender after account creation', done => {
 						library.logic.account.get(
@@ -916,6 +916,7 @@ describe('system test (blocks) - chain/deleteLastBlock', () => {
 						);
 					});
 				});
+				/* eslint-enable mocha/no-skipped-tests */
 			});
 		});
 

--- a/test/integration/blocks/chain/delete_last_block_db_trs.js
+++ b/test/integration/blocks/chain/delete_last_block_db_trs.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/integration/blocks/process/process.js
+++ b/test/integration/blocks/process/process.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/integration/blocks/verify/verify.js
+++ b/test/integration/blocks/verify/verify.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests, mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -384,6 +383,7 @@ describe('blocks/verify', () => {
 			});
 		});
 
+		/* eslint-disable mocha/no-skipped-tests */
 		describe.skip('verifyId', () => {
 			it('should reset block id when block id is an invalid alpha-numeric string value', () => {
 				var blockId = '884740302254229983';
@@ -416,6 +416,7 @@ describe('blocks/verify', () => {
 				return expect(validBlock.id).to.not.equal(11850828211026019525);
 			});
 		});
+		/* eslint-enable mocha/no-skipped-tests */
 
 		describe('verifyPayload', () => {
 			it('should fail when payload length greater than MAX_PAYLOAD_LENGTH constant value', done => {

--- a/test/integration/transactions/0.0.transfer.js
+++ b/test/integration/transactions/0.0.transfer.js
@@ -29,6 +29,7 @@ describe('system test (type 0) - double transfers', () => {
 
 	var i = 0;
 	var t = 0;
+
 	/* eslint-disable no-loop-func */
 	while (i < 1) {
 		describe('executing 30 times', () => {
@@ -119,4 +120,5 @@ describe('system test (type 0) - double transfers', () => {
 		});
 		i++;
 	}
+	/* eslint-enable no-loop-func */
 });

--- a/test/integration/transactions/1.second_signature/1.1.second_signature_from_pool_peer.js
+++ b/test/integration/transactions/1.second_signature/1.1.second_signature_from_pool_peer.js
@@ -14,7 +14,6 @@
 
 'use strict';
 
-/* eslint-disable mocha/no-skipped-tests */
 const lisk = require('lisk-elements').default;
 const expect = require('chai').expect;
 const accountFixtures = require('../../../fixtures/accounts');
@@ -184,6 +183,7 @@ describe('system test (type 1) - second signature transactions from pool and pee
 					});
 				});
 
+				/* eslint-disable mocha/no-skipped-tests */
 				// TODO: This tests will be unskipped as part of #1652
 				describe.skip('when receiving block with multiple signature transaction with different id for same account', () => {
 					let signatureTransaction2;
@@ -255,6 +255,7 @@ describe('system test (type 1) - second signature transactions from pool and pee
 						});
 					});
 				});
+				/* eslint-enable mocha/no-skipped-tests */
 			});
 		});
 	});

--- a/test/integration/transactions/2.delegates/1.same.account.same.username.js
+++ b/test/integration/transactions/2.delegates/1.same.account.same.username.js
@@ -29,6 +29,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 
 	var i = 0;
 	var t = 0;
+
 	/* eslint-disable no-loop-func */
 	while (i < 30) {
 		describe('executing 30 times', () => {
@@ -132,4 +133,5 @@ describe('system test (type 2) - double delegate registrations', () => {
 		});
 		i++;
 	}
+	/* eslint-enable no-loop-func */
 });

--- a/test/integration/transactions/2.delegates/2.same.account.different.usernames.js
+++ b/test/integration/transactions/2.delegates/2.same.account.different.usernames.js
@@ -29,6 +29,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 
 	var i = 0;
 	var t = 0;
+
 	/* eslint-disable no-loop-func */
 	while (i < 30) {
 		describe('executing 30 times', () => {
@@ -132,4 +133,5 @@ describe('system test (type 2) - double delegate registrations', () => {
 		});
 		i++;
 	}
+	/* eslint-enable no-loop-func */
 });

--- a/test/integration/transactions/2.delegates/3.different.accounts.same.username.js
+++ b/test/integration/transactions/2.delegates/3.different.accounts.same.username.js
@@ -29,6 +29,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 
 	var i = 0;
 	var t = 0;
+
 	/* eslint-disable no-loop-func */
 	while (i < 30) {
 		describe('executing 30 times', () => {
@@ -151,4 +152,5 @@ describe('system test (type 2) - double delegate registrations', () => {
 		});
 		i++;
 	}
+	/* eslint-enable no-loop-func */
 });

--- a/test/integration/transactions/2.delegates/4.different.accounts.different.usernames.js
+++ b/test/integration/transactions/2.delegates/4.different.accounts.different.usernames.js
@@ -30,6 +30,7 @@ describe('system test (type 2) - double delegate registrations', () => {
 
 	var i = 0;
 	var t = 0;
+
 	/* eslint-disable no-loop-func */
 	while (i < 30) {
 		describe('executing 30 times', () => {
@@ -155,4 +156,5 @@ describe('system test (type 2) - double delegate registrations', () => {
 		});
 		i++;
 	}
+	/* eslint-enable no-loop-func */
 });

--- a/test/integration/transactions/3.3.votes.js
+++ b/test/integration/transactions/3.3.votes.js
@@ -29,6 +29,7 @@ describe('system test (type 3) - voting with duplicate submissions', () => {
 
 	var i = 0;
 	var t = 0;
+
 	/* eslint-disable no-loop-func */
 	while (i < 30) {
 		describe('executing 30 times', () => {
@@ -210,4 +211,5 @@ describe('system test (type 3) - voting with duplicate submissions', () => {
 		});
 		i++;
 	}
+	/* eslint-enable no-loop-func */
 });

--- a/test/unit/api/fittings/lisk_cache.js
+++ b/test/unit/api/fittings/lisk_cache.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -14,6 +13,8 @@
  */
 
 'use strict';
+
+/* eslint-disable mocha/no-pending-tests */
 
 describe('lisk_compression', () => {
 	it('should be a factory function that names 2 arguments');
@@ -32,3 +33,5 @@ describe('lisk_compression', () => {
 		'should not cache responses for endpoints for which "swagger_cache_key" is set false or not provided'
 	);
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/api/fittings/lisk_compression.js
+++ b/test/unit/api/fittings/lisk_compression.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,8 @@
 
 'use strict';
 
+/* eslint-disable mocha/no-pending-tests */
+
 describe('lisk_compression', () => {
 	it('should be a factory function that names 2 arguments');
 
@@ -24,3 +25,5 @@ describe('lisk_compression', () => {
 
 	it('should compress the response as per specified level');
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/api/fittings/lisk_error_handler.js
+++ b/test/unit/api/fittings/lisk_error_handler.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,8 @@
 
 'use strict';
 
+/* eslint-disable mocha/no-pending-tests */
+
 describe('lisk_error_handler', () => {
 	it('should be a factory function that names 2 arguments');
 
@@ -28,3 +29,5 @@ describe('lisk_error_handler', () => {
 
 	it('should handle 500 errors and override response');
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/api/fittings/lisk_params_validator.js
+++ b/test/unit/api/fittings/lisk_params_validator.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -14,6 +13,8 @@
  */
 
 'use strict';
+
+/* eslint-disable mocha/no-pending-tests */
 
 describe('lisk_params_validator', () => {
 	it('should be a factory function that names 2 arguments');
@@ -32,3 +33,5 @@ describe('lisk_params_validator', () => {
 		'should response for each param error with "code", "message", "in", "name", "errors"'
 	);
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/api/fittings/lisk_response_formatter.js
+++ b/test/unit/api/fittings/lisk_response_formatter.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,8 @@
 
 'use strict';
 
+/* eslint-disable mocha/no-pending-tests */
+
 describe('lisk_response_formatter', () => {
 	it('should be a factory function that names 2 argument');
 
@@ -30,3 +31,5 @@ describe('lisk_response_formatter', () => {
 		'should check for "data", "meta" and "links" attributes if input provided is an object'
 	);
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/db/repos/migrations.js
+++ b/test/unit/db/repos/migrations.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/helpers/http_api.js
+++ b/test/unit/helpers/http_api.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests, mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/logic/multisignature.js
+++ b/test/unit/logic/multisignature.js
@@ -642,7 +642,6 @@ describe('multisignature', () => {
 	});
 
 	describe('undoConfirmed', () => {
-		/* eslint-disable mocha/no-sibling-hooks */
 		beforeEach(done => {
 			transaction = _.cloneDeep(validTransaction);
 			accountMock.merge = sinonSandbox.stub().callsArg(2);
@@ -650,7 +649,6 @@ describe('multisignature', () => {
 		});
 		/* eslint-enable */
 
-		/* eslint-disable mocha/no-nested-tests */
 		it('should set __private.unconfirmedSignatures[sender.address] = true', () => {
 			var unconfirmedSignatures = Multisignature.__get__(
 				'__private.unconfirmedSignatures'

--- a/test/unit/logic/peers.js
+++ b/test/unit/logic/peers.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -322,6 +321,7 @@ describe('peers', () => {
 			return expect(peers.exists(validPeer)).to.be.ok;
 		});
 
+		/* eslint-disable mocha/no-skipped-tests */
 		it.skip('should return true if peer with same nonce is on the list', () => {
 			var list = peers.list(true);
 			expect(list.length).equal(1);
@@ -333,6 +333,7 @@ describe('peers', () => {
 				})
 			).to.be.ok;
 		});
+		/* eslint-enable mocha/no-skipped-tests */
 
 		it('should return true if peer with same address is on the list', () => {
 			peers.upsert(validPeer);

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -103,6 +102,7 @@ describe('rounds', () => {
 				done();
 			});
 
+			/* eslint-disable mocha/no-skipped-tests */
 			describe.skip('library', () => {
 				it('should throw', done => {
 					var property = 'library';
@@ -147,6 +147,7 @@ describe('rounds', () => {
 					done();
 				});
 			});
+			/* eslint-enable mocha/no-skipped-tests */
 
 			describe('round', () => {
 				it('should throw', done => {
@@ -711,6 +712,7 @@ describe('rounds', () => {
 			return results;
 		}
 
+		/* eslint-disable mocha/no-skipped-tests */
 		describe.skip('with no delegates', () => {
 			describe('forward', () => {
 				before(done => {
@@ -752,6 +754,7 @@ describe('rounds', () => {
 				});
 			});
 		});
+		/* eslint-disable mocha/no-skipped-tests */
 
 		describe('with only one delegate', () => {
 			describe('when there are no remaining fees', () => {

--- a/test/unit/logic/round.js
+++ b/test/unit/logic/round.js
@@ -754,7 +754,7 @@ describe('rounds', () => {
 				});
 			});
 		});
-		/* eslint-disable mocha/no-skipped-tests */
+		/* eslint-enable mocha/no-skipped-tests */
 
 		describe('with only one delegate', () => {
 			describe('when there are no remaining fees', () => {

--- a/test/unit/logic/vote.js
+++ b/test/unit/logic/vote.js
@@ -216,7 +216,7 @@ describe('vote', () => {
 			}
 		);
 	});
-	/* eslint-enable */
+	/* eslint-enable mocha/no-sibling-hooks */
 
 	describe('bind', () => {
 		it('should be okay with correct params', () => {

--- a/test/unit/modules/accounts.js
+++ b/test/unit/modules/accounts.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -88,6 +87,7 @@ describe('accounts', () => {
 			).to.equal(validAccount.address);
 		});
 
+		/* eslint-disable mocha/no-skipped-tests */
 		// TODO: Design a throwable test
 		it.skip('should throw error for invalid publicKey', () => {
 			var invalidPublicKey = 'invalidPublicKey';
@@ -96,6 +96,7 @@ describe('accounts', () => {
 				accounts.generateAddressByPublicKey(invalidPublicKey);
 			}).to.throw('Invalid public key: ', invalidPublicKey);
 		});
+		/* eslint-enable mocha/no-skipped-tests */
 	});
 
 	describe('getAccount', () => {

--- a/test/unit/modules/app.js
+++ b/test/unit/modules/app.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -31,5 +30,7 @@ describe('app', () => {
 		setTimeout(done, 5000);
 	});
 
+	/* eslint-disable mocha/no-pending-tests */
 	it('should be ok');
+	/* eslint-enable mocha/no-pending-tests */
 });

--- a/test/unit/modules/blocks.js
+++ b/test/unit/modules/blocks.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/modules/blocks/chain.js
+++ b/test/unit/modules/blocks/chain.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests, mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/modules/blocks/utils.js
+++ b/test/unit/modules/blocks/utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/modules/dapps.js
+++ b/test/unit/modules/dapps.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -14,6 +13,8 @@
  */
 
 'use strict';
+
+/* eslint-disable mocha/no-pending-tests */
 
 describe('dapps', () => {
 	describe('__private', () => {
@@ -197,3 +198,5 @@ describe('dapps', () => {
 		});
 	});
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/modules/loader.skeleton.js
+++ b/test/unit/modules/loader.skeleton.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,7 @@
 
 'use strict';
 
+/* eslint-disable mocha/no-pending-tests */
 describe('loader', () => {
 	describe('constructor', () => {
 		describe('library', () => {
@@ -268,3 +268,5 @@ describe('loader', () => {
 		it('should call callback with result = undefined');
 	});
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -44,6 +43,7 @@ describe('node', () => {
 	});
 
 	describe('constructor', () => {
+		/* eslint-disable mocha/no-pending-tests */
 		describe('library', () => {
 			it('should assign build');
 
@@ -63,6 +63,7 @@ describe('node', () => {
 		it('should call callback with error = null');
 
 		it('should call callback with result as a Node instance');
+		/* eslint-enable mocha/no-pending-tests */
 	});
 
 	describe('internal', () => {
@@ -272,6 +273,7 @@ describe('node', () => {
 		});
 
 		describe('getConstants', () => {
+			/* eslint-disable mocha/no-pending-tests */
 			describe('when loaded = false', () => {
 				it('should call callback with error = "Blockchain is loading"');
 			});
@@ -315,6 +317,7 @@ describe('node', () => {
 					'should call callback with result containing version = library.config.version'
 				);
 			});
+			/* eslint-enable mocha/no-pending-tests */
 		});
 
 		describe('getStatus', () => {
@@ -452,6 +455,7 @@ describe('node', () => {
 	});
 
 	describe('onBind', () => {
+		/* eslint-disable mocha/no-pending-tests */
 		describe('modules', () => {
 			it('should assign blocks');
 
@@ -463,5 +467,6 @@ describe('node', () => {
 		});
 
 		it('should assign loaded = true');
+		/* eslint-enable mocha/no-pending-tests */
 	});
 });

--- a/test/unit/modules/signatures.js
+++ b/test/unit/modules/signatures.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,7 @@
 
 'use strict';
 
+/* eslint-disable mocha/no-pending-tests */
 describe('signatures', () => {
 	describe('isLoaded', () => {
 		it('should return true if modules exists');
@@ -78,3 +78,5 @@ describe('signatures', () => {
 		});
 	});
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/modules/system.js
+++ b/test/unit/modules/system.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -104,6 +103,7 @@ describe('system', () => {
 		});
 	});
 
+	/* eslint-disable mocha/no-pending-tests */
 	describe('static', () => {
 		describe('setHeaders', () => {
 			it('should assign the argument to __private');
@@ -187,6 +187,7 @@ describe('system', () => {
 
 		it('should return false if argument is not equal to __private.nethash');
 	});
+	/* eslint-enable mocha/no-pending-tests */
 
 	describe('versionCompatible', () => {
 		describe('when version is equal to system version', () => {
@@ -208,6 +209,7 @@ describe('system', () => {
 		});
 	});
 
+	/* eslint-disable mocha/no-pending-tests */
 	describe('nonceCompatible', () => {
 		it('should return if nonce exists and is different than the system nonce');
 
@@ -247,4 +249,5 @@ describe('system', () => {
 			it('should assign transport');
 		});
 	});
+	/* eslint-enable mocha/no-pending-tests */
 });

--- a/test/unit/modules/transactions.js
+++ b/test/unit/modules/transactions.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests, mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -860,6 +859,7 @@ describe('transactions', () => {
 				});
 			});
 
+			/* eslint-disable mocha/no-skipped-tests */
 			it.skip('should get transaction with intransfer asset for transaction id', done => {
 				var transactionId =
 					transactionsByType[transactionTypes.IN_TRANSFER].transactionId;
@@ -885,8 +885,11 @@ describe('transactions', () => {
 					done();
 				});
 			});
+			/* eslint-enable mocha/no-skipped-tests */
 
+			/* eslint-disable mocha/no-pending-tests */
 			it('should get transaction with outtransfer asset for transaction id');
+			/* eslint-enable mocha/no-pending-tests */
 		});
 
 		describe('getTransactionsCount', () => {

--- a/test/unit/modules/transport.js
+++ b/test/unit/modules/transport.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests, mocha/no-skipped-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *

--- a/test/unit/modules/voters.js
+++ b/test/unit/modules/voters.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-pending-tests */
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -15,6 +14,7 @@
 
 'use strict';
 
+/* eslint-disable mocha/no-pending-tests */
 describe('voters', () => {
 	describe('constructor', () => {
 		describe('library', () => {
@@ -222,3 +222,5 @@ describe('voters', () => {
 		it('should assign loaded = true');
 	});
 });
+
+/* eslint-enable mocha/no-pending-tests */

--- a/test/unit/modules/voters.js
+++ b/test/unit/modules/voters.js
@@ -222,5 +222,4 @@ describe('voters', () => {
 		it('should assign loaded = true');
 	});
 });
-
 /* eslint-enable mocha/no-pending-tests */


### PR DESCRIPTION
### What was the problem?
We were using `eslint-disable` comments at the top of some files and were not enabling again which can increase the chance of having inconsistent code style.
### How did I fix it?
I wrapped the code blocks with eslint-disable comments and enabled the rules at the end of the code block.
### How to test it?

### Review checklist

* The PR resolves #2447 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
