### PR TITLE
Received post block broadcast request in unexpected format - Closes #2453

### DIFF
--- a/api/ws/workers/peers_update_rules.js
+++ b/api/ws/workers/peers_update_rules.js
@@ -67,7 +67,6 @@ PeersUpdateRules.prototype.insert = function(peer, connectionId, cb) {
 			peer,
 			err => {
 				if (err) {
-					connectionsTable.remove(peer.nonce);
 					if (!err.code) {
 						err = new PeerUpdateError(
 							failureCodes.ON_MASTER.UPDATE.TRANSPORT,
@@ -104,7 +103,6 @@ PeersUpdateRules.prototype.remove = function(peer, connectionId, cb) {
 			peer,
 			err => {
 				if (err && !err.code) {
-					connectionsTable.add(peer.nonce, connectionId);
 					err = new PeerUpdateError(
 						failureCodes.ON_MASTER.UPDATE.TRANSPORT,
 						failureCodes.errorMessages[failureCodes.ON_MASTER.UPDATE.TRANSPORT],

--- a/test/unit/api/ws/workers/peers_update_rules.js
+++ b/test/unit/api/ws/workers/peers_update_rules.js
@@ -165,26 +165,34 @@ describe('PeersUpdateRules', () => {
 			});
 		});
 
-		it('should remove added entries from connectionsTable after receiving an error without code from server', done => {
+		it('should NOT remove added entries from connectionsTable after receiving an error without code from server', done => {
 			peersUpdateRules.slaveToMasterSender.send.restore();
 			peersUpdateRules.slaveToMasterSender.send = sinonSandbox
 				.stub(peersUpdateRules.slaveToMasterSender, 'send')
 				.callsArgWith(3, 'On insert error');
 			peersUpdateRules.insert(validPeer, validConnectionId, () => {
-				expect(connectionsTable.nonceToConnectionIdMap).to.be.empty;
-				expect(connectionsTable.connectionIdToNonceMap).to.be.empty;
+				expect(connectionsTable.nonceToConnectionIdMap)
+					.to.have.property(validPeer.nonce)
+					.equal(validConnectionId);
+				expect(connectionsTable.connectionIdToNonceMap)
+					.to.have.property(validConnectionId)
+					.equal(validPeer.nonce);
 				done();
 			});
 		});
 
-		it('should remove added entries from connectionsTable after receiving an error with code from server', done => {
+		it('should NOT remove added entries from connectionsTable after receiving an error with code from server', done => {
 			peersUpdateRules.slaveToMasterSender.send.restore();
 			peersUpdateRules.slaveToMasterSender.send = sinonSandbox
 				.stub(peersUpdateRules.slaveToMasterSender, 'send')
 				.callsArgWith(3, { code: validErrorCode });
 			peersUpdateRules.insert(validPeer, validConnectionId, () => {
-				expect(connectionsTable.nonceToConnectionIdMap).to.be.empty;
-				expect(connectionsTable.connectionIdToNonceMap).to.be.empty;
+				expect(connectionsTable.nonceToConnectionIdMap)
+					.to.have.property(validPeer.nonce)
+					.equal(validConnectionId);
+				expect(connectionsTable.connectionIdToNonceMap)
+					.to.have.property(validConnectionId)
+					.equal(validPeer.nonce);
 				done();
 			});
 		});
@@ -351,7 +359,7 @@ describe('PeersUpdateRules', () => {
 				});
 			});
 
-			it('should revert removed connections tables entries when invoked with valid arguments but received error without code from server', done => {
+			it('should NOT revert removed connections tables entries when invoked with valid arguments but received error without code from server', done => {
 				peersUpdateRules.slaveToMasterSender.send.restore();
 				peersUpdateRules.slaveToMasterSender.send = sinonSandbox
 					.stub(peersUpdateRules.slaveToMasterSender, 'send')
@@ -360,12 +368,8 @@ describe('PeersUpdateRules', () => {
 					expect(err)
 						.to.have.property('code')
 						.equal(failureCodes.ON_MASTER.UPDATE.TRANSPORT);
-					expect(connectionsTable.nonceToConnectionIdMap)
-						.to.have.property(validPeer.nonce)
-						.equal(validConnectionId);
-					expect(connectionsTable.connectionIdToNonceMap)
-						.to.have.property(validConnectionId)
-						.equal(validPeer.nonce);
+					expect(connectionsTable.nonceToConnectionIdMap).to.be.empty;
+					expect(connectionsTable.connectionIdToNonceMap).to.be.empty;
 					done();
 				});
 			});


### PR DESCRIPTION
### What was the problem?
Node was receiving `postBlock` call from a peer not listed in the `connectionsTable`.

### How did I fix it?
As the issue is not reproducible I've improved the code by not undoing the `connectionsTable` operation in case `slaveToMasterSender.send` fails.
The reason is because when PeersUpdateRules.prototype.{insert|remove} is invoked it means the socket has already connected/disconnected hence the `connectionsTable` should not be reverted even when `slaveToMasterSender.send` fails.

### How to test it?
Run network tests

### Review checklist

* The PR resolves #2453 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
