### PR TITLE
Unify indexOf & includes usage in exception handling - Closes #2436

### DIFF
--- a/logic/multisignature.js
+++ b/logic/multisignature.js
@@ -136,7 +136,7 @@ Multisignature.prototype.verify = function(transaction, sender, cb) {
 		const err =
 			'Invalid multisignature min. Must be less than or equal to keysgroup size';
 
-		if (exceptions.multisignatures.indexOf(transaction.id) > -1) {
+		if (exceptions.multisignatures.includes(transaction.id)) {
 			library.logger.debug(err);
 			library.logger.debug(JSON.stringify(transaction));
 		} else {

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -473,7 +473,7 @@ class Transaction {
 				sender.publicKey,
 			].join(' ');
 
-			if (exceptions.senderPublicKey.indexOf(transaction.id) > -1) {
+			if (exceptions.senderPublicKey.includes(transaction.id)) {
 				this.scope.logger.error(err);
 				this.scope.logger.debug(JSON.stringify(transaction));
 			} else {
@@ -541,7 +541,7 @@ class Transaction {
 		if (!valid) {
 			err = 'Failed to verify signature';
 
-			if (exceptions.signatures.indexOf(transaction.id) > -1) {
+			if (exceptions.signatures.includes(transaction.id)) {
 				this.scope.logger.error(err);
 				this.scope.logger.debug(JSON.stringify(transaction));
 				valid = true;

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -274,7 +274,7 @@ Vote.prototype.checkConfirmedDelegates = function(transaction, cb, tx) {
 		transaction.senderPublicKey,
 		transaction.asset.votes,
 		err => {
-			if (err && exceptions.votes.indexOf(transaction.id) > -1) {
+			if (err && exceptions.votes.includes(transaction.id)) {
 				library.logger.debug(err);
 				library.logger.debug(JSON.stringify(transaction));
 				err = null;
@@ -299,7 +299,7 @@ Vote.prototype.checkUnconfirmedDelegates = function(transaction, cb, tx) {
 		transaction.senderPublicKey,
 		transaction.asset.votes,
 		err => {
-			if (err && exceptions.votes.indexOf(transaction.id) > -1) {
+			if (err && exceptions.votes.includes(transaction.id)) {
 				library.logger.debug(err);
 				library.logger.debug(JSON.stringify(transaction));
 				err = null;

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -252,7 +252,7 @@ __private.verifyReward = function(block, result) {
 	if (
 		block.height !== 1 &&
 		!expectedReward.isEqualTo(block.reward) &&
-		exceptions.blockRewards.indexOf(block.id) === -1
+		!exceptions.blockRewards.includes(block.id)
 	) {
 		result.errors.push(
 			['Invalid block reward:', block.reward, 'expected:', expectedReward].join(


### PR DESCRIPTION
### What was the problem?
Exception handling has been spread throughout the application and not handled from a central place. Also includes and indexOf changes were being used inconsistently.
### How did I fix it?
After discussing with @nazarhussain, I decided that we can't combine all exception handling into a central logic due to complexity of the current architecture. I only replaced inconsistent indexOf usages and used `includes` in all checks.
### How to test it?

### Review checklist

* The PR resolves #2436 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
