### PR TITLE
Fix get last commit helper when git is not installed - Close #2588

### DIFF
--- a/helpers/git.js
+++ b/helpers/git.js
@@ -37,7 +37,7 @@ function getLastCommit() {
 	try {
 		spawn = childProcess.spawnSync('git', ['rev-parse', 'HEAD']);
 		// If there is git tool available and current directory is a git owned directory
-		if (!spawn.stderr) {
+		if (!spawn.stderr.toString().trim()) {
 			return spawn.stdout.toString().trim();
 		}
 	} catch (error) {

--- a/helpers/git.js
+++ b/helpers/git.js
@@ -14,8 +14,8 @@
 
 'use strict';
 
-var childProcess = require('child_process');
-var fs = require('fs');
+const childProcess = require('child_process');
+const fs = require('fs');
 
 /**
  * Helper module for parsing git commit information.
@@ -32,12 +32,19 @@ var fs = require('fs');
  * @throws {Error} If cannot get last git commit
  */
 function getLastCommit() {
-	var spawn = childProcess.spawnSync('git', ['rev-parse', 'HEAD']);
-	var err = spawn.stderr.toString().trim();
+	let spawn;
 
-	// If there is git tool available and current directory is a git owned directory
-	if (!err) {
-		return spawn.stdout.toString().trim();
+	try {
+		spawn = childProcess.spawnSync('git', ['rev-parse', 'HEAD']);
+		// If there is git tool available and current directory is a git owned directory
+		if (!spawn.stderr) {
+			return spawn.stdout.toString().trim();
+		}
+	} catch (error) {
+		// It should read REVISION file if error is that Git is not installed
+		if (error.toString() !== 'Error: spawnSync git ENOEN') {
+			throw error;
+		}
 	}
 
 	// Try looking for a file REVISION for a compiled build

--- a/helpers/git.js
+++ b/helpers/git.js
@@ -42,9 +42,11 @@ function getLastCommit() {
 		}
 	} catch (error) {
 		// It should read REVISION file if error is that Git is not installed
-		if (error.toString() !== 'Error: spawnSync git ENOEN') {
-			throw error;
-		}
+		// eslint-disable-next-line no-console
+		console.log(
+			'When getting git rev-parse HEAD, following error happened',
+			error.toString()
+		);
 	}
 
 	// Try looking for a file REVISION for a compiled build

--- a/test/unit/helpers/git.js
+++ b/test/unit/helpers/git.js
@@ -70,11 +70,12 @@ describe('git', () => {
 				sinonSandbox
 					.stub(childProcess, 'spawnSync')
 					.returns({ stderr: validErrorMessage });
+				sinonSandbox.stub(fs, 'readFileSync').throws(Error);
 				done();
 			});
 
 			it('should throw an error', done => {
-				expect(git.getLastCommit).throws(Error, validErrorMessage);
+				expect(git.getLastCommit).throw(Error, validErrorMessage);
 				done();
 			});
 		});

--- a/test/unit/helpers/git.js
+++ b/test/unit/helpers/git.js
@@ -79,5 +79,36 @@ describe('git', () => {
 				done();
 			});
 		});
+
+		describe('when git is not installed', () => {
+			var gitNotInstalledErr = 'Error: spawnSync git ENOEN';
+			var validCommitHash = '99e5458d721f73623a6fc866f15cfe2e2b18edcd';
+
+			beforeEach(done => {
+				sinonSandbox.stub(childProcess, 'spawnSync').throws(gitNotInstalledErr);
+				sinonSandbox.stub(fs, 'readFileSync').returns(validCommitHash);
+				done();
+			});
+
+			it('should return a commit hash', done => {
+				expect(git.getLastCommit()).equal(validCommitHash);
+				expect(childProcess.spawnSync).to.be.calledOnce;
+				expect(fs.readFileSync).to.be.calledOnce;
+				expect(fs.readFileSync).to.be.calledWith('REVISION');
+				done();
+			});
+		});
+
+		describe('when another error different than git is not installed', () => {
+			beforeEach(done => {
+				sinonSandbox.stub(childProcess, 'spawnSync').throws(Error);
+				done();
+			});
+
+			it('should throw an error', done => {
+				expect(git.getLastCommit).throw(Error);
+				done();
+			});
+		});
 	});
 });

--- a/test/unit/helpers/git.js
+++ b/test/unit/helpers/git.js
@@ -100,13 +100,19 @@ describe('git', () => {
 		});
 
 		describe('when another error different than git is not installed', () => {
+			var validCommitHash = '99e5458d721f73623a6fc866f15cfe2e2b18edcd';
+
 			beforeEach(done => {
 				sinonSandbox.stub(childProcess, 'spawnSync').throws(Error);
+				sinonSandbox.stub(fs, 'readFileSync').returns(validCommitHash);
 				done();
 			});
 
-			it('should throw an error', done => {
-				expect(git.getLastCommit).throw(Error);
+			it('should return a commit hash', done => {
+				expect(git.getLastCommit()).equal(validCommitHash);
+				expect(childProcess.spawnSync).to.be.calledOnce;
+				expect(fs.readFileSync).to.be.calledOnce;
+				expect(fs.readFileSync).to.be.calledWith('REVISION');
 				done();
 			});
 		});


### PR DESCRIPTION
### How to test it?

```
mocha test/unit/helpers/git.js
mocha test/functional/http/get/node/node.js
```

### Review checklist

* The PR resolves #2588 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
