### PR TITLE
Maintain delegates list in memory - Closes #2421

### DIFF
--- a/config/testnet/exceptions.js
+++ b/config/testnet/exceptions.js
@@ -92,5 +92,5 @@ module.exports = {
 	 *
 	 * So we are using the exception key below to skip caching for the rounds provided in the array.
 	 * */
-	ignoreDelegateListCacheForRounds: [80, 82],
+	ignoreDelegateListCacheForRounds: [81, 83],
 };


### PR DESCRIPTION
### What was the problem?
Wrong rounds numbers for `ignoreDelegateListCacheForRounds` testnet exceptions.
### How did I fix it?
Use correct rounds numbers.
### How to test it?
Manually.
### Review checklist

* The PR resolves #2421
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
