### PR TITLE
Fix misuse of sort() method

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -112,7 +112,7 @@ __private.updateDelegateListCache = function(round, delegatesList) {
 	// We want to cache delegates for only last 2 rounds and get rid of old ones
 	__private.delegatesListCache = Object.keys(__private.delegatesListCache)
 		// sort round numbers in ascending order so we can have most recent 2 rounds at the end of the list.
-		.sort()
+		.sort((a, b) => a - b)
 		// delete all round cache except last two rounds.
 		.slice(-2)
 		.reduce((acc, current) => {

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -735,6 +735,33 @@ describe('delegates', () => {
 						delegateListArray
 					);
 				});
+
+				// See: https://github.com/LiskHQ/lisk/issues/2652
+				it('ensures ordering rounds correctly', () => {
+					// Arrange
+					const initialSate = {
+						9: ['j', 'k', 'l'],
+						10: ['x', 'y', 'z'],
+					};
+					__private.delegatesListCache = { ...initialSate };
+					const delegateListArray = ['a', 'b', 'c'];
+					const round = 11;
+
+					// Act
+					__private.updateDelegateListCache(round, delegateListArray);
+
+					// Assert
+					expect(Object.keys(__private.delegatesListCache)).to.deep.equal([
+						'10',
+						'11',
+					]);
+					expect(__private.delegatesListCache['10']).to.deep.equal(
+						initialSate['10']
+					);
+					return expect(__private.delegatesListCache[round]).to.deep.equal(
+						delegateListArray
+					);
+				});
 			});
 
 			describe('__private.clearDelegateListCache', () => {


### PR DESCRIPTION
### What was the problem?
`sort()` method causing the updateDelegateListCache function to not behaviour as expected due to the fact it orders as strings.

### How did I fix it?
I've added a `compare function` to make sure it orders as numbers.

### How to test it?
`npm run mocha -- test/unit/modules/delegates.js`

### Review checklist

* The PR resolves #INSERT_ISSUE_NUMBER
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
