### PR TITLE
Application no longer crashing on dns lookup failure - Closes #2608

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,7 +236,7 @@ d.run(() => {
 										peer.ip
 									} to an IP address`
 								);
-								return callback(err, peer);
+								return callback(null, peer);
 							}
 							return callback(null, Object.assign({}, peer, { ip: address }));
 						});
@@ -244,9 +244,7 @@ d.run(() => {
 				);
 
 				return async.parallel(peerDomainLookupTasks, (_, results) => {
-					appConfig.peers.list = results
-						.filter(result => result.hasOwnProperty('value'))
-						.map(result => result.value);
+					appConfig.peers.list = results.map(result => result.value);
 					return cb(null, appConfig);
 				});
 			},

--- a/app.js
+++ b/app.js
@@ -224,8 +224,8 @@ d.run(() => {
 				}
 
 				// In case domain names are used, resolve those to IP addresses.
-				const peerDomainLookupTasks = appConfig.peers.list.map(
-					peer => callback => {
+				const peerDomainLookupTasks = appConfig.peers.list.map(peer =>
+					async.reflect(callback => {
 						if (net.isIPv4(peer.ip)) {
 							return setImmediate(() => callback(null, peer));
 						}
@@ -240,14 +240,13 @@ d.run(() => {
 							}
 							return callback(null, Object.assign({}, peer, { ip: address }));
 						});
-					}
+					})
 				);
 
-				return async.parallel(peerDomainLookupTasks, (err, results) => {
-					if (err) {
-						return cb(err, appConfig);
-					}
-					appConfig.peers.list = results;
+				return async.parallel(peerDomainLookupTasks, (_, results) => {
+					appConfig.peers.list = results
+						.filter(result => result.hasOwnProperty('value'))
+						.map(result => result.value);
 					return cb(null, appConfig);
 				});
 			},

--- a/app.js
+++ b/app.js
@@ -236,7 +236,7 @@ d.run(() => {
 										peer.ip
 									} to an IP address`
 								);
-								return callback(null, peer);
+								return callback(err, peer);
 							}
 							return callback(null, Object.assign({}, peer, { ip: address }));
 						});
@@ -244,7 +244,9 @@ d.run(() => {
 				);
 
 				return async.parallel(peerDomainLookupTasks, (_, results) => {
-					appConfig.peers.list = results.map(result => result.value);
+					appConfig.peers.list = results
+						.filter(result => result.hasOwnProperty('value'))
+						.map(result => result.value);
 					return cb(null, appConfig);
 				});
 			},

--- a/app.js
+++ b/app.js
@@ -245,7 +245,9 @@ d.run(() => {
 
 				return async.parallel(peerDomainLookupTasks, (_, results) => {
 					appConfig.peers.list = results
-						.filter(result => result.hasOwnProperty('value'))
+						.filter(result =>
+							Object.prototype.hasOwnProperty.call(result, 'value')
+						)
 						.map(result => result.value);
 					return cb(null, appConfig);
 				});


### PR DESCRIPTION
### What was the problem?
The application was crashing on a dns lookup failure for the peers list.
### How did I fix it?
Removed the code that was throwing an error on a dns lookup failure that was responsible of crashing the application. Now if a dns lookup fails the error is logged but it no longer halts the execution.
### How to test it?
Manually: modify one or more seed peer addresses under config.json to a fake/nonworking one. The application should report the dns lookup failure but should continue working as expected.
### Review checklist

* The PR resolves #2608 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
