### PR TITLE
Invalid error message on second signature registration - Closes #2606

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -19,6 +19,7 @@ const ByteBuffer = require('bytebuffer');
 const _ = require('lodash');
 const Bignum = require('../helpers/bignum.js');
 const slots = require('../helpers/slots.js');
+const transactionTypes = require('../helpers/transaction_types.js');
 
 const exceptions = global.exceptions;
 const POSTGRESQL_BIGINT_MAX_VALUE = '9223372036854775807';
@@ -423,6 +424,12 @@ class Transaction {
 		// Reject if transaction has requester public key
 		if (transaction.requesterPublicKey) {
 			return setImmediate(cb, 'Multisig request is not allowed');
+		}
+
+		// Check if sender account has second signature enabled.
+		// Abort if registering again.
+		if (transaction.type === transactionTypes.SIGNATURE && sender.secondSignature) {
+			return setImmediate(cb, 'This account is already enabled with second signature');
 		}
 
 		// Check for missing sender second signature

--- a/test/integration/transactions/1.second_signature/1.1.second_signature.js
+++ b/test/integration/transactions/1.second_signature/1.1.second_signature.js
@@ -104,7 +104,9 @@ describe('system test (type 1) - double second signature registrations', () => {
 
 		it('adding to pool second signature registration for same account should fail', done => {
 			localCommon.addTransaction(library, transaction1, err => {
-				expect(err).to.equal('Missing sender second signature');
+				expect(err).to.equal(
+					'This account is already enabled with second signature'
+				);
 				done();
 			});
 		});

--- a/test/integration/transactions/1.second_signature/1.X.second_signature_validated.js
+++ b/test/integration/transactions/1.second_signature/1.X.second_signature_validated.js
@@ -89,7 +89,7 @@ describe('system test (type 1) - checking validated second signature registratio
 				secondPassphrase: account.secondPassphrase,
 			});
 			localCommon.addTransaction(library, auxTransaction, err => {
-				expect(err).to.equal('Missing sender second signature');
+				expect(err).to.equal('This account is already enabled with second signature');
 				done();
 			});
 		});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -583,6 +583,24 @@ describe('transaction', () => {
 			});
 		});
 
+		it('should return error when transaction is type 1 and sender already has a second passphrase', done => {
+			const transaction = _.cloneDeep(validTransaction);
+			transaction.type = 1;
+			transaction.asset = {
+				signature: validKeypair.publicKey,
+			};
+
+			const vs = _.cloneDeep(sender);
+			vs.secondSignature = true;
+
+			transactionLogic.verify(transaction, vs, null, null, err => {
+				expect(err).to.equal(
+					'This account is already enabled with second signature'
+				);
+				done();
+			});
+		});
+
 		it('should return error when missing sender second signature', done => {
 			const transaction = _.cloneDeep(validTransaction);
 			const vs = _.cloneDeep(sender);


### PR DESCRIPTION
### What was the problem?
I have an account and I have registered the second signature on the account when I try to add the second signature the already enabled second signature account I get an error message

>  Missing sender second signature

 which is confusing for the end user.

### How did I fix it?
Added new logic to check whether the user is attempting to register a new second signature but its account already has one enabled.

Modified matching test cases to comply with new logic.

Added new unit test for `verify` function under `logic/transaction.js`

### How to test it?
(should return error when transaction is type 1 and sender already has a second passphrase)
`npm run mocha -- test/unit/logic/transaction.js`
`npm run mocha --test/integration/transactions/1.second_signature`


### Review checklist

* The PR resolves #2606 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
