### PR TITLE
lisk-core-network tests create log files under wrong path - Closes #2633

### DIFF
--- a/test/network/utils/index.js
+++ b/test/network/utils/index.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const childProcess = require('child_process');
+const path = require('path');
 const Logger = require('../../../logger');
 
 module.exports = {
@@ -22,7 +23,10 @@ module.exports = {
 	ws: require('./ws'),
 	transactions: require('./transactions'),
 	logger: new Logger({
-		filename: `${__dirname}/networkTestsLogger.logs`,
+		filename: path.relative(
+			process.cwd(),
+			`${__dirname}/networkTestsLogger.logs`
+		),
 		echo: 'log',
 	}),
 	getListeningConnections: (ports, cb) => {


### PR DESCRIPTION
### What was the problem?
Log file is created under` $PWD/PWD/test/network/utils/networkTestsLogger.log` e.g.:
`/home/lisk/workspace/lisk-core-network_PR-2597/home/lisk/workspace/lisk-core-network_PR-2597/test/network/utils/networkTestsLogger.logs` (notice the **duplicate** `home/lisk/workspace/lisk-core-network_PR-2597`)

### How did I fix it?

**Reason**: The network tests filename for logs had an absolute value
Changed the value of the network tests log filename to be relative to the working directory.
### How to test it?
Run `npm test -- mocha:default:network` and make sure a log file named `networkTestsLogger.logs` is created under `/test/network/utils/`
### Review checklist

* The PR resolves #2633 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
