### PR TITLE
Disable multiple workers support on P2P layer - Closes #2541

### DIFF
--- a/app.js
+++ b/app.js
@@ -530,7 +530,7 @@ d.run(() => {
 						return cb();
 					}
 					const webSocketConfig = {
-						workers: scope.config.wsWorkers,
+						workers: 1,
 						port: scope.config.wsPort,
 						host: '0.0.0.0',
 						wsEngine: scope.config.peers.options.wsEngine,

--- a/config/default/config.json
+++ b/config/default/config.json
@@ -8,7 +8,6 @@
 	"trustProxy": false,
 	"topAccounts": false,
 	"cacheEnabled": false,
-	"wsWorkers": 1,
 	"db": {
 		"host": "localhost",
 		"port": 5432,


### PR DESCRIPTION
### What was the problem?

We were allowing to increment the number of websocket workers but the application doesn't support it properly. This was leading to timing issues, memory leaks or other issues with peers being removed.

### Review checklist

* The PR resolves #2541
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
