### PR TITLE
Add sorting support in getter functions - Closes #2675

### DIFF
--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -281,6 +281,14 @@ class Account extends BaseEntity {
 				'mem_accounts.address IN (SELECT "accountId" FROM mem_accounts2multisignatures WHERE "dependentId" IN (${votedFor_in:csv}))',
 		});
 
+		const defaultOrderBy = {
+			orderBy: {
+				field: 'balance',
+				method: 'ASC',
+			},
+		};
+		this.extendDefaultOptions(defaultOrderBy);
+
 		this.SQLs = {
 			selectSimple: this.adapter.loadSQLFile('accounts/get.sql'),
 			selectFull: this.adapter.loadSQLFile('accounts/get_extended.sql'),
@@ -418,13 +426,14 @@ class Account extends BaseEntity {
 		const parsedFilters = this.parseFilters(mergedFilters);
 		const parsedOptions = _.defaults(
 			{},
-			_.pick(options, ['limit', 'offset', 'extended']),
-			_.pick(this.defaultOptions, ['limit', 'offset', 'extended'])
+			_.pick(options, ['limit', 'offset', 'orderBy', 'extended']),
+			_.pick(this.defaultOptions, ['limit', 'offset', 'orderBy', 'extended'])
 		);
 
 		const params = {
 			limit: parsedOptions.limit,
 			offset: parsedOptions.offset,
+			orderBy: parsedOptions.offset,
 			parsedFilters,
 		};
 

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -419,7 +419,7 @@ class Account extends BaseEntity {
 	_getResults(filters, options, tx, expectedResultCount = undefined) {
 		const mergedFilters = this.mergeFilters(filters);
 		const parsedFilters = this.parseFilters(mergedFilters);
-		const parsedSort = this.parseSort(options.sort || this.defaultOptions.sort);
+		const parsedSort = this.parseSort(options.sort);
 		const parsedOptions = _.defaults(
 			{},
 			_.pick(options, ['limit', 'offset', 'extended']),

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -419,12 +419,12 @@ class Account extends BaseEntity {
 	_getResults(filters, options, tx, expectedResultCount = undefined) {
 		const mergedFilters = this.mergeFilters(filters);
 		const parsedFilters = this.parseFilters(mergedFilters);
-		const parsedSort = this.parseSort(options.sort);
 		const parsedOptions = _.defaults(
 			{},
-			_.pick(options, ['limit', 'offset', 'extended']),
-			_.pick(this.defaultOptions, ['limit', 'offset', 'extended'])
+			_.pick(options, ['limit', 'offset', 'sort', 'extended']),
+			_.pick(this.defaultOptions, ['limit', 'offset', 'sort', 'extended'])
 		);
+		const parsedSort = this.parseSort(parsedOptions.sort);
 
 		const params = {
 			limit: parsedOptions.limit,

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -281,13 +281,8 @@ class Account extends BaseEntity {
 				'mem_accounts.address IN (SELECT "accountId" FROM mem_accounts2multisignatures WHERE "dependentId" IN (${votedFor_in:csv}))',
 		});
 
-		const defaultOrderBy = {
-			orderBy: {
-				field: 'balance',
-				method: 'ASC',
-			},
-		};
-		this.extendDefaultOptions(defaultOrderBy);
+		const defaultSort = { sort: 'balance:asc' };
+		this.extendDefaultOptions(defaultSort);
 
 		this.SQLs = {
 			selectSimple: this.adapter.loadSQLFile('accounts/get.sql'),
@@ -424,16 +419,17 @@ class Account extends BaseEntity {
 	_getResults(filters, options, tx, expectedResultCount = undefined) {
 		const mergedFilters = this.mergeFilters(filters);
 		const parsedFilters = this.parseFilters(mergedFilters);
+		const parsedSort = this.parseSort(options.sort || this.defaultOptions.sort);
 		const parsedOptions = _.defaults(
 			{},
-			_.pick(options, ['limit', 'offset', 'orderBy', 'extended']),
-			_.pick(this.defaultOptions, ['limit', 'offset', 'orderBy', 'extended'])
+			_.pick(options, ['limit', 'offset', 'extended']),
+			_.pick(this.defaultOptions, ['limit', 'offset', 'extended'])
 		);
 
 		const params = {
 			limit: parsedOptions.limit,
 			offset: parsedOptions.offset,
-			orderBy: parsedOptions.offset,
+			parsedSort,
 			parsedFilters,
 		};
 

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -332,6 +332,29 @@ class BaseEntity {
 		}
 		return { ...filters, ...this.defaultFilters };
 	}
+
+	/**
+	 * Parse sort option
+	 * @param {Array.<String>|String} sortOption
+	 * @return {String}
+	 */
+	parseSort(sortOption) {
+		const sortString = Array.isArray(sortOption)
+			? sortOption.map(this._parseSortString).join(', ')
+			: this._parseSortString(sortOption);
+
+		if (sortString) {
+			return `ORDER BY ${sortString}`;
+		}
+
+		return '';
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	_parseSortString(item) {
+		const [field, method = 'ASC'] = item.split(':');
+		return `"${field}" ${method.toUpperCase()}`;
+	}
 }
 
 module.exports = BaseEntity;

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -124,10 +124,6 @@ class BaseEntity {
 		throw new ImplementationPendingError();
 	}
 
-	getFields() {
-		return Object.keys(this.fields);
-	}
-
 	getFilters() {
 		return Object.keys(this.filters);
 	}
@@ -293,7 +289,7 @@ class BaseEntity {
 			);
 		}
 
-		if (!isSortOptionValid(options.sort, this.getFields())) {
+		if (!isSortOptionValid(options.sort, Object.keys(this.fields))) {
 			throw new NonSupportedOptionError('Invalid sort option.', options);
 		}
 

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -290,7 +290,7 @@ class BaseEntity {
 		}
 
 		if (!isSortOptionValid(options.sort, Object.keys(this.fields))) {
-			throw new NonSupportedOptionError('Invalid sort option.', options);
+			throw new NonSupportedOptionError('Invalid sort option.', options.sort);
 		}
 
 		return true;

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -19,6 +19,7 @@ const {
 	NonSupportedFilterTypeError,
 	NonSupportedOptionError,
 } = require('../errors');
+const { isSortOptionValid, parseSortString } = require('../utils/sort_option');
 const filterTypes = require('../utils/filter_types');
 const Field = require('../utils/field');
 const { filterGenerator } = require('../utils/filters');
@@ -121,6 +122,10 @@ class BaseEntity {
 	// eslint-disable-next-line class-methods-use-this
 	isPersisted() {
 		throw new ImplementationPendingError();
+	}
+
+	getFields() {
+		return Object.keys(this.fields);
 	}
 
 	getFilters() {
@@ -288,6 +293,10 @@ class BaseEntity {
 			);
 		}
 
+		if (!isSortOptionValid(options.sort, this.getFields())) {
+			throw new NonSupportedOptionError('Invalid sort option.', options);
+		}
+
 		return true;
 	}
 
@@ -338,22 +347,16 @@ class BaseEntity {
 	 * @param {Array.<String>|String} sortOption
 	 * @return {String}
 	 */
-	parseSort(sortOption) {
+	parseSort(sortOption = this.defaultOptions.sort) {
 		const sortString = Array.isArray(sortOption)
-			? sortOption.map(this._parseSortString).join(', ')
-			: this._parseSortString(sortOption);
+			? sortOption.map(parseSortString).join(', ')
+			: parseSortString(sortOption);
 
 		if (sortString) {
 			return `ORDER BY ${sortString}`;
 		}
 
 		return '';
-	}
-
-	// eslint-disable-next-line class-methods-use-this
-	_parseSortString(item) {
-		const [field, method = 'ASC'] = item.split(':');
-		return `"${field}" ${method.toUpperCase()}`;
 	}
 }
 

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -341,7 +341,7 @@ class BaseEntity {
 	/**
 	 * Parse sort option
 	 * @param {Array.<String>|String} sortOption
-	 * @return {String}
+	 * @return {string}
 	 */
 	parseSort(sortOption = this.defaultOptions.sort) {
 		const sortString = Array.isArray(sortOption)

--- a/storage/entities/block.js
+++ b/storage/entities/block.js
@@ -288,12 +288,12 @@ class Block extends BaseEntity {
 
 		const mergedFilters = this.mergeFilters(filters);
 		const parsedFilters = this.parseFilters(mergedFilters);
-		const parsedSort = this.parseSort(options.sort);
 		const parsedOptions = _.defaults(
 			{},
-			_.pick(options, ['limit', 'offset']),
-			_.pick(this.defaultOptions, ['limit', 'offset'])
+			_.pick(options, ['limit', 'offset', 'sort']),
+			_.pick(this.defaultOptions, ['limit', 'offset', 'sort'])
 		);
+		const parsedSort = this.parseSort(parsedOptions.sort);
 
 		const params = {
 			limit: parsedOptions.limit,

--- a/storage/entities/block.js
+++ b/storage/entities/block.js
@@ -178,13 +178,8 @@ class Block extends BaseEntity {
 		this.addField('reward', 'string', { filter: filterType.NUMBER });
 		this.addField('version', 'number', { filter: filterType.NUMBER });
 
-		const defaultOrderBy = {
-			orderBy: {
-				field: 'height',
-				method: 'DESC',
-			},
-		};
-		this.extendDefaultOptions(defaultOrderBy);
+		const defaultSort = { sort: 'height:desc' };
+		this.extendDefaultOptions(defaultSort);
 
 		this.SQLs = {
 			select: this.adapter.loadSQLFile('blocks/get.sql'),
@@ -293,16 +288,17 @@ class Block extends BaseEntity {
 
 		const mergedFilters = this.mergeFilters(filters);
 		const parsedFilters = this.parseFilters(mergedFilters);
+		const parsedSort = this.parseSort(options.sort || this.defaultOptions.sort);
 		const parsedOptions = _.defaults(
 			{},
-			_.pick(options, ['limit', 'offset', 'orderBy']),
-			_.pick(this.defaultOptions, ['limit', 'offset', 'orderBy'])
+			_.pick(options, ['limit', 'offset']),
+			_.pick(this.defaultOptions, ['limit', 'offset'])
 		);
 
 		const params = {
 			limit: parsedOptions.limit,
 			offset: parsedOptions.offset,
-			orderBy: parsedOptions.orderBy,
+			parsedSort,
 			parsedFilters,
 		};
 

--- a/storage/entities/block.js
+++ b/storage/entities/block.js
@@ -288,7 +288,7 @@ class Block extends BaseEntity {
 
 		const mergedFilters = this.mergeFilters(filters);
 		const parsedFilters = this.parseFilters(mergedFilters);
-		const parsedSort = this.parseSort(options.sort || this.defaultOptions.sort);
+		const parsedSort = this.parseSort(options.sort);
 		const parsedOptions = _.defaults(
 			{},
 			_.pick(options, ['limit', 'offset']),

--- a/storage/entities/block.js
+++ b/storage/entities/block.js
@@ -178,6 +178,14 @@ class Block extends BaseEntity {
 		this.addField('reward', 'string', { filter: filterType.NUMBER });
 		this.addField('version', 'number', { filter: filterType.NUMBER });
 
+		const defaultOrderBy = {
+			orderBy: {
+				field: 'height',
+				method: 'DESC',
+			},
+		};
+		this.extendDefaultOptions(defaultOrderBy);
+
 		this.SQLs = {
 			select: this.adapter.loadSQLFile('blocks/get.sql'),
 			create: this.adapter.loadSQLFile('blocks/create.sql'),
@@ -287,13 +295,14 @@ class Block extends BaseEntity {
 		const parsedFilters = this.parseFilters(mergedFilters);
 		const parsedOptions = _.defaults(
 			{},
-			_.pick(options, ['limit', 'offset']),
-			_.pick(this.defaultOptions, ['limit', 'offset'])
+			_.pick(options, ['limit', 'offset', 'orderBy']),
+			_.pick(this.defaultOptions, ['limit', 'offset', 'orderBy'])
 		);
 
 		const params = {
 			limit: parsedOptions.limit,
 			offset: parsedOptions.offset,
+			orderBy: parsedOptions.orderBy,
 			parsedFilters,
 		};
 

--- a/storage/sql/accounts/get.sql
+++ b/storage/sql/accounts/get.sql
@@ -33,4 +33,6 @@ FROM
 
 ${parsedFilters:raw}
 
-LIMIT ${limit} OFFSET ${offset}
+ORDER BY ${orderBy.field:raw} ${orderBy.method:raw}
+LIMIT ${limit}
+OFFSET ${offset}

--- a/storage/sql/accounts/get.sql
+++ b/storage/sql/accounts/get.sql
@@ -33,6 +33,7 @@ FROM
 
 ${parsedFilters:raw}
 
-ORDER BY ${orderBy.field:raw} ${orderBy.method:raw}
+${parsedSort:raw}
+
 LIMIT ${limit}
 OFFSET ${offset}

--- a/storage/sql/accounts/get_extended.sql
+++ b/storage/sql/accounts/get_extended.sql
@@ -56,6 +56,7 @@ FROM
 
 ${parsedFilters:raw}
 
-ORDER BY ${orderBy.field:raw} ${orderBy.method:raw}
+${parsedSort:raw}
+
 LIMIT ${limit}
 OFFSET ${offset}

--- a/storage/sql/accounts/get_extended.sql
+++ b/storage/sql/accounts/get_extended.sql
@@ -56,4 +56,6 @@ FROM
 
 ${parsedFilters:raw}
 
-LIMIT ${limit} OFFSET ${offset}
+ORDER BY ${orderBy.field:raw} ${orderBy.method:raw}
+LIMIT ${limit}
+OFFSET ${offset}

--- a/storage/sql/blocks/get.sql
+++ b/storage/sql/blocks/get.sql
@@ -31,4 +31,6 @@ FROM
 
 ${parsedFilters:raw}
 
-LIMIT ${limit} OFFSET ${offset}
+ORDER BY ${orderBy.field:raw} ${orderBy.method:raw}
+LIMIT ${limit}
+OFFSET ${offset}

--- a/storage/sql/blocks/get.sql
+++ b/storage/sql/blocks/get.sql
@@ -31,6 +31,7 @@ FROM
 
 ${parsedFilters:raw}
 
-ORDER BY ${orderBy.field:raw} ${orderBy.method:raw}
+${parsedSort:raw}
+
 LIMIT ${limit}
 OFFSET ${offset}

--- a/storage/utils/sort_option.js
+++ b/storage/utils/sort_option.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const isSortOptionValid = (sortOption, fields) => {
+	if (!sortOption) return true;
+	sortOption = Array.isArray(sortOption) ? sortOption : [sortOption];
+	return sortOption.reduce((acc, curr) => {
+		const { field, method } = parseSortStringToObject(curr);
+		return acc && fields.includes(field) && ['ASC', 'DESC'].includes(method);
+	}, true);
+};
+
+const parseSortString = sortString => {
+	const { field, method } = parseSortStringToObject(sortString);
+	return `"${field}" ${method.toUpperCase()}`;
+};
+
+const parseSortStringToObject = sortString => {
+	const [field, method = 'ASC'] = sortString.split(':');
+	return { field, method: method.toUpperCase() };
+};
+
+module.exports = {
+	isSortOptionValid,
+	parseSortString,
+	parseSortStringToObject,
+};

--- a/storage/utils/sort_option.js
+++ b/storage/utils/sort_option.js
@@ -16,8 +16,8 @@
 
 const isSortOptionValid = (sortOption, fields) => {
 	if (!sortOption) return true;
-	sortOption = Array.isArray(sortOption) ? sortOption : [sortOption];
-	return sortOption.reduce((acc, curr) => {
+	const sortArray = Array.isArray(sortOption) ? sortOption : [sortOption];
+	return sortArray.reduce((acc, curr) => {
 		const { field, method } = parseSortStringToObject(curr);
 		return acc && fields.includes(field) && ['ASC', 'DESC'].includes(method);
 	}, true);

--- a/test/unit/storage/entities/block.js
+++ b/test/unit/storage/entities/block.js
@@ -58,10 +58,7 @@ describe('Block', () => {
 				extended: false,
 				limit: 10,
 				offset: 0,
-				orderBy: {
-					field: 'height',
-					method: 'DESC',
-				},
+				sort: 'height:desc',
 			});
 		});
 
@@ -219,6 +216,27 @@ describe('Block', () => {
 			const options = { invalid_option: 1, offset: 0 };
 			expect(() => {
 				block.get({}, options);
+			}).to.throw(NonSupportedOptionError);
+		});
+
+		it('should accept valid sorting option', async () => {
+			const sortOption = { sort: 'height:asc' };
+			expect(() => {
+				block.get({}, sortOption);
+			}).to.not.throw(NonSupportedOptionError);
+		});
+
+		it('should throw error for invalid field sorting option', async () => {
+			const sortOption = { sort: 'invalid:asc' };
+			expect(() => {
+				block.get({}, sortOption);
+			}).to.throw(NonSupportedOptionError);
+		});
+
+		it('should throw error for invalid method sorting option', async () => {
+			const sortOption = { sort: 'height:invalid' };
+			expect(() => {
+				block.get({}, sortOption);
 			}).to.throw(NonSupportedOptionError);
 		});
 

--- a/test/unit/storage/entities/block.js
+++ b/test/unit/storage/entities/block.js
@@ -58,6 +58,10 @@ describe('Block', () => {
 				extended: false,
 				limit: 10,
 				offset: 0,
+				orderBy: {
+					field: 'height',
+					method: 'DESC',
+				},
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
There was no order by support to storage entities

### How did I fix it?
I've implemented the order by for get functions and tweak the test accordingly 

### How to test it?
`npm run mocha -- test/unit/storage/`

### Review checklist

* The PR resolves #2675
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
