### PR TITLE
Implement count method for entities - Closes #2676

### DIFF
--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -284,6 +284,7 @@ class Account extends BaseEntity {
 		this.SQLs = {
 			selectSimple: this.adapter.loadSQLFile('accounts/get.sql'),
 			selectFull: this.adapter.loadSQLFile('accounts/get_extended.sql'),
+			count: this.adapter.loadSQLFile('accounts/count.sql'),
 			create: this.adapter.loadSQLFile('accounts/create.sql'),
 			update: this.adapter.loadSQLFile('accounts/update.sql'),
 			updateOne: this.adapter.loadSQLFile('accounts/update_one.sql'),
@@ -320,6 +321,24 @@ class Account extends BaseEntity {
 	 */
 	get(filters = {}, options = {}, tx) {
 		return this._getResults(filters, options, tx);
+	}
+
+	/**
+	 * Count total entries based on filters
+	 *
+	 * @param {filters.Account|filters.Account[]} [filters = {}]
+	 * @return {Promise.<Integer, NonSupportedFilterTypeError>}
+	 */
+	count(filters = {}) {
+		this.validateFilters(filters);
+
+		const mergedFilters = this.mergeFilters(filters);
+		const parsedFilters = this.parseFilters(mergedFilters);
+		const expectedResultCount = 1;
+
+		return this.adapter
+			.executeFile(this.SQLs.count, { parsedFilters }, { expectedResultCount })
+			.then(result => +result.count);
 	}
 
 	/**

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -69,8 +69,8 @@ class BaseEntity {
 		throw new ImplementationPendingError();
 	}
 
-	// eslint-disable-next-line class-methods-use-this
-	count() {
+	// eslint-disable-next-line class-methods-use-this,no-unused-vars
+	count(filters) {
 		throw new ImplementationPendingError();
 	}
 

--- a/storage/entities/block.js
+++ b/storage/entities/block.js
@@ -180,6 +180,7 @@ class Block extends BaseEntity {
 
 		this.SQLs = {
 			select: this.adapter.loadSQLFile('blocks/get.sql'),
+			count: this.adapter.loadSQLFile('blocks/count.sql'),
 			create: this.adapter.loadSQLFile('blocks/create.sql'),
 			isPersisted: this.adapter.loadSQLFile('blocks/is_persisted.sql'),
 		};
@@ -212,6 +213,24 @@ class Block extends BaseEntity {
 	getOne(filters, options = {}, tx) {
 		const expectedResultCount = 1;
 		return this._getResults(filters, options, tx, expectedResultCount);
+	}
+
+	/**
+	 * Count total entries based on filters
+	 *
+	 * @param {filters.Block|filters.Block[]} [filters = {}]
+	 * @return {Promise.<Integer, NonSupportedFilterTypeError>}
+	 */
+	count(filters = {}) {
+		this.validateFilters(filters);
+
+		const mergedFilters = this.mergeFilters(filters);
+		const parsedFilters = this.parseFilters(mergedFilters);
+		const expectedResultCount = 1;
+
+		return this.adapter
+			.executeFile(this.SQLs.count, { parsedFilters }, { expectedResultCount })
+			.then(result => +result.count);
 	}
 
 	/**

--- a/storage/sql/accounts/count.sql
+++ b/storage/sql/accounts/count.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+SELECT count(*)
+FROM mem_accounts
+${parsedFilters:raw}

--- a/storage/sql/blocks/count.sql
+++ b/storage/sql/blocks/count.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+SELECT count(*)
+FROM blocks
+${parsedFilters:raw}

--- a/test/unit/storage/entities/block.js
+++ b/test/unit/storage/entities/block.js
@@ -51,6 +51,7 @@ describe('Block', () => {
 			expect(block.defaultFilters).to.be.eq(defaultFilters);
 			expect(block.SQLs).to.be.eql({
 				select: 'loadSQLFile',
+				count: 'loadSQLFile',
 				create: 'loadSQLFile',
 				isPersisted: 'loadSQLFile',
 			});
@@ -288,6 +289,29 @@ describe('Block', () => {
 			it('should have only specific filters');
 			// For each filter type
 			it('should return matching result for provided filter');
+		});
+	});
+
+	describe('count()', () => {
+		let block;
+
+		before(async () => {
+			const adapter = { loadSQLFile: sinonSandbox.stub() };
+			block = new Block(adapter);
+		});
+
+		it('should accept valid filters', async () => {
+			const filters = [{ height: 101 }, { timestamp_gte: 1234567890 }];
+			expect(() => {
+				block.count(filters);
+			}).to.not.throw(NonSupportedFilterTypeError);
+		});
+
+		it('should throw error for invalid filters', async () => {
+			const filters = [{ invalid_filter: 1 }, { timestamp_gte: 1234567890 }];
+			expect(() => {
+				block.count(filters);
+			}).to.throw(NonSupportedFilterTypeError);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
There was no support of counting records for any entity.

### How did I fix it?
I've implemented count method for Accounts and Blocks and also updated unit test for blocks.

### How to test it?
`npm run mocha -- test/unit/storage/`
and
`storage.entities.Account.count({ isDelegate: 1 });`
`storage.entities.Block.count({ height_gt: 101 });`

### Review checklist

* The PR resolves #2676
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
