### PR TITLE
Add unit tests for signatures module - Closes #2445

### DIFF
--- a/test/unit/modules/signatures.js
+++ b/test/unit/modules/signatures.js
@@ -14,65 +14,240 @@
 
 'use strict';
 
-/* eslint-disable mocha/no-pending-tests */
-describe('signatures', () => {
-	describe('isLoaded', () => {
-		it('should return true if modules exists');
+const application = require('../../common/application');
+const transactionTypes = require('../../../helpers/transaction_types');
+const ApiError = require('../../../helpers/api_error');
 
-		it('should return true if modules does not exist');
+/* eslint-disable mocha/no-pending-tests */
+/* eslint-disable no-unused-vars */
+describe('signatures', () => {
+	let library;
+
+	before(done => {
+		application.init(
+			{ sandbox: { name: 'lisk_test_modules_signatures' } },
+			(err, scope) => {
+				library = scope;
+				done(err);
+			}
+		);
+	});
+
+	describe('isLoaded', () => {
+		it('should return true if modules exists', done => {
+			library.rewiredModules.signatures.__set__('modules', {
+				accounts: library.modules.accounts,
+				transactions: library.modules.transactions,
+				transport: library.modules.transport,
+			});
+			expect(library.modules.signatures.isLoaded()).to.be.true;
+			done();
+		});
+
+		it('should return true if modules does not exist', done => {
+			const revert = library.rewiredModules.signatures.__set__(
+				'modules',
+				undefined
+			);
+			expect(library.modules.signatures.isLoaded()).to.be.false;
+			revert();
+			done();
+		});
 	});
 
 	describe('onBind', () => {
+		let privateModules;
+		let signatureLogicSpy;
+
+		before(done => {
+			privateModules = library.rewiredModules.signatures.__get__('modules');
+			signatureLogicSpy = sinonSandbox.spy(
+				library.rewiredModules.signatures.__get__('__private').assetTypes[
+					transactionTypes.SIGNATURE
+				],
+				'bind'
+			);
+			library.modules.signatures.onBind(library.modules);
+			done();
+		});
+
 		describe('modules', () => {
-			it('should assign accounts');
+			it('should assign accounts', done => {
+				expect(privateModules).to.have.property(
+					'accounts',
+					library.modules.accounts
+				);
+				done();
+			});
 
-			it('should assign transactions');
+			it('should assign transactions', done => {
+				expect(privateModules).to.have.property(
+					'transactions',
+					library.modules.transactions
+				);
+				done();
+			});
 
-			it('should assign transport');
+			it('should assign transport', done => {
+				expect(privateModules).to.have.property(
+					'transport',
+					library.modules.transport
+				);
+				done();
+			});
 		});
 
 		describe('assetTypes', () => {
-			it('should call bind on signature logic with scope.accounts');
+			it('should call bind on signature logic with scope.accounts', done => {
+				expect(signatureLogicSpy).to.be.calledWith(library.modules.accounts);
+				done();
+			});
 		});
 	});
 
 	describe('shared', () => {
-		describe('postSignatures', () => {
-			describe('when modules not are loaded', () => {
+		describe('postSignature', () => {
+			describe('when modules are not loaded', () => {
 				it('should call callback with ApiError');
-
 				it(
 					'should call callback with ApiError containing message = "Blockchain is loading"'
 				);
-
 				it('should call callback with ApiError containing code = 500');
 			});
 
 			describe('when modules are loaded', () => {
-				it('should call modules.transport.shared.postSignatures with req.body');
+				// Doesnt matter if request args are not valid as that is out of this scope for this tests
+				const req = {
+					body: {
+						signature: 'aSignature',
+						transactionId: 'aTransactionId',
+						publicKey: 'aPublicKey',
+					},
+				};
 
-				describe('when modules.transport.shared.postSignatures fails with result', () => {
-					it('should call callback with ApiError');
+				let postSignatureSpy;
+
+				before(done => {
+					postSignatureSpy = sinonSandbox.spy(
+						library.modules.transport.shared,
+						'postSignature'
+					);
+					library.modules.signatures.shared.postSignature(
+						req.body,
+						(error, response) => {
+							done();
+						}
+					);
+				});
+
+				it('should call modules.transport.shared.postSignature with req.body', done => {
+					expect(postSignatureSpy).to.be.calledWith({ signature: req.body });
+					sinonSandbox.restore();
+					done();
+				});
+
+				describe('when modules.transport.shared.postSignature fails with result', () => {
+					let postSignatureStub;
+
+					before(done => {
+						postSignatureStub = sinonSandbox.stub(
+							library.modules.transport.shared,
+							'postSignature'
+						);
+						done();
+					});
+
+					after(done => {
+						sinonSandbox.restore();
+						done();
+					});
+
+					it('should call callback with ApiError', done => {
+						postSignatureStub.yields(null, { success: false });
+
+						library.modules.signatures.shared.postSignature(
+							req.body,
+							(error, result) => {
+								expect(error).to.be.instanceof(ApiError);
+								done();
+							}
+						);
+					});
 
 					it(
 						'should call callback with ApiError containing message = "Blockchain is loading"'
 					);
 
-					describe('when result.message = "Invalid signatures body"', () => {
-						it('should call callback with ApiError containing code = 400');
+					describe('when result.message = "Invalid signature body"', () => {
+						it('should call callback with ApiError containing code = 400', done => {
+							// Force library.modules.transport.shared.postSignature to fail with custom message
+							postSignatureStub.yields(null, {
+								success: false,
+								message: 'Invalid signature body',
+							});
+
+							library.modules.signatures.shared.postSignature(
+								req.body,
+								(error, result) => {
+									expect(error.code).to.equal(400);
+									done();
+								}
+							);
+						});
 					});
 
-					describe('when result.message != "Invalid signatures body"', () => {
-						it('should call callback with ApiError containing code = 500');
+					describe('when result.message != "Invalid signature body"', () => {
+						it('should call callback with ApiError containing code = 500', done => {
+							// Force library.modules.transport.shared.postSignature to fail with custom message
+							postSignatureStub.yields(null, {
+								success: false,
+								message: 'A different message',
+							});
+
+							library.modules.signatures.shared.postSignature(
+								req.body,
+								(error, result) => {
+									expect(error.code).to.equal(500);
+									done();
+								}
+							);
+						});
 					});
 				});
 
-				describe('when modules.transport.shared.postSignatures succeeds with result', () => {
-					it('should call callback with error = null');
+				describe('when modules.transport.shared.postSignature succeeds with result', () => {
+					let postSignatureError;
+					let postSignatureResult;
 
-					it(
-						'should call callback with result containing status = "Signature Accepted"'
-					);
+					before(done => {
+						const postSignatureStub = sinonSandbox.stub(
+							library.modules.transport.shared,
+							'postSignature'
+						);
+						// Force library.modules.transport.shared.postSignature to succeed
+						postSignatureStub.yields(null, {
+							success: true,
+						});
+
+						library.modules.signatures.shared.postSignature(
+							req.body,
+							(error, result) => {
+								postSignatureError = error;
+								postSignatureResult = result;
+								done();
+							}
+						);
+					});
+
+					it('should call callback with error = null', done => {
+						expect(postSignatureError).to.be.null;
+						done();
+					});
+
+					it('should call callback with result containing status = "Signature Accepted"', done => {
+						expect(postSignatureResult.status).to.equal('Signature Accepted');
+						done();
+					});
 				});
 			});
 		});


### PR DESCRIPTION
### What was the problem?
Unit tests for **signatures** module weren't implemented
### How did I fix it?
Implemented unit tests for **signatures** module
### How to test it?
`npm run mocha -- test/unit/signatures`

### Review checklist

* The PR resolves #2445 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
