### PR TITLE
Create methods must accept arrays as well - Closes #2677

### DIFF
--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -354,7 +354,7 @@ class Account extends BaseEntity {
 	 * @return {*}
 	 */
 	create(data, _options, tx) {
- 		assert(data, 'Must provide data to create account');
+		assert(data, 'Must provide data to create account');
 		assert(
 			typeof data === 'object' || Array.isArray(data),
 			'Data must be an object or array of objects'

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -340,14 +340,18 @@ class Account extends BaseEntity {
 		}
 
 		values = values.map(v => _.defaults(v, defaultCreateValues));
-		const createSet = this.getValuesSet(values);
-		const attributes = Object.keys(values[0])
+
+		// We assume that all accounts have same attributes
+		// and pick first account attributes as template
+		const attributes = Object.keys(values[0]);
+		const createSet = this.getValuesSet(values, attributes);
+		const fields = attributes
 			.map(k => `"${this.fields[k].fieldName}"`)
 			.join(',');
 
 		return this.adapter.executeFile(
 			this.SQLs.create,
-			{ createSet, attributes },
+			{ createSet, fields },
 			{ expectedResultCount: 0 },
 			tx
 		);

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -325,22 +325,30 @@ class Account extends BaseEntity {
 	/**
 	 * Create account object
 	 *
-	 * @param {Object} data
-	 * @param {Object} [options]
-	 * @param {Object} tx - Transaction object
+	 * @param {Object|Array.<Object>} data
+	 * @param {Object} [_options]
+	 * @param {Object} [tx] - Transaction object
 	 * @return {*}
 	 */
 	create(data, _options, tx) {
-		const objectData = _.defaults(data, defaultCreateValues);
-		const createSet = this.getValuesSet(objectData);
-		const attributes = Object.keys(data)
+		let values;
+
+		if (Array.isArray(data)) {
+			values = data;
+		} else if (typeof data === 'object') {
+			values = [data];
+		}
+
+		values = values.map(v => _.defaults(v, defaultCreateValues));
+		const createSet = this.getValuesSet(values);
+		const attributes = Object.keys(values[0])
 			.map(k => `"${this.fields[k].fieldName}"`)
 			.join(',');
 
 		return this.adapter.executeFile(
 			this.SQLs.create,
 			{ createSet, attributes },
-			{},
+			{ expectedResultCount: 0 },
 			tx
 		);
 	}

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const assert = require('assert');
 const _ = require('lodash');
 const { stringToByte, booleanToInt } = require('../utils/inputSerializers');
 const ft = require('../utils/filter_types');
@@ -331,6 +332,12 @@ class Account extends BaseEntity {
 	 * @return {*}
 	 */
 	create(data, _options, tx) {
+		assert(data, 'Must provide data to create account.');
+		assert(
+			typeof data === 'object' || Array.isArray(data),
+			'Data must be an object or array of objects'
+		);
+
 		let values;
 
 		if (Array.isArray(data)) {
@@ -342,8 +349,8 @@ class Account extends BaseEntity {
 		values = values.map(v => _.defaults(v, defaultCreateValues));
 
 		// We assume that all accounts have same attributes
-		// and pick first account attributes as template
-		const attributes = Object.keys(values[0]);
+		// and pick defined fields as template
+		const attributes = Object.keys(this.fields);
 		const createSet = this.getValuesSet(values, attributes);
 		const fields = attributes
 			.map(k => `"${this.fields[k].fieldName}"`)

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -354,7 +354,7 @@ class Account extends BaseEntity {
 	 * @return {*}
 	 */
 	create(data, _options, tx) {
-		assert(data, 'Must provide data to create account.');
+ 		assert(data, 'Must provide data to create account');
 		assert(
 			typeof data === 'object' || Array.isArray(data),
 			'Data must be an object or array of objects'

--- a/storage/entities/account.js
+++ b/storage/entities/account.js
@@ -341,9 +341,9 @@ class Account extends BaseEntity {
 		let values;
 
 		if (Array.isArray(data)) {
-			values = data;
+			values = data.map(item => ({ ...item }));
 		} else if (typeof data === 'object') {
-			values = [data];
+			values = [{ ...data }];
 		}
 
 		values = values.map(v => _.defaults(v, defaultCreateValues));

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -176,12 +176,11 @@ class BaseEntity {
 	}
 
 	getValuesSet(data) {
-		return `(${this.adapter.parseQueryComponent(
-			Object.keys(data)
-				.map(key => this.fields[key].serializeValue(data[key], 'insert'))
-				.join(','),
-			data
-		)})`;
+		if (Array.isArray(data)) {
+			return data.map(d => this._getValueSetForObject(d)).join(',');
+		}
+
+		return this._getValueSetForObject(data);
 	}
 
 	/**
@@ -331,6 +330,15 @@ class BaseEntity {
 			return filters.map(item => ({ ...item, ...this.defaultFilters }));
 		}
 		return { ...filters, ...this.defaultFilters };
+	}
+
+	_getValueSetForObject(data) {
+		return `(${this.adapter.parseQueryComponent(
+			Object.keys(data)
+				.map(key => this.fields[key].serializeValue(data[key], 'insert'))
+				.join(','),
+			data
+		)})`;
 	}
 }
 

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -175,7 +175,7 @@ class BaseEntity {
 		);
 	}
 
-	getValuesSet(data, attributes = []) {
+	getValuesSet(data, attributes = undefined) {
 		if (Array.isArray(data)) {
 			return data.map(d => this._getValueSetForObject(d, attributes)).join(',');
 		}
@@ -332,7 +332,7 @@ class BaseEntity {
 		return { ...filters, ...this.defaultFilters };
 	}
 
-	_getValueSetForObject(data, attributes = []) {
+	_getValueSetForObject(data, attributes = undefined) {
 		return `(${this.adapter.parseQueryComponent(
 			(attributes || Object.keys(data))
 				.map(key => this.fields[key].serializeValue(data[key], 'insert'))

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -175,12 +175,12 @@ class BaseEntity {
 		);
 	}
 
-	getValuesSet(data) {
+	getValuesSet(data, attributes = []) {
 		if (Array.isArray(data)) {
-			return data.map(d => this._getValueSetForObject(d)).join(',');
+			return data.map(d => this._getValueSetForObject(d, attributes)).join(',');
 		}
 
-		return this._getValueSetForObject(data);
+		return this._getValueSetForObject(data, attributes);
 	}
 
 	/**
@@ -332,9 +332,9 @@ class BaseEntity {
 		return { ...filters, ...this.defaultFilters };
 	}
 
-	_getValueSetForObject(data) {
+	_getValueSetForObject(data, attributes = []) {
 		return `(${this.adapter.parseQueryComponent(
-			Object.keys(data)
+			(attributes || Object.keys(data))
 				.map(key => this.fields[key].serializeValue(data[key], 'insert'))
 				.join(','),
 			data

--- a/storage/sql/accounts/create.sql
+++ b/storage/sql/accounts/create.sql
@@ -13,7 +13,7 @@
  */
 
 INSERT INTO mem_accounts (
-	${attributes:raw}
+	${fields:raw}
 ) VALUES
 	${createSet:raw}
 ;

--- a/test/unit/storage/entities/account.js
+++ b/test/unit/storage/entities/account.js
@@ -84,6 +84,7 @@ describe('Account', () => {
 		it('should call getValuesSet with proper params');
 		it('should call adapter.executeFile with proper params');
 		it('should create an account object successfully');
+		it('should create multiple account objects successfully');
 		it('should skip if any invalid attribute is provided');
 		it('should reject with invalid data provided');
 		it('should populate account object with default values');


### PR DESCRIPTION
### What was the problem?
The `storage.entities.Account.create` was accepting only one object. While our implementation requires to create multiple accounts as well. 


### How did I fix it?
Added the logic to make sure it accepts both arrays and objects. 

### Review checklist

* The PR resolves #2677
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
