### PR TITLE
Base Entity parseFilters() is not grouping OR and AND - Closes #2685

### DIFF
--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -295,9 +295,9 @@ class BaseEntity {
 		let filterString = null;
 
 		const parseFilterObject = object =>
-			Object.keys(object)
+			`(${Object.keys(object)
 				.map(key => this.filters[key])
-				.join(' AND ');
+				.join(' AND ')})`;
 
 		if (Array.isArray(filters)) {
 			filterString = filters


### PR DESCRIPTION
### What was the problem?

base_entity.parseFilters() was not grouping OR and AND correctly

### How did I fix it?

By adding parens to base_entity.parseFilters()

### How to test it?

See closing issue for details about testing

### Review checklist

* The PR resolves #2685 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
