### PR TITLE
Update Peers Tests due to changes in Storage Sandbox - Closes #2694

### DIFF
--- a/test/unit/storage/entities/peer.js
+++ b/test/unit/storage/entities/peer.js
@@ -37,11 +37,11 @@ describe('Peer', () => {
 	let storage;
 
 	before(async () => {
-		const dbSandbox = new storageSandbox.StorageSandbox(
+		storage = new storageSandbox.StorageSandbox(
 			__testContext.config.db,
 			'lisk_test_peers'
 		);
-		storage = await dbSandbox.create();
+		await storage.bootstrap();
 
 		validPeerFields = [
 			'id',
@@ -163,11 +163,7 @@ describe('Peer', () => {
 			offset: 0,
 		};
 
-		adapter = {
-			loadSQLFile: sinonSandbox.stub().returns('loadSQLFile'),
-			executeFile: sinonSandbox.stub().returns(validPeer),
-			parseQueryComponent: sinonSandbox.stub(),
-		};
+		adapter = storage.adapter;
 
 		addFieldSpy = sinonSandbox.spy(Peer.prototype, 'addField');
 	});


### PR DESCRIPTION
### What was the problem?

Changes to storage sandbox bootstrap broke Peer Entity test

### How did I fix it?

By updating storage sandbox bootstrap in Peer Entity test 

### How to test it?

- run ` mocha test/unit/storage/entities/peer.js`
- Build should be green fro unit tests pipeline

### Review checklist

* The PR resolves #2694
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
