### PR TITLE
Remove clock from Peers - Closes #2687

### DIFF
--- a/api/controllers/peers.js
+++ b/api/controllers/peers.js
@@ -68,7 +68,6 @@ PeersController.getPeers = function(context, next) {
 
 		data = _.map(data, peer => {
 			delete peer.updated;
-			delete peer.clock;
 			return peer;
 		});
 

--- a/db/repos/migrations.js
+++ b/db/repos/migrations.js
@@ -65,7 +65,7 @@ class MigrationsRepository {
 	}
 
 	/**
-	 * Executes 'migrations/runtime.sql' file, to set peers clock to null and state to 1.
+	 * Executes 'migrations/runtime.sql' file to set state to 1.
 	 *
 	 * @returns {Promise<null>} Promise object that resolves with `null`.
 	 */

--- a/db/repos/peers.js
+++ b/db/repos/peers.js
@@ -45,7 +45,6 @@ class PeersRepository {
 					'height',
 					'os',
 					'version',
-					'clock',
 					{
 						name: 'broadhash',
 						init: c => (c.value ? ed.hexToBuffer(c.value) : null),

--- a/db/sql/migrations/updates/20190103000001_drop_peers_clock.sql
+++ b/db/sql/migrations/updates/20190103000001_drop_peers_clock.sql
@@ -14,10 +14,9 @@
 
 
 /*
-  DESCRIPTION: Gets all peers from database
+  DESCRIPTION: clock column not in use should be removed
 
   PARAMETERS: None
 */
 
-SELECT ip, "wsPort", state, os, version, encode(broadhash, 'hex') AS broadhash, height
-FROM peers
+ALTER TABLE peers DROP COLUMN clock;

--- a/logic/peer.js
+++ b/logic/peer.js
@@ -159,7 +159,6 @@ class Peer {
  * @property {string} version - Between 5 and 12 chars
  * @property {string} broadhash
  * @property {number} height - Minimum 1
- * @property {Date} clock
  * @property {Date} updated
  * @property {string} nonce
  * @property {string} string
@@ -172,7 +171,6 @@ Peer.prototype.properties = [
 	'version',
 	'broadhash',
 	'height',
-	'clock',
 	'updated',
 	'nonce',
 	'httpPort',

--- a/storage/entities/peer.js
+++ b/storage/entities/peer.js
@@ -32,7 +32,6 @@ const readOnlyFields = [];
  * @property {number} state
  * @property {string} os
  * @property {string} version
- * @property {number} clock
  * @property {string} broadhash
  * @property {number} height
  */
@@ -79,14 +78,6 @@ const readOnlyFields = [];
  * @property {string} [version_ne]
  * @property {string} [version_in]
  * @property {string} [version_like]
- * @property {number} [clock]
- * @property {number} [clock_eql]
- * @property {number} [clock_ne]
- * @property {number} [clock_gt]
- * @property {number} [clock_gte]
- * @property {number} [clock_lt]
- * @property {number} [clock_lte]
- * @property {number} [clock_in]
  * @property {string} [broadhash]
  * @property {string} [broadhash_eql]
  * @property {string} [broadhash_ne]
@@ -117,7 +108,6 @@ class Peer extends BaseEntity {
 		this.addField('state', 'number', { filter: filterType.NUMBER });
 		this.addField('os', 'string', { filter: filterType.TEXT });
 		this.addField('version', 'string', { filter: filterType.TEXT });
-		this.addField('clock', 'number', { filter: filterType.NUMBER });
 		this.addField(
 			'broadhash',
 			'string',

--- a/storage/sql/peers/get.sql
+++ b/storage/sql/peers/get.sql
@@ -19,7 +19,6 @@ SELECT
 	"state",
 	"os",
 	"version",
-	"clock",
 	ENCODE("broadhash", 'hex') as "broadhash",
 	"height"
 FROM

--- a/test/fixtures/peers.js
+++ b/test/fixtures/peers.js
@@ -71,11 +71,7 @@ const Peer = stampit({
 });
 
 const DBPeer = stampit(Peer, {
-	props: {
-		clock: '',
-	},
 	init() {
-		this.clock = (+new Date() / 1000).toFixed();
 		delete this.dappid;
 		delete this.httpPort;
 		delete this.nonce;

--- a/test/network/scenarios/p2p/peers.js
+++ b/test/network/scenarios/p2p/peers.js
@@ -69,7 +69,6 @@ module.exports = function(configurations, network, WSPORTS, TOTAL_PEERS) {
 						// delete the not required properties from ws peer list call
 						// to keep consistency with api/controllers/peers.js/getPeers
 						delete peer.updated;
-						delete peer.clock;
 						return expect(peer).to.have.all.keys(peerProps);
 					});
 				});

--- a/test/unit/db/repos/peers.js
+++ b/test/unit/db/repos/peers.js
@@ -74,7 +74,6 @@ describe('db', () => {
 					'height',
 					'os',
 					'version',
-					'clock',
 					'broadhash',
 				]);
 			});
@@ -114,8 +113,7 @@ describe('db', () => {
 					'os',
 					'version',
 					'broadhash',
-					'height',
-					'clock'
+					'height'
 				);
 				return expect(result).to.be.eql(peers);
 			});

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -415,7 +415,7 @@ describe('transaction', () => {
 		it('should throw an error with no param', () => {
 			return expect(
 				transactionLogic.checkConfirmed.bind(transactionLogic)
-			).to.throw('Callback must be a function');
+			).to.throw('"callback" argument must be a function');
 		});
 
 		it('should return an error with no transaction', done => {

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -415,7 +415,7 @@ describe('transaction', () => {
 		it('should throw an error with no param', () => {
 			return expect(
 				transactionLogic.checkConfirmed.bind(transactionLogic)
-			).to.throw('"callback" argument must be a function');
+			).to.throw('Callback must be a function');
 		});
 
 		it('should return an error with no transaction', done => {

--- a/test/unit/storage/entities/peer.js
+++ b/test/unit/storage/entities/peer.js
@@ -50,7 +50,6 @@ describe('Peer', () => {
 			'state',
 			'os',
 			'version',
-			'clock',
 			'broadhash',
 			'height',
 		];
@@ -97,14 +96,6 @@ describe('Peer', () => {
 			'version_ne',
 			'version_in',
 			'version_like',
-			'clock',
-			'clock_eql',
-			'clock_ne',
-			'clock_gt',
-			'clock_gte',
-			'clock_lt',
-			'clock_lte',
-			'clock_in',
 			'broadhash',
 			'broadhash_eql',
 			'broadhash_ne',
@@ -138,7 +129,6 @@ describe('Peer', () => {
 			broadhash:
 				'71b168bca5a6ec7736ed7d25b818890620133b5a9934cd4733f3be955a1ab45a',
 			height: 6857664,
-			clock: null,
 		};
 
 		invalidPeer = {
@@ -150,7 +140,6 @@ describe('Peer', () => {
 			broadhash:
 				'71b168bca5a6ec7736ed7d25b818890620133b5a9934cd4733f3be955a1ab45a',
 			height: 'foo',
-			clock: 'bar',
 		};
 
 		invalidOptions = {


### PR DESCRIPTION
### What was the problem?

Clocks should be removed from Peers as it was not being used by the application

### How did I fix it?

- Removed the clocks column from peers
- Removed references to clock from code
- Removed references to clock from peers

### How to test it?

- Run the application `node app.js` and the migration should be run and no clock column should exist in the peers table
- Build should be green
- Peers should be persisted correctly when stoping the applicaton

### Review checklist

* The PR resolves #2687
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
