### PR TITLE
Allow sort to not force a default - Closes #2700

### DIFF
--- a/storage/entities/round.js
+++ b/storage/entities/round.js
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { defaults, omit, pick } = require('lodash');
+const filterType = require('../utils/filter_types');
+const BaseEntity = require('./base_entity');
+
+const defaultCreateValues = {};
+
+const readOnlyFields = [];
+
+/**
+ * Round
+ * @typedef {Object} Round
+ * @property {string} address
+ * @property {number} amount
+ * @property {string} delegate
+ * @property {number} round
+ */
+
+/**
+ * Round Filters
+ * @typedef {Object} filters.Round
+ * @property {string} [address]
+ * @property {string} [address_eql]
+ * @property {string} [address_ne]
+ * @property {string} [address_in]
+ * @property {string} [address_like]
+ * @property {number} [amount]
+ * @property {number} [amount_eql]
+ * @property {number} [amount_ne]
+ * @property {number} [amount_gt]
+ * @property {number} [amount_gte]
+ * @property {number} [amount_lt]
+ * @property {number} [amount_lte]
+ * @property {number} [amount_in]
+ * @property {string} [delegate]
+ * @property {string} [delegate_eql]
+ * @property {string} [delegate_ne]
+ * @property {string} [delegate_in]
+ * @property {string} [delegate_like]
+ * @property {number} [round]
+ * @property {number} [round_eql]
+ * @property {number} [round_ne]
+ * @property {number} [round_gt]
+ * @property {number} [round_gte]
+ * @property {number} [round_lt]
+ * @property {number} [round_lte]
+ * @property {number} [round_in]
+ */
+
+class Round extends BaseEntity {
+	/**
+	 * Constructor
+	 * @param {BaseAdapter} adapter - Adapter to retrieve the data from
+	 * @param {filters.Round} defaultFilters - Set of default filters applied on every query
+	 */
+	constructor(adapter, defaultFilters = {}) {
+		super(adapter, defaultFilters);
+
+		this.addField('address', 'string', { filter: filterType.TEXT });
+		this.addField('amount', 'number', { filter: filterType.NUMBER });
+		this.addField('delegate', 'string', { filter: filterType.TEXT });
+		this.addField('round', 'number', { filter: filterType.NUMBER });
+
+		const defaultSort = { sort: '' };
+		this.extendDefaultOptions(defaultSort);
+
+		this.SQLs = {
+			select: this.adapter.loadSQLFile('rounds/get.sql'),
+			create: this.adapter.loadSQLFile('rounds/create.sql'),
+			update: this.adapter.loadSQLFile('rounds/update.sql'),
+			updateOne: this.adapter.loadSQLFile('rounds/update_one.sql'),
+			isPersisted: this.adapter.loadSQLFile('rounds/is_persisted.sql'),
+		};
+	}
+
+	/**
+	 * Get one round
+	 *
+	 * @param {filters.Round|filters.Round[]} [filters = {}]
+	 * @param {Object} [options = {}] - Options to filter data
+	 * @param {Number} [options.limit=10] - Number of records to fetch
+	 * @param {Number} [options.offset=0] - Offset to start the records
+	 * @param {Object} [tx] - Database transaction object
+	 * @return {Promise.<Round, Error>}
+	 */
+	getOne(filters, options = {}, tx = null) {
+		const expectedResultCount = 1;
+		return this._getResults(filters, options, tx, expectedResultCount);
+	}
+
+	/**
+	 * Get list of rounds
+	 *
+	 * @param {filters.Round|filters.Round[]} [filters = {}]
+	 * @param {Object} [options = {}] - Options to filter data
+	 * @param {Number} [options.limit=10] - Number of records to fetch
+	 * @param {Number} [options.offset=0] - Offset to start the records
+	 * @param {Object} [tx] - Database transaction object
+	 * @return {Promise.<Round[], Error>}
+	 */
+	get(filters = {}, options = {}, tx = null) {
+		return this._getResults(filters, options, tx);
+	}
+
+	_getResults(filters, options, tx, expectedResultCount = undefined) {
+		this.validateFilters(filters);
+		this.validateOptions(options);
+
+		const mergedFilters = this.mergeFilters(filters);
+		const parsedFilters = this.parseFilters(mergedFilters);
+		const parsedOptions = defaults(
+			{},
+			pick(options, ['limit', 'offset', 'sort']),
+			pick(this.defaultOptions, ['limit', 'offset', 'sort'])
+		);
+		const parsedSort = this.parseSort(parsedOptions.sort);
+
+		const params = {
+			limit: parsedOptions.limit,
+			offset: parsedOptions.offset,
+			parsedSort,
+			parsedFilters,
+		};
+
+		return this.adapter.executeFile(
+			this.SQLs.select,
+			params,
+			{ expectedResultCount },
+			tx
+		);
+	}
+
+	/**
+	 * Create round object
+	 *
+	 * @param {Object} data
+	 * @param {Object} [_options]
+	 * @param {Object} [tx] - Transaction object
+	 * @return {null}
+	 */
+	// eslint-disable-next-line no-unused-vars
+	create(data, _options = {}, tx = null) {
+		assert(data, 'Must provide data to create account');
+		assert(
+			typeof data === 'object' || Array.isArray(data),
+			'Data must be an object or array of objects'
+		);
+
+		let values;
+
+		if (Array.isArray(data)) {
+			values = data.map(item => ({ ...item }));
+		} else if (typeof data === 'object') {
+			values = [{ ...data }];
+		}
+
+		values = values.map(v => defaults(v, defaultCreateValues));
+		const attributes = Object.keys(this.fields).filter(
+			fieldname => fieldname !== 'id'
+		);
+		const createSet = this.getValuesSet(values, attributes);
+		const fields = attributes
+			.map(k => `"${this.fields[k].fieldName}"`)
+			.join(',');
+
+		return this.adapter.executeFile(
+			this.SQLs.create,
+			{ createSet, fields },
+			{ expectedResultCount: 0 },
+			tx
+		);
+	}
+
+	/**
+	 * Update the records based on given condition
+	 *
+	 * @param {filters.Round} [filters]
+	 * @param {Object} data
+	 * @param {Object} [options]
+	 * @param {Object} [tx] - Transaction object
+	 * @return {null}
+	 */
+	update(filters, data, _options, tx = null) {
+		this.validateFilters(filters);
+		const objectData = omit(data, readOnlyFields);
+		const mergedFilters = this.mergeFilters(filters);
+		const parsedFilters = this.parseFilters(mergedFilters);
+		const updateSet = this.getUpdateSet(objectData);
+
+		const params = {
+			...objectData,
+			parsedFilters,
+			updateSet,
+		};
+
+		return this.adapter.executeFile(
+			this.SQLs.update,
+			params,
+			{ expectedResultCount: 0 },
+			tx
+		);
+	}
+
+	/**
+	 * Update one record based on the condition given
+	 *
+	 * @param {filters.Round} filters
+	 * @param {Object} data
+	 * @param {Object} [options]
+	 * @param {Object} [tx] - Transaction object
+	 * @return {null}
+	 */
+	updateOne(filters, data, _options, tx = null) {
+		this.validateFilters(filters);
+		const objectData = omit(data, readOnlyFields);
+		const mergedFilters = this.mergeFilters(filters);
+		const parsedFilters = this.parseFilters(mergedFilters);
+		const updateSet = this.getUpdateSet(objectData);
+
+		const params = {
+			...objectData,
+			parsedFilters,
+			updateSet,
+		};
+
+		return this.adapter.executeFile(
+			this.SQLs.updateOne,
+			params,
+			{ expectedResultCount: 0 },
+			tx
+		);
+	}
+
+	/**
+	 * Check if the record exists with following conditions
+	 *
+	 * @param {filters.Round} filters
+	 * @param {Object} [options]
+	 * @param {Object} [tx]
+	 * @returns {Promise.<boolean, Error>}
+	 */
+	isPersisted(filters, _options, tx = null) {
+		const atLeastOneRequired = true;
+		this.validateFilters(filters, atLeastOneRequired);
+		const mergedFilters = this.mergeFilters(filters);
+		const parsedFilters = this.parseFilters(mergedFilters);
+
+		return this.adapter
+			.executeFile(
+				this.SQLs.isPersisted,
+				{ parsedFilters },
+				{ expectedResultCount: 1 },
+				tx
+			)
+			.then(result => result.exists);
+	}
+}
+
+module.exports = Round;

--- a/storage/sql/rounds/create.sql
+++ b/storage/sql/rounds/create.sql
@@ -12,15 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-'use strict';
-
-module.exports = {
-	Account: require('./account'),
-	BaseEntity: require('./base_entity'),
-	Block: require('./block'),
-	Delegate: require('./delegate'),
-	Migration: require('./migration'),
-	Peer: require('./peer'),
-	Round: require('./round'),
-	Transaction: require('./transaction'),
-};
+INSERT INTO mem_round (
+	${fields:raw}
+) VALUES
+	${createSet:raw}
+;

--- a/storage/sql/rounds/get.sql
+++ b/storage/sql/rounds/get.sql
@@ -12,15 +12,16 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-'use strict';
+SELECT
+	"address",
+	"amount",
+	"delegate",
+	"round"
+FROM
+	mem_round
 
-module.exports = {
-	Account: require('./account'),
-	BaseEntity: require('./base_entity'),
-	Block: require('./block'),
-	Delegate: require('./delegate'),
-	Migration: require('./migration'),
-	Peer: require('./peer'),
-	Round: require('./round'),
-	Transaction: require('./transaction'),
-};
+${parsedFilters:raw}
+
+${parsedSort:raw}
+
+LIMIT ${limit} OFFSET ${offset}

--- a/storage/sql/rounds/is_persisted.sql
+++ b/storage/sql/rounds/is_persisted.sql
@@ -12,15 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-'use strict';
-
-module.exports = {
-	Account: require('./account'),
-	BaseEntity: require('./base_entity'),
-	Block: require('./block'),
-	Delegate: require('./delegate'),
-	Migration: require('./migration'),
-	Peer: require('./peer'),
-	Round: require('./round'),
-	Transaction: require('./transaction'),
-};
+SELECT EXISTS (
+	SELECT 1 FROM mem_round ${parsedFilters:raw}
+);

--- a/storage/sql/rounds/update.sql
+++ b/storage/sql/rounds/update.sql
@@ -12,15 +12,5 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-'use strict';
 
-module.exports = {
-	Account: require('./account'),
-	BaseEntity: require('./base_entity'),
-	Block: require('./block'),
-	Delegate: require('./delegate'),
-	Migration: require('./migration'),
-	Peer: require('./peer'),
-	Round: require('./round'),
-	Transaction: require('./transaction'),
-};
+UPDATE mem_round SET ${updateSet:raw} ${parsedFilters:raw};

--- a/storage/sql/rounds/update_one.sql
+++ b/storage/sql/rounds/update_one.sql
@@ -12,15 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-'use strict';
-
-module.exports = {
-	Account: require('./account'),
-	BaseEntity: require('./base_entity'),
-	Block: require('./block'),
-	Delegate: require('./delegate'),
-	Migration: require('./migration'),
-	Peer: require('./peer'),
-	Round: require('./round'),
-	Transaction: require('./transaction'),
-};
+UPDATE mem_round SET ${updateSet:raw} WHERE id = (SELECT id FROM mem_round ${parsedFilters:raw} LIMIT 1);

--- a/storage/storage.js
+++ b/storage/storage.js
@@ -21,6 +21,7 @@ const {
 	Block,
 	Delegate,
 	Peer,
+	Round,
 	Transaction,
 	Migration,
 } = require('./entities');
@@ -62,6 +63,7 @@ class Storage {
 					Delegate: new Delegate(adapter),
 					Migration: new Migration(adapter),
 					Peer: new Peer(adapter),
+					Round: new Round(adapter),
 					Transaction: new Transaction(adapter),
 				};
 			}

--- a/storage/utils/sort_option.js
+++ b/storage/utils/sort_option.js
@@ -24,8 +24,12 @@ const isSortOptionValid = (sortOption, fields) => {
 };
 
 const parseSortString = sortString => {
-	const { field, method } = parseSortStringToObject(sortString);
-	return `"${field}" ${method.toUpperCase()}`;
+	let sortClause = '';
+	if (sortString) {
+		const { field, method } = parseSortStringToObject(sortString);
+		sortClause = `"${field}" ${method.toUpperCase()}`;
+	}
+	return sortClause;
 };
 
 const parseSortStringToObject = sortString => {


### PR DESCRIPTION
### What was the problem?

If sort was implemented in an storage entity a default sort had to be defined.

### How did I fix it?

By making changes to `parseSortString()` and return an empty string if no default sort

### How to test it?

- Build should be green
- Execute get() in an entity where sort was implemented but set the default to `sort: ''` i.e. no sort and the query should be well formed
- Execute get() in an entity where sort was implemented set a default and should return a well formed query
- Execute get() in an entity where sort was implemented pass any valid sort field and should return a well formed query

### Review checklist

* The PR resolves #2700
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
