### PR TITLE
Allow sort to not force a default - Closes #2700

### DIFF
--- a/storage/utils/sort_option.js
+++ b/storage/utils/sort_option.js
@@ -24,8 +24,12 @@ const isSortOptionValid = (sortOption, fields) => {
 };
 
 const parseSortString = sortString => {
-	const { field, method } = parseSortStringToObject(sortString);
-	return `"${field}" ${method.toUpperCase()}`;
+	let sortClause = '';
+	if (sortString) {
+		const { field, method } = parseSortStringToObject(sortString);
+		sortClause = `"${field}" ${method.toUpperCase()}`;
+	}
+	return sortClause;
 };
 
 const parseSortStringToObject = sortString => {


### PR DESCRIPTION
### What was the problem?

If sort was implemented in an storage entity a default sort had to be defined.

### How did I fix it?

By making changes to `parseSortString()` and return an empty string if no default sort

### How to test it?

- Build should be green
- Execute get() in an entity where sort was implemented but set the default to `sort: ''` i.e. no sort and the query should be well formed
- Execute get() in an entity where sort was implemented set a default and should return a well formed query
- Execute get() in an entity where sort was implemented pass any valid sort field and should return a well formed query

### Review checklist

* The PR resolves #2700
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
