### PR TITLE
Replace transactions getter interfaces with storage.entities.Transaction.get - Closes #2621

### DIFF
--- a/api/controllers/transactions.js
+++ b/api/controllers/transactions.js
@@ -77,7 +77,7 @@ TransactionsController.getTransactions = async function(context, next) {
 		senderId: params.senderId.value,
 		senderPublicKey: params.senderPublicKey.value,
 		type: params.type.value,
-		blockHeight: params.height.value,
+		height: params.height.value,
 		timestamp_gte: params.fromTimestamp.value,
 		timestamp_let: params.toTimestamp.value,
 		amount_gte: params.minAmount.value,

--- a/api/controllers/transactions.js
+++ b/api/controllers/transactions.js
@@ -47,9 +47,6 @@ function transactionFormatter(transaction) {
 	result.signSignature = result.signSignature || '';
 	result.signatures = result.signatures || [];
 
-	// result.amount = result.amount.toString();
-	// result.fee = result.fee.toString();
-
 	return result;
 }
 
@@ -79,7 +76,7 @@ TransactionsController.getTransactions = async function(context, next) {
 		type: params.type.value,
 		height: params.height.value,
 		timestamp_gte: params.fromTimestamp.value,
-		timestamp_let: params.toTimestamp.value,
+		timestamp_lte: params.toTimestamp.value,
 		amount_gte: params.minAmount.value,
 		amount_lte: params.maxAmount.value,
 		data_like: params.data.value,
@@ -104,13 +101,13 @@ TransactionsController.getTransactions = async function(context, next) {
 	}
 
 	try {
-		const data = await storage.entities.Transaction.get(filters, options).map(
-			transactionFormatter
-		);
-		const count = await storage.entities.Transaction.count(filters);
+		const [data, count] = await Promise.all([
+			storage.entities.Transaction.get(filters, options),
+			storage.entities.Transaction.count(filters),
+		]);
 
 		return next(null, {
-			data,
+			data: data.map(transactionFormatter),
 			meta: {
 				offset: options.offset,
 				limit: options.limit,

--- a/db/repos/transactions/index.js
+++ b/db/repos/transactions/index.js
@@ -120,51 +120,6 @@ class TransactionsRepository {
 	}
 
 	/**
-	 * Count transactions with extended params.
-	 * The params to this method comes in this format
-	 *
-	 * { where:
-	 *   [ '"t_recipientId" IN (${recipientId:csv})',
-	 *     'AND "t_senderId" IN (${senderId:csv})' ],
-	 *  owner: '',
-	 *  recipientId: '1253213165192941997L',
-	 *  senderId: '16313739661670634666L',
-	 *  limit: 10,
-	 *  offset: 0 }
-	 *
-	 *   @todo Simplify the usage and pass direct params to the method
-	 *
-	 * @param {Object} params
-	 * @param {Array} params.where
-	 * @param {string} params.owner
-	 * @returns {Promise<number>}
-	 * Transactions counter.
-	 */
-	countList(params) {
-		// Add dummy condition in case of blank to avoid conditional where clause
-		let conditions =
-			params && params.where && params.where.length ? params.where : [];
-
-		// Handle the case if single condition is provided
-		if (typeof conditions === 'string') {
-			conditions = [conditions];
-		}
-
-		// FIXME: Backward compatibility, should be removed after transitional period
-		if (params && params.owner) {
-			conditions.push(`AND ${params.owner}`);
-		}
-
-		if (conditions.length) {
-			conditions = `WHERE ${this.pgp.as.format(conditions.join(' '), params)}`;
-		} else {
-			conditions = '';
-		}
-
-		return this.db.one(sql.countList, { conditions }, a => +a.count);
-	}
-
-	/**
 	 * Gets transfer transactions from a list of id-s.
 	 *
 	 * @param {Array.<string>} ids

--- a/db/repos/transactions/index.js
+++ b/db/repos/transactions/index.js
@@ -165,23 +165,6 @@ class TransactionsRepository {
 	}
 
 	/**
-	 * Search transactions.
-	 *
-	 * @param {Object} params
-	 * @param {Array} params.where
-	 * @param {string} params.owner
-	 * @param {string} params.sortField
-	 * @param {string} params.sortMethod
-	 * @param {int} params.limit
-	 * @param {int} params.offset
-	 * @returns {Promise<[]>}
-	 * List of transactions.
-	 */
-	list(params) {
-		return this.db.any(Queries.list, params);
-	}
-
-	/**
 	 * Gets transfer transactions from a list of id-s.
 	 *
 	 * @param {Array.<string>} ids
@@ -321,30 +304,5 @@ class TransactionsRepository {
 			: this.db.tx('transactions:save', job);
 	}
 }
-
-// TODO: All these queries need to be thrown away, and use proper implementation inside corresponding methods.
-const Queries = {
-	list: params =>
-		[
-			'SELECT t_id, b_height, "t_blockId", t_type, t_timestamp, "t_senderId", "t_recipientId",',
-			't_amount, t_fee, t_signature, "t_SignSignature", t_signatures, confirmations,',
-			'encode("t_senderPublicKey", \'hex\') AS "t_senderPublicKey", encode("m_recipientPublicKey", \'hex\') AS "m_recipientPublicKey"',
-			'FROM trs_list',
-			params.where.length || params.owner ? 'WHERE' : '',
-			params.where.length ? `(${params.where.join(' ')})` : '',
-			// FIXME: Backward compatibility, should be removed after transitional period
-			params.where.length && params.owner
-				? ` AND ${params.owner}`
-				: params.owner,
-			params.sortField
-				? `ORDER BY ${[params.sortField, params.sortMethod].join(
-						' '
-					)}, "t_rowId" ASC`
-				: '',
-			'LIMIT ${limit} OFFSET ${offset}',
-		]
-			.filter(Boolean)
-			.join(' '),
-};
 
 module.exports = TransactionsRepository;

--- a/db/sql/migrations/updates/20190104000001_add_recipient_public_key_to_full_block_list.sql
+++ b/db/sql/migrations/updates/20190104000001_add_recipient_public_key_to_full_block_list.sql
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: Add support of recipientPublicKey to the view
+
+  PARAMETERS: None
+
+  Due to issue https://dba.stackexchange.com/a/589/67449 used to drop view first and then create
+*/
+
+DROP VIEW "full_blocks_list";
+
+CREATE VIEW "full_blocks_list" AS SELECT
+    b.id AS b_id,
+    b.version AS b_version,
+    b."timestamp" AS b_timestamp,
+    b.height AS b_height,
+    b."previousBlock" AS "b_previousBlock",
+    b."numberOfTransactions" AS "b_numberOfTransactions",
+    b."totalAmount" AS "b_totalAmount",
+    b."totalFee" AS "b_totalFee",
+    b.reward AS b_reward,
+    b."payloadLength" AS "b_payloadLength",
+    encode(b."payloadHash", 'hex') AS "b_payloadHash",
+    encode(b."generatorPublicKey", 'hex') AS "b_generatorPublicKey",
+    encode(b."blockSignature", 'hex') AS "b_blockSignature",
+    t.id AS t_id,
+    t."rowId" AS "t_rowId",
+    t.type AS t_type,
+    t."timestamp" AS t_timestamp,
+    encode(a."publicKey", 'hex') AS "t_recipientPublicKey",
+    encode(t."senderPublicKey", 'hex') AS "t_senderPublicKey",
+    t."senderId" AS "t_senderId",
+    t."recipientId" AS "t_recipientId",
+    t.amount AS t_amount,
+    t.fee AS t_fee,
+    encode(t.signature, 'hex') AS t_signature,
+    encode(t."signSignature", 'hex') AS "t_signSignature",
+    encode(s."publicKey", 'hex') AS "s_publicKey",
+    d.username AS d_username,
+    v.votes AS v_votes,
+    m.min AS m_min,
+    m.lifetime AS m_lifetime,
+    m.keysgroup AS m_keysgroup,
+    dapp.name AS dapp_name,
+    dapp.description AS dapp_description,
+    dapp.tags AS dapp_tags,
+    dapp.type AS dapp_type,
+    dapp.link AS dapp_link,
+    dapp.category AS dapp_category,
+    dapp.icon AS dapp_icon,
+    it."dappId" AS "in_dappId",
+    ot."dappId" AS "ot_dappId",
+    ot."outTransactionId" AS "ot_outTransactionId",
+    encode(t."requesterPublicKey", 'hex') AS "t_requesterPublicKey",
+    tf.data AS tf_data,
+    t.signatures AS t_signatures
+   FROM (((((((((blocks b
+     LEFT JOIN trs t ON (((t."blockId") = (b.id))))
+     LEFT JOIN mem_accounts a ON (((t."recipientId") = (a.address)))
+     LEFT JOIN delegates d ON (((d."transactionId") = (t.id))))
+     LEFT JOIN votes v ON (((v."transactionId") = (t.id))))
+     LEFT JOIN signatures s ON (((s."transactionId") = (t.id))))
+     LEFT JOIN multisignatures m ON (((m."transactionId") = (t.id))))
+     LEFT JOIN dapps dapp ON (((dapp."transactionId") = (t.id))))
+     LEFT JOIN intransfer it ON (((it."transactionId") = (t.id))))
+     LEFT JOIN outtransfer ot ON (((ot."transactionId") = (t.id))))
+     LEFT JOIN transfer tf ON (((tf."transactionId") = (t.id))));

--- a/helpers/newrelic_lisk.js
+++ b/helpers/newrelic_lisk.js
@@ -90,7 +90,6 @@ const modulesToInstrument = {
 	'./modules/transactions.js': {
 		identifier: 'modules.transactions',
 		callbackMethods: [
-			'shared.getTransactions',
 			'shared.getTransactionsCount',
 			'shared.getUnProcessedTransactions',
 			'shared.getMultisignatureTransactions',

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -14,24 +14,18 @@
 
 'use strict';
 
-const Promise = require('bluebird');
 const _ = require('lodash');
 const async = require('async');
 const apiCodes = require('../helpers/api_codes.js');
 const ApiError = require('../helpers/api_error.js');
 const sortBy = require('../helpers/sort_by.js').sortBy;
 const TransactionPool = require('../logic/transaction_pool.js');
-const transactionTypes = require('../helpers/transaction_types.js');
-const Transfer = require('../logic/transfer.js');
 
 // Private fields
-const { EPOCH_TIME } = global.constants;
 const __private = {};
 let modules;
 let library;
 let self;
-
-__private.assetTypes = {};
 
 /**
  * Main transactions methods. Initializes library with scope content and generates a Transfer instance
@@ -57,6 +51,7 @@ class Transactions {
 		library = {
 			logger: scope.logger,
 			db: scope.db,
+			storage: scope.storage,
 			schema: scope.schema,
 			ed: scope.ed,
 			balancesSequence: scope.balancesSequence,
@@ -78,13 +73,6 @@ class Transactions {
 			scope.config
 		);
 
-		__private.assetTypes[
-			transactionTypes.SEND
-		] = library.logic.transaction.attachAssetType(
-			transactionTypes.SEND,
-			new Transfer(library.logger, library.schema)
-		);
-
 		setImmediate(cb, null, self);
 	}
 }
@@ -94,266 +82,64 @@ class Transactions {
  * Counts totals and gets transaction list from `trs_list` view.
  *
  * @private
- * @param {Object} filter
+ * @param {Object} params
  * @param {function} cb - Callback function
  * @returns {setImmediateCallback} cb, err, {transactions, count}
  * @todo Add description for the params
  */
-__private.list = function(filter, cb) {
-	const params = {};
-	const where = [];
-
-	if (filter.data) {
-		filter.data = Buffer.from(filter.data, 'utf8');
-	}
-
-	const allowedFieldsMap = {
-		senderIdOrRecipientId:
-			'("t_senderId" = ${senderIdOrRecipientId} OR "t_recipientId" = ${senderIdOrRecipientId})',
-		id: '"t_id" = ${id}',
-		blockId: '"t_blockId" = ${blockId}',
-		fromHeight: '"b_height" >= ${fromHeight}',
-		toHeight: '"b_height" <= ${toHeight}',
-		fromTimestamp: '"t_timestamp" >= ${fromTimestamp}',
-		toTimestamp: '"t_timestamp" <= ${toTimestamp}',
-		senderId: '"t_senderId" IN (${senderId:csv})',
-		recipientId: '"t_recipientId" IN (${recipientId:csv})',
-		senderPublicKey:
-			'ENCODE ("t_senderPublicKey", \'hex\') IN (${senderPublicKey:csv})',
-		recipientPublicKey:
-			'ENCODE ("m_recipientPublicKey", \'hex\') IN (${recipientPublicKey:csv})',
-		minAmount: '"t_amount" >= ${minAmount}',
-		maxAmount: '"t_amount" <= ${maxAmount}',
-		type: '"t_type" = ${type}',
-		minConfirmations: 'confirmations >= ${minConfirmations}',
-		data:
-			't_id IN (SELECT transfer."transactionId" FROM transfer WHERE transfer.data LIKE ${data})',
-		limit: null,
-		offset: null,
-		sort: null,
-		// FIXME: Backward compatibility, should be removed after transitional period
-		ownerAddress: null,
-		ownerPublicKey: null,
-	};
-	let owner = '';
-	let isFirstWhere = true;
-
-	/**
-	 * Description of processParams.
-	 *
-	 * @todo Add @param tags
-	 * @todo Add @returns tag
-	 * @todo Add description of the function
-	 */
-	const processParams = function(value, field) {
-		// Mutating parametres when unix timestamp is supplied
-		if (_.includes(['fromUnixTime', 'toUnixTime'], field)) {
-			// Lisk epoch is 1464109200 as unix timestamp
-			value -= EPOCH_TIME.getTime() / 1000;
-			field = field.replace('UnixTime', 'Timestamp');
-		}
-
-		if (!_.includes(_.keys(allowedFieldsMap), field)) {
-			throw new Error(`Parameter is not supported: ${field}`);
-		}
-
-		// Checking for empty parameters, 0 is allowed for few
-		if (
-			!value &&
-			!(
-				value === 0 &&
-				_.includes(
-					['fromTimestamp', 'minAmount', 'minConfirmations', 'type', 'offset'],
-					field
-				)
-			)
-		) {
-			throw new Error(`Value for parameter [${field}] cannot be empty`);
-		}
-
-		if (allowedFieldsMap[field]) {
-			where.push((!isFirstWhere ? 'AND ' : '') + allowedFieldsMap[field]);
-			params[field] = value;
-			isFirstWhere = false;
-		}
+__private.list = async function(params = {}, cb) {
+	let filters = {
+		id: params.id,
+		blockId: params.blockId,
+		recipientId: params.recipientId,
+		recipientPublicKey: params.recipientPublicKey,
+		senderId: params.senderId,
+		senderPublicKey: params.senderPublicKey,
+		type: params.type,
+		height: params.height,
+		height_gte: params.fromHeight,
+		height_lte: params.toHeight,
+		timestamp_gte: params.fromTimestamp,
+		timestamp_lte: params.toTimestamp,
+		amount_gte: params.minAmount,
+		amount_lte: params.maxAmount,
 	};
 
-	// Generate list of fields with conditions
-	try {
-		_.each(filter, processParams);
-	} catch (err) {
-		return setImmediate(cb, err.message);
+	let options = {
+		sort: params.sort,
+		limit: params.limit || 100,
+		offset: params.offset || 0,
+		extended: true,
+	};
+
+	if (params.data) {
+		filters.data_like = Buffer.from(params.data, 'utf8');
 	}
 
-	// FIXME: Backward compatibility, should be removed after transitional period
-	if (filter.ownerAddress && filter.ownerPublicKey) {
-		owner =
-			'("t_senderPublicKey" = DECODE (${ownerPublicKey}, \'hex\') OR "t_recipientId" = ${ownerAddress})';
-		params.ownerPublicKey = filter.ownerPublicKey;
-		params.ownerAddress = filter.ownerAddress;
-	}
-
-	if (!filter.limit) {
-		params.limit = 100;
-	} else {
-		params.limit = Math.abs(filter.limit);
-	}
-
-	if (!filter.offset) {
-		params.offset = 0;
-	} else {
-		params.offset = Math.abs(filter.offset);
-	}
+	// Remove filters with null values
+	filters = _.pickBy(filters, v => !(v === undefined || v === null));
+	options = _.pickBy(options, v => !(v === undefined || v === null));
 
 	if (params.limit > 1000) {
 		return setImmediate(cb, 'Invalid limit, maximum is 1000');
 	}
 
-	const sort = sortBy(filter.sort, {
-		sortFields: library.db.transactions.sortFields,
-		fieldPrefix(sortField) {
-			if (['height'].indexOf(sortField) > -1) {
-				return `b_${sortField}`;
-			} else if (['confirmations'].indexOf(sortField) > -1) {
-				return sortField;
-			}
-			return `t_${sortField}`;
-		},
-	});
+	try {
+		const count = await library.storage.entities.Transaction.count(filters);
+		const transactions = await library.storage.entities.Transaction.get(
+			filters,
+			options
+		);
+		const data = {
+			transactions,
+			count,
+		};
 
-	if (sort.error) {
-		return setImmediate(cb, sort.error);
+		return setImmediate(cb, null, data);
+	} catch (error) {
+		library.logger.error(error.stack);
+		return setImmediate(cb, 'Transactions#list error');
 	}
-
-	let rawTransactionRows;
-	let count;
-
-	return library.db.transactions
-		.countList(
-			Object.assign(
-				{},
-				{
-					where,
-					owner,
-				},
-				params
-			)
-		)
-		.then(data => {
-			count = data;
-			return library.db.transactions.list(
-				Object.assign(
-					{},
-					{
-						where,
-						owner,
-						sortField: sort.sortField,
-						sortMethod: sort.sortMethod,
-					},
-					params
-				)
-			);
-		})
-		.then(rows => {
-			rawTransactionRows = rows;
-			return __private.getAssetForIds(groupTransactionIdsByType(rows));
-		})
-		.then(rows => {
-			const assetRowsByTransactionId = {};
-			_.each(rows, row => {
-				assetRowsByTransactionId[row.transaction_id] = row;
-			});
-
-			const transactions = rawTransactionRows.map(rawTransactionRow =>
-				library.logic.transaction.dbRead(
-					_.merge(
-						rawTransactionRow,
-						assetRowsByTransactionId[rawTransactionRow.t_id]
-					)
-				)
-			);
-
-			const data = {
-				transactions,
-				count,
-			};
-
-			return setImmediate(cb, null, data);
-		})
-		.catch(err => {
-			library.logger.error(err.stack);
-			return setImmediate(cb, 'Transactions#list error');
-		});
-};
-
-/**
- * Description of groupTransactionIdsByType.
- *
- * @todo Add @param tags
- * @todo Add @returns tag
- * @todo Add description of the function
- */
-function groupTransactionIdsByType(rawTransactions) {
-	const groupedTransactions = _.groupBy(rawTransactions, 't_type');
-	const transactionIdsByType = _.map(_.keys(groupedTransactions), type => {
-		const groupedTransactionsId = {};
-		groupedTransactionsId[type] = _.map(groupedTransactions[type], 't_id');
-		return groupedTransactionsId;
-	});
-
-	return _.assign.apply(null, transactionIdsByType);
-}
-
-/**
- * Description of getAssetForIds.
- *
- * @private
- * @todo Add @param tags
- * @todo Add @returns tag
- * @todo Add description of the function
- */
-__private.getAssetForIds = function(idsByType) {
-	const assetRawRows = _.values(
-		_.mapValues(idsByType, __private.getAssetForIdsBasedOnType)
-	);
-	return Promise.all(assetRawRows).then(_.flatMap);
-};
-
-/**
- * Description of getQueryNameByType.
- *
- * @private
- * @todo Add @param tags
- * @todo Add @returns tag
- * @todo Add description of the function
- */
-__private.getQueryNameByType = function(type) {
-	const queryNames = {};
-	queryNames[transactionTypes.SEND] = 'getTransferByIds';
-	queryNames[transactionTypes.SIGNATURE] = 'getSignatureByIds';
-	queryNames[transactionTypes.DELEGATE] = 'getDelegateByIds';
-	queryNames[transactionTypes.VOTE] = 'getVotesByIds';
-	queryNames[transactionTypes.MULTI] = 'getMultiByIds';
-	queryNames[transactionTypes.DAPP] = 'getDappByIds';
-	queryNames[transactionTypes.IN_TRANSFER] = 'getInTransferByIds';
-	queryNames[transactionTypes.OUT_TRANSFER] = 'getOutTransferByIds';
-
-	const queryName = queryNames[type];
-	return queryName;
-};
-
-/**
- * Description of getAssetForIdsBasedOnType.
- *
- * @private
- * @todo Add @param tags
- * @todo Add @returns tag
- * @todo Add description of the function
- */
-__private.getAssetForIdsBasedOnType = function(ids, type) {
-	const queryName = __private.getQueryNameByType(type);
-
-	return library.db.transactions[queryName](ids);
 };
 
 /**
@@ -545,6 +331,42 @@ Transactions.prototype.getMultisignatureTransactionList = function(
  */
 Transactions.prototype.getMergedTransactionList = function(reverse, limit) {
 	return __private.transactionPool.getMergedTransactionList(reverse, limit);
+};
+
+/**
+ * Search transactions based on the query parameter passed.
+ *
+ * @param {Object} filters - Filters applied to results
+ * @param {string} filters.id - Transaction id
+ * @param {string} filters.blockId - Block id
+ * @param {string} filters.recipientId - Recipient id
+ * @param {string} filters.recipientPublicKey - Recipient public key
+ * @param {string} filters.senderId - Sender id
+ * @param {string} filters.senderPublicKey - Sender public key
+ * @param {int} filters.transactionType - Transaction type
+ * @param {int} filters.fromHeight - From block height
+ * @param {int} filters.toHeight - To block height
+ * @param {string} filters.minAmount - Minimum amount
+ * @param {string} filters.maxAmount - Maximum amount
+ * @param {int} filters.fromTimestamp - From transaction timestamp
+ * @param {int} filters.toTimestamp - To transaction timestamp
+ * @param {string} filters.sort - Field to sort results by
+ * @param {int} filters.limit - Limit applied to results
+ * @param {int} filters.offset - Offset value for results
+ * @param {function} cb - Callback function
+ * @returns {setImmediateCallback} cb
+ * @todo Add description for the return value
+ */
+Transactions.prototype.getTransactions = function(filters, cb) {
+	__private.list(filters, (err, data) => {
+		if (err) {
+			return setImmediate(cb, `Failed to get transactions: ${err}`);
+		}
+		return setImmediate(cb, null, {
+			transactions: data.transactions,
+			count: data.count,
+		});
+	});
 };
 
 /**
@@ -766,7 +588,6 @@ Transactions.prototype.onBind = function(scope) {
 		scope.transactions,
 		scope.loader
 	);
-	__private.assetTypes[transactionTypes.SEND].bind(scope.accounts);
 };
 
 /**
@@ -806,42 +627,6 @@ __private.processPostResult = function(err, res, cb) {
  */
 Transactions.prototype.shared = {
 	/**
-	 * Search transactions based on the query parameter passed.
-	 *
-	 * @param {Object} filters - Filters applied to results
-	 * @param {string} filters.id - Transaction id
-	 * @param {string} filters.blockId - Block id
-	 * @param {string} filters.recipientId - Recipient id
-	 * @param {string} filters.recipientPublicKey - Recipient public key
-	 * @param {string} filters.senderId - Sender id
-	 * @param {string} filters.senderPublicKey - Sender public key
-	 * @param {int} filters.transactionType - Transaction type
-	 * @param {int} filters.fromHeight - From block height
-	 * @param {int} filters.toHeight - To block height
-	 * @param {string} filters.minAmount - Minimum amount
-	 * @param {string} filters.maxAmount - Maximum amount
-	 * @param {int} filters.fromTimestamp - From transaction timestamp
-	 * @param {int} filters.toTimestamp - To transaction timestamp
-	 * @param {string} filters.sort - Field to sort results by
-	 * @param {int} filters.limit - Limit applied to results
-	 * @param {int} filters.offset - Offset value for results
-	 * @param {function} cb - Callback function
-	 * @returns {setImmediateCallback} cb
-	 * @todo Add description for the return value
-	 */
-	getTransactions(filters, cb) {
-		__private.list(filters, (err, data) => {
-			if (err) {
-				return setImmediate(cb, `Failed to get transactions: ${err}`);
-			}
-			return setImmediate(cb, null, {
-				transactions: data.transactions,
-				count: data.count,
-			});
-		});
-	},
-
-	/**
 	 * Description of getTransactionsCount.
 	 *
 	 * @param {function} cb - Callback function
@@ -869,11 +654,10 @@ Transactions.prototype.shared = {
 						return setImmediate(waterCb, null, cachedCount, null);
 					}
 
-					return library.db.transactions
-						.count()
-						.then(transactionsCount =>
+					return library.storage.entities.Transaction.count().then(
+						transactionsCount =>
 							setImmediate(waterCb, null, null, transactionsCount)
-						);
+					);
 				},
 
 				function updateConfirmedCountToCache(cachedCount, dbCount, waterCb) {

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -20,12 +20,16 @@ const apiCodes = require('../helpers/api_codes.js');
 const ApiError = require('../helpers/api_error.js');
 const sortBy = require('../helpers/sort_by.js').sortBy;
 const TransactionPool = require('../logic/transaction_pool.js');
+const transactionTypes = require('../helpers/transaction_types.js');
+const Transfer = require('../logic/transfer.js');
 
 // Private fields
 const __private = {};
 let modules;
 let library;
 let self;
+
+__private.assetTypes = {};
 
 /**
  * Main transactions methods. Initializes library with scope content and generates a Transfer instance
@@ -71,6 +75,13 @@ class Transactions {
 			scope.logger,
 			scope.balancesSequence,
 			scope.config
+		);
+
+		__private.assetTypes[
+			transactionTypes.SEND
+		] = library.logic.transaction.attachAssetType(
+			transactionTypes.SEND,
+			new Transfer(library.logger, library.schema)
 		);
 
 		setImmediate(cb, null, self);
@@ -588,6 +599,8 @@ Transactions.prototype.onBind = function(scope) {
 		scope.transactions,
 		scope.loader
 	);
+
+	__private.assetTypes[transactionTypes.SEND].bind(scope.accounts);
 };
 
 /**

--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -307,7 +307,7 @@ class BaseEntity {
 		return true;
 	}
 
-	parseFilters(filters) {
+	parseFilters(filters, options = { filterPrefix: 'WHERE' }) {
 		let filterString = '';
 
 		const parseFilterObject = object =>
@@ -329,7 +329,7 @@ class BaseEntity {
 
 		// TODO: refactor this logic
 		if (filterString !== '()') {
-			return `WHERE ${this.adapter.parseQueryComponent(
+			return `${options.filterPrefix} ${this.adapter.parseQueryComponent(
 				filterString,
 				filtersObject
 			)}`;

--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -145,6 +145,15 @@ const assetAttributesMap = {
 	7: ['asset.outTransfer.dappId', ' asset.outTransfer.transactionId'],
 };
 
+// eslint-disable-next-line no-unused-vars
+const stringToByteOnlyInsert = (value, mode, alias, fieldName) => {
+	if (mode === 'select') {
+		return `$\{${alias}}`;
+	}
+
+	return value ? `DECODE($\{${alias}}, 'hex')` : 'NULL';
+};
+
 class Transaction extends BaseEntity {
 	/**
 	 * Constructor
@@ -182,7 +191,7 @@ class Transaction extends BaseEntity {
 				format: 'publicKey',
 				fieldName: 't_senderPublicKey',
 			},
-			stringToByte
+			stringToByteOnlyInsert
 		);
 		this.addField(
 			'recipientPublicKey',
@@ -192,7 +201,7 @@ class Transaction extends BaseEntity {
 				format: 'publicKey',
 				fieldName: 't_recipientPublicKey',
 			},
-			stringToByte
+			stringToByteOnlyInsert
 		);
 		this.addField(
 			'requesterPublicKey',
@@ -202,7 +211,7 @@ class Transaction extends BaseEntity {
 				format: 'publicKey',
 				fieldName: 't_requesterPublicKey',
 			},
-			stringToByte
+			stringToByteOnlyInsert
 		);
 		this.addField('senderId', 'string', {
 			filter: filterTypes.TEXT,

--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -618,7 +618,9 @@ class Transaction extends BaseEntity {
 			}
 		}
 
-		transaction.signatures = transaction.signatures.filter(Boolean);
+		if (transaction.signatures) {
+			transaction.signatures = transaction.signatures.filter(Boolean);
+		}
 
 		return transaction;
 	}

--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -600,7 +600,7 @@ class Transaction extends BaseEntity {
 		return transaction;
 	}
 
-	static _sanitizeFilters(filters) {
+	static _sanitizeFilters(filters = {}) {
 		const sanitizeFilterObject = filterObject => {
 			if (filterObject.data_like) {
 				filterObject.data_like = Buffer.from(filterObject.data_like, 'utf8');

--- a/storage/sql/transactions/count.sql
+++ b/storage/sql/transactions/count.sql
@@ -16,5 +16,5 @@ SELECT count(*)
 FROM
 	full_blocks_list
 
-${parsedFilters:raw}
+WHERE "t_rowId" IS NOT NULL  ${parsedFilters:raw}
 

--- a/storage/sql/transactions/get.sql
+++ b/storage/sql/transactions/get.sql
@@ -15,7 +15,7 @@
 SELECT
 	"t_id" as "id",
 	"b_id" as "blockId",
-	"b_height" as "blockHeight",
+	"b_height" as "height",
 	"t_type" as "type",
 	"t_timestamp" as "timestamp",
 	"t_senderId" as "senderId",
@@ -24,8 +24,9 @@ SELECT
 	"t_fee" as "fee",
 	"t_signature" as "signature",
 	"t_signSignature" as "signSignature",
-	"t_signatures" as "signatures",
+	regexp_split_to_array("t_signatures", ',') as "signatures",
 	"t_senderPublicKey" as "senderPublicKey",
+	"t_recipientPublicKey" as "recipientPublicKey",
 	"t_requesterPublicKey" as "requesterPublicKey",
 	(( SELECT (blocks.height + 1)
            FROM blocks
@@ -35,7 +36,7 @@ FROM
 	(full_blocks_list fbl
 	LEFT JOIN blocks b ON (((fbl."b_id")::text = (b.id)::text)))
 
-${parsedFilters:raw}
+WHERE "t_rowId" IS NOT NULL  ${parsedFilters:raw}
 
 ${parsedSort:raw}
 

--- a/storage/sql/transactions/get_extended.sql
+++ b/storage/sql/transactions/get_extended.sql
@@ -15,7 +15,7 @@
 SELECT
 	"t_id" as "id",
 	"b_id" as "blockId",
-	"b_height" as "blockHeight",
+	"b_height" as "height",
 	"t_type" as "type",
 	"t_timestamp" as "timestamp",
 	"t_senderId" as "senderId",
@@ -24,8 +24,9 @@ SELECT
 	"t_fee" as "fee",
 	"t_signature" as "signature",
 	"t_signSignature" as "signSignature",
-	"t_signatures" as "signatures",
+	regexp_split_to_array("t_signatures", ',') as "signatures",
 	"t_senderPublicKey" as "senderPublicKey",
+	"t_recipientPublicKey" as "recipientPublicKey",
 	"t_requesterPublicKey" as "requesterPublicKey",
 	(( SELECT (blocks.height + 1)
            FROM blocks
@@ -34,7 +35,7 @@ SELECT
  	"tf_data" as "asset.data",
  	"s_publicKey" as "asset.signature.publicKey",
  	"d_username" as "asset.delegate.username",
- 	"v_votes" as "asset.votes",
+ 	regexp_split_to_array("v_votes", ',') as "asset.votes",
  	"m_min" as "asset.multisignature.min",
  	"m_lifetime" as "asset.multisignature.lifetime",
  	"m_keysgroup" as "asset.multisignature.keysgroup",
@@ -52,7 +53,7 @@ FROM
 	(full_blocks_list fbl
 	LEFT JOIN blocks b ON (((fbl."b_id")::text = (b.id)::text)))
 
-${parsedFilters:raw}
+WHERE "t_rowId" IS NOT NULL ${parsedFilters:raw}
 
 ${parsedSort:raw}
 

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -249,7 +249,7 @@ function getAccountFromDb(library, address) {
 }
 
 function getTransactionFromModule(library, filter, cb) {
-	library.modules.transactions.shared.getTransactions(filter, (err, res) => {
+	library.modules.transactions.getTransactions(filter, (err, res) => {
 		cb(err, res);
 	});
 }

--- a/test/unit/db/repos/blocks.js
+++ b/test/unit/db/repos/blocks.js
@@ -59,6 +59,7 @@ const blockListFields = [
 	't_fee',
 	't_id',
 	't_recipientId',
+	't_recipientPublicKey',
 	't_requesterPublicKey',
 	't_rowId',
 	't_senderId',

--- a/test/unit/db/repos/transactions/index.js
+++ b/test/unit/db/repos/transactions/index.js
@@ -203,52 +203,6 @@ describe('db', () => {
 			});
 		});
 
-		describe('countList()', () => {
-			it('should fulfil with zero if no parameter provided', () => {
-				return expect(db.transactions.countList()).to.be.eventually.eql(0);
-			});
-
-			it('should use the correct SQL with correct parameters', function*() {
-				sinonSandbox.spy(db, 'one');
-				const params = {
-					where: ['t_id = ${id}'],
-					owner: '"t_blockId" = \'1111\'',
-					id: '123',
-				};
-				yield db.transactions.countList(params);
-
-				expect(db.one.firstCall.args[0]).to.eql(transactionsSQL.countList);
-				expect(db.one.firstCall.args[1]).to.eql({
-					conditions: "WHERE t_id = '123' AND \"t_blockId\" = '1111'",
-				});
-				return expect(db.one.firstCall.args[2]).to.be.a('function');
-			});
-
-			it('should return integer type count of transactions matching the particular id', function*() {
-				let transaction = null;
-
-				for (let i = 0; i < numSeedRecords; i++) {
-					transaction = new transactionsFixtures.Transaction({
-						blockId: seeder.getLastBlock().id,
-					});
-					yield db.transactions.save(transaction);
-				}
-				// Check for last transaction
-				const result = yield db.transactions.countList({
-					where: [`t_id = '${transaction.id}'`],
-				});
-
-				expect(result).to.be.a('number');
-				return expect(result).to.be.eql(1);
-			});
-
-			it('should be fulfilled if parameter "where" is provided as string', () => {
-				return expect(
-					db.transactions.countList({ where: "t_id = '1233'" })
-				).to.be.eventually.eql(0);
-			});
-		});
-
 		describe('getTransferByIds()', () => {
 			it('should use the correct SQL file with correct parameters', function*() {
 				sinonSandbox.spy(db, 'any');

--- a/test/unit/db/repos/transactions/index.js
+++ b/test/unit/db/repos/transactions/index.js
@@ -27,24 +27,6 @@ const numSeedRecords = 5;
 let db;
 let dbSandbox;
 
-const transactionListFields = [
-	't_id',
-	'b_height',
-	't_blockId',
-	't_type',
-	't_timestamp',
-	't_senderId',
-	't_recipientId',
-	't_amount',
-	't_fee',
-	't_signature',
-	't_SignSignature',
-	't_signatures',
-	'confirmations',
-	't_senderPublicKey',
-	'm_recipientPublicKey',
-];
-
 describe('db', () => {
 	before(done => {
 		dbSandbox = new DBSandbox(
@@ -264,101 +246,6 @@ describe('db', () => {
 				return expect(
 					db.transactions.countList({ where: "t_id = '1233'" })
 				).to.be.eventually.eql(0);
-			});
-		});
-
-		describe('list()', () => {
-			it('should throw error if called without parameters', () => {
-				return expect(db.transactions.list()).to.be.rejectedWith(
-					"Cannot read property 'where' of undefined"
-				);
-			});
-
-			it('should use the correct SQL with correct parameters', function*() {
-				sinonSandbox.spy(db, 'query');
-				const params = {
-					where: ["t_id = '1234'"],
-					owner: '"t_blockId" = \'1111\'',
-					sortField: 'b_height',
-					sortMethod: 'DESC',
-					limit: 10,
-					offset: 0,
-				};
-				yield db.transactions.list(params);
-
-				expect(db.query.firstCall.args[0]).to.be.a('function');
-				return expect(db.query.firstCall.args[1]).to.eql(params);
-			});
-
-			it('should return result in valid format', function*() {
-				let transaction = null;
-
-				for (let i = 0; i < numSeedRecords; i++) {
-					transaction = new transactionsFixtures.Transaction({
-						blockId: seeder.getLastBlock().id,
-					});
-					yield db.transactions.save(transaction);
-				}
-				// Check for last transaction
-				const result = yield db.transactions.list({
-					where: [`t_id = '${transaction.id}'`],
-					limit: 10,
-					offset: 0,
-				});
-
-				expect(result).to.not.empty;
-				expect(result).to.be.lengthOf(1);
-				expect(result[0].t_id).to.be.eql(transaction.id);
-				return expect(result[0]).to.have.all.keys(transactionListFields);
-			});
-
-			it('should paginate the results properly', function*() {
-				const block = seeder.getLastBlock();
-				let transaction = null;
-
-				for (let i = 0; i < numSeedRecords; i++) {
-					transaction = new transactionsFixtures.Transaction({
-						blockId: block.id,
-					});
-					yield db.transactions.save(transaction);
-				}
-				const result1 = yield db.transactions.list({
-					where: [`"t_blockId" = '${block.id}'`],
-					limit: 2,
-					offset: 0,
-				});
-				const result2 = yield db.transactions.list({
-					where: [`"t_blockId" = '${block.id}'`],
-					limit: 2,
-					offset: 1,
-				});
-
-				expect(result1).to.not.empty;
-				expect(result2).to.not.empty;
-				expect(result1).to.be.lengthOf(2);
-				expect(result2).to.be.lengthOf(2);
-				return expect(result1[1]).to.be.eql(result2[0]);
-			});
-
-			it('should sort the results for provided "sortField"', function*() {
-				const block = seeder.getLastBlock();
-				for (let i = 0; i < numSeedRecords; i++) {
-					yield db.transactions.save(
-						new transactionsFixtures.Transaction({
-							blockId: block.id,
-						})
-					);
-				}
-
-				const result = yield db.transactions.list({
-					where: [`"t_blockId" = '${block.id}'`],
-					sortField: 't_id',
-					sortMethod: 'ASC',
-					limit: 20,
-					offset: 0,
-				});
-
-				return expect(result).to.be.eql(_.orderBy(result, 't_id', 'asc'));
 			});
 		});
 

--- a/test/unit/modules/transactions.js
+++ b/test/unit/modules/transactions.js
@@ -37,16 +37,7 @@ const TransactionModule = rewire('../../../modules/transactions.js');
 describe('transactions', () => {
 	let transactionsModule;
 	let cacheModule;
-	let dbStub;
-	const TransactionTypeMap = {};
-	TransactionTypeMap[transactionTypes.SEND] = 'getTransferByIds';
-	TransactionTypeMap[transactionTypes.SIGNATURE] = 'getSignatureByIds';
-	TransactionTypeMap[transactionTypes.DELEGATE] = 'getDelegateByIds';
-	TransactionTypeMap[transactionTypes.VOTE] = 'getVotesByIds';
-	TransactionTypeMap[transactionTypes.MULTI] = 'getMultiByIds';
-	TransactionTypeMap[transactionTypes.DAPP] = 'getDappByIds';
-	TransactionTypeMap[transactionTypes.IN_TRANSFER] = 'getInTransferByIds';
-	TransactionTypeMap[transactionTypes.OUT_TRANSFER] = 'getOutTransferByIds';
+	let storageStub;
 
 	function attachAllAssets(
 		transactionLogic,
@@ -127,31 +118,19 @@ describe('transactions', () => {
 	}
 
 	before(done => {
-		dbStub = {
-			transactions: {
-				sortFields: [
-					'id',
-					'blockId',
-					'amount',
-					'fee',
-					'type',
-					'timestamp',
-					'senderPublicKey',
-					'senderId',
-					'recipientId',
-					'confirmations',
-					'height',
-				],
-				countList: null,
-				list: null,
-				count: null,
+		storageStub = {
+			entities: {
+				Transaction: {
+					get: null,
+					count: null,
+				},
 			},
 		};
 
 		async.auto(
 			{
 				accountLogic(cb) {
-					modulesLoader.initLogic(AccountLogic, { db: dbStub }, cb);
+					modulesLoader.initLogic(AccountLogic, {}, cb);
 				},
 				cacheModule(cb) {
 					modulesLoader.initCache(cb);
@@ -163,7 +142,6 @@ describe('transactions', () => {
 							TransactionLogic,
 							{
 								account: result.accountLogic,
-								db: dbStub,
 							},
 							cb
 						);
@@ -180,7 +158,7 @@ describe('transactions', () => {
 									transaction: result.transactionLogic,
 									account: result.accountLogic,
 								},
-								db: dbStub,
+								storage: storageStub,
 								config: {
 									loading: {
 										snapshot: false,
@@ -203,7 +181,6 @@ describe('transactions', () => {
 								logic: {
 									transaction: result.transactionLogic,
 								},
-								db: dbStub,
 							},
 							cb
 						);
@@ -220,7 +197,6 @@ describe('transactions', () => {
 									account: result.accountLogic,
 									transaction: result.transactionLogic,
 								},
-								db: dbStub,
 							},
 							cb
 						);
@@ -234,7 +210,10 @@ describe('transactions', () => {
 
 				modulesLoader.initModule(
 					TransactionModule,
-					{ db: dbStub, logic: { transaction: result.transactionLogic } },
+					{
+						storage: storageStub,
+						logic: { transaction: result.transactionLogic },
+					},
 					(initModuleErr, __transactionModule) => {
 						expect(initModuleErr).to.not.exist;
 
@@ -270,26 +249,20 @@ describe('transactions', () => {
 		);
 	});
 
-	beforeEach(() => {
-		dbStub.transactions.countList = sinonSandbox.stub().resolves();
-		dbStub.transactions.list = sinonSandbox.stub().resolves();
-		dbStub.transactions.count = sinonSandbox.stub().resolves();
-
-		return Object.keys(TransactionTypeMap).forEach(key => {
-			dbStub.transactions[
-				TransactionTypeMap[key]
-			] = sinonSandbox.stub().resolves();
-		});
+	beforeEach(done => {
+		storageStub.entities.Transaction.get = sinonSandbox.stub().resolves();
+		storageStub.entities.Transaction.count = sinonSandbox.stub().resolves();
+		done();
 	});
 
 	afterEach(() => {
 		return sinonSandbox.restore();
 	});
 
-	describe('Transaction#shared', () => {
+	describe('Transaction', () => {
 		describe('getTransaction', () => {
 			function getTransactionsById(id, done) {
-				transactionsModule.shared.getTransactions({ id }, done);
+				transactionsModule.getTransactions({ id }, done);
 			}
 
 			const transactionsByType = {
@@ -483,61 +456,12 @@ describe('transactions', () => {
 				const transaction =
 					transactionsByType[transactionTypes.SEND].transaction;
 
-				dbStub.transactions.countList.onCall(0).resolves(1);
-
-				dbStub.transactions.list.onCall(0).resolves([
-					{
-						t_id: '10707276464897629547',
-						b_height: 276,
-						t_blockId: '10342884759015889572',
-						t_type: 0,
-						t_timestamp: 40080841,
-						t_senderPublicKey:
-							'ac81bb5fa789776e26120202e0c996eae6c1987055a1d837db3dc0f621ceeb66',
-						m_recipientPublicKey:
-							'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
-						t_senderId: '2525786814299543383L',
-						t_recipientId: '16313739661670634666L',
-						t_amount: '112340000',
-						t_fee: '20000000',
-						t_signature:
-							'56a09d33ca4d19d9092ad764952d3c43fa575057b1078fc64875fcb50a1b1755230affc4665ff6a2de2671a5106cf0ae2d709e4f6e59d21c5cdc22f77060c506',
-						t_SignSignature: null,
-						t_signatures: null,
-						confirmations: 12,
-					},
-				]);
-
-				dbStub.transactions[TransactionTypeMap[transactionTypes.SEND]]
-					.onCall(0)
-					.resolves([
-						{
-							transaction_id: '10707276464897629547',
-							tf_data: 'extra information',
-						},
-					]);
+				storageStub.entities.Transaction.count.onCall(0).resolves(1);
+				storageStub.entities.Transaction.get.onCall(0).resolves([transaction]);
 
 				getTransactionsById(transactionId, (err, res) => {
 					expect(err).to.not.exist;
-					expect(res)
-						.to.have.property('transactions')
-						.which.is.an('Array');
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].amount.isEqualTo(transaction.amount)).to.be
-						.true;
-					expect(res.transactions[0].fee.isEqualTo(transaction.fee)).to.be.true;
-					expect(res.transactions[0].recipientId).to.equal(
-						transaction.recipientId
-					);
-					expect(res.transactions[0].timestamp).to.equal(transaction.timestamp);
-					expect(res.transactions[0].asset).to.eql(transaction.asset);
-					expect(res.transactions[0].senderPublicKey).to.equal(
-						transaction.senderPublicKey
-					);
-					expect(res.transactions[0].signature).to.equal(transaction.signature);
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.SEND);
+					expect(res).to.be.eql({ transactions: [transaction], count: 1 });
 					done();
 				});
 			});
@@ -548,54 +472,12 @@ describe('transactions', () => {
 				const transaction =
 					transactionsByType[transactionTypes.SIGNATURE].transaction;
 
-				dbStub.transactions.countList.onCall(0).resolves(1);
-
-				dbStub.transactions.list.onCall(0).resolves([
-					{
-						t_id: '11286126025791281057',
-						b_height: 276,
-						t_blockId: '10342884759015889572',
-						t_type: 1,
-						t_timestamp: 40080841,
-						t_senderPublicKey:
-							'f6b8bd8e0643921d90d935cbcf0eae7cd2271e77aceac35e75c9ed9d4e222237',
-						m_recipientPublicKey: null,
-						t_senderId: '10313008732729972965L',
-						t_recipientId: null,
-						t_amount: '0',
-						t_fee: '500000000',
-						t_signature:
-							'b281931b24514c0b150a3b6daf362822c98207148c8967b2469233c5118f7874520e4067595f20c359136385fc8c0ba9391b408df139f58ba86a279b9d96b305',
-						t_SignSignature: null,
-						t_signatures: null,
-						confirmations: 42,
-					},
-				]);
-
-				dbStub.transactions[TransactionTypeMap[transactionTypes.SIGNATURE]]
-					.onCall(0)
-					.resolves([
-						{
-							transaction_id: '11286126025791281057',
-							s_publicKey:
-								'e26ede27ed390a9da260b5f5b76db5908a164044d3d1f9d2b24116dd5b25dc72',
-						},
-					]);
+				storageStub.entities.Transaction.count.onCall(0).resolves(1);
+				storageStub.entities.Transaction.get.onCall(0).resolves([transaction]);
 
 				getTransactionsById(transactionId, (err, res) => {
 					expect(err).to.not.exist;
-					expect(res)
-						.to.have.property('transactions')
-						.which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount.isEqualTo(transaction.amount)).to.be
-						.true;
-					expect(res.transactions[0].asset.signature.publicKey).to.equal(
-						transaction.asset.signature.publicKey
-					);
-					expect(res.transactions[0].fee.isEqualTo(transaction.fee)).to.be.true;
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.SIGNATURE);
+					expect(res).to.be.eql({ transactions: [transaction], count: 1 });
 					done();
 				});
 			});
@@ -606,59 +488,12 @@ describe('transactions', () => {
 				const transaction =
 					transactionsByType[transactionTypes.DELEGATE].transaction;
 
-				dbStub.transactions.countList.onCall(0).resolves(1);
-
-				dbStub.transactions.list.onCall(0).resolves([
-					{
-						t_id: '6092156606242987573',
-						b_height: 371,
-						t_blockId: '17233974955873751907',
-						t_type: 2,
-						t_timestamp: 40081792,
-						t_senderPublicKey:
-							'81fc017321367f5ebfd75c9b115c321ca8dbbaaf6c794feeefa0bd70f364f98d',
-						m_recipientPublicKey: null,
-						t_senderId: '13683056641259213857L',
-						t_recipientId: null,
-						t_amount: '0',
-						t_fee: '2500000000',
-						t_signature:
-							'00732b1bc95d8b459bde261cbdd27c7e06bb023483446f350101f42bdd2f5d807be0115ea5ef9f3e15246659a8d3d14cbae5afe5ad2862a3416ddee29870b009',
-						t_SignSignature: null,
-						t_signatures: null,
-						confirmations: 13,
-					},
-				]);
-
-				dbStub.transactions[TransactionTypeMap[transactionTypes.DELEGATE]]
-					.onCall(0)
-					.resolves([
-						{
-							transaction_id: '6092156606242987573',
-							d_username: '&im',
-						},
-					]);
+				storageStub.entities.Transaction.count.onCall(0).resolves(1);
+				storageStub.entities.Transaction.get.onCall(0).resolves([transaction]);
 
 				getTransactionsById(transactionId, (err, res) => {
 					expect(err).to.not.exist;
-					expect(res)
-						.to.have.property('transactions')
-						.which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount.isEqualTo(transaction.amount)).to.be
-						.true;
-					expect(res.transactions[0].asset.username).to.equal(
-						transaction.asset.username
-					);
-					expect(res.transactions[0].asset.publicKey).to.equal(
-						transaction.asset.publicKey
-					);
-					expect(res.transactions[0].asset.address).to.equal(
-						transaction.asset.address
-					);
-					expect(res.transactions[0].fee.isEqualTo(transaction.fee)).to.be.true;
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.DELEGATE);
+					expect(res).to.be.eql({ transactions: [transaction], count: 1 });
 					done();
 				});
 			});
@@ -669,55 +504,12 @@ describe('transactions', () => {
 				const transaction =
 					transactionsByType[transactionTypes.VOTE].transaction;
 
-				dbStub.transactions.countList.onCall(0).resolves(1);
-
-				dbStub.transactions.list.onCall(0).resolves([
-					{
-						t_id: '6820432253266933365',
-						b_height: 371,
-						t_blockId: '17233974955873751907',
-						t_type: 3,
-						t_timestamp: 40081792,
-						t_senderPublicKey:
-							'31ab15b507bbdbb8f53b0dfbca65e78aafc3efe73e793b5f7db94dae53f94aba',
-						m_recipientPublicKey:
-							'31ab15b507bbdbb8f53b0dfbca65e78aafc3efe73e793b5f7db94dae53f94aba',
-						t_senderId: '8643584619166983815L',
-						t_recipientId: '8643584619166983815L',
-						t_amount: '0',
-						t_fee: '100000000',
-						t_signature:
-							'02dacc2888e1c4608e812d7099a2657e6f57f1446af6489811a942621f5619292873429621c097078276047a5905bb8e11af5ad5a96a389b767e6c7c019f6c0b',
-						t_SignSignature: null,
-						t_signatures: null,
-						confirmations: 40,
-					},
-				]);
-
-				dbStub.transactions[TransactionTypeMap[transactionTypes.VOTE]]
-					.onCall(0)
-					.resolves([
-						{
-							transaction_id: '6820432253266933365',
-							v_votes:
-								'+9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f,+141b16ac8d5bd150f16b1caa08f689057ca4c4434445e56661831f4e671b7c0a',
-						},
-					]);
+				storageStub.entities.Transaction.count.onCall(0).resolves(1);
+				storageStub.entities.Transaction.get.onCall(0).resolves([transaction]);
 
 				getTransactionsById(transactionId, (err, res) => {
 					expect(err).to.not.exist;
-					expect(res)
-						.to.have.property('transactions')
-						.which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount.isEqualTo(transaction.amount)).to.be
-						.true;
-					expect(res.transactions[0].asset.votes).to.eql(
-						transaction.asset.votes
-					);
-					expect(res.transactions[0].fee.isEqualTo(transaction.fee)).to.be.true;
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.VOTE);
+					expect(res).to.be.eql({ transactions: [transaction], count: 1 });
 					done();
 				});
 			});
@@ -728,63 +520,12 @@ describe('transactions', () => {
 				const transaction =
 					transactionsByType[transactionTypes.MULTI].transaction;
 
-				dbStub.transactions.countList.onCall(0).resolves(1);
-
-				dbStub.transactions.list.onCall(0).resolves([
-					{
-						t_id: '481620703379194749',
-						b_height: 371,
-						t_blockId: '17233974955873751907',
-						t_type: 4,
-						t_timestamp: 40081792,
-						t_senderPublicKey:
-							'aae5e1ccc5f30e1983aaf38867ce6f33acbee116a396ae5249ea6495fdc9bcf7',
-						m_recipientPublicKey: null,
-						t_senderId: '10952279861355607751L',
-						t_recipientId: null,
-						t_amount: '0',
-						t_fee: '1500000000',
-						t_signature:
-							'c05e4fe662f64c14529331d37611ccfc66f41901f92faa6c7c010f7a2f6fcda9c594aa67c5634f46b795d9dc0cb75943c6a20f757e56f86e88205876ae17b103',
-						t_SignSignature: null,
-						t_signatures:
-							'fa67d933ca29f6c476b02e5f0057fe8ecdae4a15d06acd6df515389c7e1d989f20e931c51483632059d4173fc69e472ef889e06e05a73ec48b7cea887ae4da0f,83946b53e06e89eeb76a667c8607bcb93cee2c63932040eb49f78a1eb7480071f5c9e89e3bbf96f63cd31b664baa489c2765b81376c793daace7573566611900',
-						confirmations: 65,
-					},
-				]);
-
-				dbStub.transactions[TransactionTypeMap[transactionTypes.MULTI]]
-					.onCall(0)
-					.resolves([
-						{
-							transaction_id: '481620703379194749',
-							m_min: 2,
-							m_lifetime: 1,
-							m_keysgroup:
-								'+f497c0187575ca25d01e4afc454b04be71a4f3a45c48b86e6e86c71fdeecb4f4,+cbc6f7f616035cbc5d21c398735d5dc1baf68eec7f4671fba2390b34eb4fd854',
-						},
-					]);
+				storageStub.entities.Transaction.count.onCall(0).resolves(1);
+				storageStub.entities.Transaction.get.onCall(0).resolves([transaction]);
 
 				getTransactionsById(transactionId, (err, res) => {
 					expect(err).to.not.exist;
-					expect(res)
-						.to.have.property('transactions')
-						.which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount.isEqualTo(transaction.amount)).to.be
-						.true;
-					expect(res.transactions[0].asset.multisignature.lifetime).to.equal(
-						transaction.asset.multisignature.lifetime
-					);
-					expect(res.transactions[0].asset.multisignature.min).to.equal(
-						transaction.asset.multisignature.min
-					);
-					expect(res.transactions[0].asset.multisignature.keysgroup).to.eql(
-						transaction.asset.multisignature.keysgroup
-					);
-					expect(res.transactions[0].fee.isEqualTo(transaction.fee)).to.be.true;
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].type).to.equal(transactionTypes.MULTI);
+					expect(res).to.be.eql({ transactions: [transaction], count: 1 });
 					done();
 				});
 			});
@@ -795,69 +536,12 @@ describe('transactions', () => {
 				const transaction =
 					transactionsByType[transactionTypes.DAPP].transaction;
 
-				dbStub.transactions.countList.onCall(0).resolves(1);
-
-				dbStub.transactions.list.onCall(0).resolves([
-					{
-						t_id: '1907088915785679339',
-						b_height: 371,
-						t_blockId: '17233974955873751907',
-						t_type: 5,
-						t_timestamp: 40081792,
-						t_senderPublicKey:
-							'644485a01cb11e06a1f4ffef90a7ba251e56d54eb06a0cb2ecb5693a8cc163a2',
-						m_recipientPublicKey: null,
-						t_senderId: '5519106118231224961L',
-						t_recipientId: null,
-						t_amount: '0',
-						t_fee: '2500000000',
-						t_signature:
-							'b024f90f73e53c9fee943f3c3ef7a9e3da99bab2f9fa3cbfd5ad05ed79cdbbe21130eb7b27698692bf491a1cf573a518dfa63607dc88bc0c01925fda18304905',
-						t_SignSignature: null,
-						t_signatures: null,
-						confirmations: 97,
-					},
-				]);
-
-				dbStub.transactions[TransactionTypeMap[transactionTypes.DAPP]]
-					.onCall(0)
-					.resolves([
-						{
-							transaction_id: '1907088915785679339',
-							dapp_name: 'AO7ezB11CgCdUZi5o8YzxCAtoRLA6Fi',
-							dapp_description: null,
-							dapp_tags: null,
-							dapp_link:
-								'http://www.lisk.io/AO7ezB11CgCdUZi5o8YzxCAtoRLA6Fi.zip',
-							dapp_type: 1,
-							dapp_category: 2,
-							dapp_icon: null,
-						},
-					]);
+				storageStub.entities.Transaction.count.onCall(0).resolves(1);
+				storageStub.entities.Transaction.get.onCall(0).resolves([transaction]);
 
 				getTransactionsById(transactionId, (err, res) => {
 					expect(err).to.not.exist;
-					expect(res)
-						.to.have.property('transactions')
-						.which.is.an('array');
-					expect(res.transactions[0].id).to.equal(transaction.id);
-					expect(res.transactions[0].amount.isEqualTo(transaction.amount)).to.be
-						.true;
-					expect(res.transactions[0].fee.isEqualTo(transaction.fee)).to.be.true;
-					expect(res.transactions[0].type).to.equal(transaction.type);
-					expect(res.transactions[0].asset.dapp.name).to.equal(
-						transaction.asset.dapp.name
-					);
-					expect(res.transactions[0].asset.dapp.category).to.equal(
-						transaction.asset.dapp.category
-					);
-					expect(res.transactions[0].asset.dapp.link).to.equal(
-						transaction.asset.dapp.link
-					);
-					expect(res.transactions[0].asset.dapp.type).to.equal(
-						transaction.asset.dapp.type
-					);
-					expect(res.transactions[0].type).to.equal(transactionTypes.DAPP);
+					expect(res).to.be.eql({ transactions: [transaction], count: 1 });
 					done();
 				});
 			});
@@ -895,170 +579,172 @@ describe('transactions', () => {
 			/* eslint-enable mocha/no-pending-tests */
 		});
 
-		describe('getTransactionsCount', () => {
-			beforeEach(() => {
-				sinonSandbox.spy(async, 'waterfall');
-				return dbStub.transactions.count.onCall(0).resolves(10);
-			});
-
-			const expectValidCountResponse = data => {
-				expect(data).to.have.keys(
-					'total',
-					'confirmed',
-					'unconfirmed',
-					'unprocessed',
-					'unsigned'
-				);
-				expect(data.total).to.be.a('number');
-				expect(data.confirmed).to.be.a('number');
-				expect(data.unconfirmed).to.be.a('number');
-				expect(data.unprocessed).to.be.a('number');
-				expect(data.unsigned).to.be.a('number');
-				expect(data.total).to.be.eql(
-					data.confirmed + data.unconfirmed + data.unprocessed + data.unsigned
-				);
-			};
-
-			it('should return transaction count in correct format', done => {
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
-
-					done();
+		describe('shared', () => {
+			describe('getTransactionsCount', () => {
+				beforeEach(() => {
+					sinonSandbox.spy(async, 'waterfall');
+					return storageStub.entities.Transaction.count.onCall(0).resolves(10);
 				});
-			});
 
-			it('should try to get transaction count from cache first', done => {
-				sinonSandbox.spy(cacheModule, 'getJsonForKey');
-
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
-
-					expect(async.waterfall).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
+				const expectValidCountResponse = data => {
+					expect(data).to.have.keys(
+						'total',
+						'confirmed',
+						'unconfirmed',
+						'unprocessed',
+						'unsigned'
 					);
-
-					done();
-				});
-			});
-
-			it('should use cached transaction count if found', done => {
-				sinonSandbox
-					.stub(cacheModule, 'getJsonForKey')
-					.callsArgWith(1, null, { confirmed: 999 });
-
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
-
-					expect(async.waterfall).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
+					expect(data.total).to.be.a('number');
+					expect(data.confirmed).to.be.a('number');
+					expect(data.unconfirmed).to.be.a('number');
+					expect(data.unprocessed).to.be.a('number');
+					expect(data.unsigned).to.be.a('number');
+					expect(data.total).to.be.eql(
+						data.confirmed + data.unconfirmed + data.unprocessed + data.unsigned
 					);
-					expect(dbStub.transactions.count).to.be.not.calledOnce;
+				};
 
-					expect(data.confirmed).to.be.eql(999);
+				it('should return transaction count in correct format', done => {
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
 
-					done();
-				});
-			});
-
-			it('should get transaction count from db if cache fails', done => {
-				sinonSandbox
-					.stub(cacheModule, 'getJsonForKey')
-					.callsArgWith(1, new Error('Cache error'));
-
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
-
-					expect(async.waterfall).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
-					);
-					expect(dbStub.transactions.count).to.be.calledOnce;
-					expect(data.confirmed).to.be.eql(10);
-
-					done();
-				});
-			});
-
-			it('should get transaction count from db if no cache exists', done => {
-				sinonSandbox
-					.stub(cacheModule, 'getJsonForKey')
-					.callsArgWith(1, null, null);
-
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
-
-					expect(async.waterfall).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
-					);
-					expect(dbStub.transactions.count).to.be.calledOnce;
-					expect(data.confirmed).to.be.eql(10);
-					done();
-				});
-			});
-
-			it('should update the transaction count in cache if not already persisted', done => {
-				sinonSandbox
-					.stub(cacheModule, 'getJsonForKey')
-					.callsArgWith(1, null, null);
-				sinonSandbox.spy(cacheModule, 'setJsonForKey');
-
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
-
-					expect(async.waterfall).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
-					);
-					expect(data.confirmed).to.be.eql(10);
-					expect(dbStub.transactions.count).to.be.calledOnce;
-
-					expect(cacheModule.setJsonForKey).to.be.calledOnce;
-					expect(cacheModule.setJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
-					);
-					expect(cacheModule.setJsonForKey.firstCall.args[1]).to.be.eql({
-						confirmed: 10,
+						done();
 					});
-
-					done();
 				});
-			});
 
-			it('should skip updating transaction count cache if already persisted', done => {
-				sinonSandbox
-					.stub(cacheModule, 'getJsonForKey')
-					.callsArgWith(1, null, { confirmed: 999 });
-				sinonSandbox.spy(cacheModule, 'setJsonForKey');
+				it('should try to get transaction count from cache first', done => {
+					sinonSandbox.spy(cacheModule, 'getJsonForKey');
 
-				transactionsModule.shared.getTransactionsCount((err, data) => {
-					expect(err).to.be.null;
-					expectValidCountResponse(data);
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
 
-					expect(async.waterfall).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey).to.be.calledOnce;
-					expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
-						cacheModule.KEYS.transactionCount
-					);
-					expect(data.confirmed).to.be.eql(999);
-					expect(dbStub.transactions.count).to.not.be.called;
+						expect(async.waterfall).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
 
-					expect(cacheModule.setJsonForKey).to.be.not.called;
+						done();
+					});
+				});
 
-					done();
+				it('should use cached transaction count if found', done => {
+					sinonSandbox
+						.stub(cacheModule, 'getJsonForKey')
+						.callsArgWith(1, null, { confirmed: 999 });
+
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
+
+						expect(async.waterfall).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
+						expect(storageStub.entities.Transaction.count).to.be.not.calledOnce;
+
+						expect(data.confirmed).to.be.eql(999);
+
+						done();
+					});
+				});
+
+				it('should get transaction count from db if cache fails', done => {
+					sinonSandbox
+						.stub(cacheModule, 'getJsonForKey')
+						.callsArgWith(1, new Error('Cache error'));
+
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
+
+						expect(async.waterfall).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
+						expect(storageStub.entities.Transaction.count).to.be.calledOnce;
+						expect(data.confirmed).to.be.eql(10);
+
+						done();
+					});
+				});
+
+				it('should get transaction count from db if no cache exists', done => {
+					sinonSandbox
+						.stub(cacheModule, 'getJsonForKey')
+						.callsArgWith(1, null, null);
+
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
+
+						expect(async.waterfall).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
+						expect(storageStub.entities.Transaction.count).to.be.calledOnce;
+						expect(data.confirmed).to.be.eql(10);
+						done();
+					});
+				});
+
+				it('should update the transaction count in cache if not already persisted', done => {
+					sinonSandbox
+						.stub(cacheModule, 'getJsonForKey')
+						.callsArgWith(1, null, null);
+					sinonSandbox.spy(cacheModule, 'setJsonForKey');
+
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
+
+						expect(async.waterfall).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
+						expect(data.confirmed).to.be.eql(10);
+						expect(storageStub.entities.Transaction.count).to.be.calledOnce;
+
+						expect(cacheModule.setJsonForKey).to.be.calledOnce;
+						expect(cacheModule.setJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
+						expect(cacheModule.setJsonForKey.firstCall.args[1]).to.be.eql({
+							confirmed: 10,
+						});
+
+						done();
+					});
+				});
+
+				it('should skip updating transaction count cache if already persisted', done => {
+					sinonSandbox
+						.stub(cacheModule, 'getJsonForKey')
+						.callsArgWith(1, null, { confirmed: 999 });
+					sinonSandbox.spy(cacheModule, 'setJsonForKey');
+
+					transactionsModule.shared.getTransactionsCount((err, data) => {
+						expect(err).to.be.null;
+						expectValidCountResponse(data);
+
+						expect(async.waterfall).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey).to.be.calledOnce;
+						expect(cacheModule.getJsonForKey.firstCall.args[0]).to.be.eql(
+							cacheModule.KEYS.transactionCount
+						);
+						expect(data.confirmed).to.be.eql(999);
+						expect(storageStub.entities.Transaction.count).to.not.be.called;
+
+						expect(cacheModule.setJsonForKey).to.be.not.called;
+
+						done();
+					});
 				});
 			});
 		});

--- a/test/unit/storage/entities/transaction.js
+++ b/test/unit/storage/entities/transaction.js
@@ -22,6 +22,7 @@ const transactionsFixtures = require('../../../fixtures').transactions;
 const transactionTypes = require('../../../../helpers/transaction_types');
 
 const numSeedRecords = 5;
+const NON_EXISTENT_ID = '1234';
 
 const expectValidTransactionRow = (row, transaction) => {
 	expect(row.id).to.be.eql(transaction.id);
@@ -347,7 +348,7 @@ describe('Transaction', () => {
 
 		it('should resolve with zero if matching record not found', async () => {
 			const result = await storage.entities.Transaction.count({
-				id: '1234',
+				id: NON_EXISTENT_ID,
 			});
 
 			expect(result).to.be.a('number');

--- a/test/unit/storage/entities/transaction.js
+++ b/test/unit/storage/entities/transaction.js
@@ -324,8 +324,35 @@ describe('Transaction', () => {
 	describe('count()', () => {
 		it('should accept only valid filters');
 		it('should throw error for in-valid filters');
-		it('should resolve with integer value if matching record found');
-		it('should resolve with zero if matching record not found');
+		it('should resolve with integer value if matching record found', async () => {
+			let transaction = null;
+			const transactions = [];
+
+			for (let i = 0; i < numSeedRecords; i++) {
+				transaction = new transactionsFixtures.Transaction({
+					blockId: seeder.getLastBlock().id,
+				});
+				transactions.push(transaction);
+			}
+			await storage.entities.Transaction.create(transactions);
+
+			// Check for last transaction
+			const result = await storage.entities.Transaction.count({
+				id: transaction.id,
+			});
+
+			expect(result).to.be.a('number');
+			return expect(result).to.be.eql(1);
+		});
+
+		it('should resolve with zero if matching record not found', async () => {
+			const result = await storage.entities.Transaction.count({
+				id: '1234',
+			});
+
+			expect(result).to.be.a('number');
+			return expect(result).to.be.eql(0);
+		});
 	});
 
 	describe('create()', () => {


### PR DESCRIPTION
### What was the problem?
Dependency of transactions getter functions from account modules were used in API. Making it a strict dependency for API.

### How did I fix it?
For all persisted transactions data, fetched the code directly from the database.

### How to test it?
Run transactions functional tests.

### Review checklist

* The PR resolves #2621
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
