### PR TITLE
Use strict nodejs engine in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine AS builder
+FROM node:8.14.0-alpine AS builder
 
 ENV NODE_ENV=production
 
@@ -18,7 +18,7 @@ RUN npm install && \
     date --utc "+%Y-%m-%dT%H:%M:%S.000Z" >.build
 
 
-FROM node:8-alpine
+FROM node:8.14.0-alpine
 
 ENV NODE_ENV=production
 ENV WFI_COMMIT=e34c502a3efe0e8b8166ea6148d55b73da5c8401


### PR DESCRIPTION
### What was the problem?
Docker was not using strict Nodejs engine, which allowed it to use the latest engine leading to having a difference in Nodejs engine for binary build and docker build.
### How did I fix it?
Using strict/specific version in docker
### How to test it?
Run docker build