### PR TITLE
Add Pull Reminders badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Join the chat at https://gitter.im/LiskHQ/lisk](https://badges.gitter.im/LiskHQ/lisk.svg)](https://gitter.im/LiskHQ/lisk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 <a href="https://david-dm.org/LiskHQ/lisk"><img src="https://david-dm.org/LiskHQ/lisk.svg" alt="Dependency Status"></a>
 <a href="https://david-dm.org/LiskHQ/lisk/?type=dev"><img src="https://david-dm.org/LiskHQ/lisk/dev-status.svg" alt="devDependency Status"></a>
+<a href="https://pullreminders.com?ref=badge"><img src="https://pullreminders.com/badge.svg" alt="Pull Reminders Enabled"></a>
 
 Lisk is a next generation crypto-currency and decentralized application platform, written entirely in JavaScript. The official documentation about the whole ecosystem can be found in https://lisk.io/documentation.
 


### PR DESCRIPTION
Hi everyone!

The purpose of the README badge is to drive some traffic back to [Pull Reminders](http://pullreminders.com) so that we can continue to sustainably provide free accounts for open-source organizations like yours. Currently over 500 open-source orgs use Pull Reminders for free. We are also working on creating embeddable charts of open-source metrics if that'd be preferred over the badge. Here's the page explaining our badge program: https://pullreminders.com/badge

Let me know if you have any concerns about adding this!