### PR TITLE
Remove unnecessary webSocket config parameter `appName` - Closes #2720

### DIFF
--- a/app.js
+++ b/app.js
@@ -534,7 +534,6 @@ d.run(() => {
 						port: scope.config.wsPort,
 						host: '0.0.0.0',
 						wsEngine: scope.config.peers.options.wsEngine,
-						appName: 'lisk',
 						workerController: workersControllerPath,
 						perMessageDeflate: false,
 						secretKey: 'liskSecretKey',

--- a/test/common/ws/server.js
+++ b/test/common/ws/server.js
@@ -79,7 +79,6 @@ const wsServer = {
 		workers: 1,
 		port: 9999,
 		wsEngine: 'ws',
-		appName: 'testWSServer',
 		secretKey: 'liskSecretKey',
 		workerController: `${__dirname}/server.js`,
 	},

--- a/test/common/ws/server_process.js
+++ b/test/common/ws/server_process.js
@@ -36,7 +36,6 @@ function WSServer(headers) {
 		workers: 1,
 		port: this.headers.wsPort,
 		wsEngine: 'ws',
-		appName: `LiskTestServer-${randomstring.generate(8)}`,
 		secretKey: 'liskSecretKey',
 		headers,
 		perMessageDeflate: false,


### PR DESCRIPTION
### How to test it?

Trigger any network test scenario and check if logs from every peer is showing the error mentioned in the issue. 
`npm test -- mocha:propagation:network`

### Review checklist

* The PR resolves #2720
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
