### PR TITLE
Replace extended blocks getter interfaces with storage.entities.Block.get - Closes #2726

### DIFF
--- a/logic/block.js
+++ b/logic/block.js
@@ -527,6 +527,7 @@ Block.prototype.storageRead = function(raw) {
 	if (!raw.id) {
 		return null;
 	}
+
 	const block = {
 		id: raw.id,
 		version: parseInt(raw.version),
@@ -544,7 +545,13 @@ Block.prototype.storageRead = function(raw) {
 		blockSignature: raw.blockSignature,
 		confirmations: parseInt(raw.confirmations),
 	};
+
+	if (raw.transactions) {
+		block.transactions = raw.transactions;
+	}
+
 	block.totalForged = block.totalFee.plus(block.reward).toString();
+
 	return block;
 };
 

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1277,7 +1277,7 @@ class Transaction {
 
 		const transaction = {
 			id: raw.id,
-			height: raw.blockHeight,
+			height: raw.height,
 			blockId: raw.blockId,
 			type: parseInt(raw.type),
 			timestamp: parseInt(raw.timestamp),
@@ -1292,17 +1292,11 @@ class Transaction {
 			signSignature: raw.signSignature,
 			signatures: raw.signatures ? raw.signatures.split(',') : [],
 			confirmations: parseInt(raw.confirmations),
-			asset: {},
+			asset: raw.asset || {},
 		};
 
 		if (!__private.types[transaction.type]) {
 			throw `Unknown transaction type ${transaction.type}`;
-		}
-
-		const asset = __private.types[transaction.type].dbRead(raw);
-
-		if (asset) {
-			transaction.asset = Object.assign(transaction.asset, asset);
 		}
 
 		return transaction;

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -1258,6 +1258,55 @@ class Transaction {
 
 		return transaction;
 	}
+
+	/**
+	 * Calls `dbRead` based on transaction type (privateTypes) to add tr asset.
+	 *
+	 * @see {@link privateTypes}
+	 * @param {Object} raw
+	 * @throws {string} If unknown transaction type
+	 * @returns {null|transaction}
+	 * @todo Add description for the params
+	 */
+
+	/* eslint-disable class-methods-use-this */
+	storageRead(raw) {
+		if (!raw.id) {
+			return null;
+		}
+
+		const transaction = {
+			id: raw.id,
+			height: raw.blockHeight,
+			blockId: raw.blockId,
+			type: parseInt(raw.type),
+			timestamp: parseInt(raw.timestamp),
+			senderPublicKey: raw.senderPublicKey,
+			requesterPublicKey: raw.requesterPublicKey,
+			senderId: raw.senderId,
+			recipientId: raw.recipientId,
+			recipientPublicKey: raw.requesterPublicKey || null,
+			amount: new Bignum(raw.amount),
+			fee: new Bignum(raw.fee),
+			signature: raw.signature,
+			signSignature: raw.signSignature,
+			signatures: raw.signatures ? raw.signatures.split(',') : [],
+			confirmations: parseInt(raw.confirmations),
+			asset: {},
+		};
+
+		if (!__private.types[transaction.type]) {
+			throw `Unknown transaction type ${transaction.type}`;
+		}
+
+		const asset = __private.types[transaction.type].dbRead(raw);
+
+		if (asset) {
+			transaction.asset = Object.assign(transaction.asset, asset);
+		}
+
+		return transaction;
+	}
 	/* eslint-enable class-methods-use-this */
 }
 

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -373,9 +373,9 @@ Process.prototype.loadBlocksOffset = function(
 	// Calculate toHeight
 	const toHeight = fromHeight + blocksAmount;
 
-	library.logger.debug('Loading blocks fromHeight', {
-		fromHeight,
-		toHeight,
+	library.logger.debug('Loading blocks offset', {
+		limit: toHeight,
+		offset: fromHeight,
 	});
 
 	const filters = {

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -375,14 +375,14 @@ Process.prototype.loadBlocksOffset = function(limit, offset, cb) {
 		offset,
 	});
 
-	// Loads full blocks from database
-	// FIXME: Weird logic in that SQL query, also ordering used can be performance bottleneck - to rewrite
-	library.db.blocks
-		// TODO: REPLACE BY STORAGE WHEN EXTENDED BLOCK IS IMPLEMENTED
-		.loadBlocksOffset(params.offset, params.limit)
+	// Loads extended blocks from storage
+	library.storage.entities.Block.get(
+		{ height_gte: params.offset, height_lt: params.limit },
+		{ limit: null, sort: ['height:asc', 'rowId:asc'], extended: true }
+	)
 		.then(rows => {
 			// Normalize blocks
-			const blocks = modules.blocks.utils.readDbRows(rows);
+			const blocks = modules.blocks.utils.readStorageRows(rows);
 
 			async.eachSeries(
 				blocks,
@@ -400,6 +400,7 @@ Process.prototype.loadBlocksOffset = function(limit, offset, cb) {
 							setImmediate(eachBlockSeriesCb, err)
 						);
 					}
+
 					// Process block - broadcast: false, saveBlock: false
 					return modules.blocks.verify.processBlock(
 						block,

--- a/storage/entities/block.js
+++ b/storage/entities/block.js
@@ -158,6 +158,7 @@ class Block extends BaseEntity {
 
 		this.transactionEntity = new Transaction(adapter);
 
+		this.addField('rowId', 'number');
 		this.addField('id', 'string', { filter: filterType.TEXT });
 		this.addField('height', 'number', { filter: filterType.NUMBER });
 		this.addField(

--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -617,7 +617,7 @@ class Transaction extends BaseEntity {
 			}
 		});
 
-		if (transaction.type === 0 && transaction.asset.data) {
+		if (transaction.type === 0 && transaction.asset && transaction.asset.data) {
 			try {
 				transaction.asset.data = transaction.asset.data.toString('utf8');
 			} catch (e) {

--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -612,10 +612,12 @@ class Transaction extends BaseEntity {
 			assetAttributesMap[transaction.type] || [];
 
 		transactionAssetAttributes.forEach(assetKey => {
-			_.set(transaction, assetKey, row[assetKey]);
+			if (row[assetKey]) {
+				_.set(transaction, assetKey, row[assetKey]);
+			}
 		});
 
-		if (transaction.asset.data) {
+		if (transaction.type === 0 && transaction.asset.data) {
 			try {
 				transaction.asset.data = transaction.asset.data.toString('utf8');
 			} catch (e) {
@@ -623,7 +625,7 @@ class Transaction extends BaseEntity {
 				// library.logger.error(
 				// 	'Logic-Transfer-dbRead: Failed to convert data field into utf8'
 				// );
-				transaction.asset.data = null;
+				delete transaction.asset;
 			}
 		}
 

--- a/test/integration/blocks/process/process.js
+++ b/test/integration/blocks/process/process.js
@@ -68,8 +68,8 @@ describe('system test (blocks) - process', () => {
 							'forks_stat',
 							'votes WHERE "transactionId" = \'17502993173215211070\'',
 						],
-						table => {
-							clearDatabaseTable(db, modulesLoader.logger, table, seriesCb);
+						(table, everyCb) => {
+							clearDatabaseTable(db, modulesLoader.logger, table, everyCb);
 						},
 						err => {
 							if (err) {

--- a/test/unit/modules/blocks/process.js
+++ b/test/unit/modules/blocks/process.js
@@ -51,6 +51,7 @@ describe('blocks/process', () => {
 			entities: {
 				Block: {
 					isPersisted: sinonSandbox.stub(),
+					get: sinonSandbox.stub(),
 				},
 			},
 		};
@@ -185,6 +186,7 @@ describe('blocks/process', () => {
 			utils: {
 				getIdSequence: sinonSandbox.stub(),
 				readDbRows: sinonSandbox.stub(),
+				readStorageRows: sinonSandbox.stub(),
 			},
 			isCleaning: {
 				get: sinonSandbox.stub(),
@@ -1179,10 +1181,10 @@ describe('blocks/process', () => {
 			);
 		});
 
-		describe('library.db.blocks.loadBlocksOffset', () => {
+		describe('library.storage.entities.Block.get', () => {
 			describe('when fails', () => {
 				beforeEach(() => {
-					return library.db.blocks.loadBlocksOffset.rejects(
+					return library.storage.entities.Block.get.rejects(
 						'blocks.loadBlocksOffset-REJECTS'
 					);
 				});
@@ -1204,12 +1206,12 @@ describe('blocks/process', () => {
 			describe('when succeeds', () => {
 				describe('when query returns empty array', () => {
 					beforeEach(() => {
-						library.db.blocks.loadBlocksOffset.resolves([]);
-						return modules.blocks.utils.readDbRows.returns([]);
+						library.storage.entities.Block.get.resolves([]);
+						return modules.blocks.utils.readStorageRows.returns([]);
 					});
 
 					afterEach(() => {
-						expect(modules.blocks.utils.readDbRows.calledOnce).to.be.true;
+						expect(modules.blocks.utils.readStorageRows.calledOnce).to.be.true;
 						expect(modules.blocks.lastBlock.get.calledOnce).to.be.true;
 						return expect(modules.blocks.isCleaning.get.calledOnce).to.be.false;
 					});
@@ -1228,7 +1230,7 @@ describe('blocks/process', () => {
 
 				describe('when query returns rows', () => {
 					beforeEach(() => {
-						return library.db.blocks.loadBlocksOffset.resolves([dummyBlock]);
+						return library.storage.entities.Block.get.resolves([dummyBlock]);
 					});
 
 					afterEach(() => {
@@ -1271,7 +1273,7 @@ describe('blocks/process', () => {
 
 							describe('when block id is genesis block', () => {
 								beforeEach(() => {
-									return modules.blocks.utils.readDbRows.returns([
+									return modules.blocks.utils.readStorageRows.returns([
 										{
 											id: '6524861224470851795',
 											height: 1,
@@ -1342,7 +1344,9 @@ describe('blocks/process', () => {
 
 							describe('when block id is not genesis block', () => {
 								beforeEach(() => {
-									return modules.blocks.utils.readDbRows.returns([dummyBlock]);
+									return modules.blocks.utils.readStorageRows.returns([
+										dummyBlock,
+									]);
 								});
 
 								afterEach(() => {

--- a/test/unit/modules/blocks/utils.js
+++ b/test/unit/modules/blocks/utils.js
@@ -46,6 +46,49 @@ const fullBlocksListRows = [
 	},
 ];
 
+const storageBlocksListRows = [
+	{
+		id: '13068833527549895884',
+		height: 3, // Block 1
+		transactions: [
+			{
+				id: '6950874693022090568',
+				type: 0,
+			},
+		],
+	},
+	{
+		id: '13068833527549895884',
+		height: 3, // Block 1
+		transactions: [
+			{
+				id: '13831767660337349834',
+				type: 1,
+			},
+		],
+	},
+	{
+		id: '7018883617995376402',
+		height: 4, // Block 2
+		transactions: [
+			{
+				id: '10550826199952791739',
+				type: 2,
+			},
+		],
+	},
+	{
+		id: '7018883617995376402',
+		height: 4, // Block 2
+		transactions: [
+			{
+				id: '3502881310841638511',
+				type: 3,
+			},
+		],
+	},
+];
+
 describe('blocks/utils', () => {
 	let dbStub;
 	let storageStub;
@@ -94,6 +137,9 @@ describe('blocks/utils', () => {
 			dbRead(input) {
 				return { id: input.b_id, height: input.b_height };
 			},
+			storageRead(input) {
+				return { id: input.id, height: input.height };
+			},
 		};
 
 		transactionMock = {
@@ -136,6 +182,7 @@ describe('blocks/utils', () => {
 				},
 				utils: {
 					readDbRows: blocksUtilsModule.readDbRows,
+					readStorageRows: blocksUtilsModule.readStorageRows,
 				},
 			},
 		};
@@ -158,6 +205,7 @@ describe('blocks/utils', () => {
 		it('should assign params to library', () => {
 			expect(library.logger).to.eql(loggerStub);
 			expect(library.db).to.eql(dbStub);
+			expect(library.storage).to.eql(storageStub);
 			expect(library.logic.account).to.eql(accountMock);
 			expect(library.logic.block).to.eql(blockMock);
 			return expect(library.logic.transaction).to.eql(transactionMock);
@@ -314,12 +362,12 @@ describe('blocks/utils', () => {
 	});
 
 	describe('loadLastBlock', () => {
-		it('should return error when library.db.blocks.loadLastBlock fails', done => {
-			library.db.blocks.loadLastBlock = sinonSandbox.stub().resolves(null);
+		it('should return error when library.storage.entities.Block.get fails', done => {
+			library.storage.entities.Block.get = sinonSandbox.stub().resolves(null);
 
 			blocksUtilsModule.loadLastBlock((err, block) => {
 				expect(loggerStub.error.args[0][0]).to.contains(
-					"TypeError: Cannot read property 'length' of null"
+					"TypeError: Cannot read property 'map' of null"
 				);
 				expect(err).to.equal('Blocks#loadLastBlock error');
 				expect(block).to.be.undefined;
@@ -329,9 +377,9 @@ describe('blocks/utils', () => {
 
 		describe('sorting the block.transactions array', () => {
 			it('should call modules.blocks.lastBlock.set with block', done => {
-				library.db.blocks.loadLastBlock = sinonSandbox
+				library.storage.entities.Block.get = sinonSandbox
 					.stub()
-					.resolves(fullBlocksListRows);
+					.resolves(storageBlocksListRows);
 
 				modules.blocks.lastBlock.set = sinonSandbox.spy();
 


### PR DESCRIPTION
### What was the problem?
Extended Blocks getter interfaces using db module

### How did I fix it?
Replaced them by storage module

### How to test it?
Regular test suite

### Review checklist

* The PR resolves #2726
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
