### PR TITLE
Enable readonly API mode when snapshotting - Closes #2729

### DIFF
--- a/app.js
+++ b/app.js
@@ -794,10 +794,6 @@ d.run(() => {
 				 * @param {function} cb - Callback function
 				 */
 				function(scope, cb) {
-					if (!appConfig.api.enabled) {
-						return cb();
-					}
-
 					// Security vulnerabilities fixed by Node v8.14.0 - "Slowloris (cve-2018-12122)"
 					scope.network.server.headersTimeout =
 						appConfig.api.options.limits.headersTimeout;

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -172,9 +172,9 @@ function Config(packageJson, parseCommandLineOptions = true) {
 
 		validateForce(appConfig);
 
-		// Disable api, peers, broadcasts, syncing and ws workers when snapshotting mode required
+		// Adding API READONLY mode and disabling peers, broadcasts, syncing and ws workers when snapshotting mode required
 		if (program.snapshot) {
-			appConfig.api.enabled = false;
+			appConfig.api.mode = 'READONLY';
 			appConfig.peers.enabled = false;
 			appConfig.peers.list = [];
 			appConfig.broadcasts.active = false;

--- a/helpers/http_api.js
+++ b/helpers/http_api.js
@@ -152,6 +152,13 @@ const middleware = {
 				errors: ['API access blocked.'],
 			});
 		}
+
+		if (config.api.mode === 'READONLY' && req.method !== 'GET') {
+			return res.status(apiCodes.FORBIDDEN).send({
+				message: 'API write access denied',
+				errors: ['API write access blocked.'],
+			});
+		}
 		return next();
 	},
 


### PR DESCRIPTION
### How to test it?
```
LISK_CONSOLE_LOG_LEVEL=info node app.js -n TESTNET -s latest
curl -X POST localhost:7000/api/node/status | jq //Refused
curl -X GET localhost:7000/api/node/status | jq //Accepted
```
### Review checklist

* The PR resolves #INSERT_ISSUE_NUMBER
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
