### PR TITLE
Add interface to register entities with storage module - Closes #2736

### DIFF
--- a/storage/errors.js
+++ b/storage/errors.js
@@ -25,10 +25,12 @@ class ImplementationPendingError extends BaseStorageError {}
 class NonSupportedFilterTypeError extends BaseStorageError {}
 class NonSupportedOptionError extends BaseStorageError {}
 class NonSupportedOperationError extends BaseStorageError {}
+class EntityRegistrationError extends BaseStorageError {}
 
 module.exports = {
 	ImplementationPendingError,
 	NonSupportedFilterTypeError,
 	NonSupportedOptionError,
 	NonSupportedOperationError,
+	EntityRegistrationError,
 };

--- a/storage/index.js
+++ b/storage/index.js
@@ -28,13 +28,13 @@ const {
 module.exports = function createStorage(options, logger) {
 	const storage = new Storage(options, logger);
 
-	storage.register('Account', Account);
-	storage.register('Block', Block);
-	storage.register('Delegate', Delegate);
-	storage.register('Migration', Migration);
-	storage.register('Peer', Peer);
-	storage.register('Round', Round);
-	storage.register('Transaction', Transaction);
+	storage.registerEntity('Account', Account);
+	storage.registerEntity('Block', Block);
+	storage.registerEntity('Delegate', Delegate);
+	storage.registerEntity('Migration', Migration);
+	storage.registerEntity('Peer', Peer);
+	storage.registerEntity('Round', Round);
+	storage.registerEntity('Transaction', Transaction);
 
 	return storage;
 };

--- a/storage/index.js
+++ b/storage/index.js
@@ -15,7 +15,26 @@
 'use strict';
 
 const Storage = require('./storage');
+const {
+	Account,
+	Block,
+	Delegate,
+	Peer,
+	Round,
+	Transaction,
+	Migration,
+} = require('./entities');
 
 module.exports = function createStorage(options, logger) {
-	return new Storage(options, logger);
+	const storage = new Storage(options, logger);
+
+	storage.register('Account', Account);
+	storage.register('Block', Block);
+	storage.register('Delegate', Delegate);
+	storage.register('Migration', Migration);
+	storage.register('Peer', Peer);
+	storage.register('Round', Round);
+	storage.register('Transaction', Transaction);
+
+	return storage;
 };

--- a/storage/storage.js
+++ b/storage/storage.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const assert = require('assert');
 const path = require('path');
 const { BaseEntity } = require('./entities');
 const PgpAdapter = require('./adapters/pgp_adapter');
@@ -62,7 +63,7 @@ class Storage {
 
 	/**
 	 * Register an entity by initializing its object.
-	 * It would be accessible through `storage.entities.[identifier]
+	 * It will be accessible through `storage.entities.[identifier]
 	 *
 	 * @param {string} identifier - Identifier used to access the object from stoage.entities.* namespace
 	 * @param {BaseEntity} Entity - A class constructor extended from BaseEntity
@@ -71,7 +72,10 @@ class Storage {
 	 * @param {Array.<*>} [options.initParams] - Extra parameters to pass to initialization of entity
 	 * @returns {BaseEntity}
 	 */
-	register(identifier, Entity, options = {}) {
+	registerEntity(identifier, Entity, options = {}) {
+		assert(identifier, 'Identifier is required to register an entity.');
+		assert(Entity, 'Entity is required to register it.');
+
 		const existed = Object.keys(Storage.instance.entities).includes(identifier);
 
 		if (existed && !options.replaceExisting) {

--- a/storage/storage.js
+++ b/storage/storage.js
@@ -30,6 +30,12 @@ class Storage {
 
 		this.isReady = false;
 		Storage.instance = this;
+		Storage.instance.adapter = new PgpAdapter({
+			...this.options,
+			inTest: process.env.NODE_ENV === 'test',
+			sqlDirectory: path.join(path.dirname(__filename), './sql'),
+			logger: this.logger,
+		});
 		Storage.instance.BaseEntity = BaseEntity;
 		Storage.instance.entities = {};
 	}
@@ -38,17 +44,9 @@ class Storage {
 	 * @return Promise
 	 */
 	bootstrap() {
-		const adapter = new PgpAdapter({
-			...this.options,
-			inTest: process.env.NODE_ENV === 'test',
-			sqlDirectory: path.join(path.dirname(__filename), './sql'),
-			logger: this.logger,
-		});
-
-		return adapter.connect().then(status => {
+		return Storage.instance.adapter.connect().then(status => {
 			if (status) {
 				this.isReady = true;
-				Storage.instance.adapter = adapter;
 			}
 
 			return status;

--- a/storage/storage.js
+++ b/storage/storage.js
@@ -29,15 +29,16 @@ class Storage {
 		}
 
 		this.isReady = false;
-		Storage.instance = this;
-		Storage.instance.adapter = new PgpAdapter({
+		this.adapter = new PgpAdapter({
 			...this.options,
 			inTest: process.env.NODE_ENV === 'test',
 			sqlDirectory: path.join(path.dirname(__filename), './sql'),
 			logger: this.logger,
 		});
-		Storage.instance.BaseEntity = BaseEntity;
-		Storage.instance.entities = {};
+		this.BaseEntity = BaseEntity;
+		this.entities = {};
+
+		Storage.instance = this;
 	}
 
 	/**

--- a/test/common/storage_sandbox.js
+++ b/test/common/storage_sandbox.js
@@ -18,6 +18,15 @@ const child_process = require('child_process');
 const pgpLib = require('pg-promise');
 const Storage = require('../../storage/storage');
 const PgpAdapter = require('../../storage/adapters/pgp_adapter');
+const {
+	Account,
+	Block,
+	Delegate,
+	Peer,
+	Round,
+	Transaction,
+	Migration,
+} = require('../../storage/entities');
 
 const dbNames = [];
 
@@ -71,6 +80,15 @@ class StorageSandbox extends Storage {
 		await this._dropDB();
 		await this._createDB();
 		await super.bootstrap();
+
+		this.register('Account', Account);
+		this.register('Block', Block);
+		this.register('Delegate', Delegate);
+		this.register('Migration', Migration);
+		this.register('Peer', Peer);
+		this.register('Round', Round);
+		this.register('Transaction', Transaction);
+
 		await this._createSchema(this.adapter.db);
 		return true;
 	}

--- a/test/common/storage_sandbox.js
+++ b/test/common/storage_sandbox.js
@@ -81,13 +81,13 @@ class StorageSandbox extends Storage {
 		await this._createDB();
 		await super.bootstrap();
 
-		this.register('Account', Account);
-		this.register('Block', Block);
-		this.register('Delegate', Delegate);
-		this.register('Migration', Migration);
-		this.register('Peer', Peer);
-		this.register('Round', Round);
-		this.register('Transaction', Transaction);
+		this.registerEntity('Account', Account);
+		this.registerEntity('Block', Block);
+		this.registerEntity('Delegate', Delegate);
+		this.registerEntity('Migration', Migration);
+		this.registerEntity('Peer', Peer);
+		this.registerEntity('Round', Round);
+		this.registerEntity('Transaction', Transaction);
 
 		await this._createSchema(this.adapter.db);
 		return true;

--- a/test/unit/storage/storage.js
+++ b/test/unit/storage/storage.js
@@ -30,8 +30,10 @@ describe('Storage', () => {
 		);
 	});
 
-	describe('register', () => {
+	describe('registerEntity', () => {
 		it('should accept three parameters');
+		it('should throw error if identifier is not provided');
+		it('should throw error if Entity is not provided');
 		it('should initialize an entity and return its object');
 		it(
 			'should initialize an entity and assign to storage.entities.* namespace'

--- a/test/unit/storage/storage.js
+++ b/test/unit/storage/storage.js
@@ -30,6 +30,21 @@ describe('Storage', () => {
 		);
 	});
 
+	describe('register', () => {
+		it('should accept three parameters');
+		it('should initialize an entity and return its object');
+		it(
+			'should initialize an entity and assign to storage.entities.* namespace'
+		);
+		it('should throw error if an entity already registered');
+		it(
+			'should not throw error if an entity already registered but options.replaceExisting is set true'
+		);
+		it(
+			'should pass provided options.initParams as additional constructor parameters'
+		);
+	});
+
 	describe('cleanup()', () => {
 		it('should resolved successfully');
 		it('should reject in case of any error on adapter layer');


### PR DESCRIPTION
### What was the problem?
There was no method to register the custom entities. 

### How did I fix it?
Added a new method `registerEntity` which is utilized by default entities as well as custom entities in future. 

### How to test it?
Run all unit tests. 

### Review checklist

* The PR resolves #2736
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
