### PR TITLE
getDelegatesFromPreviousRound using non existing library.db.rounds - Closes #2749

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -169,13 +169,10 @@ __private.getKeysSortByVote = function(cb, tx) {
  * @todo Add description for the return value
  */
 __private.getDelegatesFromPreviousRound = function(cb, tx) {
-	(tx || library.db).rounds
-		.getDelegatesSnapshot(ACTIVE_DELEGATES)
+	library.storage.entities.Round
+		.getDelegatesSnapshot(ACTIVE_DELEGATES, tx)
 		.then(rows => {
-			const delegatesPublicKeys = [];
-			rows.forEach(row => {
-				delegatesPublicKeys.push(row.publicKey.toString('hex'));
-			});
+			const delegatesPublicKeys = rows.map(({ publicKey }) => publicKey);
 			return setImmediate(cb, null, delegatesPublicKeys);
 		})
 		.catch(err => {

--- a/storage/sql/rounds/get_delegates_snapshot.sql
+++ b/storage/sql/rounds/get_delegates_snapshot.sql
@@ -18,6 +18,6 @@
   PARAMETERS: ?
 */
 
-SELECT "publicKey"
+SELECT ENCODE("publicKey", 'hex') as "publicKey"
 FROM mem_votes_snapshot
 ORDER BY vote DESC, "publicKey" ASC LIMIT ${limit}

--- a/test/unit/storage/entities/round.js
+++ b/test/unit/storage/entities/round.js
@@ -924,7 +924,7 @@ describe('Round', () => {
 			const result = await RoundEntity.getDelegatesSnapshot(3);
 
 			expect(
-				result.map(r => Buffer.from(r.publicKey).toString('hex'))
+				result.map(({ publicKey }) => publicKey)
 			).to.be.eql(
 				_.orderBy(accounts, ['vote', 'publicKey'], ['desc', 'asc']).map(
 					r => r.publicKey


### PR DESCRIPTION
### What was the problem?
`getDelegatesFromPreviousRound` using `library.db.rounds` after rounds repository was removed

### How did I fix it?
Replaced `library.db.rounds` for `storage.entities.Round`

### How to test it?
Regular test suite

### Review checklist

* The PR resolves #2749
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
