### PR TITLE
Update node reference in Readme - Closes #2754

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Install System wide via package manager:
 * Ubuntu:
 
 ```
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 


### PR DESCRIPTION
### What was the problem?
Old reference for Node.Js was descirbed in Readme

### How did I fix it?
Updated link to Node.Js script.

### Review checklist
* The PR resolves #2754 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
