### PR TITLE
Remove PM2 section from Readme - Closes #2756

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,6 @@ nvm install 10.14.1
 
 For the following steps, logout from the 'lisk' user again with `CTRL+D`, and continue with your user with sudo rights.
 
-### [PM2](https://github.com/Unitech/pm2) (recommended)
-
-PM2 manages the node process for Lisk.
-
-```
-npm install -g pm2
-```
-
 ### PostgreSQL:
 
 * Ubuntu:

--- a/README.md
+++ b/README.md
@@ -288,25 +288,25 @@ This will start the lisk instance with `devnet` configuration. Once the process 
 This will fork the process into the background and automatically recover the process if it fails.
 
 ```
-pm2 start --name lisk app.js
+npx pm2 start --name lisk app.js
 ```
 
 After the process is started, its runtime status and log location can be retrieved by issuing the following command:
 
 ```
-pm2 show lisk
+npx pm2 show lisk
 ```
 
 To stop Lisk after it has been started with `pm2`, issue the following command:
 
 ```
-pm2 stop lisk
+npx pm2 stop lisk
 ```
 
 **NOTE:** The **port**, **address** and **config-path** can be overridden by providing the relevant command switch:
 
 ```
-pm2 start --name lisk app.js -- -p [port] -a [address] -c [config-path] -n [network]
+npx pm2 start --name lisk app.js -- -p [port] -a [address] -c [config-path] -n [network]
 ```
 
 You can pass any of `devnet`, `alphanet`, `betanet`, `testnet` or `mainnet` for the network option.


### PR DESCRIPTION
### What was the problem?
PM2 is now part of the dependencies of Lisk Core and gets automatically installed when `npm ci` is executed by the user.

### How did I fix it?
Removed PM2 section, because it's obsolete now.

### Review checklist

* The PR resolves #2756 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
