### PR TITLE
Fix JSDoc return type - Closes #2788

### DIFF
--- a/storage/entities/base_entity.js
+++ b/storage/entities/base_entity.js
@@ -216,7 +216,9 @@ class BaseEntity {
 		this.adapter.SQLs[entityLabel] = this.adapter.SQLs[entityLabel] || {};
 		Object.keys(sqlFiles).forEach(key => {
 			if (!this.adapter.SQLs[entityLabel][key]) {
-				this.adapter.SQLs[entityLabel][key] = this.adapter.loadSQLFile(sqlFiles[key]);
+				this.adapter.SQLs[entityLabel][key] = this.adapter.loadSQLFile(
+					sqlFiles[key]
+				);
 			}
 		});
 		return this.adapter.SQLs[entityLabel];
@@ -267,7 +269,7 @@ class BaseEntity {
 	 * Validate allowed filters
 	 * @param {Array.<Object>|Object} filters
 	 * @param {Boolean} atLeastOneRequired
-	 * @return {true, NonSupportedFilterTypeError>}
+	 * @return {Boolean|Object} true or NonSupportedFilterTypeError
 	 */
 	validateFilters(filters = {}, atLeastOneRequired = false) {
 		if (atLeastOneRequired && (!filters || !Object.keys(filters).length)) {
@@ -306,7 +308,7 @@ class BaseEntity {
 	 * Validate allowed options
 	 * @param {Object} options
 	 * @param {Boolean} atLeastOneRequired
-	 * @return {true, NonSupportedFilterTypeError>}
+	 * @return {Boolean|Object} true or NonSupportedFilterTypeError
 	 */
 	validateOptions(options = {}, atLeastOneRequired = false) {
 		if (atLeastOneRequired && (!options || !Object.keys(options).length)) {


### PR DESCRIPTION
### What was the problem?
`npm run docs:build` failed with error 
```
ERROR: Unable to parse a tag's type expression for source file /path/to/lisk/storage/entities/base_entity.js in line 266 with tag title "return" and text "{true, NonSupportedFilterTypeError}": Invalid type expression "true, NonSupportedFilterTypeError": Expected "!", "=", "?", "[]", "|" or end of input but "," found.
```

### How did I fix it?
Replaced invalid return type expressions with valid ones.

### How to test it?
Run `npm run docs:build` and check, that no errors are thrown during generation.
To see results in browser, run: `npm run docs:serve`

### Review checklist

* The PR resolves #2788 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
