### PR TITLE
Hardcoded limit param to retrieve all the peers from storage - Closes #2787

### DIFF
--- a/modules/peers.js
+++ b/modules/peers.js
@@ -379,8 +379,7 @@ __private.insertSeeds = function(cb) {
 __private.dbLoad = function(cb) {
 	let updated = 0;
 	library.logger.trace('Importing peers from database');
-	library.storage.entities.Peer
-		.get({}, { limit: 10000 }) // @TODO: Arbitrary limit set for now. Base issue should be addressed in storage module for this cases
+	library.storage.entities.Peer.get({}, { limit: null })
 		.then(rows => {
 			library.logger.info('Imported peers from database', {
 				count: rows.length,
@@ -450,12 +449,11 @@ __private.dbSave = function(cb) {
 	}
 
 	// Wrap sql queries in transaction and execute
-	return library.storage.entities.Peer
-		.begin('modules:peers:dbSave', t =>
-			library.storage.entities.Peer
-				.delete({}, {}, t)
-				.then(() => library.storage.entities.Peer.create(peers, {}, t))
+	return library.storage.entities.Peer.begin('modules:peers:dbSave', t =>
+		library.storage.entities.Peer.delete({}, {}, t).then(() =>
+			library.storage.entities.Peer.create(peers, {}, t)
 		)
+	)
 		.then(() => {
 			library.logger.info('Peers exported to database');
 			return setImmediate(cb);

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -886,7 +886,9 @@ describe('peers', () => {
 
 				beforeEach(done => {
 					dbPeersListResults = [prefixedPeer];
-					storageMock.entities.Peer.get = sinonSandbox.stub().resolves(dbPeersListResults);
+					storageMock.entities.Peer.get = sinonSandbox
+						.stub()
+						.resolves(dbPeersListResults);
 					peersLogicMock.upsert = sinonSandbox.spy();
 					// Call onBlockchainReady and wait 100ms
 					peers.onBlockchainReady();
@@ -897,6 +899,12 @@ describe('peers', () => {
 					return dbPeersListResults.forEach(dbPeer => {
 						expect(peersLogicMock.upsert).calledWith(dbPeer, true);
 					});
+				});
+
+				it('should call storage get method with limit = null for pulling all peers', async () => {
+					expect(
+						storageMock.entities.Peer.get.firstCall.args[1].limit
+					).to.be.eql(null);
 				});
 			});
 		});
@@ -1076,19 +1084,13 @@ describe('peers', () => {
 					.stub()
 					.returns(true);
 				__private.updatePeerStatus(undefined, status, peer);
-				expect(peersLogicMock.upsert).to.be.calledWithExactly(
-					peer,
-					false
-				);
+				expect(peersLogicMock.upsert).to.be.calledWithExactly(peer, false);
 				// When it's not compatible
 				modules.system.protocolVersionCompatible = sinonSandbox
 					.stub()
 					.returns(false);
 				__private.updatePeerStatus(undefined, status, peer);
-				expect(peersLogicMock.upsert).to.be.calledWithExactly(
-					peer,
-					false
-				);
+				expect(peersLogicMock.upsert).to.be.calledWithExactly(peer, false);
 				done();
 			});
 		});


### PR DESCRIPTION
### What was the problem?

When the Peers entity was implemented storage forced a limit but that was corrected and a hardcoded limit was no longer needed.

### How did I fix it?

By setting the limit to null storage doesn't generate a `limit` clause

### How to test it?

- Build should be green
- Seed the peers table and a call to http://localhost:4000/api/peers should return all the seeded peers

### Review checklist

* The PR resolves #2787
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
