### PR TITLE
New migrations being created on wrong folder (old db folder) - Closes #2805

### DIFF
--- a/tasks/new_migration.js
+++ b/tasks/new_migration.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
 		fs.writeFile(
 			path.join(
 				process.cwd(),
-				'./db/sql/migrations/updates',
+				'./storage/sql/migrations/updates',
 				migration.filename
 			),
 			'',


### PR DESCRIPTION
### What was the problem?
When running` grunt newMigrations` a new migration is created on the old `db` folder `./db/sql/migrations/updates`
### How did I fix it?
Fixed wrong path on grunt task by changing `./db/...` to `./storage/...`
### How to test it?
Run `grunt new Migration` and check if the creation has been created in `./storage/sql/migrations/updates`
### Review checklist

* The PR resolves #2805 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated