### PR TITLE
Performance degradation of transaction related API endpoints - Closes #2803

### DIFF
--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -150,6 +150,7 @@ const sqlFiles = {
 	selectExtended: 'transactions/get_extended.sql',
 	isPersisted: 'transactions/is_persisted.sql',
 	count: 'transactions/count.sql',
+	count_all: 'transactions/count_all.sql',
 	create: 'transactions/create.sql',
 	createType0: 'transactions/create_type_0.sql',
 	createType1: 'transactions/create_type_1.sql',
@@ -328,8 +329,10 @@ class Transaction extends BaseEntity {
 		};
 		const expectedResultCount = 1;
 
+		const sql = parsedFilters === '' ? this.SQLs.count_all : this.SQLs.count;
+
 		return this.adapter
-			.executeFile(this.SQLs.count, params, { expectedResultCount }, tx)
+			.executeFile(sql, params, { expectedResultCount }, tx)
 			.then(data => +data.count);
 	}
 

--- a/storage/sql/transactions/count_all.sql
+++ b/storage/sql/transactions/count_all.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+SELECT count(*)
+FROM trs;
+
+

--- a/storage/sql/transactions/count_all.sql
+++ b/storage/sql/transactions/count_all.sql
@@ -14,5 +14,3 @@
 
 SELECT count(*)
 FROM trs;
-
-

--- a/test/unit/storage/entities/transaction.js
+++ b/test/unit/storage/entities/transaction.js
@@ -237,6 +237,7 @@ describe('Transaction', () => {
 
 	afterEach(() => {
 		sinonSandbox.reset();
+		sinonSandbox.restore();
 		return seeder.reset(storage);
 	});
 
@@ -842,6 +843,24 @@ describe('Transaction', () => {
 
 			expect(result).to.be.a('number');
 			return expect(result).to.be.eql(0);
+		});
+
+		it('should use view query file if some conditions provided', async () => {
+			sinonSandbox.spy(adapter, 'executeFile');
+			await storage.entities.Transaction.count({
+				id: NON_EXISTENT_ID,
+			});
+
+			expect(adapter.executeFile).to.be.calledOnce;
+			expect(adapter.executeFile).to.be.calledWith(SQLs.count);
+		});
+
+		it('should use trs  query file if no conditions provided', async () => {
+			sinonSandbox.spy(adapter, 'executeFile');
+			await storage.entities.Transaction.count();
+
+			expect(adapter.executeFile).to.be.calledOnce;
+			expect(adapter.executeFile).to.be.calledWith(SQLs.count_all);
 		});
 	});
 

--- a/test/unit/storage/entities/transaction.js
+++ b/test/unit/storage/entities/transaction.js
@@ -228,10 +228,10 @@ describe('Transaction', () => {
 		};
 
 		adapter = storage.adapter;
-		addFieldSpy = sinonSandbox.spy(Transaction.prototype, 'addField');
 	});
 
 	beforeEach(() => {
+		addFieldSpy = sinonSandbox.spy(Transaction.prototype, 'addField');
 		return seeder.seed(storage);
 	});
 


### PR DESCRIPTION
### What was the problem?

The `count` queries were performed not he view. Which was expensive in case we need to count all records. 

### How did I fix it?

Conditional count on view or table. 

### How to test it?

Run storage tets. 

### Review checklist

* The PR resolves #2803
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
