### PR TITLE
1.5.0-alpha.1 Testnet and Mainnet Snapshotting failure - Closes #2810

### DIFF
--- a/storage/entities/transaction.js
+++ b/storage/entities/transaction.js
@@ -142,7 +142,7 @@ const assetAttributesMap = {
 		'asset.dapp.category',
 	],
 	6: ['asset.inTransfer.dappId'],
-	7: ['asset.outTransfer.dappId', ' asset.outTransfer.transactionId'],
+	7: ['asset.outTransfer.dappId', 'asset.outTransfer.transactionId'],
 };
 
 const sqlFiles = {

--- a/storage/sql/transactions/get_extended.sql
+++ b/storage/sql/transactions/get_extended.sql
@@ -38,7 +38,7 @@ SELECT
  	regexp_split_to_array("v_votes", ',') as "asset.votes",
  	"m_min" as "asset.multisignature.min",
  	"m_lifetime" as "asset.multisignature.lifetime",
- 	"m_keysgroup" as "asset.multisignature.keysgroup",
+	regexp_split_to_array("m_keysgroup", ',') as "asset.multisignature.keysgroup",
  	"dapp_type" as "asset.dapp.type",
  	"dapp_name" as "asset.dapp.name",
  	"dapp_description" as "asset.dapp.description",
@@ -58,4 +58,3 @@ WHERE "t_rowId" IS NOT NULL ${parsedFilters:raw}
 ${parsedSort:raw}
 
 LIMIT ${limit} OFFSET ${offset}
-


### PR DESCRIPTION
### What was the problem?
Snapshotting failing on mainnet and testnet

### How did I fix it?
Fixed extra space in mapping string and parsed keysgroup as array instead of string

### How to test it?
Run snapshot in mainnet and testnet

### Review checklist

* The PR resolves #2810
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
