### PR TITLE
Snapshotting failed on testnet and mainnet for 1.5.0-alpha.2 

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -769,7 +769,7 @@ __private.createSnapshot = height => {
 
 	const snapshotRound = library.config.loading.snapshotRound;
 	const totalRounds = Math.floor(height / ACTIVE_DELEGATES);
-	const targetRound = Number.isNaN(snapshotRound)
+	const targetRound = Number.isNaN(parseInt(snapshotRound))
 		? totalRounds
 		: Math.min(totalRounds, snapshotRound);
 	const targetHeight = targetRound * ACTIVE_DELEGATES;


### PR DESCRIPTION
### What was the problem?
The behavior of `isNaN` and `Number.isNaN` is different. Previously we were using `NaN` and updated it to `Number.isNaN`.

### How did I fix it?

Used `parseInt` before passing parameter to `Number.isNaN`

### How to test it?
Do snapshotting for the full rounds. 

### Review checklist

* The PR resolves #2831
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
