### PR TITLE
Consistent dependencies on transaction types - Closes #2779

### DIFF
--- a/framework/src/modules/chain/logic/dapp.js
+++ b/framework/src/modules/chain/logic/dapp.js
@@ -37,10 +37,13 @@ __private.unconfirmedAscii = {};
  * @requires bytebuffer
  * @requires valid
  * @requires helpers/dapp_categories
- * @param {Storage} storage
- * @param {Object} logger
- * @param {ZSchema} schema
- * @param {Object} network
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Storage} dependencies.components.storage
+ * @param {logger} dependencies.components.logger
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Object} dependencies,libraries.network
  * @todo Add description for the params
  */
 class DApp {

--- a/framework/src/modules/chain/logic/dapp.js
+++ b/framework/src/modules/chain/logic/dapp.js
@@ -36,25 +36,22 @@ __private.unconfirmedAscii = {};
  * @requires bytebuffer
  * @requires valid
  * @requires helpers/dapp_categories
- * @param {Object} dependencies
- * @param {Object} dependencies.components
- * @param {Object} dependencies.libraries
- * @param {Storage} dependencies.components.storage
- * @param {logger} dependencies.components.logger
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Object} dependencies,libraries.network
+ * @param {Object} scope
+ * @param {Object} scope.components
+ * @param {Storage} scope.components.storage
+ * @param {logger} scope.components.logger
+ * @param {ZSchema} scope.schema
+ * @param {Object} scope.network
  * @todo Add description for the params
  */
 class DApp {
-	constructor({ components, libraries }) {
+	constructor({ components: { storage, logger }, network, schema }) {
 		__private.components = {
-			storage: components.storage,
-			logger: components.logger,
+			storage,
+			logger,
 		};
-		__private.libraries = {
-			network: libraries.network,
-			schema: libraries.schema,
-		};
+		__private.network = network;
+		__private.schema = schema;
 	}
 }
 
@@ -459,13 +456,13 @@ DApp.prototype.objectNormalize = function(transaction) {
 		}
 	});
 
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset.dapp,
 		DApp.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate dapp schema: ${__private.libraries.schema
+		throw `Failed to validate dapp schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;
@@ -507,8 +504,8 @@ DApp.prototype.dbRead = function(raw) {
  * @todo Add description for the params
  */
 DApp.prototype.afterSave = function(transaction, cb) {
-	if (__private.libraries) {
-		__private.libraries.network.io.sockets.emit('dapps/change', {});
+	if (__private.network) {
+		__private.network.io.sockets.emit('dapps/change', {});
 	}
 	return setImmediate(cb);
 };

--- a/framework/src/modules/chain/logic/dapp.js
+++ b/framework/src/modules/chain/logic/dapp.js
@@ -82,7 +82,7 @@ DApp.prototype.calculateFee = function() {
  * @returns {SetImmediate} error, transaction
  * @todo Add description for the params
  */
-DApp.prototype.verify = async function(transaction, sender, cb, tx) {
+DApp.prototype.verify = function(transaction, sender, cb, tx) {
 	if (transaction.recipientId) {
 		return setImmediate(cb, 'Invalid recipient');
 	}

--- a/framework/src/modules/chain/logic/dapp.js
+++ b/framework/src/modules/chain/logic/dapp.js
@@ -22,8 +22,8 @@ const Bignum = require('../helpers/bignum.js');
 
 let library;
 const { FEES } = global.constants;
-const __private = {};
 
+const __private = {};
 __private.unconfirmedNames = {};
 __private.unconfirmedLinks = {};
 __private.unconfirmedAscii = {};
@@ -44,12 +44,14 @@ __private.unconfirmedAscii = {};
  * @todo Add description for the params
  */
 class DApp {
-	constructor(storage, logger, schema, network) {
-		library = {
-			storage,
-			logger,
-			schema,
-			network,
+	constructor({ components, libraries }) {
+		__private.components = {
+			storage: components.storage,
+			logger: components.logger,
+		};
+		__private.libraries = {
+			network: libraries.network,
+			schema: libraries.schema,
 		};
 	}
 }
@@ -454,13 +456,13 @@ DApp.prototype.objectNormalize = function(transaction) {
 		}
 	});
 
-	const report = library.schema.validate(
+	const report = __private.libraries.schema.validate(
 		transaction.asset.dapp,
 		DApp.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate dapp schema: ${library.schema
+		throw `Failed to validate dapp schema: ${__private.libraries.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;
@@ -502,8 +504,8 @@ DApp.prototype.dbRead = function(raw) {
  * @todo Add description for the params
  */
 DApp.prototype.afterSave = function(transaction, cb) {
-	if (library) {
-		library.network.io.sockets.emit('dapps/change', {});
+	if (__private.libraries) {
+		__private.libraries.network.io.sockets.emit('dapps/change', {});
 	}
 	return setImmediate(cb);
 };

--- a/framework/src/modules/chain/logic/dapp.js
+++ b/framework/src/modules/chain/logic/dapp.js
@@ -20,7 +20,6 @@ const dappCategories = require('../helpers/dapp_categories.js');
 const transactionTypes = require('../helpers/transaction_types');
 const Bignum = require('../helpers/bignum.js');
 
-let library;
 const { FEES } = global.constants;
 
 const __private = {};
@@ -64,6 +63,7 @@ class DApp {
 /**
  * Binds scope.modules to private variable modules.
  */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
 DApp.prototype.bind = function() {};
 
 /**
@@ -205,7 +205,7 @@ DApp.prototype.verify = function(transaction, sender, cb, tx) {
 		},
 	];
 
-	return library.storage.entities.Transaction.get(
+	return __private.components.storage.entities.Transaction.get(
 		filter,
 		{ extended: true },
 		tx
@@ -231,7 +231,7 @@ DApp.prototype.verify = function(transaction, sender, cb, tx) {
 			return setImmediate(cb, null, transaction);
 		})
 		.catch(err => {
-			library.logger.error(err.stack);
+			__private.components.logger.error(err.stack);
 			return setImmediate(cb, 'DApp#verify error');
 		});
 };

--- a/framework/src/modules/chain/logic/delegate.js
+++ b/framework/src/modules/chain/logic/delegate.js
@@ -29,8 +29,11 @@ const __private = {};
  * @memberof logic
  * @see Parent: {@link logic}
  * @requires async
- * @param {logger} logger
- * @param {ZSchema} schema
+ * @param {Object} dependencies
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Accounts} dependencies.modules.accounts
  * @todo Add description for the params
  */
 class Delegate {
@@ -186,12 +189,22 @@ Delegate.prototype.checkDuplicates = function(
 				const query = {};
 				query[isDelegate] = true;
 				query.publicKey = transaction.senderPublicKey;
-				return __private.modules.accounts.getAccount(query, [username], eachCb, tx);
+				return __private.modules.accounts.getAccount(
+					query,
+					[username],
+					eachCb,
+					tx
+				);
 			},
 			duplicatedUsername(eachCb) {
 				const query = {};
 				query[username] = transaction.asset.delegate.username;
-				return __private.modules.accounts.getAccount(query, [username], eachCb, tx);
+				return __private.modules.accounts.getAccount(
+					query,
+					[username],
+					eachCb,
+					tx
+				);
 			},
 		},
 		(err, res) => {

--- a/framework/src/modules/chain/logic/delegate.js
+++ b/framework/src/modules/chain/logic/delegate.js
@@ -34,10 +34,10 @@ const __private = {};
  * @todo Add description for the params
  */
 class Delegate {
-	constructor({ library, modules }) {
+	constructor({ libraries, modules }) {
 		self = this;
-		__private.library = {
-			schema: library.schema,
+		__private.libraries = {
+			schema: libraries.schema,
 		};
 		__private.modules = {
 			accounts: modules.accounts,
@@ -379,13 +379,13 @@ Delegate.prototype.schema = {
  * @todo Add description for the params
  */
 Delegate.prototype.objectNormalize = function(transaction) {
-	const report = __private.library.schema.validate(
+	const report = __private.libraries.schema.validate(
 		transaction.asset.delegate,
 		Delegate.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate delegate schema: ${__private.library.schema
+		throw `Failed to validate delegate schema: ${__private.libraries.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/delegate.js
+++ b/framework/src/modules/chain/logic/delegate.js
@@ -37,20 +37,29 @@ const __private = {};
  * @todo Add description for the params
  */
 class Delegate {
-	constructor({ libraries, modules }) {
+	constructor({ libraries }) {
 		self = this;
 		__private.libraries = {
 			schema: libraries.schema,
 		};
-		__private.modules = {
-			accounts: modules.accounts,
-		};
+		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
 /**
+ * Binds input parameters to private variables modules.
+ *
+ * @param {Accounts} accounts
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+Delegate.prototype.bind = function(accounts) {
+	__private.modules = {
+		accounts,
+	};
+};
 
 /**
  * Obtains constant fee delegate.

--- a/framework/src/modules/chain/logic/delegate.js
+++ b/framework/src/modules/chain/logic/delegate.js
@@ -29,19 +29,16 @@ const __private = {};
  * @memberof logic
  * @see Parent: {@link logic}
  * @requires async
- * @param {Object} dependencies
- * @param {Object} dependencies.libraries
- * @param {Object} dependencies.modules
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Accounts} dependencies.modules.accounts
+ * @param {Object} scope
+ * @param {Object} scope.modules
+ * @param {Accounts} scope.modules.accounts
+ * @param {ZSchema} scope.schema
  * @todo Add description for the params
  */
 class Delegate {
-	constructor({ libraries }) {
+	constructor({ schema }) {
 		self = this;
-		__private.libraries = {
-			schema: libraries.schema,
-		};
+		__private.schema = schema;
 		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
@@ -401,13 +398,13 @@ Delegate.prototype.schema = {
  * @todo Add description for the params
  */
 Delegate.prototype.objectNormalize = function(transaction) {
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset.delegate,
 		Delegate.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate delegate schema: ${__private.libraries.schema
+		throw `Failed to validate delegate schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/delegate.js
+++ b/framework/src/modules/chain/logic/delegate.js
@@ -77,7 +77,7 @@ Delegate.prototype.calculateFee = function() {
  * @returns {SetImmediate|Object} error, transaction
  * @todo Add description for the params
  */
-Delegate.prototype.verify = async function(transaction, sender, cb, tx) {
+Delegate.prototype.verify = function(transaction, sender, cb, tx) {
 	if (transaction.recipientId) {
 		return setImmediate(cb, 'Invalid recipient');
 	}

--- a/framework/src/modules/chain/logic/delegate.js
+++ b/framework/src/modules/chain/logic/delegate.js
@@ -20,7 +20,7 @@ const Bignum = require('../helpers/bignum.js');
 const { FEES } = global.constants;
 let self;
 
-const __private = {};
+const __scope = {};
 
 /**
  * Main delegate logic. Initializes library.
@@ -38,8 +38,8 @@ const __private = {};
 class Delegate {
 	constructor({ schema }) {
 		self = this;
-		__private.schema = schema;
-		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
+		__scope.schema = schema;
+		// TODO: Add modules to contructor argument and assign accounts to __scope.modules.accounts
 	}
 }
 
@@ -53,7 +53,7 @@ class Delegate {
  */
 // TODO: Remove this method as modules will be loaded prior to trs logic.
 Delegate.prototype.bind = function(accounts) {
-	__private.modules = {
+	__scope.modules = {
 		accounts,
 	};
 };
@@ -77,7 +77,7 @@ Delegate.prototype.calculateFee = function() {
  * @returns {SetImmediate|Object} error, transaction
  * @todo Add description for the params
  */
-Delegate.prototype.verify = function(transaction, sender, cb, tx) {
+Delegate.prototype.verify = async function(transaction, sender, cb, tx) {
 	if (transaction.recipientId) {
 		return setImmediate(cb, 'Invalid recipient');
 	}
@@ -195,7 +195,7 @@ Delegate.prototype.checkDuplicates = function(
 				const query = {};
 				query[isDelegate] = true;
 				query.publicKey = transaction.senderPublicKey;
-				return __private.modules.accounts.getAccount(
+				return __scope.modules.accounts.getAccount(
 					query,
 					[username],
 					eachCb,
@@ -205,7 +205,7 @@ Delegate.prototype.checkDuplicates = function(
 			duplicatedUsername(eachCb) {
 				const query = {};
 				query[username] = transaction.asset.delegate.username;
-				return __private.modules.accounts.getAccount(
+				return __scope.modules.accounts.getAccount(
 					query,
 					[username],
 					eachCb,
@@ -296,7 +296,7 @@ Delegate.prototype.applyConfirmed = function(
 				self.checkConfirmed(transaction, seriesCb, tx);
 			},
 			function(seriesCb) {
-				__private.modules.accounts.setAccountAndGet(data, seriesCb, tx);
+				__scope.modules.accounts.setAccountAndGet(data, seriesCb, tx);
 			},
 		],
 		cb
@@ -327,7 +327,7 @@ Delegate.prototype.undoConfirmed = function(
 		username: null,
 	};
 
-	__private.modules.accounts.setAccountAndGet(data, cb, tx);
+	__scope.modules.accounts.setAccountAndGet(data, cb, tx);
 };
 
 /**
@@ -352,7 +352,7 @@ Delegate.prototype.applyUnconfirmed = function(transaction, sender, cb, tx) {
 				self.checkUnconfirmed(transaction, seriesCb, tx);
 			},
 			function(seriesCb) {
-				__private.modules.accounts.setAccountAndGet(data, seriesCb, tx);
+				__scope.modules.accounts.setAccountAndGet(data, seriesCb, tx);
 			},
 		],
 		cb
@@ -374,7 +374,7 @@ Delegate.prototype.undoUnconfirmed = function(transaction, sender, cb, tx) {
 		u_username: null,
 	};
 
-	__private.modules.accounts.setAccountAndGet(data, cb, tx);
+	__scope.modules.accounts.setAccountAndGet(data, cb, tx);
 };
 
 Delegate.prototype.schema = {
@@ -398,13 +398,13 @@ Delegate.prototype.schema = {
  * @todo Add description for the params
  */
 Delegate.prototype.objectNormalize = function(transaction) {
-	const report = __private.schema.validate(
+	const report = __scope.schema.validate(
 		transaction.asset.delegate,
 		Delegate.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate delegate schema: ${__private.schema
+		throw `Failed to validate delegate schema: ${__scope.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/in_transfer.js
+++ b/framework/src/modules/chain/logic/in_transfer.js
@@ -31,8 +31,14 @@ const __private = {};
  * @see Parent: {@link logic}
  * @requires helpers/milestones
  * @requires helpers/slots
- * @param {ZSchema} schema
- * @param {Storage} storage
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {Storage} dependencies.components.storage
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Object} dependencies.libraries.sharedApi
+ * @param {Accounts} dependencies.modules.accounts
  * @todo Add description for the params
  */
 class InTransfer {

--- a/framework/src/modules/chain/logic/in_transfer.js
+++ b/framework/src/modules/chain/logic/in_transfer.js
@@ -21,7 +21,7 @@ const transactionTypes = require('../helpers/transaction_types.js');
 const { FEES } = global.constants;
 const exceptions = global.exceptions;
 
-const __private = {};
+const __scope = {};
 
 /**
  * Main InTransfer logic. Initializes library.
@@ -42,11 +42,11 @@ const __private = {};
  */
 class InTransfer {
 	constructor({ components: { storage }, schema }) {
-		__private.components = {
+		__scope.components = {
 			storage,
 		};
-		__private.schema = schema;
-		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
+		__scope.schema = schema;
+		// TODO: Add modules to contructor argument and assign accounts to __scope.modules.accounts
 	}
 }
 
@@ -61,10 +61,10 @@ class InTransfer {
  */
 // TODO: Remove this method as modules will be loaded prior to trs logic.
 InTransfer.prototype.bind = function(accounts, sharedApi) {
-	__private.modules = {
+	__scope.modules = {
 		accounts,
 	};
-	__private.shared = sharedApi;
+	__scope.shared = sharedApi;
 };
 
 /**
@@ -87,8 +87,8 @@ InTransfer.prototype.calculateFee = function() {
  * @returns {SetImmediate} error
  * @todo Add description for the params
  */
-InTransfer.prototype.verify = async (transaction, sender, cb, tx) => {
-	let lastBlock = await __private.components.storage.entities.Block.get(
+InTransfer.prototype.verify = async function(transaction, sender, cb, tx) {
+	let lastBlock = await __scope.components.storage.entities.Block.get(
 		{},
 		{ sort: 'height:desc', limit: 1 }
 	);
@@ -111,7 +111,7 @@ InTransfer.prototype.verify = async (transaction, sender, cb, tx) => {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
 
-	return __private.components.storage.entities.Transaction.isPersisted(
+	return __scope.components.storage.entities.Transaction.isPersisted(
 		{
 			id: transaction.asset.inTransfer.dappId,
 			type: transactionTypes.DAPP,
@@ -183,13 +183,13 @@ InTransfer.prototype.applyConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.shared.getGenesis(
+	__scope.shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
 		(getGenesisErr, res) => {
 			if (getGenesisErr) {
 				return setImmediate(cb, getGenesisErr);
 			}
-			return __private.modules.accounts.mergeAccountAndGet(
+			return __scope.modules.accounts.mergeAccountAndGet(
 				{
 					address: res.authorId,
 					balance: transaction.amount,
@@ -223,13 +223,13 @@ InTransfer.prototype.undoConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.shared.getGenesis(
+	__scope.shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
 		(getGenesisErr, res) => {
 			if (getGenesisErr) {
 				return setImmediate(cb, getGenesisErr);
 			}
-			return __private.modules.accounts.mergeAccountAndGet(
+			return __scope.modules.accounts.mergeAccountAndGet(
 				{
 					address: res.authorId,
 					balance: -transaction.amount,
@@ -293,13 +293,13 @@ InTransfer.prototype.schema = {
  * @todo Add description for the params
  */
 InTransfer.prototype.objectNormalize = function(transaction) {
-	const report = __private.schema.validate(
+	const report = __scope.schema.validate(
 		transaction.asset.inTransfer,
 		InTransfer.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate inTransfer schema: ${__private.schema
+		throw `Failed to validate inTransfer schema: ${__scope.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/in_transfer.js
+++ b/framework/src/modules/chain/logic/in_transfer.js
@@ -42,7 +42,7 @@ const __private = {};
  * @todo Add description for the params
  */
 class InTransfer {
-	constructor({ components, libraries, modules }) {
+	constructor({ components, libraries }) {
 		__private.components = {
 			storage: components.storage,
 		};
@@ -50,14 +50,26 @@ class InTransfer {
 			schema: libraries.schema,
 			shared: libraries.sharedApi,
 		};
-		__private.modules = {
-			accounts: modules.accounts,
-		};
+		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
+/**
+ * Binds input parameters to private variables modules and shared.
+ *
+ * @param {Accounts} accounts
+ * @param {Object} sharedApi
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+InTransfer.prototype.bind = function(accounts, sharedApi) {
+	__private.modules = {
+		accounts,
+	};
+	__private.libraries.shared = sharedApi;
+};
 
 /**
  * Returns send fee from constants.
@@ -175,7 +187,7 @@ InTransfer.prototype.applyConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.library.shared.getGenesis(
+	__private.libraries.shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
 		(getGenesisErr, res) => {
 			if (getGenesisErr) {

--- a/framework/src/modules/chain/logic/in_transfer.js
+++ b/framework/src/modules/chain/logic/in_transfer.js
@@ -31,25 +31,21 @@ const __private = {};
  * @see Parent: {@link logic}
  * @requires helpers/milestones
  * @requires helpers/slots
- * @param {Object} dependencies
- * @param {Object} dependencies.components
- * @param {Object} dependencies.libraries
- * @param {Object} dependencies.modules
- * @param {Storage} dependencies.components.storage
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Object} dependencies.libraries.sharedApi
- * @param {Accounts} dependencies.modules.accounts
+ * @param {Object} scope
+ * @param {Object} scope.components
+ * @param {Storage} scope.components.storage
+ * @param {Object} scope.modules
+ * @param {Accounts} scope.modules.accounts
+ * @param {ZSchema} scope.schema
+ * @param {Object} scope.shared
  * @todo Add description for the params
  */
 class InTransfer {
-	constructor({ components, libraries }) {
+	constructor({ components: { storage }, schema }) {
 		__private.components = {
-			storage: components.storage,
+			storage,
 		};
-		__private.libraries = {
-			schema: libraries.schema,
-			shared: libraries.sharedApi,
-		};
+		__private.schema = schema;
 		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
@@ -68,7 +64,7 @@ InTransfer.prototype.bind = function(accounts, sharedApi) {
 	__private.modules = {
 		accounts,
 	};
-	__private.libraries.shared = sharedApi;
+	__private.shared = sharedApi;
 };
 
 /**
@@ -187,7 +183,7 @@ InTransfer.prototype.applyConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.libraries.shared.getGenesis(
+	__private.shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
 		(getGenesisErr, res) => {
 			if (getGenesisErr) {
@@ -227,7 +223,7 @@ InTransfer.prototype.undoConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.libraries.shared.getGenesis(
+	__private.shared.getGenesis(
 		{ dappid: transaction.asset.inTransfer.dappId },
 		(getGenesisErr, res) => {
 			if (getGenesisErr) {
@@ -297,13 +293,13 @@ InTransfer.prototype.schema = {
  * @todo Add description for the params
  */
 InTransfer.prototype.objectNormalize = function(transaction) {
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset.inTransfer,
 		InTransfer.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate inTransfer schema: ${__private.library.schema
+		throw `Failed to validate inTransfer schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/multisignature.js
+++ b/framework/src/modules/chain/logic/multisignature.js
@@ -37,10 +37,16 @@ __private.unconfirmedSignatures = {};
  * @requires bytebuffer
  * @requires helpers/diff
  * @requires helpers/slots
- * @param {ZSchema} schema
- * @param {Object} network
- * @param {Transaction} transaction
- * @param {Object} logger
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {logger} dependencies.components.logger
+ * @param {ZSchema} dependencies.libraries.schem
+ * @param {Object} dependencies.libraries.network
+ * @param {Transaction} dependencies.libraries.logic.transaction
+ * @param {Account} dependencies.libraries.logic.account
+ * @param {Accounts} dependencies.modules.accounts
  * @todo Add description for the params
  */
 class Multisignature {
@@ -348,7 +354,9 @@ Multisignature.prototype.applyConfirmed = function(
 				transaction.asset.multisignature.keysgroup,
 				(transactionToGetKey, eachSeriesCb) => {
 					const key = transactionToGetKey.substring(1);
-					const address = __private.modules.accounts.generateAddressByPublicKey(key);
+					const address = __private.modules.accounts.generateAddressByPublicKey(
+						key
+					);
 
 					// Create accounts
 					__private.modules.accounts.setAccountAndGet(
@@ -559,7 +567,10 @@ Multisignature.prototype.dbRead = function(raw) {
  * @todo Add description for the params
  */
 Multisignature.prototype.afterSave = function(transaction, cb) {
-	__private.libraries.network.io.sockets.emit('multisignatures/change', transaction);
+	__private.libraries.network.io.sockets.emit(
+		'multisignatures/change',
+		transaction
+	);
 	return setImmediate(cb);
 };
 

--- a/framework/src/modules/chain/logic/multisignature.js
+++ b/framework/src/modules/chain/logic/multisignature.js
@@ -50,7 +50,7 @@ __private.unconfirmedSignatures = {};
  * @todo Add description for the params
  */
 class Multisignature {
-	constructor({ components, libraries, modules }) {
+	constructor({ components, libraries }) {
 		__private.components = {
 			logger: components.logger,
 		};
@@ -62,14 +62,24 @@ class Multisignature {
 				account: libraries.logic.account,
 			},
 		};
-		__private.modules = {
-			accounts: modules.accounts,
-		};
+		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
+/**
+ * Binds input parameters to private variable modules.
+ *
+ * @param {Accounts} accounts
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+Multisignature.prototype.bind = function(accounts) {
+	__private.modules = {
+		accounts,
+	};
+};
 
 /**
  * Obtains constant fee multisignature and multiply by quantity of signatures.
@@ -336,7 +346,7 @@ Multisignature.prototype.applyConfirmed = function(
 ) {
 	__private.unconfirmedSignatures[sender.address] = false;
 
-	__private.components.logic.account.merge(
+	__private.libraries.logic.account.merge(
 		sender.address,
 		{
 			membersPublicKeys: transaction.asset.multisignature.keysgroup,
@@ -518,13 +528,13 @@ Multisignature.prototype.schema = {
  * @returns {transaction} Validated transaction
  */
 Multisignature.prototype.objectNormalize = function(transaction) {
-	const report = __private.components.schema.validate(
+	const report = __private.libraries.schema.validate(
 		transaction.asset.multisignature,
 		Multisignature.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate multisignature schema: ${__private.components.schema
+		throw `Failed to validate multisignature schema: ${__private.libraries.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/multisignature.js
+++ b/framework/src/modules/chain/logic/multisignature.js
@@ -66,7 +66,7 @@ class Multisignature {
 			account,
 		};
 
-		// TODO: Add modules to contructor argument and assign accounts to __scope.modules.accounts
+		// TODO: Add modules to constructor argument and assign accounts to __scope.modules.accounts
 	}
 }
 
@@ -107,7 +107,7 @@ Multisignature.prototype.calculateFee = function(transaction) {
  * @returns {SetImmediate} error, transaction
  * @todo Add description for the params
  */
-Multisignature.prototype.verify = async function(transaction, sender, cb) {
+Multisignature.prototype.verify = function(transaction, sender, cb) {
 	if (!transaction.asset || !transaction.asset.multisignature) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}

--- a/framework/src/modules/chain/logic/out_transfer.js
+++ b/framework/src/modules/chain/logic/out_transfer.js
@@ -45,7 +45,7 @@ __private.unconfirmedOutTansfers = {};
  * @todo Add description for the params
  */
 class OutTransfer {
-	constructor({ components, libraries, modules }) {
+	constructor({ components, libraries }) {
 		__private.components = {
 			storage: components.storage,
 			logger: components.logger,
@@ -53,14 +53,24 @@ class OutTransfer {
 		__private.libraries = {
 			schema: libraries.schema,
 		};
-		__private.modules = {
-			accounts: modules.accounts,
-		};
+		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
+/**
+ * Binds input modules to private variable module.
+ *
+ * @param {Accounts} accounts
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+OutTransfer.prototype.bind = function(accounts) {
+	__private.modules = {
+		accounts,
+	};
+};
 
 /**
  * Returns send fee from constants.

--- a/framework/src/modules/chain/logic/out_transfer.js
+++ b/framework/src/modules/chain/logic/out_transfer.js
@@ -33,6 +33,15 @@ __private.unconfirmedOutTansfers = {};
  * @param {ZSchema} schema
  * @param {Object} logger
  * @param {Storage} storage
+ *
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {Storage} dependencies.components.storage
+ * @param {logger} dependencies.components.logger
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Accounts} dependencies.modules.accounts
  * @todo Add description for the params
  */
 class OutTransfer {

--- a/framework/src/modules/chain/logic/out_transfer.js
+++ b/framework/src/modules/chain/logic/out_transfer.js
@@ -30,29 +30,20 @@ __private.unconfirmedOutTansfers = {};
  * @class
  * @memberof logic
  * @see Parent: {@link logic}
- * @param {ZSchema} schema
- * @param {Object} logger
- * @param {Storage} storage
- *
- * @param {Object} dependencies
- * @param {Object} dependencies.components
- * @param {Object} dependencies.libraries
- * @param {Object} dependencies.modules
- * @param {Storage} dependencies.components.storage
- * @param {logger} dependencies.components.logger
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Accounts} dependencies.modules.accounts
+ * @param {Object} scope
+ * @param {Object} scope.components
+ * @param {Storage} scope.components.storage
+ * @param {Object} scope.modules
+ * @param {Accounts} scope.modules.accounts
+ * @param {ZSchema} scope.schema
  * @todo Add description for the params
  */
 class OutTransfer {
-	constructor({ components, libraries }) {
+	constructor({ components: { storage }, schema }) {
 		__private.components = {
-			storage: components.storage,
-			logger: components.logger,
+			storage,
 		};
-		__private.libraries = {
-			schema: libraries.schema,
-		};
+		__private.schema = schema;
 		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
@@ -359,13 +350,13 @@ OutTransfer.prototype.schema = {
  * @todo Add description for the params
  */
 OutTransfer.prototype.objectNormalize = function(transaction) {
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset.outTransfer,
 		OutTransfer.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate outTransfer schema: ${__private.libraries.schema
+		throw `Failed to validate outTransfer schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/out_transfer.js
+++ b/framework/src/modules/chain/logic/out_transfer.js
@@ -81,39 +81,40 @@ OutTransfer.prototype.calculateFee = function() {
  * @returns {SetImmediate} error, transaction
  * @todo Add description for the params
  */
-OutTransfer.prototype.verify = async function(transaction, sender, cb) {
-	let lastBlock = await __scope.components.storage.entities.Block.get(
+OutTransfer.prototype.verify = function(transaction, sender, cb) {
+	return __scope.components.storage.entities.Block.get(
 		{},
 		{ sort: 'height:desc', limit: 1 }
-	);
-	lastBlock = lastBlock[0];
+	).then(lastBlock => {
+		lastBlock = lastBlock[0];
 
-	if (lastBlock.height >= exceptions.precedent.disableDappTransfer) {
-		return setImmediate(cb, `Transaction type ${transaction.type} is frozen`);
-	}
+		if (lastBlock.height >= exceptions.precedent.disableDappTransfer) {
+			return setImmediate(cb, `Transaction type ${transaction.type} is frozen`);
+		}
 
-	if (!transaction.recipientId) {
-		return setImmediate(cb, 'Invalid recipient');
-	}
+		if (!transaction.recipientId) {
+			return setImmediate(cb, 'Invalid recipient');
+		}
 
-	const amount = new Bignum(transaction.amount);
-	if (amount.isLessThanOrEqualTo(0)) {
-		return setImmediate(cb, 'Invalid transaction amount');
-	}
+		const amount = new Bignum(transaction.amount);
+		if (amount.isLessThanOrEqualTo(0)) {
+			return setImmediate(cb, 'Invalid transaction amount');
+		}
 
-	if (!transaction.asset || !transaction.asset.outTransfer) {
-		return setImmediate(cb, 'Invalid transaction asset');
-	}
+		if (!transaction.asset || !transaction.asset.outTransfer) {
+			return setImmediate(cb, 'Invalid transaction asset');
+		}
 
-	if (!/^[0-9]+$/.test(transaction.asset.outTransfer.dappId)) {
-		return setImmediate(cb, 'Invalid outTransfer dappId');
-	}
+		if (!/^[0-9]+$/.test(transaction.asset.outTransfer.dappId)) {
+			return setImmediate(cb, 'Invalid outTransfer dappId');
+		}
 
-	if (!/^[0-9]+$/.test(transaction.asset.outTransfer.transactionId)) {
-		return setImmediate(cb, 'Invalid outTransfer transactionId');
-	}
+		if (!/^[0-9]+$/.test(transaction.asset.outTransfer.transactionId)) {
+			return setImmediate(cb, 'Invalid outTransfer transactionId');
+		}
 
-	return setImmediate(cb, null, transaction);
+		return setImmediate(cb, null, transaction);
+	});
 };
 
 /**

--- a/framework/src/modules/chain/logic/signature.js
+++ b/framework/src/modules/chain/logic/signature.js
@@ -38,21 +38,31 @@ const __private = {};
  * @todo Add description for the params
  */
 class Signature {
-	constructor({ components, libraries, modules }) {
+	constructor({ components, libraries }) {
 		__private.libraries = {
 			schema: libraries.schema,
 		};
 		__private.components = {
 			logger: components.logger,
 		};
-		__private.modules = {
-			accounts: modules.accounts,
-		};
+		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
+/**
+ * Binds input parameters to private variable modules.
+ *
+ * @param {Accounts} accounts
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+Signature.prototype.bind = function(accounts) {
+	__private.modules = {
+		accounts,
+	};
+};
 
 /**
  * Obtains constant fee secondSignature.

--- a/framework/src/modules/chain/logic/signature.js
+++ b/framework/src/modules/chain/logic/signature.js
@@ -28,8 +28,13 @@ const __private = {};
  * @memberof logic
  * @see Parent: {@link logic}
  * @requires bytebuffer
- * @param {ZSchema} schema
- * @param {Object} logger
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {logger} dependencies.components.logger
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Accounts} dependencies.modules.accounts
  * @todo Add description for the params
  */
 class Signature {

--- a/framework/src/modules/chain/logic/signature.js
+++ b/framework/src/modules/chain/logic/signature.js
@@ -20,7 +20,7 @@ const ed = require('../helpers/ed.js');
 
 const { FEES } = global.constants;
 
-const __private = {};
+const __scope = {};
 /**
  * Main signature logic. Initializes library.
  *
@@ -38,11 +38,11 @@ const __private = {};
  */
 class Signature {
 	constructor({ components: { logger }, schema }) {
-		__private.schema = schema;
-		__private.components = {
+		__scope.schema = schema;
+		__scope.components = {
 			logger,
 		};
-		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
+		// TODO: Add modules to contructor argument and assign accounts to __scope.modules.accounts
 	}
 }
 
@@ -56,7 +56,7 @@ class Signature {
  */
 // TODO: Remove this method as modules will be loaded prior to trs logic.
 Signature.prototype.bind = function(accounts) {
-	__private.modules = {
+	__scope.modules = {
 		accounts,
 	};
 };
@@ -80,7 +80,7 @@ Signature.prototype.calculateFee = function() {
  * @returns {SetImmediate} error, transaction
  * @todo Add description for the params
  */
-Signature.prototype.verify = function(transaction, sender, cb) {
+Signature.prototype.verify = async function(transaction, sender, cb) {
 	if (!transaction.asset || !transaction.asset.signature) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}
@@ -98,7 +98,7 @@ Signature.prototype.verify = function(transaction, sender, cb) {
 			return setImmediate(cb, 'Invalid public key');
 		}
 	} catch (e) {
-		__private.components.logger.error(e.stack);
+		__scope.components.logger.error(e.stack);
 		return setImmediate(cb, 'Invalid public key');
 	}
 
@@ -162,7 +162,7 @@ Signature.prototype.applyConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.modules.accounts.setAccountAndGet(
+	__scope.modules.accounts.setAccountAndGet(
 		{
 			address: sender.address,
 			secondSignature: 1,
@@ -189,7 +189,7 @@ Signature.prototype.undoConfirmed = function(
 	cb,
 	tx
 ) {
-	__private.modules.accounts.setAccountAndGet(
+	__scope.modules.accounts.setAccountAndGet(
 		{
 			address: sender.address,
 			secondSignature: 0,
@@ -215,7 +215,7 @@ Signature.prototype.applyUnconfirmed = function(transaction, sender, cb, tx) {
 		return setImmediate(cb, 'Second signature already enabled');
 	}
 
-	return __private.modules.accounts.setAccountAndGet(
+	return __scope.modules.accounts.setAccountAndGet(
 		{ address: sender.address, u_secondSignature: 1 },
 		cb,
 		tx
@@ -232,7 +232,7 @@ Signature.prototype.applyUnconfirmed = function(transaction, sender, cb, tx) {
  * @todo Add description for the params
  */
 Signature.prototype.undoUnconfirmed = function(transaction, sender, cb, tx) {
-	__private.modules.accounts.setAccountAndGet(
+	__scope.modules.accounts.setAccountAndGet(
 		{ address: sender.address, u_secondSignature: 0 },
 		cb,
 		tx
@@ -262,13 +262,13 @@ Signature.prototype.schema = {
  * @returns {transaction} Validated transaction
  */
 Signature.prototype.objectNormalize = function(transaction) {
-	const report = __private.schema.validate(
+	const report = __scope.schema.validate(
 		transaction.asset.signature,
 		Signature.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate signature schema: ${__private.schema
+		throw `Failed to validate signature schema: ${__scope.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/signature.js
+++ b/framework/src/modules/chain/logic/signature.js
@@ -80,7 +80,7 @@ Signature.prototype.calculateFee = function() {
  * @returns {SetImmediate} error, transaction
  * @todo Add description for the params
  */
-Signature.prototype.verify = async function(transaction, sender, cb) {
+Signature.prototype.verify = function(transaction, sender, cb) {
 	if (!transaction.asset || !transaction.asset.signature) {
 		return setImmediate(cb, 'Invalid transaction asset');
 	}

--- a/framework/src/modules/chain/logic/signature.js
+++ b/framework/src/modules/chain/logic/signature.js
@@ -28,22 +28,19 @@ const __private = {};
  * @memberof logic
  * @see Parent: {@link logic}
  * @requires bytebuffer
- * @param {Object} dependencies
- * @param {Object} dependencies.components
- * @param {Object} dependencies.libraries
- * @param {Object} dependencies.modules
- * @param {logger} dependencies.components.logger
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Accounts} dependencies.modules.accounts
+ * @param {Object} scope
+ * @param {Object} scope.components
+ * @param {logger} scope.components.logger
+ * @param {Object} scope.modules
+ * @param {Accounts} scope.modules.accounts
+ * @param {ZSchema} scope.schema
  * @todo Add description for the params
  */
 class Signature {
-	constructor({ components, libraries }) {
-		__private.libraries = {
-			schema: libraries.schema,
-		};
+	constructor({ components: { logger }, schema }) {
+		__private.schema = schema;
 		__private.components = {
-			logger: components.logger,
+			logger,
 		};
 		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
@@ -265,13 +262,13 @@ Signature.prototype.schema = {
  * @returns {transaction} Validated transaction
  */
 Signature.prototype.objectNormalize = function(transaction) {
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset.signature,
 		Signature.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate signature schema: ${__private.libraries.schema
+		throw `Failed to validate signature schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/transaction.js
+++ b/framework/src/modules/chain/logic/transaction.js
@@ -701,13 +701,13 @@ class Transaction {
 			);
 		}
 
-		const verifyTransactionTypes = (
+		const verifyTransactionTypes = async (
 			transactionToVeryfi,
 			senderToVerify,
 			txToVerify,
 			verifyTransactionTypesCb
 		) => {
-			__private.types[transactionToVeryfi.type].verify(
+			await __private.types[transactionToVeryfi.type].verify(
 				transactionToVeryfi,
 				senderToVerify,
 				verifyErr => {

--- a/framework/src/modules/chain/logic/transaction.js
+++ b/framework/src/modules/chain/logic/transaction.js
@@ -701,13 +701,13 @@ class Transaction {
 			);
 		}
 
-		const verifyTransactionTypes = async (
+		const verifyTransactionTypes = (
 			transactionToVeryfi,
 			senderToVerify,
 			txToVerify,
 			verifyTransactionTypesCb
 		) => {
-			await __private.types[transactionToVeryfi.type].verify(
+			__private.types[transactionToVeryfi.type].verify(
 				transactionToVeryfi,
 				senderToVerify,
 				verifyErr => {

--- a/framework/src/modules/chain/logic/transfer.js
+++ b/framework/src/modules/chain/logic/transfer.js
@@ -38,21 +38,31 @@ const __private = {};
  * @todo Add description for the params
  */
 class Transfer {
-	constructor({ components, libraries, modules }) {
+	constructor({ components, libraries }) {
 		__private.libraries = {
 			schema: libraries.schema,
 		};
 		__private.components = {
 			logger: components.logger,
 		};
-		__private.modules = {
-			accounts: modules.accounts,
-		};
+		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
 }
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
+/**
+ * Binds input parameters to private variable modules.
+ *
+ * @param {Accounts} accounts
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+Transfer.prototype.bind = function(accounts) {
+	__private.modules = {
+		accounts,
+	};
+};
 
 /**
  * Returns send fees from constants.

--- a/framework/src/modules/chain/logic/transfer.js
+++ b/framework/src/modules/chain/logic/transfer.js
@@ -20,7 +20,6 @@ const Bignum = require('../helpers/bignum.js');
 const { ADDITIONAL_DATA, FEES } = global.constants;
 const __private = {};
 
-
 /**
  * Main transfer logic.
  *
@@ -29,8 +28,13 @@ const __private = {};
  * @see Parent: {@link logic}
  * @requires helpers/bignum
  * @requires helpers/slots
- * @param {Object} logger
- * @param {Object} schema
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {logger} dependencies.components.logger
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Accounts} dependencies.modules.accounts
  * @todo Add description for the params
  */
 class Transfer {

--- a/framework/src/modules/chain/logic/transfer.js
+++ b/framework/src/modules/chain/logic/transfer.js
@@ -28,22 +28,19 @@ const __private = {};
  * @see Parent: {@link logic}
  * @requires helpers/bignum
  * @requires helpers/slots
- * @param {Object} dependencies
- * @param {Object} dependencies.components
- * @param {Object} dependencies.libraries
- * @param {Object} dependencies.modules
- * @param {logger} dependencies.components.logger
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Accounts} dependencies.modules.accounts
+ * @param {Object} scope
+ * @param {Object} scope.components
+ * @param {logger} scope.components.logger
+ * @param {Object} scope.modules
+ * @param {Accounts} scope.modules.accounts
+ * @param {ZSchema} scope.schema
  * @todo Add description for the params
  */
 class Transfer {
-	constructor({ components, libraries }) {
-		__private.libraries = {
-			schema: libraries.schema,
-		};
+	constructor({ components: { logger }, schema }) {
+		__private.schema = schema;
 		__private.components = {
-			logger: components.logger,
+			logger,
 		};
 		// TODO: Add modules to contructor argument and assign accounts to __private.modules.accounts
 	}
@@ -264,13 +261,13 @@ Transfer.prototype.objectNormalize = function(transaction) {
 		return transaction;
 	}
 
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset,
 		Transfer.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate transfer schema: ${__private.libraries.schema
+		throw `Failed to validate transfer schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/transfer.js
+++ b/framework/src/modules/chain/logic/transfer.js
@@ -80,7 +80,7 @@ Transfer.prototype.calculateFee = function() {
  * @returns {SetImmediate} error, transaction
  * @todo Add description for the params
  */
-Transfer.prototype.verify = async function(transaction, sender, cb) {
+Transfer.prototype.verify = function(transaction, sender, cb) {
 	if (!transaction.recipientId) {
 		return setImmediate(cb, 'Missing recipient');
 	}

--- a/framework/src/modules/chain/logic/vote.js
+++ b/framework/src/modules/chain/logic/vote.js
@@ -52,7 +52,7 @@ let self;
  * @todo Add description for the params
  */
 class Vote {
-	constructor({ components, libraries, modules }) {
+	constructor({ components, libraries }) {
 		self = this;
 		__private.components = {
 			logger: components.logger,
@@ -61,9 +61,7 @@ class Vote {
 			schema: libraries.schema,
 			account: libraries.account,
 		};
-		__private.modules = {
-			delegates: modules.delegates,
-		};
+		// TODO: Add modules to contructor argument and assign delegates module to __private.modules.delegates
 	}
 
 	/**
@@ -128,6 +126,18 @@ class Vote {
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
+/**
+ * Binds module content to private object modules.
+ *
+ * @param {Delegates} delegates
+ * @todo Add description for the params
+ */
+// TODO: Remove this method as modules will be loaded prior to trs logic.
+Vote.prototype.bind = function(delegates) {
+	__private.modules = {
+		delegates,
+	};
+};
 
 /**
  * Obtains constant fee vote.

--- a/framework/src/modules/chain/logic/vote.js
+++ b/framework/src/modules/chain/logic/vote.js
@@ -23,8 +23,7 @@ const Bignum = require('../helpers/bignum.js');
 const exceptions = global.exceptions;
 const { FEES, MAX_VOTES_PER_TRANSACTION } = global.constants;
 
-let modules;
-let library;
+const __private = {};
 let self;
 
 /**
@@ -44,12 +43,17 @@ let self;
  * @todo Add description for the params
  */
 class Vote {
-	constructor(logger, schema, account) {
+	constructor({ components, libraries, modules }) {
 		self = this;
-		library = {
-			logger,
-			schema,
-			account,
+		__private.components = {
+			logger: components.logger,
+		};
+		__private.libraries = {
+			schema: libraries.schema,
+			account: libraries.account,
+		};
+		__private.modules = {
+			delegates: modules.delegates,
 		};
 	}
 
@@ -115,17 +119,6 @@ class Vote {
 
 // TODO: The below functions should be converted into static functions,
 // however, this will lead to incompatibility with modules and tests implementation.
-/**
- * Binds module content to private object modules.
- *
- * @param {Delegates} delegates
- * @todo Add description for the params
- */
-Vote.prototype.bind = function(delegates) {
-	modules = {
-		delegates,
-	};
-};
 
 /**
  * Obtains constant fee vote.

--- a/framework/src/modules/chain/logic/vote.js
+++ b/framework/src/modules/chain/logic/vote.js
@@ -81,7 +81,7 @@ class Vote {
 
 		const votesInvert = Diff.reverse(transaction.asset.votes);
 
-		return __private.libraries.account.merge(
+		return __private.logic.account.merge(
 			sender.address,
 			{
 				votedDelegatesPublicKeys: votesInvert,
@@ -111,7 +111,7 @@ class Vote {
 
 		const votesInvert = Diff.reverse(transaction.asset.votes);
 
-		return __private.libraries.account.merge(
+		return __private.logic.account.merge(
 			sender.address,
 			{ u_votedDelegatesPublicKeys: votesInvert },
 			mergeErr => setImmediate(cb, mergeErr),
@@ -362,7 +362,7 @@ Vote.prototype.applyConfirmed = function(transaction, block, sender, cb, tx) {
 				self.checkConfirmedDelegates(transaction, seriesCb, tx);
 			},
 			function() {
-				__private.libraries.account.merge(
+				__private.logic.account.merge(
 					sender.address,
 					{
 						votedDelegatesPublicKeys: transaction.asset.votes,
@@ -393,7 +393,7 @@ Vote.prototype.applyUnconfirmed = function(transaction, sender, cb, tx) {
 				self.checkUnconfirmedDelegates(transaction, seriesCb, tx);
 			},
 			function(seriesCb) {
-				__private.libraries.account.merge(
+				__private.logic.account.merge(
 					sender.address,
 					{
 						u_votedDelegatesPublicKeys: transaction.asset.votes,
@@ -436,13 +436,13 @@ Vote.prototype.schema = {
  * @todo Add description for the params
  */
 Vote.prototype.objectNormalize = function(transaction) {
-	const report = __private.libraries.schema.validate(
+	const report = __private.schema.validate(
 		transaction.asset,
 		Vote.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate vote schema: ${__private.libraries.schema
+		throw `Failed to validate vote schema: ${__private.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/vote.js
+++ b/framework/src/modules/chain/logic/vote.js
@@ -40,6 +40,15 @@ let self;
  * @requires helpers/slots
  * @param {Object} logger
  * @param {ZSchema} schema
+ *
+ * @param {Object} dependencies
+ * @param {Object} dependencies.components
+ * @param {Object} dependencies.libraries
+ * @param {Object} dependencies.modules
+ * @param {logger} dependencies.components.logger
+ * @param {ZSchema} dependencies.libraries.schema
+ * @param {Account} dependencies.libraries.account
+ * @param {Delegates} dependencies.modules.delegates
  * @todo Add description for the params
  */
 class Vote {
@@ -77,7 +86,7 @@ class Vote {
 
 		const votesInvert = Diff.reverse(transaction.asset.votes);
 
-		return library.account.merge(
+		return __private.libraries.account.merge(
 			sender.address,
 			{
 				votedDelegatesPublicKeys: votesInvert,
@@ -107,7 +116,7 @@ class Vote {
 
 		const votesInvert = Diff.reverse(transaction.asset.votes);
 
-		return library.account.merge(
+		return __private.libraries.account.merge(
 			sender.address,
 			{ u_votedDelegatesPublicKeys: votesInvert },
 			mergeErr => setImmediate(cb, mergeErr),
@@ -201,13 +210,13 @@ Vote.prototype.verify = function(transaction, sender, cb, tx) {
 		waterErr => {
 			if (waterErr) {
 				if (exceptions.votes.includes(transaction.id)) {
-					library.logger.warn(
+					__private.components.logger.warn(
 						`vote.verify: Invalid transaction identified as exception "${
 							transaction.id
 						}"`
 					);
-					library.logger.error(waterErr);
-					library.logger.debug(JSON.stringify(transaction));
+					__private.components.logger.error(waterErr);
+					__private.components.logger.debug(JSON.stringify(transaction));
 				} else {
 					return setImmediate(cb, waterErr);
 				}
@@ -256,13 +265,13 @@ Vote.prototype.verifyVote = function(vote, cb) {
  * @todo Add description for the params
  */
 Vote.prototype.checkConfirmedDelegates = function(transaction, cb, tx) {
-	modules.delegates.checkConfirmedDelegates(
+	__private.modules.delegates.checkConfirmedDelegates(
 		transaction.senderPublicKey,
 		transaction.asset.votes,
 		err => {
 			if (err && exceptions.votes.includes(transaction.id)) {
-				library.logger.debug(err);
-				library.logger.debug(JSON.stringify(transaction));
+				__private.components.logger.debug(err);
+				__private.components.logger.debug(JSON.stringify(transaction));
 				err = null;
 			}
 
@@ -281,13 +290,13 @@ Vote.prototype.checkConfirmedDelegates = function(transaction, cb, tx) {
  * @todo Add description for the params
  */
 Vote.prototype.checkUnconfirmedDelegates = function(transaction, cb, tx) {
-	modules.delegates.checkUnconfirmedDelegates(
+	__private.modules.delegates.checkUnconfirmedDelegates(
 		transaction.senderPublicKey,
 		transaction.asset.votes,
 		err => {
 			if (err && exceptions.votes.includes(transaction.id)) {
-				library.logger.debug(err);
-				library.logger.debug(JSON.stringify(transaction));
+				__private.components.logger.debug(err);
+				__private.components.logger.debug(JSON.stringify(transaction));
 				err = null;
 			}
 
@@ -346,7 +355,7 @@ Vote.prototype.applyConfirmed = function(transaction, block, sender, cb, tx) {
 				self.checkConfirmedDelegates(transaction, seriesCb, tx);
 			},
 			function() {
-				library.account.merge(
+				__private.libraries.account.merge(
 					sender.address,
 					{
 						votedDelegatesPublicKeys: transaction.asset.votes,
@@ -377,7 +386,7 @@ Vote.prototype.applyUnconfirmed = function(transaction, sender, cb, tx) {
 				self.checkUnconfirmedDelegates(transaction, seriesCb, tx);
 			},
 			function(seriesCb) {
-				library.account.merge(
+				__private.libraries.account.merge(
 					sender.address,
 					{
 						u_votedDelegatesPublicKeys: transaction.asset.votes,
@@ -420,13 +429,13 @@ Vote.prototype.schema = {
  * @todo Add description for the params
  */
 Vote.prototype.objectNormalize = function(transaction) {
-	const report = library.schema.validate(
+	const report = __private.libraries.schema.validate(
 		transaction.asset,
 		Vote.prototype.schema
 	);
 
 	if (!report) {
-		throw `Failed to validate vote schema: ${library.schema
+		throw `Failed to validate vote schema: ${__private.libraries.schema
 			.getLastErrors()
 			.map(err => err.message)
 			.join(', ')}`;

--- a/framework/src/modules/chain/logic/vote.js
+++ b/framework/src/modules/chain/logic/vote.js
@@ -38,29 +38,26 @@ let self;
  * @requires lodash
  * @requires helpers/diff
  * @requires helpers/slots
- * @param {Object} logger
- * @param {ZSchema} schema
- *
- * @param {Object} dependencies
- * @param {Object} dependencies.components
- * @param {Object} dependencies.libraries
- * @param {Object} dependencies.modules
- * @param {logger} dependencies.components.logger
- * @param {ZSchema} dependencies.libraries.schema
- * @param {Account} dependencies.libraries.account
- * @param {Delegates} dependencies.modules.delegates
+ * @param {Object} scope
+ * @param {Object} scope.components
+ * @param {logger} scope.components.logger
+ * @param {Object} scope.modules
+ * @param {Delegates} scope.modules.delegates
+ * @param {Object} scope.logic
+ * @param {Account} scope.logic.account
+ * @param {ZSchema} scope.schema
  * @todo Add description for the params
  */
 class Vote {
-	constructor({ components, libraries }) {
+	constructor({ components: { logger }, logic: { account }, schema }) {
 		self = this;
 		__private.components = {
-			logger: components.logger,
+			logger,
 		};
-		__private.libraries = {
-			schema: libraries.schema,
-			account: libraries.account,
+		__private.logic = {
+			account,
 		};
+		__private.schema = schema;
 		// TODO: Add modules to contructor argument and assign delegates module to __private.modules.delegates
 	}
 

--- a/framework/src/modules/chain/logic/vote.js
+++ b/framework/src/modules/chain/logic/vote.js
@@ -154,7 +154,7 @@ Vote.prototype.calculateFee = function() {
  * @returns {SetImmediate|checkConfirmedDelegates}
  * @todo Add description for the params
  */
-Vote.prototype.verify = async function(transaction, sender, cb, tx) {
+Vote.prototype.verify = function(transaction, sender, cb, tx) {
 	async.waterfall(
 		[
 			waterCb => {

--- a/framework/src/modules/chain/modules/accounts.js
+++ b/framework/src/modules/chain/modules/accounts.js
@@ -65,7 +65,15 @@ class Accounts {
 			transactionTypes.VOTE
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.VOTE,
-			new Vote(scope.logger, library.schema, library.logic.account)
+			new Vote({
+				components: {
+					logger: scope.logger,
+				},
+				libraries: {
+					schema: library.schema,
+					account: library.logic.account,
+				},
+			})
 		);
 
 		setImmediate(cb, null, self);

--- a/framework/src/modules/chain/modules/accounts.js
+++ b/framework/src/modules/chain/modules/accounts.js
@@ -69,8 +69,8 @@ class Accounts {
 				components: {
 					logger: scope.logger,
 				},
-				libraries: {
-					schema: library.schema,
+				schema: library.schema,
+				logic: {
 					account: library.logic.account,
 				},
 			})

--- a/framework/src/modules/chain/modules/dapps.js
+++ b/framework/src/modules/chain/modules/dapps.js
@@ -77,30 +77,45 @@ class DApps {
 			transactionTypes.DAPP
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.DAPP,
-			new DApp(
-				scope.components.storage,
-				scope.components.logger,
-				scope.schema,
-				scope.network
-			)
+			new DApp({
+				components: {
+					storage: scope.components.storage,
+					logger: scope.components.logger,
+				},
+				libraries: {
+					schema: scope.schema,
+					network: scope.network,
+				},
+			})
 		);
 
 		__private.assetTypes[
 			transactionTypes.IN_TRANSFER
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.IN_TRANSFER,
-			new InTransfer(scope.components.storage, scope.schema)
+			new InTransfer({
+				components: {
+					storage: scope.components.storage,
+				},
+				libraries: {
+					schema: scope.schema,
+				},
+			})
 		);
-
 		__private.assetTypes[
 			transactionTypes.OUT_TRANSFER
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.OUT_TRANSFER,
-			new OutTransfer(
-				scope.components.storage,
-				scope.schema,
-				scope.components.logger
-			)
+
+			new OutTransfer({
+				components: {
+					storage: scope.components.storage,
+					logger: scope.components.logger,
+				},
+				libraries: {
+					schema: scope.schema,
+				},
+			})
 		);
 
 		/**
@@ -131,13 +146,11 @@ DApps.prototype.onBind = function(scope) {
 
 	__private.assetTypes[transactionTypes.IN_TRANSFER].bind(
 		scope.modules.accounts,
-		scope.modules.blocks,
 		shared
 	);
 
 	__private.assetTypes[transactionTypes.OUT_TRANSFER].bind(
 		scope.modules.accounts,
-		scope.modules.blocks,
 		scope.modules.dapps
 	);
 };

--- a/framework/src/modules/chain/modules/dapps.js
+++ b/framework/src/modules/chain/modules/dapps.js
@@ -82,10 +82,8 @@ class DApps {
 					storage: scope.components.storage,
 					logger: scope.components.logger,
 				},
-				libraries: {
-					schema: scope.schema,
-					network: scope.network,
-				},
+				schema: scope.schema,
+				network: scope.network,
 			})
 		);
 
@@ -97,9 +95,7 @@ class DApps {
 				components: {
 					storage: scope.components.storage,
 				},
-				libraries: {
-					schema: scope.schema,
-				},
+				schema: scope.schema,
 			})
 		);
 		__private.assetTypes[
@@ -112,9 +108,7 @@ class DApps {
 					storage: scope.components.storage,
 					logger: scope.components.logger,
 				},
-				libraries: {
-					schema: scope.schema,
-				},
+				schema: scope.schema,
 			})
 		);
 

--- a/framework/src/modules/chain/modules/delegates.js
+++ b/framework/src/modules/chain/modules/delegates.js
@@ -89,7 +89,11 @@ class Delegates {
 			transactionTypes.DELEGATE
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.DELEGATE,
-			new Delegate(scope.components.logger, scope.schema)
+			new Delegate({
+				libraries: {
+					schema: scope.schema,
+				},
+			})
 		);
 
 		setImmediate(cb, null, self);

--- a/framework/src/modules/chain/modules/delegates.js
+++ b/framework/src/modules/chain/modules/delegates.js
@@ -90,9 +90,7 @@ class Delegates {
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.DELEGATE,
 			new Delegate({
-				libraries: {
-					schema: scope.schema,
-				},
+				schema: scope.schema,
 			})
 		);
 

--- a/framework/src/modules/chain/modules/multisignatures.js
+++ b/framework/src/modules/chain/modules/multisignatures.js
@@ -55,13 +55,19 @@ function Multisignatures(cb, scope) {
 		logic: {
 			transaction: scope.logic.transaction,
 			account: scope.logic.account,
-			multisignature: new Multisignature(
-				scope.schema,
-				scope.network,
-				scope.logic.transaction,
-				scope.logic.account,
-				scope.components.logger
-			),
+			multisignature: new Multisignature({
+				components: {
+					logger: scope.components.logger,
+				},
+				libraries: {
+					schema: scope.schema,
+					network: scope.network,
+					logic: {
+						account: scope.logic.account,
+						transaction: scope.logic.transaction,
+					},
+				},
+			}),
 		},
 	};
 	self = this;

--- a/framework/src/modules/chain/modules/multisignatures.js
+++ b/framework/src/modules/chain/modules/multisignatures.js
@@ -59,13 +59,11 @@ function Multisignatures(cb, scope) {
 				components: {
 					logger: scope.components.logger,
 				},
-				libraries: {
-					schema: scope.schema,
-					network: scope.network,
-					logic: {
-						account: scope.logic.account,
-						transaction: scope.logic.transaction,
-					},
+				schema: scope.schema,
+				network: scope.network,
+				logic: {
+					account: scope.logic.account,
+					transaction: scope.logic.transaction,
 				},
 			}),
 		},

--- a/framework/src/modules/chain/modules/signatures.js
+++ b/framework/src/modules/chain/modules/signatures.js
@@ -58,7 +58,14 @@ class Signatures {
 			transactionTypes.SIGNATURE
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.SIGNATURE,
-			new Signature(scope.schema, scope.components.logger)
+			new Signature({
+				components: {
+					logger: scope.components.logger,
+				},
+				libraries: {
+					schema: scope.schema,
+				},
+			})
 		);
 
 		setImmediate(cb, null, self);

--- a/framework/src/modules/chain/modules/signatures.js
+++ b/framework/src/modules/chain/modules/signatures.js
@@ -62,9 +62,7 @@ class Signatures {
 				components: {
 					logger: scope.components.logger,
 				},
-				libraries: {
-					schema: scope.schema,
-				},
+				schema: scope.schema,
 			})
 		);
 

--- a/framework/src/modules/chain/modules/transactions.js
+++ b/framework/src/modules/chain/modules/transactions.js
@@ -84,7 +84,14 @@ class Transactions {
 			transactionTypes.SEND
 		] = library.logic.transaction.attachAssetType(
 			transactionTypes.SEND,
-			new Transfer(library.logger, library.schema)
+			new Transfer({
+				components: {
+					logger: library.logger,
+				},
+				libraries: {
+					schema: library.schema,
+				},
+			})
 		);
 
 		setImmediate(cb, null, self);

--- a/framework/src/modules/chain/modules/transactions.js
+++ b/framework/src/modules/chain/modules/transactions.js
@@ -88,9 +88,7 @@ class Transactions {
 				components: {
 					logger: library.logger,
 				},
-				libraries: {
-					schema: library.schema,
-				},
+				schema: library.schema,
 			})
 		);
 

--- a/framework/test/unit/modules/chain/unit/logic/account.js
+++ b/framework/test/unit/modules/chain/unit/logic/account.js
@@ -90,7 +90,7 @@ describe('account', () => {
 			new Account(
 				storageStub,
 				modulesLoader.scope.schema,
-				modulesLoader.scope.logger,
+				modulesLoader.scope.components.logger,
 				(err, lgAccount) => {
 					accountLogic = lgAccount;
 					library = Account.__get__('library');
@@ -106,7 +106,7 @@ describe('account', () => {
 			expect(accountLogic.scope.storage).to.eql(storageStub));
 
 		it('should attach logger to library variable', async () =>
-			expect(library.logger).to.eql(modulesLoader.scope.logger));
+			expect(library.logger).to.eql(modulesLoader.scope.components.logger));
 	});
 
 	describe('objectNormalize', () => {

--- a/framework/test/unit/modules/chain/unit/logic/dapp.js
+++ b/framework/test/unit/modules/chain/unit/logic/dapp.js
@@ -47,13 +47,16 @@ describe('dapp', () => {
 				},
 			},
 		};
-
-		dapp = new Dapp(
-			storageStub,
-			modulesLoader.scope.components.logger,
-			modulesLoader.scope.schema,
-			modulesLoader.scope.network
-		);
+		dapp = new Dapp({
+			components: {
+				storage: storageStub,
+				logger: modulesLoader.scope.components.logger,
+			},
+			libraries: {
+				network: modulesLoader.scope.network,
+				schema: modulesLoader.scope.schema,
+			},
+		});
 		done();
 	});
 
@@ -66,31 +69,41 @@ describe('dapp', () => {
 		});
 
 		describe('constructor', () => {
-			describe('private library object', () => {
-				let library;
+			describe('__private object', () => {
+				let __private;
 
 				beforeEach(done => {
-					new Dapp(
-						storageStub,
-						modulesLoader.scope.logger,
-						modulesLoader.scope.schema,
-						modulesLoader.scope.network
-					);
-					library = Dapp.__get__('library');
+					new Dapp({
+						components: {
+							storage: storageStub,
+							logger: modulesLoader.scope.components.logger,
+						},
+						libraries: {
+							network: modulesLoader.scope.network,
+							schema: modulesLoader.scope.schema,
+						},
+					});
+					__private = Dapp.__get__('__private');
 					done();
 				});
 
 				it('should be updated with storage stub object', async () =>
-					expect(library.storage).to.eql(storageStub));
+					expect(__private.components.storage).to.eql(storageStub));
 
 				it('should be loaded schema from modulesLoader', async () =>
-					expect(library.schema).to.eql(modulesLoader.scope.schema));
+					expect(__private.libraries.schema).to.eql(
+						modulesLoader.scope.schema
+					));
 
 				it('should be loaded logger from modulesLoader', async () =>
-					expect(library.logger).to.eql(modulesLoader.scope.logger));
+					expect(__private.components.logger).to.eql(
+						modulesLoader.scope.logger
+					));
 
 				it('should be loaded network from modulesLoader', async () =>
-					expect(library.network).to.eql(modulesLoader.scope.network));
+					expect(__private.libraries.network).to.eql(
+						modulesLoader.scope.network
+					));
 			});
 		});
 

--- a/framework/test/unit/modules/chain/unit/logic/dapp.js
+++ b/framework/test/unit/modules/chain/unit/logic/dapp.js
@@ -52,10 +52,8 @@ describe('dapp', () => {
 				storage: storageStub,
 				logger: modulesLoader.scope.components.logger,
 			},
-			libraries: {
-				network: modulesLoader.scope.network,
-				schema: modulesLoader.scope.schema,
-			},
+			network: modulesLoader.scope.network,
+			schema: modulesLoader.scope.schema,
 		});
 		done();
 	});
@@ -78,10 +76,8 @@ describe('dapp', () => {
 							storage: storageStub,
 							logger: modulesLoader.scope.components.logger,
 						},
-						libraries: {
-							network: modulesLoader.scope.network,
-							schema: modulesLoader.scope.schema,
-						},
+						network: modulesLoader.scope.network,
+						schema: modulesLoader.scope.schema,
 					});
 					__private = Dapp.__get__('__private');
 					done();
@@ -91,9 +87,7 @@ describe('dapp', () => {
 					expect(__private.components.storage).to.eql(storageStub));
 
 				it('should be loaded schema from modulesLoader', async () =>
-					expect(__private.libraries.schema).to.eql(
-						modulesLoader.scope.schema
-					));
+					expect(__private.schema).to.eql(modulesLoader.scope.schema));
 
 				it('should be loaded logger from modulesLoader', async () =>
 					expect(__private.components.logger).to.eql(
@@ -101,9 +95,7 @@ describe('dapp', () => {
 					));
 
 				it('should be loaded network from modulesLoader', async () =>
-					expect(__private.libraries.network).to.eql(
-						modulesLoader.scope.network
-					));
+					expect(__private.network).to.eql(modulesLoader.scope.network));
 			});
 		});
 
@@ -695,12 +687,12 @@ describe('dapp', () => {
 			});
 
 			describe('schema properties', () => {
-				let library;
+				let __private;
 				let schemaSpy;
 
 				beforeEach(done => {
-					library = Dapp.__get__('library');
-					schemaSpy = sinonSandbox.spy(library.schema, 'validate');
+					__private = Dapp.__get__('__private');
+					schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
 					done();
 				});
 

--- a/framework/test/unit/modules/chain/unit/logic/dapp.js
+++ b/framework/test/unit/modules/chain/unit/logic/dapp.js
@@ -67,8 +67,8 @@ describe('dapp', () => {
 		});
 
 		describe('constructor', () => {
-			describe('__private object', () => {
-				let __private;
+			describe('__scope object', () => {
+				let __scope;
 
 				beforeEach(done => {
 					new Dapp({
@@ -79,23 +79,21 @@ describe('dapp', () => {
 						network: modulesLoader.scope.network,
 						schema: modulesLoader.scope.schema,
 					});
-					__private = Dapp.__get__('__private');
+					__scope = Dapp.__get__('__scope');
 					done();
 				});
 
 				it('should be updated with storage stub object', async () =>
-					expect(__private.components.storage).to.eql(storageStub));
+					expect(__scope.components.storage).to.eql(storageStub));
 
 				it('should be loaded schema from modulesLoader', async () =>
-					expect(__private.schema).to.eql(modulesLoader.scope.schema));
+					expect(__scope.schema).to.eql(modulesLoader.scope.schema));
 
 				it('should be loaded logger from modulesLoader', async () =>
-					expect(__private.components.logger).to.eql(
-						modulesLoader.scope.logger
-					));
+					expect(__scope.components.logger).to.eql(modulesLoader.scope.logger));
 
 				it('should be loaded network from modulesLoader', async () =>
-					expect(__private.network).to.eql(modulesLoader.scope.network));
+					expect(__scope.network).to.eql(modulesLoader.scope.network));
 			});
 		});
 
@@ -517,8 +515,8 @@ describe('dapp', () => {
 			let unconfirmedLinks;
 
 			beforeEach(done => {
-				unconfirmedNames = Dapp.__get__('__private.unconfirmedNames');
-				unconfirmedLinks = Dapp.__get__('__private.unconfirmedLinks');
+				unconfirmedNames = Dapp.__get__('__scope.unconfirmedNames');
+				unconfirmedLinks = Dapp.__get__('__scope.unconfirmedLinks');
 				done();
 			});
 
@@ -555,8 +553,8 @@ describe('dapp', () => {
 				beforeEach(() => {
 					const dappNames = {};
 					dappNames[transaction.asset.dapp.name] = true;
-					Dapp.__set__('__private.unconfirmedNames', dappNames);
-					return Dapp.__set__('__private.unconfirmedLinks', {});
+					Dapp.__set__('__scope.unconfirmedNames', dappNames);
+					return Dapp.__set__('__scope.unconfirmedLinks', {});
 				});
 
 				it('should call callback with error', done => {
@@ -571,8 +569,8 @@ describe('dapp', () => {
 				beforeEach(() => {
 					const dappLinks = {};
 					dappLinks[transaction.asset.dapp.link] = true;
-					Dapp.__set__('__private.unconfirmedLinks', dappLinks);
-					return Dapp.__set__('__private.unconfirmedNames', {});
+					Dapp.__set__('__scope.unconfirmedLinks', dappLinks);
+					return Dapp.__set__('__scope.unconfirmedNames', {});
 				});
 
 				it('should call callback with error', done => {
@@ -590,10 +588,10 @@ describe('dapp', () => {
 				beforeEach(done => {
 					const dappNames = {};
 					const dappLinks = {};
-					Dapp.__set__('__private.unconfirmedLinks', dappLinks);
-					Dapp.__set__('__private.unconfirmedNames', dappNames);
-					unconfirmedNames = Dapp.__get__('__private.unconfirmedNames');
-					unconfirmedLinks = Dapp.__get__('__private.unconfirmedLinks');
+					Dapp.__set__('__scope.unconfirmedLinks', dappLinks);
+					Dapp.__set__('__scope.unconfirmedNames', dappNames);
+					unconfirmedNames = Dapp.__get__('__scope.unconfirmedNames');
+					unconfirmedLinks = Dapp.__get__('__scope.unconfirmedLinks');
 					done();
 				});
 
@@ -630,10 +628,10 @@ describe('dapp', () => {
 			beforeEach(done => {
 				const dappNames = {};
 				const dappLinks = {};
-				Dapp.__set__('__private.unconfirmedLinks', dappLinks);
-				Dapp.__set__('__private.unconfirmedNames', dappNames);
-				unconfirmedNames = Dapp.__get__('__private.unconfirmedNames');
-				unconfirmedLinks = Dapp.__get__('__private.unconfirmedLinks');
+				Dapp.__set__('__scope.unconfirmedLinks', dappLinks);
+				Dapp.__set__('__scope.unconfirmedNames', dappNames);
+				unconfirmedNames = Dapp.__get__('__scope.unconfirmedNames');
+				unconfirmedLinks = Dapp.__get__('__scope.unconfirmedLinks');
 				done();
 			});
 
@@ -687,12 +685,12 @@ describe('dapp', () => {
 			});
 
 			describe('schema properties', () => {
-				let __private;
+				let __scope;
 				let schemaSpy;
 
 				beforeEach(done => {
-					__private = Dapp.__get__('__private');
-					schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
+					__scope = Dapp.__get__('__scope');
+					schemaSpy = sinonSandbox.spy(__scope.schema, 'validate');
 					done();
 				});
 

--- a/framework/test/unit/modules/chain/unit/logic/dapp.js
+++ b/framework/test/unit/modules/chain/unit/logic/dapp.js
@@ -90,7 +90,9 @@ describe('dapp', () => {
 					expect(__scope.schema).to.eql(modulesLoader.scope.schema));
 
 				it('should be loaded logger from modulesLoader', async () =>
-					expect(__scope.components.logger).to.eql(modulesLoader.scope.logger));
+					expect(__scope.components.logger).to.eql(
+						modulesLoader.scope.components.logger
+					));
 
 				it('should be loaded network from modulesLoader', async () =>
 					expect(__scope.network).to.eql(modulesLoader.scope.network));

--- a/framework/test/unit/modules/chain/unit/logic/delegate.js
+++ b/framework/test/unit/modules/chain/unit/logic/delegate.js
@@ -113,9 +113,7 @@ describe('delegate', () => {
 		};
 
 		delegate = new Delegate({
-			libraries: {
-				schema: modulesLoader.scope.schema,
-			},
+			schema: modulesLoader.scope.schema,
 		});
 
 		return delegate.bind(accountsMock);
@@ -129,8 +127,8 @@ describe('delegate', () => {
 			done();
 		});
 
-		it('should attach schema to __private.libraries', async () => {
-			return expect(__private.libraries)
+		it('should attach schema to __private', async () => {
+			return expect(__private)
 				.to.have.property('schema')
 				.equal(modulesLoader.scope.schema);
 		});
@@ -942,8 +940,8 @@ describe('delegate', () => {
 
 	describe('objectNormalize', () => {
 		it('should use the correct format to validate against', async () => {
-			const libraries = Delegate.__get__('__private.libraries');
-			const schemaSpy = sinonSandbox.spy(libraries.schema, 'validate');
+			const __private = Delegate.__get__('__private');
+			const schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
 			delegate.objectNormalize(transaction);
 			expect(schemaSpy.calledOnce).to.equal(true);
 			expect(
@@ -955,7 +953,7 @@ describe('delegate', () => {
 			return schemaSpy.restore();
 		});
 
-		describe('when __private.libraries.schema.validate fails', () => {
+		describe('when __private.schema.validate fails', () => {
 			const schemaDynamicTest = new SchemaDynamicTest({
 				testStyle: SchemaDynamicTest.TEST_STYLE.THROWABLE,
 				customPropertyAssertion(input, expectedType, property, err) {
@@ -997,7 +995,7 @@ describe('delegate', () => {
 			});
 		});
 
-		describe('when __private.libraries.schema.validate succeeds', () => {
+		describe('when __private.schema.validate succeeds', () => {
 			it('should return transaction', async () =>
 				expect(delegate.objectNormalize(transaction)).to.eql(transaction));
 		});

--- a/framework/test/unit/modules/chain/unit/logic/delegate.js
+++ b/framework/test/unit/modules/chain/unit/logic/delegate.js
@@ -94,8 +94,6 @@ const rawValidTransaction = {
 describe('delegate', () => {
 	let accountsMock;
 	let delegate;
-	let loggerMock;
-
 	let dummyBlock;
 	let transaction;
 	let rawTransaction;
@@ -114,43 +112,43 @@ describe('delegate', () => {
 			setAccountAndGet: sinonSandbox.stub().callsArg(1),
 		};
 
-		loggerMock = {
-			debug: sinonSandbox.spy(),
-		};
+		delegate = new Delegate({
+			libraries: {
+				schema: modulesLoader.scope.schema,
+			},
+		});
 
-		delegate = new Delegate(loggerMock, modulesLoader.scope.schema);
 		return delegate.bind(accountsMock);
 	});
 
 	describe('constructor', () => {
-		it('should attach schema to library variable', async () => {
-			const library = Delegate.__get__('library');
-			return expect(library)
-				.to.have.property('schema')
-				.equal(modulesLoader.scope.schema);
+		let __private;
+
+		beforeEach(done => {
+			__private = Delegate.__get__('__private');
+			done();
 		});
 
-		it('should attach logger to library variable', async () => {
-			const library = Delegate.__get__('library');
-			return expect(library)
-				.to.have.property('logger')
-				.equal(loggerMock);
+		it('should attach schema to __private.libraries', async () => {
+			return expect(__private.libraries)
+				.to.have.property('schema')
+				.equal(modulesLoader.scope.schema);
 		});
 	});
 
 	describe('bind', () => {
-		it('should attach empty object to private modules.accounts variable', async () => {
+		it('should attach empty object to __private.modules.accounts', async () => {
 			delegate.bind({});
-			const modules = Delegate.__get__('modules');
+			const modules = Delegate.__get__('__private.modules');
 
 			return expect(modules).to.eql({
 				accounts: {},
 			});
 		});
 
-		it('should bind modules with accounts object', async () => {
+		it('should bind __private.modules with accounts object', async () => {
 			delegate.bind(accountsMock);
-			const modules = Delegate.__get__('modules');
+			const modules = Delegate.__get__('__private.modules');
 
 			return expect(modules).to.eql({
 				accounts: accountsMock,
@@ -944,8 +942,8 @@ describe('delegate', () => {
 
 	describe('objectNormalize', () => {
 		it('should use the correct format to validate against', async () => {
-			const library = Delegate.__get__('library');
-			const schemaSpy = sinonSandbox.spy(library.schema, 'validate');
+			const libraries = Delegate.__get__('__private.libraries');
+			const schemaSpy = sinonSandbox.spy(libraries.schema, 'validate');
 			delegate.objectNormalize(transaction);
 			expect(schemaSpy.calledOnce).to.equal(true);
 			expect(
@@ -957,7 +955,7 @@ describe('delegate', () => {
 			return schemaSpy.restore();
 		});
 
-		describe('when library.schema.validate fails', () => {
+		describe('when __private.libraries.schema.validate fails', () => {
 			const schemaDynamicTest = new SchemaDynamicTest({
 				testStyle: SchemaDynamicTest.TEST_STYLE.THROWABLE,
 				customPropertyAssertion(input, expectedType, property, err) {
@@ -999,7 +997,7 @@ describe('delegate', () => {
 			});
 		});
 
-		describe('when library.schema.validate succeeds', () => {
+		describe('when __private.libraries.schema.validate succeeds', () => {
 			it('should return transaction', async () =>
 				expect(delegate.objectNormalize(transaction)).to.eql(transaction));
 		});

--- a/framework/test/unit/modules/chain/unit/logic/delegate.js
+++ b/framework/test/unit/modules/chain/unit/logic/delegate.js
@@ -120,33 +120,33 @@ describe('delegate', () => {
 	});
 
 	describe('constructor', () => {
-		let __private;
+		let __scope;
 
 		beforeEach(done => {
-			__private = Delegate.__get__('__private');
+			__scope = Delegate.__get__('__scope');
 			done();
 		});
 
-		it('should attach schema to __private', async () => {
-			return expect(__private)
+		it('should attach schema to __scope', async () => {
+			return expect(__scope)
 				.to.have.property('schema')
 				.equal(modulesLoader.scope.schema);
 		});
 	});
 
 	describe('bind', () => {
-		it('should attach empty object to __private.modules.accounts', async () => {
+		it('should attach empty object to __scope.modules.accounts', async () => {
 			delegate.bind({});
-			const modules = Delegate.__get__('__private.modules');
+			const modules = Delegate.__get__('__scope.modules');
 
 			return expect(modules).to.eql({
 				accounts: {},
 			});
 		});
 
-		it('should bind __private.modules with accounts object', async () => {
+		it('should bind __scope.modules with accounts object', async () => {
 			delegate.bind(accountsMock);
-			const modules = Delegate.__get__('__private.modules');
+			const modules = Delegate.__get__('__scope.modules');
 
 			return expect(modules).to.eql({
 				accounts: accountsMock,
@@ -940,8 +940,8 @@ describe('delegate', () => {
 
 	describe('objectNormalize', () => {
 		it('should use the correct format to validate against', async () => {
-			const __private = Delegate.__get__('__private');
-			const schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
+			const __scope = Delegate.__get__('__scope');
+			const schemaSpy = sinonSandbox.spy(__scope.schema, 'validate');
 			delegate.objectNormalize(transaction);
 			expect(schemaSpy.calledOnce).to.equal(true);
 			expect(
@@ -953,7 +953,7 @@ describe('delegate', () => {
 			return schemaSpy.restore();
 		});
 
-		describe('when __private.schema.validate fails', () => {
+		describe('when __scope.schema.validate fails', () => {
 			const schemaDynamicTest = new SchemaDynamicTest({
 				testStyle: SchemaDynamicTest.TEST_STYLE.THROWABLE,
 				customPropertyAssertion(input, expectedType, property, err) {
@@ -995,7 +995,7 @@ describe('delegate', () => {
 			});
 		});
 
-		describe('when __private.schema.validate succeeds', () => {
+		describe('when __scope.schema.validate succeeds', () => {
 			it('should return transaction', async () =>
 				expect(delegate.objectNormalize(transaction)).to.eql(transaction));
 		});

--- a/framework/test/unit/modules/chain/unit/logic/in_transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/in_transfer.js
@@ -155,8 +155,8 @@ describe('inTransfer', () => {
 	});
 
 	describe('constructor', () => {
-		describe('library', () => {
-			let __private;
+		describe('__scope', () => {
+			let __scope;
 
 			beforeEach(done => {
 				new InTransfer({
@@ -165,17 +165,17 @@ describe('inTransfer', () => {
 					},
 					schema: modulesLoader.scope.schema,
 				});
-				__private = InTransfer.__get__('__private');
+				__scope = InTransfer.__get__('__scope');
 				done();
 			});
 
 			it('should assign storage', async () =>
-				expect(__private)
+				expect(__scope)
 					.to.have.nested.property('components.storage')
 					.eql(storageStub));
 
 			it('should assign schema', async () =>
-				expect(__private)
+				expect(__scope)
 					.to.have.property('schema')
 					.eql(modulesLoader.scope.schema));
 		});
@@ -187,8 +187,8 @@ describe('inTransfer', () => {
 
 		beforeEach(done => {
 			inTransfer.bind(accountsStub, sharedStub);
-			modules = InTransfer.__get__('__private.modules');
-			shared = InTransfer.__get__('__private.shared');
+			modules = InTransfer.__get__('__scope.modules');
+			shared = InTransfer.__get__('__scope.shared');
 			done();
 		});
 
@@ -460,31 +460,31 @@ describe('inTransfer', () => {
 				done();
 			});
 
-			it('should call __private.modules.accounts.mergeAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet', async () =>
 				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ address: validGetGensisResult.authorId })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with balance = trs.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with balance = trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ balance: trs.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with u_balance = trs.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with u_balance = trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ u_balance: trs.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ round: slots.calcRound(dummyBlock.height) })
@@ -492,7 +492,7 @@ describe('inTransfer', () => {
 				).to.be.true);
 		});
 
-		describe('when __private.modules.accounts.mergeAccountAndGet fails', () => {
+		describe('when __scope.modules.accounts.mergeAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.mergeAccountAndGet = sinonSandbox
 					.stub()
@@ -506,7 +506,7 @@ describe('inTransfer', () => {
 				}));
 		});
 
-		describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
+		describe('when __scope.modules.accounts.mergeAccountAndGet succeeds', () => {
 			it('should call callback with error = undefined', async () =>
 				inTransfer.applyConfirmed(trs, dummyBlock, sender, err => {
 					expect(err).to.be.undefined;
@@ -554,31 +554,31 @@ describe('inTransfer', () => {
 				done();
 			});
 
-			it('should call __private.modules.accounts.mergeAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet', async () =>
 				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ address: validGetGensisResult.authorId })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with balance = -trs.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with balance = -trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ balance: -trs.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with u_balance = -trs.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with u_balance = -trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ u_balance: -trs.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ round: slots.calcRound(dummyBlock.height) })
@@ -586,7 +586,7 @@ describe('inTransfer', () => {
 				).to.be.true);
 		});
 
-		describe('when __private.modules.accounts.mergeAccountAndGet fails', () => {
+		describe('when __scope.modules.accounts.mergeAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.mergeAccountAndGet = sinonSandbox
 					.stub()
@@ -600,7 +600,7 @@ describe('inTransfer', () => {
 				}));
 		});
 
-		describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
+		describe('when __scope.modules.accounts.mergeAccountAndGet succeeds', () => {
 			it('should call callback with error = undefined', async () =>
 				inTransfer.undoConfirmed(trs, dummyBlock, sender, err => {
 					expect(err).to.be.undefined;
@@ -646,28 +646,28 @@ describe('inTransfer', () => {
 	});
 
 	describe('objectNormalize', () => {
-		let __private;
+		let __scope;
 		let schemaSpy;
 
 		beforeEach(done => {
-			__private = InTransfer.__get__('__private');
-			schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
+			__scope = InTransfer.__get__('__scope');
+			schemaSpy = sinonSandbox.spy(__scope.schema, 'validate');
 			done();
 		});
 
 		afterEach(() => schemaSpy.restore());
 
-		it('should call __private.schema.validate', async () => {
+		it('should call __scope.schema.validate', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.calledOnce).to.be.true;
 		});
 
-		it('should call __private.schema.validate with trs.asset.inTransfer', async () => {
+		it('should call __scope.schema.validate with trs.asset.inTransfer', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.calledWith(trs.asset.inTransfer)).to.be.true;
 		});
 
-		it('should call __private.schema.validate InTransfer.prototype.schema', async () => {
+		it('should call __scope.schema.validate InTransfer.prototype.schema', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.args[0][1]).to.eql(InTransfer.prototype.schema);
 		});

--- a/framework/test/unit/modules/chain/unit/logic/in_transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/in_transfer.js
@@ -139,9 +139,7 @@ describe('inTransfer', () => {
 			components: {
 				storage: storageStub,
 			},
-			libraries: {
-				schema: modulesLoader.scope.schema,
-			},
+			schema: modulesLoader.scope.schema,
 		});
 
 		inTransfer.bind(accountsStub, sharedStub);
@@ -165,9 +163,7 @@ describe('inTransfer', () => {
 					components: {
 						storage: storageStub,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				});
 				__private = InTransfer.__get__('__private');
 				done();
@@ -180,7 +176,7 @@ describe('inTransfer', () => {
 
 			it('should assign schema', async () =>
 				expect(__private)
-					.to.have.nested.property('libraries.schema')
+					.to.have.property('schema')
 					.eql(modulesLoader.scope.schema));
 		});
 	});
@@ -192,7 +188,7 @@ describe('inTransfer', () => {
 		beforeEach(done => {
 			inTransfer.bind(accountsStub, sharedStub);
 			modules = InTransfer.__get__('__private.modules');
-			shared = InTransfer.__get__('__private.libraries.shared');
+			shared = InTransfer.__get__('__private.shared');
 			done();
 		});
 
@@ -655,23 +651,23 @@ describe('inTransfer', () => {
 
 		beforeEach(done => {
 			__private = InTransfer.__get__('__private');
-			schemaSpy = sinonSandbox.spy(__private.libraries.schema, 'validate');
+			schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
 			done();
 		});
 
 		afterEach(() => schemaSpy.restore());
 
-		it('should call __private.libraries.schema.validate', async () => {
+		it('should call __private.schema.validate', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.calledOnce).to.be.true;
 		});
 
-		it('should call __private.libraries.schema.validate with trs.asset.inTransfer', async () => {
+		it('should call __private.schema.validate with trs.asset.inTransfer', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.calledWith(trs.asset.inTransfer)).to.be.true;
 		});
 
-		it('should call __private.libraries.schema.validate InTransfer.prototype.schema', async () => {
+		it('should call __private.schema.validate InTransfer.prototype.schema', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.args[0][1]).to.eql(InTransfer.prototype.schema);
 		});

--- a/framework/test/unit/modules/chain/unit/logic/in_transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/in_transfer.js
@@ -102,7 +102,6 @@ describe('inTransfer', () => {
 	let inTransfer;
 	let sharedStub;
 	let accountsStub;
-	let blocksStub;
 	let storageStub;
 
 	let trs;
@@ -111,10 +110,18 @@ describe('inTransfer', () => {
 	let dummyBlock;
 
 	beforeEach(done => {
+		dummyBlock = {
+			id: '9314232245035524467',
+			height: 1,
+		};
+
 		storageStub = {
 			entities: {
 				Transaction: {
 					isPersisted: sinonSandbox.stub().resolves(),
+				},
+				Block: {
+					get: sinonSandbox.stub().resolves([dummyBlock]),
 				},
 			},
 		};
@@ -128,17 +135,16 @@ describe('inTransfer', () => {
 			mergeAccountAndGet: sinonSandbox.stub().callsArg(1),
 			getAccount: sinonSandbox.stub(),
 		};
-		dummyBlock = {
-			id: '9314232245035524467',
-			height: 1,
-		};
-		blocksStub = {
-			lastBlock: {
-				get: sinonSandbox.stub().returns(dummyBlock),
+		inTransfer = new InTransfer({
+			components: {
+				storage: storageStub,
 			},
-		};
-		inTransfer = new InTransfer(storageStub, modulesLoader.scope.schema);
-		inTransfer.bind(accountsStub, blocksStub, sharedStub);
+			libraries: {
+				schema: modulesLoader.scope.schema,
+			},
+		});
+
+		inTransfer.bind(accountsStub, sharedStub);
 
 		trs = _.cloneDeep(validTransaction);
 		rawTrs = _.cloneDeep(rawValidTransaction);
@@ -152,22 +158,29 @@ describe('inTransfer', () => {
 
 	describe('constructor', () => {
 		describe('library', () => {
-			let library;
+			let __private;
 
 			beforeEach(done => {
-				new InTransfer(storageStub, modulesLoader.scope.schema);
-				library = InTransfer.__get__('library');
+				new InTransfer({
+					components: {
+						storage: storageStub,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				});
+				__private = InTransfer.__get__('__private');
 				done();
 			});
 
 			it('should assign storage', async () =>
-				expect(library)
-					.to.have.property('storage')
+				expect(__private)
+					.to.have.nested.property('components.storage')
 					.eql(storageStub));
 
 			it('should assign schema', async () =>
-				expect(library)
-					.to.have.property('schema')
+				expect(__private)
+					.to.have.nested.property('libraries.schema')
 					.eql(modulesLoader.scope.schema));
 		});
 	});
@@ -177,9 +190,9 @@ describe('inTransfer', () => {
 		let shared;
 
 		beforeEach(done => {
-			inTransfer.bind(accountsStub, blocksStub, sharedStub);
-			modules = InTransfer.__get__('modules');
-			shared = InTransfer.__get__('shared');
+			inTransfer.bind(accountsStub, sharedStub);
+			modules = InTransfer.__get__('__private.modules');
+			shared = InTransfer.__get__('__private.libraries.shared');
 			done();
 		});
 
@@ -188,11 +201,6 @@ describe('inTransfer', () => {
 				expect(modules)
 					.to.have.property('accounts')
 					.eql(accountsStub));
-
-			it('should assign blocks', async () =>
-				expect(modules)
-					.to.have.property('blocks')
-					.eql(blocksStub));
 		});
 
 		it('should assign shared', async () => expect(shared).to.eql(sharedStub));
@@ -204,7 +212,7 @@ describe('inTransfer', () => {
 	});
 
 	describe('verify', () => {
-		beforeEach(() => inTransfer.bind(accountsStub, blocksStub, sharedStub));
+		beforeEach(() => inTransfer.bind(accountsStub, sharedStub));
 
 		describe('when trs.recipientId exists', () => {
 			it('should call callback with error = "Transaction type 6 is frozen"', done => {
@@ -293,6 +301,13 @@ describe('inTransfer', () => {
 					expect(err).to.equal('Transaction type 6 is frozen');
 					done();
 				});
+			});
+		});
+
+		it('should call entities.Block.get', done => {
+			inTransfer.verify(trs, sender, async () => {
+				expect(storageStub.entities.Block.get).to.be.calledOnce;
+				done();
 			});
 		});
 
@@ -449,31 +464,31 @@ describe('inTransfer', () => {
 				done();
 			});
 
-			it('should call modules.accounts.mergeAccountAndGet', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet', async () =>
 				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ address: validGetGensisResult.authorId })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with balance = trs.amount', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with balance = trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ balance: trs.amount })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with u_balance = trs.amount', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with u_balance = trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ u_balance: trs.amount })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ round: slots.calcRound(dummyBlock.height) })
@@ -481,7 +496,7 @@ describe('inTransfer', () => {
 				).to.be.true);
 		});
 
-		describe('when modules.accounts.mergeAccountAndGet fails', () => {
+		describe('when __private.modules.accounts.mergeAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.mergeAccountAndGet = sinonSandbox
 					.stub()
@@ -495,7 +510,7 @@ describe('inTransfer', () => {
 				}));
 		});
 
-		describe('when modules.accounts.mergeAccountAndGet succeeds', () => {
+		describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
 			it('should call callback with error = undefined', async () =>
 				inTransfer.applyConfirmed(trs, dummyBlock, sender, err => {
 					expect(err).to.be.undefined;
@@ -543,31 +558,31 @@ describe('inTransfer', () => {
 				done();
 			});
 
-			it('should call modules.accounts.mergeAccountAndGet', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet', async () =>
 				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with address = dapp.authorId', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ address: validGetGensisResult.authorId })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with balance = -trs.amount', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with balance = -trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ balance: -trs.amount })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with u_balance = -trs.amount', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with u_balance = -trs.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ u_balance: -trs.amount })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
+			it('should call __private.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ round: slots.calcRound(dummyBlock.height) })
@@ -575,7 +590,7 @@ describe('inTransfer', () => {
 				).to.be.true);
 		});
 
-		describe('when modules.accounts.mergeAccountAndGet fails', () => {
+		describe('when __private.modules.accounts.mergeAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.mergeAccountAndGet = sinonSandbox
 					.stub()
@@ -589,7 +604,7 @@ describe('inTransfer', () => {
 				}));
 		});
 
-		describe('when modules.accounts.mergeAccountAndGet succeeds', () => {
+		describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
 			it('should call callback with error = undefined', async () =>
 				inTransfer.undoConfirmed(trs, dummyBlock, sender, err => {
 					expect(err).to.be.undefined;
@@ -635,28 +650,28 @@ describe('inTransfer', () => {
 	});
 
 	describe('objectNormalize', () => {
-		let library;
+		let __private;
 		let schemaSpy;
 
 		beforeEach(done => {
-			library = InTransfer.__get__('library');
-			schemaSpy = sinonSandbox.spy(library.schema, 'validate');
+			__private = InTransfer.__get__('__private');
+			schemaSpy = sinonSandbox.spy(__private.libraries.schema, 'validate');
 			done();
 		});
 
 		afterEach(() => schemaSpy.restore());
 
-		it('should call library.schema.validate', async () => {
+		it('should call __private.libraries.schema.validate', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.calledOnce).to.be.true;
 		});
 
-		it('should call library.schema.validate with trs.asset.inTransfer', async () => {
+		it('should call __private.libraries.schema.validate with trs.asset.inTransfer', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.calledWith(trs.asset.inTransfer)).to.be.true;
 		});
 
-		it('should call library.schema.validate InTransfer.prototype.schema', async () => {
+		it('should call __private.libraries.schema.validate InTransfer.prototype.schema', async () => {
 			inTransfer.objectNormalize(trs);
 			return expect(schemaSpy.args[0][1]).to.eql(InTransfer.prototype.schema);
 		});

--- a/framework/test/unit/modules/chain/unit/logic/multisignature.js
+++ b/framework/test/unit/modules/chain/unit/logic/multisignature.js
@@ -72,13 +72,11 @@ describe('multisignature', () => {
 			components: {
 				logger: modulesLoader.logger,
 			},
-			libraries: {
-				schema: modulesLoader.scope.schema,
-				network: modulesLoader.scope.network,
-				logic: {
-					transaction: transactionMock,
-					account: accountMock,
-				},
+			schema: modulesLoader.scope.schema,
+			network: modulesLoader.scope.network,
+			logic: {
+				transaction: transactionMock,
+				account: accountMock,
 			},
 		});
 		return multisignature.bind(accountsMock);
@@ -98,33 +96,31 @@ describe('multisignature', () => {
 				components: {
 					logger: modulesLoader.logger,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-					network: modulesLoader.scope.network,
-					logic: {
-						transaction: transactionMock,
-						account: accountMock,
-					},
+				schema: modulesLoader.scope.schema,
+				network: modulesLoader.scope.network,
+				logic: {
+					transaction: transactionMock,
+					account: accountMock,
 				},
 			});
 			__private = Multisignature.__get__('__private');
 			done();
 		});
 
-		it('should attach schema to __private.libraries', async () =>
-			expect(__private.libraries.schema).to.eql(modulesLoader.scope.schema));
+		it('should attach schema to __private', async () =>
+			expect(__private.schema).to.eql(modulesLoader.scope.schema));
 
-		it('should attach network to __private.libraries', async () =>
-			expect(__private.libraries.network).to.eql(modulesLoader.scope.network));
+		it('should attach network to __private', async () =>
+			expect(__private.network).to.eql(modulesLoader.scope.network));
 
 		it('should attach logger to __private.components', async () =>
 			expect(__private.components.logger).to.eql(modulesLoader.logger));
 
-		it('should attach logic.transaction to __private.libraries.logic', async () =>
-			expect(__private.libraries.logic.transaction).to.eql(transactionMock));
+		it('should attach logic.transaction to __private.logic', async () =>
+			expect(__private.logic.transaction).to.eql(transactionMock));
 
-		it('should attach account to __private.libraries.logic', async () =>
-			expect(__private.libraries.logic.account).to.eql(accountMock));
+		it('should attach account to __private.logic', async () =>
+			expect(__private.logic.account).to.eql(accountMock));
 	});
 
 	describe('bind', () => {
@@ -520,13 +516,13 @@ describe('multisignature', () => {
 				.equal(false);
 		});
 
-		it('should call __private.libraries.logic.account.merge', async () =>
+		it('should call __private.logic.account.merge', async () =>
 			expect(accountMock.merge.calledOnce).to.be.true);
 
-		it('should call __private.libraries.logic.account.merge with sender.address', async () =>
+		it('should call __private.logic.account.merge with sender.address', async () =>
 			expect(accountMock.merge.calledWith(sender.address)).to.be.true);
 
-		it('should call __private.libraries.logic.account.merge with expected params', async () => {
+		it('should call __private.logic.account.merge with expected params', async () => {
 			const expectedParams = {
 				membersPublicKeys: transaction.asset.multisignature.keysgroup,
 				multiMin: transaction.asset.multisignature.min,
@@ -536,7 +532,7 @@ describe('multisignature', () => {
 			return expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
 		});
 
-		describe('when __private.libraries.logic.account.merge fails', () => {
+		describe('when __private.logic.account.merge fails', () => {
 			beforeEach(done => {
 				accountMock.merge = sinonSandbox.stub().callsArgWith(2, 'merge error');
 				done();
@@ -548,7 +544,7 @@ describe('multisignature', () => {
 				}));
 		});
 
-		describe('when __private.libraries.logic.account.merge succeeds', () => {
+		describe('when __private.logic.account.merge succeeds', () => {
 			describe('for every keysgroup member', () => {
 				validTransaction.asset.multisignature.keysgroup.forEach(member => {
 					it('should call modules.accounts.generateAddressByPublicKey', async () =>
@@ -573,19 +569,19 @@ describe('multisignature', () => {
 							done();
 						});
 
-						it('should call __private.libraries.logic.account.setAccountAndGet', async () =>
+						it('should call __private.logic.account.setAccountAndGet', async () =>
 							expect(accountsMock.setAccountAndGet.callCount).to.equal(
 								validTransaction.asset.multisignature.keysgroup.length
 							));
 
-						it('should call __private.libraries.logic.account.setAccountAndGet with {address: address}', async () =>
+						it('should call __private.logic.account.setAccountAndGet with {address: address}', async () =>
 							expect(
 								accountsMock.setAccountAndGet.calledWith(
 									sinonSandbox.match({ address })
 								)
 							).to.be.true);
 
-						it('should call __private.libraries.logic.account.setAccountAndGet with sender.address', async () =>
+						it('should call __private.logic.account.setAccountAndGet with sender.address', async () =>
 							expect(
 								accountsMock.setAccountAndGet.calledWith(
 									sinonSandbox.match({ publicKey: key })
@@ -655,13 +651,13 @@ describe('multisignature', () => {
 				.equal(true);
 		});
 
-		it('should call __private.libraries.logic.account.merge', async () =>
+		it('should call __private.logic.account.merge', async () =>
 			expect(accountMock.merge.calledOnce).to.be.true);
 
-		it('should call __private.libraries.logic.account.merge with sender.address', async () =>
+		it('should call __private.logic.account.merge with sender.address', async () =>
 			expect(accountMock.merge.calledWith(sender.address)).to.be.true);
 
-		it('should call __private.libraries.logic.account.merge with expected params', async () => {
+		it('should call __private.logic.account.merge with expected params', async () => {
 			const expectedParams = {
 				membersPublicKeys: Diff.reverse(
 					transaction.asset.multisignature.keysgroup
@@ -673,7 +669,7 @@ describe('multisignature', () => {
 			return expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
 		});
 
-		describe('when __private.libraries.logic.account.merge fails', () => {
+		describe('when __private.logic.account.merge fails', () => {
 			beforeEach(done => {
 				accountMock.merge = sinonSandbox.stub().callsArgWith(2, 'merge error');
 				done();
@@ -685,7 +681,7 @@ describe('multisignature', () => {
 				}));
 		});
 
-		describe('when __private.libraries.logic.account.merge succeeds', () => {
+		describe('when __private.logic.account.merge succeeds', () => {
 			it('should call callback with error = null', async () =>
 				multisignature.applyConfirmed(transaction, dummyBlock, sender, err => {
 					expect(err).to.be.null;
@@ -745,21 +741,21 @@ describe('multisignature', () => {
 				});
 			});
 
-			it('should call __private.libraries.logic.account.merge', done => {
+			it('should call __private.logic.account.merge', done => {
 				multisignature.applyUnconfirmed(transaction, sender, async () => {
 					expect(accountMock.merge.calledOnce).to.be.true;
 					done();
 				});
 			});
 
-			it('should call __private.libraries.logic.account.merge with sender.address', done => {
+			it('should call __private.logic.account.merge with sender.address', done => {
 				multisignature.applyUnconfirmed(transaction, sender, async () => {
 					expect(accountMock.merge.calledWith(sender.address)).to.be.true;
 					done();
 				});
 			});
 
-			it('should call __private.libraries.logic.account.merge with expected params', done => {
+			it('should call __private.logic.account.merge with expected params', done => {
 				const expectedParams = {
 					u_membersPublicKeys: transaction.asset.multisignature.keysgroup,
 					u_multiMin: transaction.asset.multisignature.min,
@@ -771,7 +767,7 @@ describe('multisignature', () => {
 				});
 			});
 
-			describe('when __private.libraries.logic.account.merge fails', () => {
+			describe('when __private.logic.account.merge fails', () => {
 				beforeEach(() => accountMock.merge.callsArgWith(2, 'merge error'));
 
 				afterEach(() => accountMock.merge.resetHistory());
@@ -785,7 +781,7 @@ describe('multisignature', () => {
 				});
 			});
 
-			describe('when __private.libraries.logic.account.merge succeeds', () => {
+			describe('when __private.logic.account.merge succeeds', () => {
 				it('should call callback with error = null', done => {
 					multisignature.applyUnconfirmed(transaction, sender, err => {
 						expect(err).to.be.not.exist;
@@ -818,13 +814,13 @@ describe('multisignature', () => {
 				.equal(false);
 		});
 
-		it('should call __private.libraries.logic.account.merge', async () =>
+		it('should call __private.logic.account.merge', async () =>
 			expect(accountMock.merge.calledOnce).to.be.true);
 
-		it('should call __private.libraries.logic.account.merge with sender.address', async () =>
+		it('should call __private.logic.account.merge with sender.address', async () =>
 			expect(accountMock.merge.calledWith(sender.address)).to.be.true);
 
-		it('should call __private.libraries.logic.account.merge with expected params', async () => {
+		it('should call __private.logic.account.merge with expected params', async () => {
 			const expectedParams = {
 				u_membersPublicKeys: Diff.reverse(
 					transaction.asset.multisignature.keysgroup
@@ -835,7 +831,7 @@ describe('multisignature', () => {
 			return expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
 		});
 
-		describe('when __private.libraries.logic.account.merge fails', () => {
+		describe('when __private.logic.account.merge fails', () => {
 			beforeEach(done => {
 				accountMock.merge = sinonSandbox.stub().callsArgWith(2, 'merge error');
 				done();
@@ -847,7 +843,7 @@ describe('multisignature', () => {
 				}));
 		});
 
-		describe('when __private.libraries.logic.account.merge succeeds', () => {
+		describe('when __private.logic.account.merge succeeds', () => {
 			it('should call callback with error = null', async () =>
 				multisignature.applyConfirmed(transaction, dummyBlock, sender, err => {
 					expect(err).to.be.null;
@@ -1129,8 +1125,8 @@ describe('multisignature', () => {
 		});
 
 		it('should use the correct format to validate against', async () => {
-			const libraries = Multisignature.__get__('__private.libraries');
-			const schemaSpy = sinonSandbox.spy(libraries.schema, 'validate');
+			const __private = Multisignature.__get__('__private');
+			const schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
 			multisignature.objectNormalize(transaction);
 			expect(schemaSpy.calledOnce).to.equal(true);
 			expect(

--- a/framework/test/unit/modules/chain/unit/logic/multisignature.js
+++ b/framework/test/unit/modules/chain/unit/logic/multisignature.js
@@ -89,7 +89,7 @@ describe('multisignature', () => {
 	});
 
 	describe('constructor', () => {
-		let __private;
+		let __scope;
 
 		beforeEach(done => {
 			new Multisignature({
@@ -103,31 +103,31 @@ describe('multisignature', () => {
 					account: accountMock,
 				},
 			});
-			__private = Multisignature.__get__('__private');
+			__scope = Multisignature.__get__('__scope');
 			done();
 		});
 
-		it('should attach schema to __private', async () =>
-			expect(__private.schema).to.eql(modulesLoader.scope.schema));
+		it('should attach schema to __scope', async () =>
+			expect(__scope.schema).to.eql(modulesLoader.scope.schema));
 
-		it('should attach network to __private', async () =>
-			expect(__private.network).to.eql(modulesLoader.scope.network));
+		it('should attach network to __scope', async () =>
+			expect(__scope.network).to.eql(modulesLoader.scope.network));
 
-		it('should attach logger to __private.components', async () =>
-			expect(__private.components.logger).to.eql(modulesLoader.logger));
+		it('should attach logger to __scope.components', async () =>
+			expect(__scope.components.logger).to.eql(modulesLoader.logger));
 
-		it('should attach logic.transaction to __private.logic', async () =>
-			expect(__private.logic.transaction).to.eql(transactionMock));
+		it('should attach logic.transaction to __scope.logic', async () =>
+			expect(__scope.logic.transaction).to.eql(transactionMock));
 
-		it('should attach account to __private.logic', async () =>
-			expect(__private.logic.account).to.eql(accountMock));
+		it('should attach account to __scope.logic', async () =>
+			expect(__scope.logic.account).to.eql(accountMock));
 	});
 
 	describe('bind', () => {
 		describe('modules', () => {
 			it('should assign accounts', async () => {
 				multisignature.bind(accountsMock);
-				const modules = Multisignature.__get__('__private.modules');
+				const modules = Multisignature.__get__('__scope.modules');
 
 				return expect(modules).to.eql({
 					accounts: accountsMock,
@@ -507,22 +507,22 @@ describe('multisignature', () => {
 			multisignature.applyConfirmed(transaction, dummyBlock, sender, done);
 		});
 
-		it('should set __private.unconfirmedSignatures[sender.address] = false', async () => {
+		it('should set __scope.unconfirmedSignatures[sender.address] = false', async () => {
 			const unconfirmedSignatures = Multisignature.__get__(
-				'__private.unconfirmedSignatures'
+				'__scope.unconfirmedSignatures'
 			);
 			return expect(unconfirmedSignatures)
 				.to.contain.property(sender.address)
 				.equal(false);
 		});
 
-		it('should call __private.logic.account.merge', async () =>
+		it('should call __scope.logic.account.merge', async () =>
 			expect(accountMock.merge.calledOnce).to.be.true);
 
-		it('should call __private.logic.account.merge with sender.address', async () =>
+		it('should call __scope.logic.account.merge with sender.address', async () =>
 			expect(accountMock.merge.calledWith(sender.address)).to.be.true);
 
-		it('should call __private.logic.account.merge with expected params', async () => {
+		it('should call __scope.logic.account.merge with expected params', async () => {
 			const expectedParams = {
 				membersPublicKeys: transaction.asset.multisignature.keysgroup,
 				multiMin: transaction.asset.multisignature.min,
@@ -532,7 +532,7 @@ describe('multisignature', () => {
 			return expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
 		});
 
-		describe('when __private.logic.account.merge fails', () => {
+		describe('when __scope.logic.account.merge fails', () => {
 			beforeEach(done => {
 				accountMock.merge = sinonSandbox.stub().callsArgWith(2, 'merge error');
 				done();
@@ -544,7 +544,7 @@ describe('multisignature', () => {
 				}));
 		});
 
-		describe('when __private.logic.account.merge succeeds', () => {
+		describe('when __scope.logic.account.merge succeeds', () => {
 			describe('for every keysgroup member', () => {
 				validTransaction.asset.multisignature.keysgroup.forEach(member => {
 					it('should call modules.accounts.generateAddressByPublicKey', async () =>
@@ -552,7 +552,7 @@ describe('multisignature', () => {
 							validTransaction.asset.multisignature.keysgroup.length
 						));
 
-					it('should call __private.modules.accounts.generateAddressByPublicKey with member.substring(1)', async () =>
+					it('should call __scope.modules.accounts.generateAddressByPublicKey with member.substring(1)', async () =>
 						expect(
 							accountsMock.generateAddressByPublicKey.calledWith(
 								member.substring(1)
@@ -569,26 +569,26 @@ describe('multisignature', () => {
 							done();
 						});
 
-						it('should call __private.logic.account.setAccountAndGet', async () =>
+						it('should call __scope.logic.account.setAccountAndGet', async () =>
 							expect(accountsMock.setAccountAndGet.callCount).to.equal(
 								validTransaction.asset.multisignature.keysgroup.length
 							));
 
-						it('should call __private.logic.account.setAccountAndGet with {address: address}', async () =>
+						it('should call __scope.logic.account.setAccountAndGet with {address: address}', async () =>
 							expect(
 								accountsMock.setAccountAndGet.calledWith(
 									sinonSandbox.match({ address })
 								)
 							).to.be.true);
 
-						it('should call __private.logic.account.setAccountAndGet with sender.address', async () =>
+						it('should call __scope.logic.account.setAccountAndGet with sender.address', async () =>
 							expect(
 								accountsMock.setAccountAndGet.calledWith(
 									sinonSandbox.match({ publicKey: key })
 								)
 							).to.be.true);
 
-						describe('when __private.modules.accounts.setAccountAndGet fails', () => {
+						describe('when __scope.modules.accounts.setAccountAndGet fails', () => {
 							beforeEach(done => {
 								accountsMock.setAccountAndGet = sinonSandbox
 									.stub()
@@ -607,7 +607,7 @@ describe('multisignature', () => {
 								));
 						});
 
-						describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
+						describe('when __scope.modules.accounts.mergeAccountAndGet succeeds', () => {
 							it('should call callback with error = null', async () =>
 								multisignature.applyConfirmed(
 									transaction,
@@ -642,22 +642,22 @@ describe('multisignature', () => {
 		});
 		/* eslint-enable */
 
-		it('should set __private.unconfirmedSignatures[sender.address] = true', async () => {
+		it('should set __scope.unconfirmedSignatures[sender.address] = true', async () => {
 			const unconfirmedSignatures = Multisignature.__get__(
-				'__private.unconfirmedSignatures'
+				'__scope.unconfirmedSignatures'
 			);
 			return expect(unconfirmedSignatures)
 				.to.contain.property(sender.address)
 				.equal(true);
 		});
 
-		it('should call __private.logic.account.merge', async () =>
+		it('should call __scope.logic.account.merge', async () =>
 			expect(accountMock.merge.calledOnce).to.be.true);
 
-		it('should call __private.logic.account.merge with sender.address', async () =>
+		it('should call __scope.logic.account.merge with sender.address', async () =>
 			expect(accountMock.merge.calledWith(sender.address)).to.be.true);
 
-		it('should call __private.logic.account.merge with expected params', async () => {
+		it('should call __scope.logic.account.merge with expected params', async () => {
 			const expectedParams = {
 				membersPublicKeys: Diff.reverse(
 					transaction.asset.multisignature.keysgroup
@@ -669,7 +669,7 @@ describe('multisignature', () => {
 			return expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
 		});
 
-		describe('when __private.logic.account.merge fails', () => {
+		describe('when __scope.logic.account.merge fails', () => {
 			beforeEach(done => {
 				accountMock.merge = sinonSandbox.stub().callsArgWith(2, 'merge error');
 				done();
@@ -681,7 +681,7 @@ describe('multisignature', () => {
 				}));
 		});
 
-		describe('when __private.logic.account.merge succeeds', () => {
+		describe('when __scope.logic.account.merge succeeds', () => {
 			it('should call callback with error = null', async () =>
 				multisignature.applyConfirmed(transaction, dummyBlock, sender, err => {
 					expect(err).to.be.null;
@@ -704,7 +704,7 @@ describe('multisignature', () => {
 		describe('when transaction is pending for confirmation', () => {
 			beforeEach(done => {
 				const unconfirmedSignatures = Multisignature.__get__(
-					'__private.unconfirmedSignatures'
+					'__scope.unconfirmedSignatures'
 				);
 				unconfirmedSignatures[sender.address] = true;
 				done();
@@ -723,15 +723,15 @@ describe('multisignature', () => {
 		describe('when transaction is not pending confirmation', () => {
 			beforeEach(done => {
 				const unconfirmedSignatures = Multisignature.__get__(
-					'__private.unconfirmedSignatures'
+					'__scope.unconfirmedSignatures'
 				);
 				unconfirmedSignatures[sender.address] = false;
 				done();
 			});
 
-			it('should set __private.unconfirmedSignatures[sender.address] = true', done => {
+			it('should set __scope.unconfirmedSignatures[sender.address] = true', done => {
 				const unconfirmedSignatures = Multisignature.__get__(
-					'__private.unconfirmedSignatures'
+					'__scope.unconfirmedSignatures'
 				);
 				multisignature.applyUnconfirmed(transaction, sender, async () => {
 					expect(unconfirmedSignatures)
@@ -741,21 +741,21 @@ describe('multisignature', () => {
 				});
 			});
 
-			it('should call __private.logic.account.merge', done => {
+			it('should call __scope.logic.account.merge', done => {
 				multisignature.applyUnconfirmed(transaction, sender, async () => {
 					expect(accountMock.merge.calledOnce).to.be.true;
 					done();
 				});
 			});
 
-			it('should call __private.logic.account.merge with sender.address', done => {
+			it('should call __scope.logic.account.merge with sender.address', done => {
 				multisignature.applyUnconfirmed(transaction, sender, async () => {
 					expect(accountMock.merge.calledWith(sender.address)).to.be.true;
 					done();
 				});
 			});
 
-			it('should call __private.logic.account.merge with expected params', done => {
+			it('should call __scope.logic.account.merge with expected params', done => {
 				const expectedParams = {
 					u_membersPublicKeys: transaction.asset.multisignature.keysgroup,
 					u_multiMin: transaction.asset.multisignature.min,
@@ -767,7 +767,7 @@ describe('multisignature', () => {
 				});
 			});
 
-			describe('when __private.logic.account.merge fails', () => {
+			describe('when __scope.logic.account.merge fails', () => {
 				beforeEach(() => accountMock.merge.callsArgWith(2, 'merge error'));
 
 				afterEach(() => accountMock.merge.resetHistory());
@@ -781,7 +781,7 @@ describe('multisignature', () => {
 				});
 			});
 
-			describe('when __private.logic.account.merge succeeds', () => {
+			describe('when __scope.logic.account.merge succeeds', () => {
 				it('should call callback with error = null', done => {
 					multisignature.applyUnconfirmed(transaction, sender, err => {
 						expect(err).to.be.not.exist;
@@ -805,22 +805,22 @@ describe('multisignature', () => {
 			multisignature.undoUnconfirmed(transaction, sender, done);
 		});
 
-		it('should set __private.unconfirmedSignatures[sender.address] = false', async () => {
+		it('should set __scope.unconfirmedSignatures[sender.address] = false', async () => {
 			const unconfirmedSignatures = Multisignature.__get__(
-				'__private.unconfirmedSignatures'
+				'__scope.unconfirmedSignatures'
 			);
 			return expect(unconfirmedSignatures)
 				.to.contain.property(sender.address)
 				.equal(false);
 		});
 
-		it('should call __private.logic.account.merge', async () =>
+		it('should call __scope.logic.account.merge', async () =>
 			expect(accountMock.merge.calledOnce).to.be.true);
 
-		it('should call __private.logic.account.merge with sender.address', async () =>
+		it('should call __scope.logic.account.merge with sender.address', async () =>
 			expect(accountMock.merge.calledWith(sender.address)).to.be.true);
 
-		it('should call __private.logic.account.merge with expected params', async () => {
+		it('should call __scope.logic.account.merge with expected params', async () => {
 			const expectedParams = {
 				u_membersPublicKeys: Diff.reverse(
 					transaction.asset.multisignature.keysgroup
@@ -831,7 +831,7 @@ describe('multisignature', () => {
 			return expect(accountMock.merge.args[0][1]).to.eql(expectedParams);
 		});
 
-		describe('when __private.logic.account.merge fails', () => {
+		describe('when __scope.logic.account.merge fails', () => {
 			beforeEach(done => {
 				accountMock.merge = sinonSandbox.stub().callsArgWith(2, 'merge error');
 				done();
@@ -843,7 +843,7 @@ describe('multisignature', () => {
 				}));
 		});
 
-		describe('when __private.logic.account.merge succeeds', () => {
+		describe('when __scope.logic.account.merge succeeds', () => {
 			it('should call callback with error = null', async () =>
 				multisignature.applyConfirmed(transaction, dummyBlock, sender, err => {
 					expect(err).to.be.null;
@@ -1125,8 +1125,8 @@ describe('multisignature', () => {
 		});
 
 		it('should use the correct format to validate against', async () => {
-			const __private = Multisignature.__get__('__private');
-			const schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
+			const __scope = Multisignature.__get__('__scope');
+			const schemaSpy = sinonSandbox.spy(__scope.schema, 'validate');
 			multisignature.objectNormalize(transaction);
 			expect(schemaSpy.calledOnce).to.equal(true);
 			expect(

--- a/framework/test/unit/modules/chain/unit/logic/out_transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/out_transfer.js
@@ -67,7 +67,7 @@ describe('outTransfer', () => {
 		rawTransaction = _.cloneDeep(rawValidTransaction);
 		sender = _.cloneDeep(validSender);
 
-		OutTransfer.__set__('__private.unconfirmedOutTansfers', {});
+		OutTransfer.__set__('__scope.unconfirmedOutTansfers', {});
 
 		outTransfer = new OutTransfer({
 			components: {
@@ -81,8 +81,8 @@ describe('outTransfer', () => {
 	});
 
 	describe('constructor', () => {
-		describe('__private', () => {
-			let __private;
+		describe('__scope', () => {
+			let __scope;
 
 			beforeEach(done => {
 				new OutTransfer({
@@ -92,17 +92,17 @@ describe('outTransfer', () => {
 					},
 					schema: modulesLoader.scope.schema,
 				});
-				__private = OutTransfer.__get__('__private');
+				__scope = OutTransfer.__get__('__scope');
 				done();
 			});
 
 			it('should assign storage', async () =>
-				expect(__private)
+				expect(__scope)
 					.to.have.nested.property('components.storage')
 					.eql(storageStub));
 
 			it('should assign schema', async () =>
-				expect(__private)
+				expect(__scope)
 					.to.have.property('schema')
 					.eql(modulesLoader.scope.schema));
 		});
@@ -113,7 +113,7 @@ describe('outTransfer', () => {
 
 		beforeEach(done => {
 			outTransfer.bind(accountsStub);
-			modules = OutTransfer.__get__('__private.modules');
+			modules = OutTransfer.__get__('__scope.modules');
 			done();
 		});
 
@@ -134,7 +134,7 @@ describe('outTransfer', () => {
 	describe('verify', () => {
 		beforeEach(() => outTransfer.bind(accountsStub));
 
-		it('should call __private.components.storage.entities.Block.get once', async () => {
+		it('should call __scope.components.storage.entities.Block.get once', async () => {
 			outTransfer.verify(transaction, sender, () => {
 				expect(storageStub.entities.Block.get).to.be.calledOnce;
 			});
@@ -266,9 +266,7 @@ describe('outTransfer', () => {
 	});
 
 	describe('process', () => {
-		beforeEach(() =>
-			OutTransfer.__set__('__private.unconfirmedOutTansfers', {})
-		);
+		beforeEach(() => OutTransfer.__set__('__scope.unconfirmedOutTansfers', {}));
 
 		it('should call storageStub.entities.Transaction.isPersisted', done => {
 			outTransfer.process(transaction, sender, async () => {
@@ -353,7 +351,7 @@ describe('outTransfer', () => {
 						] = true;
 
 						return OutTransfer.__set__(
-							'__private.unconfirmedOutTansfers',
+							'__scope.unconfirmedOutTansfers',
 							unconfirmedTransactionExistsMap
 						);
 					});
@@ -372,7 +370,7 @@ describe('outTransfer', () => {
 
 				describe('when unconfirmed out transfer does not exist', () => {
 					beforeEach(() =>
-						OutTransfer.__set__('__private.unconfirmedOutTansfers', {})
+						OutTransfer.__set__('__scope.unconfirmedOutTansfers', {})
 					);
 
 					it('should call storageStub.entities.Transaction.isPersisted second time', done => {
@@ -503,26 +501,26 @@ describe('outTransfer', () => {
 			outTransfer.applyConfirmed(transaction, dummyBlock, sender, done);
 		});
 
-		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false', async () => {
+		it('should set __scope.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false', async () => {
 			const unconfirmedOutTransfers = OutTransfer.__get__(
-				'__private.unconfirmedOutTansfers'
+				'__scope.unconfirmedOutTansfers'
 			);
 			return expect(unconfirmedOutTransfers)
 				.to.contain.property(transaction.asset.outTransfer.transactionId)
 				.equal(false);
 		});
 
-		it('should call __private.modules.accounts.setAccountAndGet', async () =>
+		it('should call __scope.modules.accounts.setAccountAndGet', async () =>
 			expect(accountsStub.setAccountAndGet.calledOnce).to.be.true);
 
-		it('should call __private.modules.accounts.setAccountAndGet with {address: transaction.recipientId}', async () =>
+		it('should call __scope.modules.accounts.setAccountAndGet with {address: transaction.recipientId}', async () =>
 			expect(
 				accountsStub.setAccountAndGet.calledWith({
 					address: transaction.recipientId,
 				})
 			).to.be.true);
 
-		describe('when __private.modules.accounts.setAccountAndGet fails', () => {
+		describe('when __scope.modules.accounts.setAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.setAccountAndGet = sinonSandbox
 					.stub()
@@ -536,44 +534,44 @@ describe('outTransfer', () => {
 				}));
 		});
 
-		describe('when __private.modules.accounts.setAccountAndGet succeeds', () => {
+		describe('when __scope.modules.accounts.setAccountAndGet succeeds', () => {
 			beforeEach(done => {
 				accountsStub.setAccountAndGet = sinonSandbox.stub().callsArg(1);
 				done();
 			});
 
-			it('should call __private.modules.accounts.mergeAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet', async () =>
 				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with address = transaction.recipientId', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with address = transaction.recipientId', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ address: transaction.recipientId })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with balance = transaction.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with balance = transaction.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ balance: transaction.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with u_balance = transaction.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with u_balance = transaction.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ u_balance: transaction.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ round: slots.calcRound(dummyBlock.height) })
 					)
 				).to.be.true);
 
-			describe('when __private.modules.accounts.mergeAccountAndGet fails', () => {
+			describe('when __scope.modules.accounts.mergeAccountAndGet fails', () => {
 				beforeEach(done => {
 					accountsStub.mergeAccountAndGet = sinonSandbox
 						.stub()
@@ -587,7 +585,7 @@ describe('outTransfer', () => {
 					}));
 			});
 
-			describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
+			describe('when __scope.modules.accounts.mergeAccountAndGet succeeds', () => {
 				it('should call callback with error = undefined', async () =>
 					outTransfer.applyConfirmed(transaction, dummyBlock, sender, err => {
 						expect(err).to.be.undefined;
@@ -611,26 +609,26 @@ describe('outTransfer', () => {
 			outTransfer.undoConfirmed(transaction, dummyBlock, sender, done);
 		});
 
-		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true', async () => {
+		it('should set __scope.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true', async () => {
 			const unconfirmedOutTransfers = OutTransfer.__get__(
-				'__private.unconfirmedOutTansfers'
+				'__scope.unconfirmedOutTansfers'
 			);
 			return expect(unconfirmedOutTransfers)
 				.to.contain.property(transaction.asset.outTransfer.transactionId)
 				.equal(true);
 		});
 
-		it('should call __private.modules.accounts.setAccountAndGet', async () =>
+		it('should call __scope.modules.accounts.setAccountAndGet', async () =>
 			expect(accountsStub.setAccountAndGet.calledOnce).to.be.true);
 
-		it('should call __private.modules.accounts.setAccountAndGet with {address: transaction.recipientId}', async () =>
+		it('should call __scope.modules.accounts.setAccountAndGet with {address: transaction.recipientId}', async () =>
 			expect(
 				accountsStub.setAccountAndGet.calledWith({
 					address: transaction.recipientId,
 				})
 			).to.be.true);
 
-		describe('when __private.modules.accounts.setAccountAndGet fails', () => {
+		describe('when __scope.modules.accounts.setAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.setAccountAndGet = sinonSandbox
 					.stub()
@@ -644,37 +642,37 @@ describe('outTransfer', () => {
 				}));
 		});
 
-		describe('when __private.modules.accounts.setAccountAndGet succeeds', () => {
+		describe('when __scope.modules.accounts.setAccountAndGet succeeds', () => {
 			beforeEach(done => {
 				accountsStub.setAccountAndGet = sinonSandbox.stub().callsArg(1);
 				done();
 			});
 
-			it('should call __private.modules.accounts.mergeAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet', async () =>
 				expect(accountsStub.mergeAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with address = transaction.recipientId', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with address = transaction.recipientId', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ address: transaction.recipientId })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with balance = -transaction.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with balance = -transaction.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ balance: -transaction.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with u_balance = -transaction.amount', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with u_balance = -transaction.amount', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ u_balance: -transaction.amount })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
+			it('should call __scope.modules.accounts.mergeAccountAndGet with round = slots.calcRound result', async () =>
 				expect(
 					accountsStub.mergeAccountAndGet.calledWith(
 						sinonSandbox.match({ round: slots.calcRound(dummyBlock.height) })
@@ -682,7 +680,7 @@ describe('outTransfer', () => {
 				).to.be.true);
 		});
 
-		describe('when __private.modules.accounts.mergeAccountAndGet fails', () => {
+		describe('when __scope.modules.accounts.mergeAccountAndGet fails', () => {
 			beforeEach(done => {
 				accountsStub.mergeAccountAndGet = sinonSandbox
 					.stub()
@@ -696,7 +694,7 @@ describe('outTransfer', () => {
 				}));
 		});
 
-		describe('when __private.modules.accounts.mergeAccountAndGet succeeds', () => {
+		describe('when __scope.modules.accounts.mergeAccountAndGet succeeds', () => {
 			it('should call callback with error = undefined', async () =>
 				outTransfer.undoConfirmed(transaction, dummyBlock, sender, err => {
 					expect(err).to.be.undefined;
@@ -715,9 +713,9 @@ describe('outTransfer', () => {
 	});
 
 	describe('applyUnconfirmed', () => {
-		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true', done => {
+		it('should set __scope.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = true', done => {
 			const unconfirmedOutTransfers = OutTransfer.__get__(
-				'__private.unconfirmedOutTansfers'
+				'__scope.unconfirmedOutTansfers'
 			);
 			outTransfer.applyUnconfirmed(transaction, sender, async () => {
 				expect(unconfirmedOutTransfers)
@@ -743,9 +741,9 @@ describe('outTransfer', () => {
 	});
 
 	describe('undoUnconfirmed', () => {
-		it('should set __private.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false', done => {
+		it('should set __scope.unconfirmedOutTansfers[transaction.asset.outTransfer.transactionId] = false', done => {
 			const unconfirmedOutTransfers = OutTransfer.__get__(
-				'__private.unconfirmedOutTansfers'
+				'__scope.unconfirmedOutTansfers'
 			);
 			outTransfer.undoUnconfirmed(transaction, sender, async () => {
 				expect(unconfirmedOutTransfers)
@@ -771,29 +769,29 @@ describe('outTransfer', () => {
 	});
 
 	describe('objectNormalize', () => {
-		let __private;
+		let __scope;
 		let schemaSpy;
 
 		beforeEach(done => {
-			__private = OutTransfer.__get__('__private');
-			schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
+			__scope = OutTransfer.__get__('__scope');
+			schemaSpy = sinonSandbox.spy(__scope.schema, 'validate');
 			done();
 		});
 
 		afterEach(() => schemaSpy.restore());
 
-		it('should call __private.schema.validate', async () => {
+		it('should call __scope.schema.validate', async () => {
 			outTransfer.objectNormalize(transaction);
 			return expect(schemaSpy.calledOnce).to.be.true;
 		});
 
-		it('should call __private.schema.validate with transaction.asset.outTransfer', async () => {
+		it('should call __scope.schema.validate with transaction.asset.outTransfer', async () => {
 			outTransfer.objectNormalize(transaction);
 			return expect(schemaSpy.calledWith(transaction.asset.outTransfer)).to.be
 				.true;
 		});
 
-		it('should call __private.schema.validate outTransfer.prototype.schema', async () => {
+		it('should call __scope.schema.validate outTransfer.prototype.schema', async () => {
 			outTransfer.objectNormalize(transaction);
 			return expect(schemaSpy.args[0][1]).to.eql(OutTransfer.prototype.schema);
 		});

--- a/framework/test/unit/modules/chain/unit/logic/out_transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/out_transfer.js
@@ -74,9 +74,7 @@ describe('outTransfer', () => {
 				storage: storageStub,
 				logger: modulesLoader.logger,
 			},
-			libraries: {
-				schema: modulesLoader.scope.schema,
-			},
+			schema: modulesLoader.scope.schema,
 		});
 
 		return outTransfer.bind(accountsStub);
@@ -92,9 +90,7 @@ describe('outTransfer', () => {
 						storage: storageStub,
 						logger: modulesLoader.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				});
 				__private = OutTransfer.__get__('__private');
 				done();
@@ -105,14 +101,9 @@ describe('outTransfer', () => {
 					.to.have.nested.property('components.storage')
 					.eql(storageStub));
 
-			it('should assign logger', async () =>
-				expect(__private)
-					.to.have.nested.property('components.logger')
-					.eql(modulesLoader.logger));
-
 			it('should assign schema', async () =>
 				expect(__private)
-					.to.have.nested.property('libraries.schema')
+					.to.have.property('schema')
 					.eql(modulesLoader.scope.schema));
 		});
 	});
@@ -780,29 +771,29 @@ describe('outTransfer', () => {
 	});
 
 	describe('objectNormalize', () => {
-		let libraries;
+		let __private;
 		let schemaSpy;
 
 		beforeEach(done => {
-			libraries = OutTransfer.__get__('__private.libraries');
-			schemaSpy = sinonSandbox.spy(libraries.schema, 'validate');
+			__private = OutTransfer.__get__('__private');
+			schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
 			done();
 		});
 
 		afterEach(() => schemaSpy.restore());
 
-		it('should call __private.libraries.schema.validate', async () => {
+		it('should call __private.schema.validate', async () => {
 			outTransfer.objectNormalize(transaction);
 			return expect(schemaSpy.calledOnce).to.be.true;
 		});
 
-		it('should call __private.libraries.schema.validate with transaction.asset.outTransfer', async () => {
+		it('should call __private.schema.validate with transaction.asset.outTransfer', async () => {
 			outTransfer.objectNormalize(transaction);
 			return expect(schemaSpy.calledWith(transaction.asset.outTransfer)).to.be
 				.true;
 		});
 
-		it('should call __private.libraries.schema.validate outTransfer.prototype.schema', async () => {
+		it('should call __private.schema.validate outTransfer.prototype.schema', async () => {
 			outTransfer.objectNormalize(transaction);
 			return expect(schemaSpy.args[0][1]).to.eql(OutTransfer.prototype.schema);
 		});

--- a/framework/test/unit/modules/chain/unit/logic/signature.js
+++ b/framework/test/unit/modules/chain/unit/logic/signature.js
@@ -102,12 +102,17 @@ describe('signature', () => {
 		accountsMock = {
 			setAccountAndGet: sinonSandbox.mock().callsArg(1),
 		};
-		signature = new Signature(
-			modulesLoader.scope.schema,
-			modulesLoader.scope.components.logger
-		);
-		signature.bind(accountsMock);
 
+		signature = new Signature({
+			components: {
+				logger: modulesLoader.scope.components.logger,
+			},
+			libraries: {
+				schema: modulesLoader.scope.schema,
+			},
+		});
+
+		signature.bind(accountsMock);
 		done();
 	});
 
@@ -126,29 +131,35 @@ describe('signature', () => {
 		});
 
 		describe('constructor', () => {
-			let library;
+			let __private;
 
 			beforeEach(done => {
-				new Signature(
-					modulesLoader.scope.schema,
-					modulesLoader.scope.components.logger
-				);
-				library = Signature.__get__('library');
+				new Signature({
+					components: {
+						logger: modulesLoader.scope.components.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				});
+				__private = Signature.__get__('__private');
 				done();
 			});
 
-			it('should attach schema to library variable', async () =>
-				expect(library.schema).to.eql(modulesLoader.scope.schema));
+			it('should attach schema to __private.libraries', async () =>
+				expect(__private.libraries.schema).to.eql(modulesLoader.scope.schema));
 
-			it('should attach logger to library variable', async () =>
-				expect(library.logger).to.eql(modulesLoader.scope.components.logger));
+			it('should attach logger to __private.components', async () =>
+				expect(__private.components.logger).to.eql(
+					modulesLoader.scope.components.logger
+				));
 		});
 
 		describe('bind', () => {
 			describe('modules', () => {
 				it('should assign accounts', async () => {
 					signature.bind(accountsMock);
-					const modules = Signature.__get__('modules');
+					const modules = Signature.__get__('__private.modules');
 					return expect(modules).to.eql({
 						accounts: accountsMock,
 					});
@@ -293,24 +304,24 @@ describe('signature', () => {
 				signature.applyConfirmed(validTransaction, dummyBlock, sender, done);
 			});
 
-			it('should call modules.accounts.setAccountAndGet', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with secondSignature = 1', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with secondSignature = 1', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ secondSignature: 1 })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with secondPublicKey = validTransaction.asset.signature.publicKey', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with secondPublicKey = validTransaction.asset.signature.publicKey', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({
@@ -325,24 +336,24 @@ describe('signature', () => {
 				signature.undoConfirmed(validTransaction, dummyBlock, sender, done);
 			});
 
-			it('should call modules.accounts.setAccountAndGet', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with secondSignature = 0', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with secondSignature = 0', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ secondSignature: 0 })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with secondPublicKey = null', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with secondPublicKey = null', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ secondPublicKey: null })
@@ -383,17 +394,17 @@ describe('signature', () => {
 				signature.applyUnconfirmed(validTransaction, sender, done);
 			});
 
-			it('should call modules.accounts.setAccountAndGet', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with u_secondSignature = 1', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with u_secondSignature = 1', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ u_secondSignature: 1 })
@@ -406,17 +417,17 @@ describe('signature', () => {
 				signature.undoUnconfirmed(validTransaction, sender, done);
 			});
 
-			it('should call modules.accounts.setAccountAndGet', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call modules.accounts.setAccountAndGet with u_secondSignature = 0', async () =>
+			it('should call __private.modules.accounts.setAccountAndGet with u_secondSignature = 0', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ u_secondSignature: 0 })
@@ -426,12 +437,12 @@ describe('signature', () => {
 
 		describe('objectNormalize', () => {
 			describe('schema.validate should validate against signature schema', () => {
-				let library;
+				let __private;
 				let schemaSpy;
 
 				beforeEach(() => {
-					library = Signature.__get__('library');
-					schemaSpy = sinonSandbox.spy(library.schema, 'validate');
+					__private = Signature.__get__('__private');
+					schemaSpy = sinonSandbox.spy(__private.libraries.schema, 'validate');
 					return signature.objectNormalize(transaction);
 				});
 
@@ -492,7 +503,7 @@ describe('signature', () => {
 				});
 			});
 
-			describe('when library.schema.validate succeeds', () => {
+			describe('when __private.libraries.schema.validate succeeds', () => {
 				it('should return transaction', async () =>
 					expect(signature.objectNormalize(transaction)).to.eql(transaction));
 			});

--- a/framework/test/unit/modules/chain/unit/logic/signature.js
+++ b/framework/test/unit/modules/chain/unit/logic/signature.js
@@ -107,9 +107,7 @@ describe('signature', () => {
 			components: {
 				logger: modulesLoader.scope.components.logger,
 			},
-			libraries: {
-				schema: modulesLoader.scope.schema,
-			},
+			schema: modulesLoader.scope.schema,
 		});
 
 		signature.bind(accountsMock);
@@ -138,16 +136,14 @@ describe('signature', () => {
 					components: {
 						logger: modulesLoader.scope.components.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				});
 				__private = Signature.__get__('__private');
 				done();
 			});
 
-			it('should attach schema to __private.libraries', async () =>
-				expect(__private.libraries.schema).to.eql(modulesLoader.scope.schema));
+			it('should attach schema to __private', async () =>
+				expect(__private.schema).to.eql(modulesLoader.scope.schema));
 
 			it('should attach logger to __private.components', async () =>
 				expect(__private.components.logger).to.eql(
@@ -442,7 +438,7 @@ describe('signature', () => {
 
 				beforeEach(() => {
 					__private = Signature.__get__('__private');
-					schemaSpy = sinonSandbox.spy(__private.libraries.schema, 'validate');
+					schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
 					return signature.objectNormalize(transaction);
 				});
 
@@ -503,7 +499,7 @@ describe('signature', () => {
 				});
 			});
 
-			describe('when __private.libraries.schema.validate succeeds', () => {
+			describe('when __private.schema.validate succeeds', () => {
 				it('should return transaction', async () =>
 					expect(signature.objectNormalize(transaction)).to.eql(transaction));
 			});

--- a/framework/test/unit/modules/chain/unit/logic/signature.js
+++ b/framework/test/unit/modules/chain/unit/logic/signature.js
@@ -129,7 +129,7 @@ describe('signature', () => {
 		});
 
 		describe('constructor', () => {
-			let __private;
+			let __scope;
 
 			beforeEach(done => {
 				new Signature({
@@ -138,15 +138,15 @@ describe('signature', () => {
 					},
 					schema: modulesLoader.scope.schema,
 				});
-				__private = Signature.__get__('__private');
+				__scope = Signature.__get__('__scope');
 				done();
 			});
 
-			it('should attach schema to __private', async () =>
-				expect(__private.schema).to.eql(modulesLoader.scope.schema));
+			it('should attach schema to __scope', async () =>
+				expect(__scope.schema).to.eql(modulesLoader.scope.schema));
 
-			it('should attach logger to __private.components', async () =>
-				expect(__private.components.logger).to.eql(
+			it('should attach logger to __scope.components', async () =>
+				expect(__scope.components.logger).to.eql(
 					modulesLoader.scope.components.logger
 				));
 		});
@@ -155,7 +155,7 @@ describe('signature', () => {
 			describe('modules', () => {
 				it('should assign accounts', async () => {
 					signature.bind(accountsMock);
-					const modules = Signature.__get__('__private.modules');
+					const modules = Signature.__get__('__scope.modules');
 					return expect(modules).to.eql({
 						accounts: accountsMock,
 					});
@@ -300,24 +300,24 @@ describe('signature', () => {
 				signature.applyConfirmed(validTransaction, dummyBlock, sender, done);
 			});
 
-			it('should call __private.modules.accounts.setAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with secondSignature = 1', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with secondSignature = 1', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ secondSignature: 1 })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with secondPublicKey = validTransaction.asset.signature.publicKey', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with secondPublicKey = validTransaction.asset.signature.publicKey', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({
@@ -332,24 +332,24 @@ describe('signature', () => {
 				signature.undoConfirmed(validTransaction, dummyBlock, sender, done);
 			});
 
-			it('should call __private.modules.accounts.setAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with secondSignature = 0', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with secondSignature = 0', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ secondSignature: 0 })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with secondPublicKey = null', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with secondPublicKey = null', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ secondPublicKey: null })
@@ -390,17 +390,17 @@ describe('signature', () => {
 				signature.applyUnconfirmed(validTransaction, sender, done);
 			});
 
-			it('should call __private.modules.accounts.setAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with u_secondSignature = 1', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with u_secondSignature = 1', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ u_secondSignature: 1 })
@@ -413,17 +413,17 @@ describe('signature', () => {
 				signature.undoUnconfirmed(validTransaction, sender, done);
 			});
 
-			it('should call __private.modules.accounts.setAccountAndGet', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet', async () =>
 				expect(accountsMock.setAccountAndGet.calledOnce).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with address = sender.address', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with address = sender.address', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ address: sender.address })
 					)
 				).to.be.true);
 
-			it('should call __private.modules.accounts.setAccountAndGet with u_secondSignature = 0', async () =>
+			it('should call __scope.modules.accounts.setAccountAndGet with u_secondSignature = 0', async () =>
 				expect(
 					accountsMock.setAccountAndGet.calledWith(
 						sinonSandbox.match({ u_secondSignature: 0 })
@@ -433,12 +433,12 @@ describe('signature', () => {
 
 		describe('objectNormalize', () => {
 			describe('schema.validate should validate against signature schema', () => {
-				let __private;
+				let __scope;
 				let schemaSpy;
 
 				beforeEach(() => {
-					__private = Signature.__get__('__private');
-					schemaSpy = sinonSandbox.spy(__private.schema, 'validate');
+					__scope = Signature.__get__('__scope');
+					schemaSpy = sinonSandbox.spy(__scope.schema, 'validate');
 					return signature.objectNormalize(transaction);
 				});
 
@@ -499,7 +499,7 @@ describe('signature', () => {
 				});
 			});
 
-			describe('when __private.schema.validate succeeds', () => {
+			describe('when __scope.schema.validate succeeds', () => {
 				it('should return transaction', async () =>
 					expect(signature.objectNormalize(transaction)).to.eql(transaction));
 			});

--- a/framework/test/unit/modules/chain/unit/logic/transaction.js
+++ b/framework/test/unit/modules/chain/unit/logic/transaction.js
@@ -171,7 +171,7 @@ describe('transaction', () => {
 	before(done => {
 		const transfer = new Transfer({
 			components: {
-				logger: modulesLoader.scope.logger,
+				logger: modulesLoader.scope.components.logger,
 			},
 			schema: modulesLoader.scope.schema,
 		});
@@ -1449,7 +1449,7 @@ describe('transaction', () => {
 				transactionTypes.SEND,
 				new Transfer({
 					components: {
-						logger: modulesLoader.scope.logger,
+						logger: modulesLoader.scope.components.logger,
 					},
 					schema: modulesLoader.scope.schema,
 				})

--- a/framework/test/unit/modules/chain/unit/logic/transaction.js
+++ b/framework/test/unit/modules/chain/unit/logic/transaction.js
@@ -1487,6 +1487,7 @@ describe('transaction', () => {
 					components: {
 						logger: modulesLoader.logger,
 					},
+					logic: {},
 					schema: modulesLoader.scope.schema,
 				})
 			);

--- a/framework/test/unit/modules/chain/unit/logic/transaction.js
+++ b/framework/test/unit/modules/chain/unit/logic/transaction.js
@@ -173,9 +173,7 @@ describe('transaction', () => {
 			components: {
 				logger: modulesLoader.scope.logger,
 			},
-			libraries: {
-				schema: modulesLoader.scope.schema,
-			},
+			schema: modulesLoader.scope.schema,
 		});
 		application.init(
 			{ sandbox: { name: 'lisk_test_logic_transactions' } },
@@ -1437,8 +1435,8 @@ describe('transaction', () => {
 					components: {
 						logger: modulesLoader.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
+					schema: modulesLoader.scope.schema,
+					logic: {
 						account: accountLogic,
 					},
 				})
@@ -1453,9 +1451,7 @@ describe('transaction', () => {
 					components: {
 						logger: modulesLoader.scope.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Transfer);
@@ -1465,9 +1461,7 @@ describe('transaction', () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.DELEGATE,
 				new Delegate({
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Delegate);
@@ -1480,9 +1474,7 @@ describe('transaction', () => {
 					components: {
 						logger: modulesLoader.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Signature);
@@ -1495,10 +1487,7 @@ describe('transaction', () => {
 					components: {
 						logger: modulesLoader.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-						logic: {},
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Multisignature);
@@ -1512,9 +1501,7 @@ describe('transaction', () => {
 						storage: modulesLoader.storage,
 						logger: modulesLoader.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Dapp);
@@ -1527,9 +1514,7 @@ describe('transaction', () => {
 					components: {
 						storage: modulesLoader.storage,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(InTransfer);
@@ -1543,9 +1528,7 @@ describe('transaction', () => {
 						storage: modulesLoader.storage,
 						logger: modulesLoader.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(OutTransfer);

--- a/framework/test/unit/modules/chain/unit/logic/transaction.js
+++ b/framework/test/unit/modules/chain/unit/logic/transaction.js
@@ -165,17 +165,23 @@ const unconfirmedTransaction = {
 
 describe('transaction', () => {
 	let transactionLogic;
+	let accountLogic;
 	let accountModule;
 
 	before(done => {
-		const transfer = new Transfer(
-			modulesLoader.scope.logger,
-			modulesLoader.scope.schema
-		);
+		const transfer = new Transfer({
+			components: {
+				logger: modulesLoader.scope.logger,
+			},
+			libraries: {
+				schema: modulesLoader.scope.schema,
+			},
+		});
 		application.init(
 			{ sandbox: { name: 'lisk_test_logic_transactions' } },
 			(_err, scope) => {
 				transactionLogic = scope.logic.transaction;
+				accountLogic = scope.logic.account;
 				accountModule = scope.modules.accounts;
 				transfer.bind(accountModule);
 				transactionLogic.attachAssetType(transactionTypes.SEND, transfer);
@@ -1427,7 +1433,15 @@ describe('transaction', () => {
 		it('should attach VOTE transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.VOTE,
-				new Vote()
+				new Vote({
+					components: {
+						logger: modulesLoader.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+						account: accountLogic,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Vote);
 		});
@@ -1435,7 +1449,14 @@ describe('transaction', () => {
 		it('should attach SEND transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.SEND,
-				new Transfer(modulesLoader.scope.logger, modulesLoader.scope.schema)
+				new Transfer({
+					components: {
+						logger: modulesLoader.scope.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Transfer);
 		});
@@ -1443,7 +1464,11 @@ describe('transaction', () => {
 		it('should attach DELEGATE transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.DELEGATE,
-				new Delegate()
+				new Delegate({
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Delegate);
 		});
@@ -1451,7 +1476,14 @@ describe('transaction', () => {
 		it('should attach SIGNATURE transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.SIGNATURE,
-				new Signature()
+				new Signature({
+					components: {
+						logger: modulesLoader.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Signature);
 		});
@@ -1459,7 +1491,15 @@ describe('transaction', () => {
 		it('should attach MULTI transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.MULTI,
-				new Multisignature()
+				new Multisignature({
+					components: {
+						logger: modulesLoader.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+						logic: {},
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Multisignature);
 		});
@@ -1467,7 +1507,15 @@ describe('transaction', () => {
 		it('should attach DAPP transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.DAPP,
-				new Dapp()
+				new Dapp({
+					components: {
+						storage: modulesLoader.storage,
+						logger: modulesLoader.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(Dapp);
 		});
@@ -1475,7 +1523,14 @@ describe('transaction', () => {
 		it('should attach IN_TRANSFER transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.IN_TRANSFER,
-				new InTransfer()
+				new InTransfer({
+					components: {
+						storage: modulesLoader.storage,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(InTransfer);
 		});
@@ -1483,7 +1538,15 @@ describe('transaction', () => {
 		it('should attach OUT_TRANSFER transaction types', async () => {
 			appliedLogic = transactionLogic.attachAssetType(
 				transactionTypes.OUT_TRANSFER,
-				new OutTransfer()
+				new OutTransfer({
+					components: {
+						storage: modulesLoader.storage,
+						logger: modulesLoader.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				})
 			);
 			return expect(appliedLogic).to.be.an.instanceof(OutTransfer);
 		});

--- a/framework/test/unit/modules/chain/unit/logic/transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/transfer.js
@@ -117,9 +117,7 @@ describe('transfer', () => {
 					components: {
 						logger: modulesLoader.scope.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
-					},
+					schema: modulesLoader.scope.schema,
 				});
 				transferBindings = {
 					account: accountModule,
@@ -150,10 +148,8 @@ describe('transfer', () => {
 			);
 		});
 
-		it('should assign schema to __private.libraries', () => {
-			return expect(__private.libraries.schema).to.equal(
-				modulesLoader.scope.schema
-			);
+		it('should assign schema to __private', () => {
+			return expect(__private.schema).to.equal(modulesLoader.scope.schema);
 		});
 	});
 

--- a/framework/test/unit/modules/chain/unit/logic/transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/transfer.js
@@ -115,7 +115,7 @@ describe('transfer', () => {
 
 				transfer = new Transfer({
 					components: {
-						logger: modulesLoader.scope.logger,
+						logger: modulesLoader.scope.components.logger,
 					},
 					schema: modulesLoader.scope.schema,
 				});
@@ -144,7 +144,7 @@ describe('transfer', () => {
 
 		it('should assign logger to __scope.components', () => {
 			return expect(__scope.components.logger).to.equal(
-				modulesLoader.scope.logger
+				modulesLoader.scope.components.logger
 			);
 		});
 

--- a/framework/test/unit/modules/chain/unit/logic/transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/transfer.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const crypto = require('crypto');
+const rewire = require('rewire');
 const randomstring = require('randomstring');
 const accountFixtures = require('../../../../../fixtures/accounts');
 const modulesLoader = require('../../../../../common/modules_loader');
@@ -22,7 +23,8 @@ const application = require('../../../../../common/application');
 const transactionTypes = require('../../../../../../src/modules/chain/helpers/transaction_types');
 const ed = require('../../../../../../src/modules/chain/helpers/ed');
 const Bignum = require('../../../../../../src/modules/chain/helpers/bignum.js');
-const Transfer = require('../../../../../../src/modules/chain/logic/transfer');
+
+const Transfer = rewire('../../../../../../src/modules/chain/logic/transfer');
 
 const { FEES, ADDITIONAL_DATA } = __testContext.config.constants;
 const validPassphrase =
@@ -110,10 +112,15 @@ describe('transfer', () => {
 			{ sandbox: { name: 'lisk_test_logic_transfer' } },
 			(_err, scope) => {
 				accountModule = scope.modules.accounts;
-				transfer = new Transfer(
-					modulesLoader.scope.logger,
-					modulesLoader.scope.schema
-				);
+
+				transfer = new Transfer({
+					components: {
+						logger: modulesLoader.scope.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+					},
+				});
 				transferBindings = {
 					account: accountModule,
 				};
@@ -127,6 +134,27 @@ describe('transfer', () => {
 
 	after(done => {
 		application.cleanup(done);
+	});
+
+	describe('constructor', () => {
+		let __private;
+
+		beforeEach(done => {
+			__private = Transfer.__get__('__private');
+			done();
+		});
+
+		it('should assign logger to __private.components', () => {
+			return expect(__private.components.logger).to.equal(
+				modulesLoader.scope.logger
+			);
+		});
+
+		it('should assign schema to __private.libraries', () => {
+			return expect(__private.libraries.schema).to.equal(
+				modulesLoader.scope.schema
+			);
+		});
 	});
 
 	describe('bind', () => {

--- a/framework/test/unit/modules/chain/unit/logic/transfer.js
+++ b/framework/test/unit/modules/chain/unit/logic/transfer.js
@@ -135,21 +135,21 @@ describe('transfer', () => {
 	});
 
 	describe('constructor', () => {
-		let __private;
+		let __scope;
 
 		beforeEach(done => {
-			__private = Transfer.__get__('__private');
+			__scope = Transfer.__get__('__scope');
 			done();
 		});
 
-		it('should assign logger to __private.components', () => {
-			return expect(__private.components.logger).to.equal(
+		it('should assign logger to __scope.components', () => {
+			return expect(__scope.components.logger).to.equal(
 				modulesLoader.scope.logger
 			);
 		});
 
-		it('should assign schema to __private', () => {
-			return expect(__private.schema).to.equal(modulesLoader.scope.schema);
+		it('should assign schema to __scope', () => {
+			return expect(__scope.schema).to.equal(modulesLoader.scope.schema);
 		});
 	});
 

--- a/framework/test/unit/modules/chain/unit/logic/vote.js
+++ b/framework/test/unit/modules/chain/unit/logic/vote.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const crypto = require('crypto');
+const rewire = require('rewire');
 const async = require('async');
 const lisk = require('lisk-elements').default;
 const accountFixtures = require('../../../../../fixtures/accounts');
@@ -25,8 +26,9 @@ const ed = require('../../../../../../src/modules/chain/helpers/ed');
 const diff = require('../../../../../../src/modules/chain/helpers/diff');
 const transactionTypes = require('../../../../../../src/modules/chain/helpers/transaction_types');
 const Bignum = require('../../../../../../src/modules/chain/helpers/bignum.js');
-const Vote = require('../../../../../../src/modules/chain/logic/vote');
 const Transfer = require('../../../../../../src/modules/chain/logic/transfer');
+
+const Vote = rewire('../../../../../../src/modules/chain/logic/vote');
 
 const { FEES, MAX_VOTES_PER_TRANSACTION } = __testContext.config.constants;
 const validPassphrase =
@@ -79,6 +81,7 @@ describe('vote', () => {
 	let voteBindings;
 	let vote;
 	let accountsModule;
+	let accountLogic;
 	let delegatesModule;
 	let transactionLogic;
 	const dummyBlock = {
@@ -139,11 +142,17 @@ describe('vote', () => {
 			(err, scope) => {
 				accountsModule = scope.modules.accounts;
 				delegatesModule = scope.modules.delegates;
-				vote = new Vote(
-					modulesLoader.scope.logger,
-					modulesLoader.scope.schema,
-					scope.logic.account
-				);
+
+				vote = new Vote({
+					components: {
+						logger: modulesLoader.scope.logger,
+					},
+					libraries: {
+						schema: modulesLoader.scope.schema,
+						account: scope.logic.account,
+					},
+				});
+
 				voteBindings = {
 					delegate: delegatesModule,
 					account: accountsModule,
@@ -155,6 +164,7 @@ describe('vote', () => {
 					},
 				});
 				transactionLogic = scope.logic.transaction;
+				accountLogic = scope.logic.account;
 				transactionLogic.attachAssetType(transactionTypes.VOTE, vote);
 				done();
 			}
@@ -167,7 +177,14 @@ describe('vote', () => {
 	/* eslint-disable mocha/no-sibling-hooks */
 	before(done => {
 		// create new account for testing;
-		const transfer = new Transfer();
+		const transfer = new Transfer({
+			components: {
+				logger: modulesLoader.logger,
+			},
+			libraries: {
+				schema: modulesLoader.scope.schema,
+			},
+		});
 		transfer.bind(voteBindings.account);
 		transactionLogic.attachAssetType(transactionTypes.SEND, transfer);
 
@@ -209,6 +226,31 @@ describe('vote', () => {
 		});
 	});
 	/* eslint-enable mocha/no-sibling-hooks */
+
+	describe('constructor', () => {
+		let __private;
+
+		beforeEach(done => {
+			__private = Vote.__get__('__private');
+			done();
+		});
+
+		it('should assign logger to __private.components', () => {
+			return expect(__private.components.logger).to.equal(
+				modulesLoader.scope.logger
+			);
+		});
+
+		it('should assign schema to __private.libraries', () => {
+			return expect(__private.libraries.schema).to.equal(
+				modulesLoader.scope.schema
+			);
+		});
+
+		it('should assign account to __private.libraries', () => {
+			return expect(__private.libraries.account).to.equal(accountLogic);
+		});
+	});
 
 	describe('bind', () => {
 		it('should be okay with correct params', async () =>

--- a/framework/test/unit/modules/chain/unit/logic/vote.js
+++ b/framework/test/unit/modules/chain/unit/logic/vote.js
@@ -226,25 +226,25 @@ describe('vote', () => {
 	/* eslint-enable mocha/no-sibling-hooks */
 
 	describe('constructor', () => {
-		let __private;
+		let __scope;
 
 		beforeEach(done => {
-			__private = Vote.__get__('__private');
+			__scope = Vote.__get__('__scope');
 			done();
 		});
 
-		it('should assign logger to __private.components', () => {
-			return expect(__private.components.logger).to.equal(
+		it('should assign logger to __scope.components', () => {
+			return expect(__scope.components.logger).to.equal(
 				modulesLoader.scope.logger
 			);
 		});
 
-		it('should assign schema to __private', () => {
-			return expect(__private.schema).to.equal(modulesLoader.scope.schema);
+		it('should assign schema to __scope', () => {
+			return expect(__scope.schema).to.equal(modulesLoader.scope.schema);
 		});
 
-		it('should assign account to __private.logic', () => {
-			return expect(__private.logic.account).to.equal(accountLogic);
+		it('should assign account to __scope.logic', () => {
+			return expect(__scope.logic.account).to.equal(accountLogic);
 		});
 	});
 

--- a/framework/test/unit/modules/chain/unit/logic/vote.js
+++ b/framework/test/unit/modules/chain/unit/logic/vote.js
@@ -147,8 +147,8 @@ describe('vote', () => {
 					components: {
 						logger: modulesLoader.scope.logger,
 					},
-					libraries: {
-						schema: modulesLoader.scope.schema,
+					schema: modulesLoader.scope.schema,
+					logic: {
 						account: scope.logic.account,
 					},
 				});
@@ -181,9 +181,7 @@ describe('vote', () => {
 			components: {
 				logger: modulesLoader.logger,
 			},
-			libraries: {
-				schema: modulesLoader.scope.schema,
-			},
+			schema: modulesLoader.scope.schema,
 		});
 		transfer.bind(voteBindings.account);
 		transactionLogic.attachAssetType(transactionTypes.SEND, transfer);
@@ -241,14 +239,12 @@ describe('vote', () => {
 			);
 		});
 
-		it('should assign schema to __private.libraries', () => {
-			return expect(__private.libraries.schema).to.equal(
-				modulesLoader.scope.schema
-			);
+		it('should assign schema to __private', () => {
+			return expect(__private.schema).to.equal(modulesLoader.scope.schema);
 		});
 
-		it('should assign account to __private.libraries', () => {
-			return expect(__private.libraries.account).to.equal(accountLogic);
+		it('should assign account to __private.logic', () => {
+			return expect(__private.logic.account).to.equal(accountLogic);
 		});
 	});
 

--- a/framework/test/unit/modules/chain/unit/logic/vote.js
+++ b/framework/test/unit/modules/chain/unit/logic/vote.js
@@ -145,7 +145,7 @@ describe('vote', () => {
 
 				vote = new Vote({
 					components: {
-						logger: modulesLoader.scope.logger,
+						logger: modulesLoader.scope.components.logger,
 					},
 					schema: modulesLoader.scope.schema,
 					logic: {
@@ -235,7 +235,7 @@ describe('vote', () => {
 
 		it('should assign logger to __scope.components', () => {
 			return expect(__scope.components.logger).to.equal(
-				modulesLoader.scope.logger
+				modulesLoader.scope.components.logger
 			);
 		});
 

--- a/framework/test/unit/modules/chain/unit/modules/multisignatures.js
+++ b/framework/test/unit/modules/chain/unit/modules/multisignatures.js
@@ -145,13 +145,11 @@ describe('multisignatures', () => {
 				components: {
 					logger: validScope.components.logger,
 				},
-				libraries: {
-					schema: validScope.schema,
-					network: validScope.network,
-					logic: {
-						transaction: validScope.logic.transaction,
-						account: validScope.logic.account,
-					},
+				schema: validScope.schema,
+				network: validScope.network,
+				logic: {
+					transaction: validScope.logic.transaction,
+					account: validScope.logic.account,
 				},
 			});
 		});

--- a/framework/test/unit/modules/chain/unit/modules/multisignatures.js
+++ b/framework/test/unit/modules/chain/unit/modules/multisignatures.js
@@ -141,13 +141,19 @@ describe('multisignatures', () => {
 
 		it('should instantiate Multisignature logic with proper params', async () => {
 			expect(stubs.Multisignature).to.have.been.calledOnce;
-			return expect(stubs.Multisignature).to.have.been.calledWith(
-				validScope.schema,
-				validScope.network,
-				validScope.logic.transaction,
-				validScope.logic.account,
-				validScope.components.logger
-			);
+			return expect(stubs.Multisignature).to.have.been.calledWith({
+				components: {
+					logger: validScope.components.logger,
+				},
+				libraries: {
+					schema: validScope.schema,
+					network: validScope.network,
+					logic: {
+						transaction: validScope.logic.transaction,
+						account: validScope.logic.account,
+					},
+				},
+			});
 		});
 
 		it('should call callback with result = self', async () =>

--- a/framework/test/unit/modules/chain/unit/modules/transactions.js
+++ b/framework/test/unit/modules/chain/unit/modules/transactions.js
@@ -69,6 +69,7 @@ describe('transactions', () => {
 				components: {
 					logger: modulesLoader.logger,
 				},
+				logic: {},
 				schema: modulesLoader.scope.schema,
 			})
 		);

--- a/framework/test/unit/modules/chain/unit/modules/transactions.js
+++ b/framework/test/unit/modules/chain/unit/modules/transactions.js
@@ -33,7 +33,7 @@ const DelegateLogic = require('../../../../../../src/modules/chain/logic/delegat
 const SignatureLogic = require('../../../../../../src/modules/chain/logic/signature.js');
 const MultisignatureLogic = require('../../../../../../src/modules/chain/logic/multisignature.js');
 const DappLogic = require('../../../../../../src/modules/chain/logic/dapp.js');
-const InTransferLogic = require('../../../../../../src/modules/chain//logic/in_transfer.js');
+const InTransferLogic = require('../../../../../../src/modules/chain/logic/in_transfer.js');
 const OutTransferLogic = require('../../../../../../src/modules/chain/logic/out_transfer.js');
 
 const TransactionModule = rewire(
@@ -53,70 +53,117 @@ describe('transactions', () => {
 	) {
 		const sendLogic = transactionLogic.attachAssetType(
 			transactionTypes.SEND,
-			new TransferLogic()
+			new TransferLogic({
+				components: {
+					logger: modulesLoader.logger,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+				},
+			})
 		);
 		sendLogic.bind(accountsModule);
 		expect(sendLogic).to.be.an.instanceof(TransferLogic);
 
 		const voteLogic = transactionLogic.attachAssetType(
 			transactionTypes.VOTE,
-			new VoteLogic(modulesLoader.logger, modulesLoader.scope.schema)
+			new VoteLogic({
+				components: {
+					logger: modulesLoader.logger,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+				},
+			})
 		);
 		voteLogic.bind(delegatesModule);
 		expect(voteLogic).to.be.an.instanceof(VoteLogic);
 
 		const delegateLogic = transactionLogic.attachAssetType(
 			transactionTypes.DELEGATE,
-			new DelegateLogic(modulesLoader.scope.schema)
+			new DelegateLogic({
+				libraries: {
+					schema: modulesLoader.scope.schema,
+				},
+			})
 		);
 		delegateLogic.bind(accountsModule);
 		expect(delegateLogic).to.be.an.instanceof(DelegateLogic);
 
 		const signatureLogic = transactionLogic.attachAssetType(
 			transactionTypes.SIGNATURE,
-			new SignatureLogic(modulesLoader.logger, modulesLoader.scope.schema)
+			new SignatureLogic({
+				components: {
+					logger: modulesLoader,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+				},
+			})
 		);
 		signatureLogic.bind(accountsModule);
 		expect(signatureLogic).to.be.an.instanceof(SignatureLogic);
 
 		const multiLogic = transactionLogic.attachAssetType(
 			transactionTypes.MULTI,
-			new MultisignatureLogic(
-				modulesLoader.scope.schema,
-				modulesLoader.scope.network,
-				transactionLogic,
-				accountLogic,
-				modulesLoader.logger
-			)
+			new MultisignatureLogic({
+				components: {
+					logger: modulesLoader.logger,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+					network: modulesLoader.scope.network,
+					logic: {
+						account: accountLogic,
+						transaction: transactionLogic,
+					},
+				},
+			})
 		);
+
 		multiLogic.bind(accountsModule);
 		expect(multiLogic).to.be.an.instanceof(MultisignatureLogic);
 
 		const dappLogic = transactionLogic.attachAssetType(
 			transactionTypes.DAPP,
-			new DappLogic(
-				modulesLoader.storage,
-				modulesLoader.logger,
-				modulesLoader.scope.schema,
-				modulesLoader.scope.network
-			)
+			new DappLogic({
+				components: {
+					storage: modulesLoader.storage,
+					logger: modulesLoader.logger,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+					network: modulesLoader.scope.network,
+				},
+			})
 		);
 		expect(dappLogic).to.be.an.instanceof(DappLogic);
 
 		const inTransferLogic = transactionLogic.attachAssetType(
 			transactionTypes.IN_TRANSFER,
-			new InTransferLogic(modulesLoader.storage, modulesLoader.scope.schema)
+			new InTransferLogic({
+				components: {
+					storage: modulesLoader.storage,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+				},
+			})
 		);
 		inTransferLogic.bind(accountsModule, /* sharedApi */ null);
 		expect(inTransferLogic).to.be.an.instanceof(InTransferLogic);
 
 		const outTransfer = transactionLogic.attachAssetType(
 			transactionTypes.OUT_TRANSFER,
-			new OutTransferLogic(
-				modulesLoader.storage,
-				modulesLoader.scope.schema,
-				modulesLoader.logger
-			)
+			new OutTransferLogic({
+				components: {
+					storage: modulesLoader.storage,
+					logger: modulesLoader.logger,
+				},
+				libraries: {
+					schema: modulesLoader.scope.schema,
+				},
+			})
 		);
 		outTransfer.bind(accountsModule, /* sharedApi */ null);
 		expect(outTransfer).to.be.an.instanceof(OutTransferLogic);

--- a/framework/test/unit/modules/chain/unit/modules/transactions.js
+++ b/framework/test/unit/modules/chain/unit/modules/transactions.js
@@ -57,9 +57,7 @@ describe('transactions', () => {
 				components: {
 					logger: modulesLoader.logger,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-				},
+				schema: modulesLoader.scope.schema,
 			})
 		);
 		sendLogic.bind(accountsModule);
@@ -71,9 +69,7 @@ describe('transactions', () => {
 				components: {
 					logger: modulesLoader.logger,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-				},
+				schema: modulesLoader.scope.schema,
 			})
 		);
 		voteLogic.bind(delegatesModule);
@@ -82,9 +78,7 @@ describe('transactions', () => {
 		const delegateLogic = transactionLogic.attachAssetType(
 			transactionTypes.DELEGATE,
 			new DelegateLogic({
-				libraries: {
-					schema: modulesLoader.scope.schema,
-				},
+				schema: modulesLoader.scope.schema,
 			})
 		);
 		delegateLogic.bind(accountsModule);
@@ -96,9 +90,7 @@ describe('transactions', () => {
 				components: {
 					logger: modulesLoader,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-				},
+				schema: modulesLoader.scope.schema,
 			})
 		);
 		signatureLogic.bind(accountsModule);
@@ -110,13 +102,11 @@ describe('transactions', () => {
 				components: {
 					logger: modulesLoader.logger,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-					network: modulesLoader.scope.network,
-					logic: {
-						account: accountLogic,
-						transaction: transactionLogic,
-					},
+				schema: modulesLoader.scope.schema,
+				network: modulesLoader.scope.network,
+				logic: {
+					account: accountLogic,
+					transaction: transactionLogic,
 				},
 			})
 		);
@@ -131,10 +121,8 @@ describe('transactions', () => {
 					storage: modulesLoader.storage,
 					logger: modulesLoader.logger,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-					network: modulesLoader.scope.network,
-				},
+				schema: modulesLoader.scope.schema,
+				network: modulesLoader.scope.network,
 			})
 		);
 		expect(dappLogic).to.be.an.instanceof(DappLogic);
@@ -145,9 +133,7 @@ describe('transactions', () => {
 				components: {
 					storage: modulesLoader.storage,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-				},
+				schema: modulesLoader.scope.schema,
 			})
 		);
 		inTransferLogic.bind(accountsModule, /* sharedApi */ null);
@@ -160,9 +146,7 @@ describe('transactions', () => {
 					storage: modulesLoader.storage,
 					logger: modulesLoader.logger,
 				},
-				libraries: {
-					schema: modulesLoader.scope.schema,
-				},
+				schema: modulesLoader.scope.schema,
 			})
 		);
 		outTransfer.bind(accountsModule, /* sharedApi */ null);


### PR DESCRIPTION
### What was the problem?
Transactions logic didn't have a consistent common interface. Some of the logic presented completely different constructor definitions even passing the same dependencies.
### How did I fix it?
Unifying (to some extent) how Transactions logic is instantiated and simplified their constructor definition.
### How to test it?
Run unit tests
### Review checklist
* The PR resolves #2779 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
