### PR TITLE
Implement StateStore for fetching accounts and transactions and saving updated accounts in the database - Closes #2820

### DIFF
--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -66,17 +66,18 @@ class AccountStore {
 	}
 
 	getOrDefault(primaryValue) {
-		let element = this.data.find(
+		const element = this.data.find(
 			item => item[this.primaryKey] === primaryValue
 		);
-		if (!element) {
-			element = {
-				...defaultAccount,
-				[this.primaryKey]: primaryValue,
-			};
-			this.data.push(element);
+		if (element) {
+			return element;
 		}
-		return element;
+		const defaultElement = {
+			...defaultAccount,
+			[this.primaryKey]: primaryValue,
+		};
+		this.data.push(defaultElement);
+		return defaultElement;
 	}
 
 	find(fn) {

--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -1,0 +1,127 @@
+const _ = require('lodash');
+
+const defaultAccount = {
+	publicKey: null,
+	secondPublicKey: null,
+	secondSignature: false,
+	u_secondSignature: false,
+	username: null,
+	u_username: null,
+	isDelegate: false,
+	u_isDelegate: false,
+	balance: '0',
+	u_balance: '0',
+	missedBlocks: 0,
+	producedBlocks: 0,
+	rank: null,
+	fees: '0',
+	rewards: '0',
+	vote: '0',
+	nameExist: false,
+	u_nameExist: false,
+	multiMin: 0,
+	u_multiMin: 0,
+	multiLifetime: 0,
+	u_multiLifetime: 0,
+};
+
+class AccountStore {
+	constructor(accountEntity, { mutate } = { mutate: true }) {
+		this.account = accountEntity;
+		this.data = [];
+		this.updatedKeys = {};
+		this.primaryKey = 'address';
+		this.name = 'Account';
+		this.mutate = mutate;
+	}
+
+	async cache(filter, tx) {
+		const result = await this.account.get(filter, {}, tx);
+		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
+		return result;
+	}
+
+	get(primaryValue) {
+		const element = this.data.find(
+			item => item[this.primaryKey] === primaryValue
+		);
+		if (!element) {
+			throw new Error(
+				`${this.name} with ${this.primaryKey} = ${primaryValue} does not exist`
+			);
+		}
+		return element;
+	}
+
+	getOrDefault(primaryValue) {
+		let element = this.data.find(
+			item => item[this.primaryKey] === primaryValue
+		);
+		if (!element) {
+			element = {
+				...defaultAccount,
+				[this.primaryKey]: primaryValue,
+			};
+		}
+		return element;
+	}
+
+	find(fn) {
+		return this.data.find(fn);
+	}
+
+	set(primaryValue, updatedElement) {
+		if (!this.mutate) {
+			return;
+		}
+
+		const elementIndex = this.data.findIndex(
+			item => item[this.primaryKey] === primaryValue
+		);
+
+		if (elementIndex === -1) {
+			throw new Error(
+				`${this.name} with ${this.primaryKey} = ${primaryValue} does not exist`
+			);
+		}
+
+		const updatedKeys = Object.entries(updatedElement).reduce(
+			(existingUpdatedKeys, [key, value]) => {
+				if (value !== this.data[elementIndex][key]) {
+					existingUpdatedKeys.push(key);
+				}
+
+				return existingUpdatedKeys;
+			},
+			[]
+		);
+
+		this.data[elementIndex] = updatedElement;
+		this.updatedKeys[elementIndex] = this.updatedKeys[elementIndex]
+			? _.uniq([...this.updatedKeys[elementIndex], ...updatedKeys])
+			: updatedKeys;
+	}
+
+	finalize(tx) {
+		if (!this.mutate) {
+			throw new Error(
+				'Cannot finalize when store is initialized with mutate = false'
+			);
+		}
+		const affectedAccounts = Object.entries(this.updatedKeys).map(
+			([index, updatedKeys]) => ({
+				updatedItem: this.data[index],
+				updatedKeys,
+			})
+		);
+
+		return affectedAccounts.map(({ updatedItem, updatedKeys }) => {
+			const filter = { [this.primaryKey]: updatedItem[this.primaryKey] };
+			const updatedData = _.pick(updatedItem, updatedKeys);
+
+			return this.account.upsert(filter, updatedData, null, tx);
+		});
+	}
+}
+
+module.exports = AccountStore;

--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -37,8 +37,8 @@ class AccountStore {
 		this.originalUpdatedKeys = {};
 	}
 
-	async cache(filter, tx) {
-		const result = await this.account.get(filter, {}, tx);
+	async cache(filter) {
+		const result = await this.account.get(filter, {});
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
 		return result;
 	}

--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -33,12 +33,24 @@ class AccountStore {
 		this.primaryKey = 'address';
 		this.name = 'Account';
 		this.mutate = mutate;
+		this.originalData = [];
+		this.originalUpdatedKeys = {};
 	}
 
 	async cache(filter, tx) {
 		const result = await this.account.get(filter, {}, tx);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
 		return result;
+	}
+
+	createSnapshot() {
+		this.originalData = _.clone(this.data);
+		this.updatedKeys = _.clone(this.updatedKeys);
+	}
+
+	restoreSnapshot() {
+		this.data = this.originalData;
+		this.updatedKeys = {};
 	}
 
 	get(primaryValue) {
@@ -62,6 +74,7 @@ class AccountStore {
 				...defaultAccount,
 				[this.primaryKey]: primaryValue,
 			};
+			this.data.push(element);
 		}
 		return element;
 	}
@@ -71,10 +84,6 @@ class AccountStore {
 	}
 
 	set(primaryValue, updatedElement) {
-		if (!this.mutate) {
-			return;
-		}
-
 		const elementIndex = this.data.findIndex(
 			item => item[this.primaryKey] === primaryValue
 		);

--- a/framework/src/modules/chain/logic/state_store/index.js
+++ b/framework/src/modules/chain/logic/state_store/index.js
@@ -8,14 +8,27 @@ class StateStoreManager {
 			Transaction: storage.entities.Transaction,
 		};
 
+		this.sandbox = {};
+
 		return setImmediate(cb, null, this);
 	}
 
 	createSandbox(options) {
-		return {
+		this.sandbox = {
 			account: new AccountStore(this.entities.Account, options),
 			transaction: new TransactionStore(this.entities.Transaction, options),
 		};
+		return this.sandbox;
+	}
+
+	createSnapshot() {
+		this.sandbox.account.createSnapshot();
+		this.sandbox.transaction.createSnapshot();
+	}
+
+	restoreSnapshot() {
+		this.sandbox.account.restoreSnapshot();
+		this.sandbox.transaction.restoreSnapshot();
 	}
 }
 

--- a/framework/src/modules/chain/logic/state_store/index.js
+++ b/framework/src/modules/chain/logic/state_store/index.js
@@ -8,17 +8,17 @@ class StateStoreManager {
 			Transaction: storage.entities.Transaction,
 		};
 
-		this.sandbox = {};
+		this.stateStore = {};
 
 		return setImmediate(cb, null, this);
 	}
 
-	createSandbox(options) {
-		this.sandbox = {
+	createStore(options) {
+		this.stateStore = {
 			account: new AccountStore(this.entities.Account, options),
 			transaction: new TransactionStore(this.entities.Transaction, options),
 		};
-		return this.sandbox;
+		return this.stateStore;
 	}
 
 	createSnapshot() {

--- a/framework/src/modules/chain/logic/state_store/index.js
+++ b/framework/src/modules/chain/logic/state_store/index.js
@@ -1,0 +1,22 @@
+const AccountStore = require('./account_store');
+const TransactionStore = require('./transaction_store');
+
+class StateStoreManager {
+	constructor(storage, cb) {
+		this.entities = {
+			Account: storage.entities.Account,
+			Transaction: storage.entities.Transaction,
+		};
+
+		return setImmediate(cb, null, this);
+	}
+
+	createSandbox(options) {
+		return {
+			account: new AccountStore(this.entities.Account, options),
+			transaction: new TransactionStore(this.entities.Transaction, options),
+		};
+	}
+}
+
+module.exports = StateStoreManager;

--- a/framework/src/modules/chain/logic/state_store/index.js
+++ b/framework/src/modules/chain/logic/state_store/index.js
@@ -22,13 +22,13 @@ class StateStoreManager {
 	}
 
 	createSnapshot() {
-		this.sandbox.account.createSnapshot();
-		this.sandbox.transaction.createSnapshot();
+		this.stateStore.account.createSnapshot();
+		this.stateStore.transaction.createSnapshot();
 	}
 
 	restoreSnapshot() {
-		this.sandbox.account.restoreSnapshot();
-		this.sandbox.transaction.restoreSnapshot();
+		this.stateStore.account.restoreSnapshot();
+		this.stateStore.transaction.restoreSnapshot();
 	}
 }
 

--- a/framework/src/modules/chain/logic/state_store/transaction_store.js
+++ b/framework/src/modules/chain/logic/state_store/transaction_store.js
@@ -8,8 +8,8 @@ class TransactionStore {
 		this.name = 'Transaction';
 	}
 
-	async cache(filter, tx) {
-		const result = await this.transaction.get(filter, {}, tx);
+	async cache(filter) {
+		const result = await this.transaction.get(filter, {});
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
 		return result;
 	}

--- a/framework/src/modules/chain/logic/state_store/transaction_store.js
+++ b/framework/src/modules/chain/logic/state_store/transaction_store.js
@@ -1,18 +1,31 @@
 const _ = require('lodash');
 
 class TransactionStore {
-	constructor(transactionEntity, { mutate } = { mutate: true }) {
+	constructor(transactionEntity) {
 		this.transaction = transactionEntity;
 		this.data = [];
 		this.primaryKey = 'id';
 		this.name = 'Transaction';
-		this.mutate = mutate;
 	}
 
 	async cache(filter, tx) {
 		const result = await this.transaction.get(filter, {}, tx);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
 		return result;
+	}
+
+	add(element) {
+		this.data.push(element);
+	}
+
+	createSnapshot() {
+		this.originalData = _.clone(this.data);
+		this.originalUpdatedKeys = _.clone(this.updatedKeys);
+	}
+
+	restoreSnapshot() {
+		this.data = _.clone(this.originalData);
+		this.updatedKeys = _.clone(this.originalUpdatedKeys);
 	}
 
 	get(primaryValue) {

--- a/framework/src/modules/chain/logic/state_store/transaction_store.js
+++ b/framework/src/modules/chain/logic/state_store/transaction_store.js
@@ -1,0 +1,48 @@
+const _ = require('lodash');
+
+class TransactionStore {
+	constructor(transactionEntity, { mutate } = { mutate: true }) {
+		this.transaction = transactionEntity;
+		this.data = [];
+		this.primaryKey = 'id';
+		this.name = 'Transaction';
+		this.mutate = mutate;
+	}
+
+	async cache(filter, tx) {
+		const result = await this.transaction.get(filter, {}, tx);
+		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
+		return result;
+	}
+
+	get(primaryValue) {
+		const element = this.data.find(
+			item => item[this.primaryKey] === primaryValue
+		);
+		if (!element) {
+			throw new Error(
+				`${this.name} with ${this.primaryKey} = ${primaryValue} does not exist`
+			);
+		}
+		return element;
+	}
+
+	getOrDefault() {
+		throw new Error(`getOrDefault cannot be called for ${this.name}`);
+	}
+
+	find(fn) {
+		return this.data.find(fn);
+	}
+
+	set() {
+		throw new Error(`set cannot be called for ${this.name}`);
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	finalize() {
+		throw new Error(`finalize cannot be called for ${this.name}`);
+	}
+}
+
+module.exports = TransactionStore;

--- a/framework/test/integration/state_store/account_store.js
+++ b/framework/test/integration/state_store/account_store.js
@@ -1,0 +1,167 @@
+const localCommon = require('../common');
+const AccountStore = require('../../../src/modules/chain/logic/state_store/account_store.js');
+
+describe('system test - account store', () => {
+	let library;
+	let accountStore;
+	const persistedAddresses = ['1085993630748340485L', '16313739661670634666L'];
+	const updatedData = {
+		secondPublicKey:
+			'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+		secondSignature: true,
+	};
+
+	const accountQuery = [
+		{
+			address: persistedAddresses[0],
+		},
+		{
+			address: persistedAddresses[1],
+		},
+	];
+
+	localCommon.beforeBlock('account_state_store', lib => {
+		library = lib;
+	});
+
+	beforeEach(async () => {
+		accountStore = new AccountStore(library.storage.entities.Account, {
+			mutate: true,
+		});
+	});
+
+	describe('cache', () => {
+		it('should fetch account from the database', async () => {
+			const results = await accountStore.cache(accountQuery);
+			expect(results).to.have.length(2);
+			expect(results.map(account => account.address)).to.eql(
+				persistedAddresses
+			);
+		});
+
+		it('should set the cache property for account store', async () => {
+			await accountStore.cache(accountQuery);
+			expect(accountStore.data.map(account => account.address)).to.eql(
+				persistedAddresses
+			);
+		});
+	});
+
+	describe('get', () => {
+		beforeEach(async () => {
+			await accountStore.cache(accountQuery);
+		});
+
+		it('should cache the account from after prepare is called', async () => {
+			const account = accountStore.get(persistedAddresses[1]);
+			expect(account.address).to.equal(persistedAddresses[1]);
+		});
+
+		it('should throw if account does not exist', async () => {
+			expect(
+				accountStore.get.bind(
+					accountStore,
+					persistedAddresses[1].replace('0', '1')
+				)
+			).to.throw();
+		});
+	});
+
+	describe('getOrDefault', () => {
+		beforeEach(async () => {
+			await accountStore.cache(accountQuery);
+		});
+
+		it('should cache the account from after prepare is called', async () => {
+			const account = accountStore.getOrDefault(persistedAddresses[1]);
+			expect(account.address).to.equal(persistedAddresses[1]);
+		});
+
+		it('should return default account if it does not exist', async () => {
+			const account = accountStore.getOrDefault(
+				persistedAddresses[1].replace('0', '1')
+			);
+			expect(account).to.exist;
+		});
+	});
+
+	describe('set', () => {
+		let accounts;
+
+		beforeEach(async () => {
+			accounts = await accountStore.cache(accountQuery);
+		});
+
+		it('should set the updated values for the account', async () => {
+			const updateToAccount = {
+				...accounts[0],
+				...updatedData,
+			};
+			accountStore.set(updateToAccount.address, updateToAccount);
+			expect(accountStore.get(accounts[0].address)).to.deep.equal(
+				updateToAccount
+			);
+		});
+
+		it('should update the updateKeys property', async () => {
+			const updateToAccount = {
+				...accounts[0],
+				...updatedData,
+			};
+			accountStore.set(updateToAccount.address, updateToAccount);
+			expect(accountStore.updatedKeys[0]).to.deep.equal(
+				Object.keys(updatedData)
+			);
+		});
+
+		it('should not update accounts if mutate option is set to false', async () => {
+			const accountStoreWithoutMutation = new AccountStore(
+				library.storage.entities.Account,
+				{ mutate: false }
+			);
+			accounts = await accountStoreWithoutMutation.cache(accountQuery);
+			const updateToAccount = {
+				...accounts[0],
+				...updatedData,
+			};
+			accountStoreWithoutMutation.set(updateToAccount.address, updateToAccount);
+			const accountAfterSet = accountStoreWithoutMutation.get(
+				updateToAccount.address
+			);
+			expect(accountAfterSet).to.deep.equal(accounts[0]);
+		});
+	});
+
+	describe('finalize', () => {
+		let accounts;
+		let updateToAccount;
+
+		beforeEach(async () => {
+			accounts = await accountStore.cache(accountQuery);
+			updateToAccount = {
+				...accounts[0],
+				...updatedData,
+			};
+			accountStore.set(updateToAccount.address, updateToAccount);
+		});
+
+		it('should save the account state in the database', async () => {
+			await Promise.all(accountStore.finalize());
+			accountStore = new AccountStore(library.storage.entities.Account);
+			const newResults = await accountStore.cache({
+				address: updateToAccount.address,
+			});
+			expect(newResults[0]).to.deep.equal(updateToAccount);
+		});
+
+		it('should throw an error if mutate option is set to false', async () => {
+			const accountStoreWithoutMutation = new AccountStore(
+				library.storage.entities.Account,
+				{ mutate: false }
+			);
+			expect(
+				accountStore.finalize.bind(accountStoreWithoutMutation)
+			).to.throw();
+		});
+	});
+});

--- a/framework/test/integration/state_store/account_store.js
+++ b/framework/test/integration/state_store/account_store.js
@@ -113,23 +113,6 @@ describe('system test - account store', () => {
 				Object.keys(updatedData)
 			);
 		});
-
-		it('should not update accounts if mutate option is set to false', async () => {
-			const accountStoreWithoutMutation = new AccountStore(
-				library.storage.entities.Account,
-				{ mutate: false }
-			);
-			accounts = await accountStoreWithoutMutation.cache(accountQuery);
-			const updateToAccount = {
-				...accounts[0],
-				...updatedData,
-			};
-			accountStoreWithoutMutation.set(updateToAccount.address, updateToAccount);
-			const accountAfterSet = accountStoreWithoutMutation.get(
-				updateToAccount.address
-			);
-			expect(accountAfterSet).to.deep.equal(accounts[0]);
-		});
 	});
 
 	describe('finalize', () => {

--- a/framework/test/integration/state_store/transaction_store.js
+++ b/framework/test/integration/state_store/transaction_store.js
@@ -1,0 +1,77 @@
+const localCommon = require('../common');
+const TransactionStore = require('../../../src/modules/chain/logic/state_store/transaction_store.js');
+
+describe('system test - transaction store', () => {
+	let library;
+	let transactionStore;
+	const persistedIds = ['1465651642158264047', '3634383815892709956'];
+
+	const transactionQuery = [
+		{
+			id: persistedIds[0],
+		},
+		{
+			id: persistedIds[1],
+		},
+	];
+
+	localCommon.beforeBlock('transaction_state_store', lib => {
+		library = lib;
+	});
+
+	beforeEach(async () => {
+		transactionStore = new TransactionStore(
+			library.storage.entities.Transaction
+		);
+	});
+
+	describe('cache', () => {
+		it('should fetch transaction from the database', async () => {
+			const results = await transactionStore.cache(transactionQuery);
+			expect(results).to.have.length(2);
+			expect(results.map(transaction => transaction.id)).to.eql(persistedIds);
+		});
+
+		it('should set the cache property for transaction store', async () => {
+			await transactionStore.cache(transactionQuery);
+			expect(transactionStore.data.map(transaction => transaction.id)).to.eql(
+				persistedIds
+			);
+		});
+	});
+
+	describe('get', () => {
+		beforeEach(async () => {
+			await transactionStore.cache(transactionQuery);
+		});
+
+		it('should cache the transaction after prepare is called', async () => {
+			const transaction = transactionStore.get(persistedIds[1]);
+			expect(transaction.id).to.equal(persistedIds[1]);
+		});
+
+		it('should throw if the transaction does not exist', async () => {
+			expect(
+				transactionStore.get.bind(persistedIds[0].replace('0', '1'))
+			).to.throw();
+		});
+	});
+
+	describe('getOrDefault', () => {
+		it('should throw an error', async () => {
+			expect(transactionStore.getOrDefault).to.throw();
+		});
+	});
+
+	describe('set', () => {
+		it('should throw an error', async () => {
+			expect(transactionStore.set.bind(transactionStore)).to.throw();
+		});
+	});
+
+	describe('finalize', () => {
+		it('should throw an error', async () => {
+			expect(transactionStore.finalize).to.throw();
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?
We need to implement StateStore for transactions and accounts as part of transaction processing efficiency LIP
### How did I fix it?
Added functionality for StateStore
### How to test it?
Run tests
### Review checklist

* The PR resolves #2820
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
