### PR TITLE
Fix intermittent test failure for database unit tests - Closes #2834

### DIFF
--- a/framework/test/unit/components/storage/entities/round.js
+++ b/framework/test/unit/components/storage/entities/round.js
@@ -20,7 +20,7 @@ const {
 	BaseEntity,
 	Round,
 } = require('../../../../../src/components/storage/entities');
-const storageSandbox = require('../../../../common/storage_sandbox');
+const { StorageSandbox } = require('../../../../common/storage_sandbox');
 const seeder = require('../../../../common/storage_seed');
 const accountsFixtures = require('../../../../fixtures').accounts;
 const roundsFixtures = require('../../../../fixtures').rounds;
@@ -32,9 +32,9 @@ const {
 const checkTableExists = (adapter, tableName) =>
 	adapter
 		.execute(
-			`SELECT EXISTS 
+			`SELECT EXISTS
 					(
-						SELECT 1 
+						SELECT 1
 						FROM pg_tables
 						WHERE schemaname = 'public'
 						AND tablename = '${tableName}'
@@ -42,7 +42,7 @@ const checkTableExists = (adapter, tableName) =>
 		)
 		.then(result => result[0].exists);
 
-describe('Round', () => {
+describe('Round @sequential', () => {
 	let adapter;
 	let storage;
 	let RoundEntity;
@@ -105,10 +105,7 @@ describe('Round', () => {
 	const validFilter = { round: validRound.round };
 
 	before(async () => {
-		storage = new storageSandbox.StorageSandbox(
-			__testContext.config.db,
-			'lisk_test_round'
-		);
+		storage = new StorageSandbox(__testContext.config.db, 'lisk_test_round');
 		await storage.bootstrap();
 
 		adapter = storage.adapter;


### PR DESCRIPTION
### What was the problem?
We were randomly getting the error below:

```
1) Round
       checkSnapshotAvailability()
         should use the correct SQL file with one parameter:
     error: relation "mem_round_snapshot" already exists
```
### How did I fix it?
I tagged this test suite with `@sequential` tag to solve the conflicts.

### How to test it?

### Review checklist

* The PR resolves #2834 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
