### PR TITLE
Refactor the event model and remove source from event - Closes #2912

### DIFF
--- a/framework/src/controller/channels/base.js
+++ b/framework/src/controller/channels/base.js
@@ -38,7 +38,7 @@ class BaseChannel {
 		eventsList.set(
 			this,
 			(options.skipInternalEvents ? events : internalEvents.concat(events)).map(
-				e => new Event(`${this.moduleAlias}:${e}`, null, null)
+				e => new Event(`${this.moduleAlias}:${e}`, null)
 			)
 		);
 		actionsList.set(

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -76,6 +76,12 @@ class EventEmitterChannel extends BaseChannel {
 	publish(eventName, data) {
 		const event = new Event(eventName, data);
 
+		if (event.module !== this.moduleAlias) {
+			throw new Error(
+				`Event "${eventName}" not registered in "${this.moduleAlias}".`
+			);
+		}
+
 		this.bus.emit(event.key(), event.serialize());
 	}
 

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -74,7 +74,7 @@ class EventEmitterChannel extends BaseChannel {
 	 * @param {Object} data - Data to publish with event
 	 */
 	publish(eventName, data) {
-		const event = new Event(eventName, data, this.moduleAlias);
+		const event = new Event(eventName, data);
 
 		this.bus.emit(event.key(), event.serialize());
 	}

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -78,7 +78,7 @@ class EventEmitterChannel extends BaseChannel {
 
 		if (event.module !== this.moduleAlias) {
 			throw new Error(
-				`Event "${eventName}" not registered in "${this.moduleAlias}".`
+				`Event "${eventName}" not registered in "${this.moduleAlias}" module.`
 			);
 		}
 

--- a/framework/src/controller/event.js
+++ b/framework/src/controller/event.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 
-const moduleNameReg = /^[a-zA-Z][a-zA-Z0-9]*$/;
 const eventWithModuleNameReg = /^([a-zA-Z][a-zA-Z0-9]*)((?::[a-zA-Z][a-zA-Z0-9]*)+)$/;
 
 /**
@@ -17,9 +16,8 @@ class Event {
 	 *
 	 * @param {string} name - Can be simple event or be combination of module:event
 	 * @param {string|Object} [data] - Data associated with the event
-	 * @param {string} [source] - Source module which triggers the event
 	 */
-	constructor(name, data = null, source = null) {
+	constructor(name, data = null) {
 		assert(
 			eventWithModuleNameReg.test(name),
 			`Event name "${name}" must be a valid name with module name.`
@@ -29,14 +27,6 @@ class Event {
 		// Remove the first prefixed ':' symbol
 		this.name = this.name.substring(1);
 		this.data = data;
-
-		if (source) {
-			assert(
-				moduleNameReg.test(source),
-				`Source name "${source}" must be a valid module name.`
-			);
-			this.source = source;
-		}
 	}
 
 	/**
@@ -48,18 +38,17 @@ class Event {
 		return {
 			name: this.name,
 			module: this.module,
-			source: this.source,
 			data: this.data,
 		};
 	}
 
 	/**
-	 * Getter function for source and event label data.
+	 * Getter function for event label data.
 	 *
 	 * @return {string} stringified event object
 	 */
 	toString() {
-		return `${this.source} -> ${this.module}:${this.name}`;
+		return `${this.module}:${this.name}`;
 	}
 
 	/**
@@ -81,11 +70,7 @@ class Event {
 		let object = null;
 		if (typeof data === 'string') object = JSON.parse(data);
 		else object = data;
-		return new Event(
-			`${object.module}:${object.name}`,
-			object.data,
-			object.source
-		);
+		return new Event(`${object.module}:${object.name}`, object.data);
 	}
 }
 


### PR DESCRIPTION
### What was the problem?
Any modules could emit events from any other module

### How did I fix it?
I've added a step to verify if the event to be published belongs to the module and remove the `source` param as it's not required anymore.

### How to test it?
Run test suite

### Review checklist

* The PR resolves #2912
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
