### PR TITLE
Refactor the action layer for modules to load the actions directly not just names - Closes #2913

### DIFF
--- a/framework/src/controller/bus.js
+++ b/framework/src/controller/bus.js
@@ -55,20 +55,24 @@ class Bus extends EventEmitter2 {
 	 */
 	// eslint-disable-next-line no-unused-vars
 	async registerChannel(moduleAlias, events, actions, options) {
-		events.forEach(e => {
-			const eventName = `${moduleAlias}:${e}`;
-			if (this.events[eventName]) {
-				throw new Error(`Event "${eventName}" already registered with bus.`);
+		events.forEach(eventName => {
+			const eventFullName = `${moduleAlias}:${eventName}`;
+			if (this.events[eventFullName]) {
+				throw new Error(
+					`Event "${eventFullName}" already registered with bus.`
+				);
 			}
-			this.events[eventName] = true;
+			this.events[eventFullName] = true;
 		});
 
-		actions.forEach(a => {
-			const actionName = `${moduleAlias}:${a}`;
-			if (this.actions[actionName]) {
-				throw new Error(`Action "${actionName}" already registered with bus.`);
+		actions.forEach(actionName => {
+			const actionFullName = `${moduleAlias}:${actionName}`;
+			if (this.actions[actionFullName]) {
+				throw new Error(
+					`Action "${actionFullName}" already registered with bus.`
+				);
 			}
-			this.actions[actionName] = true;
+			this.actions[actionFullName] = true;
 		});
 	}
 

--- a/framework/src/controller/channels/base.js
+++ b/framework/src/controller/channels/base.js
@@ -25,7 +25,7 @@ class BaseChannel {
 	 *
 	 * @param {string} moduleAlias - Label used for module
 	 * @param {module.Event} events - Collection of events for event listener
-	 * @param {module.Action} actions - Collection of actions for event listener
+	 * @param {module.Action} actions - Collection of actions available
 	 * @param {Object} [options] - Options impacting events and actions list
 	 * @param {boolean} [options.skipInternalEvents] - Skip internal events
 	 *
@@ -34,16 +34,20 @@ class BaseChannel {
 	constructor(moduleAlias, events, actions, options = {}) {
 		this.moduleAlias = moduleAlias;
 		this.options = options;
+		this.actions = actions;
 
 		eventsList.set(
 			this,
 			(options.skipInternalEvents ? events : internalEvents.concat(events)).map(
-				e => new Event(`${this.moduleAlias}:${e}`, null)
+				eventName => new Event(`${this.moduleAlias}:${eventName}`)
 			)
 		);
+
 		actionsList.set(
 			this,
-			actions.map(a => new Action(`${this.moduleAlias}:${a}`, null, null))
+			Object.keys(actions).map(
+				actionName => new Action(`${this.moduleAlias}:${actionName}`)
+			)
 		);
 	}
 

--- a/framework/src/controller/channels/base.js
+++ b/framework/src/controller/channels/base.js
@@ -53,15 +53,15 @@ class BaseChannel {
 		_actions.set(this, actions);
 	}
 
-	getActionsList() {
+	get actionsList() {
 		return _actionsList.get(this);
 	}
 
-	getEventsList() {
+	get eventsList() {
 		return _eventsList.get(this);
 	}
 
-	getActions() {
+	get actions() {
 		return _actions.get(this);
 	}
 

--- a/framework/src/controller/channels/base.js
+++ b/framework/src/controller/channels/base.js
@@ -80,12 +80,6 @@ class BaseChannel {
 		throw new TypeError('This method must be implemented in child classes. ');
 	}
 
-	// Register action available to your moduleAlias
-	// eslint-disable-next-line no-unused-vars, class-methods-use-this
-	action(actionName, cb) {
-		throw new TypeError('This method must be implemented in child classes. ');
-	}
-
 	// Call action of any moduleAlias through controller
 	// Specified as moduleName:actionName
 	// eslint-disable-next-line no-unused-vars, class-methods-use-this

--- a/framework/src/controller/channels/base.js
+++ b/framework/src/controller/channels/base.js
@@ -1,8 +1,9 @@
 const Event = require('../event');
 const Action = require('../action');
 
-const eventsList = new WeakMap();
-const actionsList = new WeakMap();
+const _eventsList = new WeakMap();
+const _actionsList = new WeakMap();
+const _actions = new WeakMap();
 
 const internalEvents = [
 	'registeredToBus',
@@ -34,29 +35,34 @@ class BaseChannel {
 	constructor(moduleAlias, events, actions, options = {}) {
 		this.moduleAlias = moduleAlias;
 		this.options = options;
-		this.actions = actions;
 
-		eventsList.set(
+		_eventsList.set(
 			this,
 			(options.skipInternalEvents ? events : internalEvents.concat(events)).map(
 				eventName => new Event(`${this.moduleAlias}:${eventName}`)
 			)
 		);
 
-		actionsList.set(
+		_actionsList.set(
 			this,
 			Object.keys(actions).map(
 				actionName => new Action(`${this.moduleAlias}:${actionName}`)
 			)
 		);
+
+		_actions.set(this, actions);
+	}
+
+	getActionsList() {
+		return _actionsList.get(this);
+	}
+
+	getEventsList() {
+		return _eventsList.get(this);
 	}
 
 	getActions() {
-		return actionsList.get(this);
-	}
-
-	getEvents() {
-		return eventsList.get(this);
+		return _actions.get(this);
 	}
 
 	// eslint-disable-next-line class-methods-use-this

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -36,8 +36,8 @@ class EventEmitterChannel extends BaseChannel {
 	async registerToBus() {
 		await this.bus.registerChannel(
 			this.moduleAlias,
-			this.getEvents().map(e => e.name),
-			this.getActions().map(a => a.name),
+			this.getEvents().map(event => event.name),
+			this.getActions().map(action => action.name),
 			{}
 		);
 	}

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -36,8 +36,8 @@ class EventEmitterChannel extends BaseChannel {
 	async registerToBus() {
 		await this.bus.registerChannel(
 			this.moduleAlias,
-			this.getEvents().map(event => event.name),
-			this.getActions().map(action => action.name),
+			this.getEventsList().map(event => event.name),
+			this.getActionsList().map(action => action.name),
 			{}
 		);
 	}
@@ -105,7 +105,7 @@ class EventEmitterChannel extends BaseChannel {
 		}
 
 		if (action.module === this.moduleAlias) {
-			return this.actions[action.name](action);
+			return this.getActions()[action.name](action);
 		}
 
 		return this.bus.invoke(action.serialize());

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -26,7 +26,6 @@ class EventEmitterChannel extends BaseChannel {
 	constructor(moduleAlias, events, actions, bus, options = {}) {
 		super(moduleAlias, events, actions, options);
 		this.bus = bus;
-		this.actionMap = {};
 	}
 
 	/**
@@ -86,17 +85,6 @@ class EventEmitterChannel extends BaseChannel {
 	}
 
 	/**
-	 * Register new action.
-	 *
-	 * @param {string} actionName - Name of action to create
-	 * @param {requestCallback} cb - The callback that handles the specified action
-	 */
-	action(actionName, cb) {
-		const action = new Action(`${this.moduleAlias}:${actionName}`, null, null);
-		this.actionMap[action.key()] = cb;
-	}
-
-	/**
 	 * Invoke specific action.
 	 *
 	 * @async
@@ -117,7 +105,7 @@ class EventEmitterChannel extends BaseChannel {
 		}
 
 		if (action.module === this.moduleAlias) {
-			return this.actionMap[action.key()](action);
+			return this.actions[action.name](action);
 		}
 
 		return this.bus.invoke(action.serialize());

--- a/framework/src/controller/channels/event_emitter.js
+++ b/framework/src/controller/channels/event_emitter.js
@@ -36,8 +36,8 @@ class EventEmitterChannel extends BaseChannel {
 	async registerToBus() {
 		await this.bus.registerChannel(
 			this.moduleAlias,
-			this.getEventsList().map(event => event.name),
-			this.getActionsList().map(action => action.name),
+			this.eventsList.map(event => event.name),
+			this.actionsList.map(action => action.name),
 			{}
 		);
 	}
@@ -104,8 +104,11 @@ class EventEmitterChannel extends BaseChannel {
 			action = actionName;
 		}
 
-		if (action.module === this.moduleAlias) {
-			return this.getActions()[action.name](action);
+		if (
+			action.module === this.moduleAlias &&
+			typeof this.actions[action.name] === 'function'
+		) {
+			return this.actions[action.name](action);
 		}
 
 		return this.bus.invoke(action.serialize());


### PR DESCRIPTION
### What was the problem?
Different ways to define the actions which was confusing for module developers.

### How did I fix it?
Concentrate actions to actions method inside module class

### How to test it?
Test suite

### Review checklist

* The PR resolves #2913
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
