### PR TITLE
Support running single test files with npx mocha - Closes #2930

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+../framework/test/mocha/mocha.opts


### PR DESCRIPTION
### What was the problem?
We were not able to run mocha tests with `npx mocha <file>` command.
### How did I fix it?
I created a symlink for mocha.opts file under `test/mocha.opts` so mocha can read the options by default.
### How to test it?
Run:

`npx mocha framework/test/mocha/unit/components/cache/cache.js`

### Review checklist

* The PR resolves #2930 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
