### PR TITLE
Calculate broadhash from "id" instead of legacy "b_id" field - Closes #2953

### DIFF
--- a/modules/system.js
+++ b/modules/system.js
@@ -186,12 +186,12 @@ System.prototype.getBroadhash = function(cb) {
 		{},
 		{ limit: 5, sort: 'height:desc' }
 	)
-		.then(rows => {
-			if (rows.length <= 1) {
+		.then(maxFiveLatestBlocks => {
+			if (maxFiveLatestBlocks.length <= 1) {
 				// In case that we have only genesis block in database (query returns 1 row) - skip broadhash update
 				return setImmediate(cb, null, __private.nethash);
 			}
-			const seed = rows.map(row => row.b_id).join('');
+			const seed = maxFiveLatestBlocks.map(block => block.id).join('');
 			const broadhash = crypto
 				.createHash('sha256')
 				.update(seed, 'utf8')


### PR DESCRIPTION
### What was the problem?
Broadhash was calculated from the legacy "b_id" block field.
### How did I fix it?
Broadhash is now calculated from the existing "id" block field.
### How to test it?
Check the broadhash being updated every time a block is saved.
### Review checklist

* The PR resolves #2953
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
