### PR TITLE
Fix typo on dns lookup resolution code - Closes #2961

### DIFF
--- a/framework/src/modules/chain/init_steps/lookup_peers_ips.js
+++ b/framework/src/modules/chain/init_steps/lookup_peers_ips.js
@@ -18,7 +18,7 @@ module.exports = async (peersList, enabled) => {
 			}
 
 			try {
-				const address = await lookupPromise(peer.id, { family: 4 });
+				const address = await lookupPromise(peer.ip, { family: 4 });
 				return Object.assign({}, peer, { ip: address });
 			} catch (err) {
 				console.error(


### PR DESCRIPTION
### What was the problem?
`peer.ip` was written as peer.id and therefore a call against `dns.lookup()`
with undefined value was triggering a crash on `socketcluster` trying
to connect to an undefined peer.
### How did I fix it?
Changed `peer.id` by `peer.ip`
### How to test it?
Run the application and it shouldn't crash anymore
### Review checklist
* The PR resolves #2961 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
