### PR TITLE
Fix Peer object string address - Closes #2964

### DIFF
--- a/framework/src/modules/chain/init_steps/lookup_peers_ips.js
+++ b/framework/src/modules/chain/init_steps/lookup_peers_ips.js
@@ -18,7 +18,7 @@ module.exports = async (peersList, enabled) => {
 			}
 
 			try {
-				const address = await lookupPromise(peer.ip, { family: 4 });
+				const { address } = await lookupPromise(peer.ip, { family: 4 });
 				return Object.assign({}, peer, { ip: address });
 			} catch (err) {
 				console.error(


### PR DESCRIPTION
### What was the problem?
Peers are being stringified to for example `[object Object]:7001` and SocketCluster is crashing because of it.
### How did I fix it?
`address` needed to be destructured
`const { address } = await lookupPromise(peer.ip, { family: 4 });`
### How to test it?
Run the application and it shouldn't crash anymore
### Review checklist

* The PR resolves #2964 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
