### PR TITLE
Account productivity not showing decimal places - Closes #2965

### DIFF
--- a/storage/sql/accounts/get.sql
+++ b/storage/sql/accounts/get.sql
@@ -40,7 +40,7 @@ SELECT
 	when
 		"producedBlocks" + "missedBlocks" = 0 then 0
 	else
-		(("producedBlocks"::float / ("producedBlocks" + "missedBlocks")) * 100.0)::integer
+		ROUND((("producedBlocks"::float / ("producedBlocks" + "missedBlocks")) * 100.0)::numeric, 2)::float
 	end AS productivity
 FROM
 	mem_accounts

--- a/storage/sql/accounts/get_extended.sql
+++ b/storage/sql/accounts/get_extended.sql
@@ -40,7 +40,7 @@ SELECT
     when
     	"producedBlocks" + "missedBlocks" = 0 then 0
     else
-		(("producedBlocks"::float / ("producedBlocks" + "missedBlocks")) * 100.0)::integer
+		ROUND((("producedBlocks"::float / ("producedBlocks" + "missedBlocks")) * 100.0)::numeric, 2)::float
 	end AS productivity,
 	(SELECT array_agg("dependentId")
 		FROM mem_accounts2delegates

--- a/test/unit/storage/entities/account.js
+++ b/test/unit/storage/entities/account.js
@@ -560,15 +560,15 @@ describe('Account', () => {
 			});
 
 			it('should fetch "productivity" with correct query', async () => {
-				const producedBlocks = 5;
+				const producedBlocks = 50;
 				const missedBlocks = 3;
 				const validAccount = new accountFixtures.Account({
 					producedBlocks,
 					missedBlocks,
 				});
 				await AccountEntity.create(validAccount);
-				const productivity = parseInt(
-					producedBlocks / (producedBlocks + missedBlocks) * 100.0
+				const productivity = parseFloat(
+					(producedBlocks / (producedBlocks + missedBlocks) * 100.0).toFixed(2)
 				);
 
 				const account = await AccountEntity.getOne(

--- a/test/unit/storage/entities/account.js
+++ b/test/unit/storage/entities/account.js
@@ -559,17 +559,33 @@ describe('Account', () => {
 				);
 			});
 
-			it('should fetch "productivity" with correct query', async () => {
+			it('should fetch "productivity" with two decimal places when value is not integer', async () => {
 				const producedBlocks = 50;
-				const missedBlocks = 3;
+				const missedBlocks = 25;
 				const validAccount = new accountFixtures.Account({
 					producedBlocks,
 					missedBlocks,
 				});
 				await AccountEntity.create(validAccount);
-				const productivity = parseFloat(
-					(producedBlocks / (producedBlocks + missedBlocks) * 100.0).toFixed(2)
+				const productivity = 66.67;
+
+				const account = await AccountEntity.getOne(
+					{ address: validAccount.address },
+					{ extended: true }
 				);
+
+				expect(account.productivity).to.be.eql(productivity);
+			});
+
+			it('should fetch "productivity" with no decimal places when value is integer', async () => {
+				const producedBlocks = 75;
+				const missedBlocks = 25;
+				const validAccount = new accountFixtures.Account({
+					producedBlocks,
+					missedBlocks,
+				});
+				await AccountEntity.create(validAccount);
+				const productivity = 75;
 
 				const account = await AccountEntity.getOne(
 					{ address: validAccount.address },


### PR DESCRIPTION
### What was the problem?
Account productivity not showing decimal places and returning as string

### How did I fix it?
Fixed the SQL responsible to calculate the productivity

### How to test it?
GET `/api/delegates` - productivity should be number with 2 decimal places

### Review checklist

* The PR resolves #2965
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
