### PR TITLE
API voters votes field value changed from count of voters to vote weight - Closes #2968

### DIFF
--- a/api/controllers/voters.js
+++ b/api/controllers/voters.js
@@ -125,7 +125,11 @@ VotersController.getVoters = async function(context, next) {
 			_.pick(voter, ['address', 'publicKey', 'balance'])
 		);
 
-		data.votes = voters.length;
+		const votersCount = await storage.entities.Account.count({
+			votedDelegatesPublicKeys_in: [delegate.publicKey],
+		});
+
+		data.votes = votersCount;
 
 		return next(null, {
 			data,

--- a/api/controllers/voters.js
+++ b/api/controllers/voters.js
@@ -111,7 +111,6 @@ VotersController.getVoters = async function(context, next) {
 			'address',
 			'balance',
 		]);
-		data.votes = parseInt(delegate.vote);
 
 		// TODO: Make sure we return empty string in case of null username
 		// This can be avoided when we fix the `isDelegate` inconsistency mentioned above.
@@ -125,6 +124,8 @@ VotersController.getVoters = async function(context, next) {
 		data.voters = _.map(voters, voter =>
 			_.pick(voter, ['address', 'publicKey', 'balance'])
 		);
+
+		data.votes = voters.length;
 
 		return next(null, {
 			data,

--- a/schema/swagger.yml
+++ b/schema/swagger.yml
@@ -2803,9 +2803,7 @@ definitions:
         type: integer
         example: 108877
         description: |
-          The voters weight of the delegate.
-          Represents the total amount of Lisk (in Beddows) that the delegates' voters own.
-          The voters weight decides which rank the delegate gets in relation to the other delegates and their voters weights.
+          Total number of accounts that voted for the queried delegate.
       address:
         type: string
         format: address

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -34,7 +34,7 @@ describe('GET /api/voters', () => {
 	const validNotExistingAddress = '11111111111111111111L';
 
 	function expectValidVotedDelegateResponse(res) {
-		expect(res.body.data.votes).to.be.eql(res.body.data.voters.length);
+		expect(res.body.data.votes).to.be.least(res.body.data.voters.length);
 	}
 
 	function expectValidNotVotedDelegateResponse(res) {

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -237,6 +237,32 @@ describe('GET /api/voters', () => {
 			});
 		});
 
+		describe('votes', () => {
+			it('should return total number of accounts that voted for the queried delegate', async () => {
+				let delegate;
+				let hasResult = true;
+				let votesCount = 0;
+
+				// The following loop is a workaround to get votes count as the number of votes will change each time the test runs
+				// REF.: https://github.com/LiskHQ/lisk/pull/2969
+				do {
+					// eslint-disable-next-line no-await-in-loop
+					const result = await votersEndpoint.makeRequest(
+						{
+							username: validVotedDelegate.delegateName,
+							limit: 1,
+							offset: votesCount,
+						},
+						200
+					);
+					delegate = result.body.data;
+					hasResult = delegate.voters.length > 0 ? ++votesCount : false;
+				} while (hasResult);
+
+				expect(delegate.votes).to.eql(votesCount);
+			});
+		});
+
 		describe('sort', () => {
 			const validExtraDelegateVoter = randomUtil.account();
 

--- a/test/functional/http/get/voters.js
+++ b/test/functional/http/get/voters.js
@@ -34,7 +34,7 @@ describe('GET /api/voters', () => {
 	const validNotExistingAddress = '11111111111111111111L';
 
 	function expectValidVotedDelegateResponse(res) {
-		expect(res.body.data.votes).to.be.least(res.body.data.voters.length);
+		expect(res.body.data.votes).to.be.eql(res.body.data.voters.length);
 	}
 
 	function expectValidNotVotedDelegateResponse(res) {


### PR DESCRIPTION
### What was the problem?
Wrong value for votes in `/api/voters`

### How did I fix it?
I used `storage.entities.Account.count` to get the total accounts that voted for queried delegate

### How to test it?
GET `/api/voters?username=genesis_1&limit=1`

### Review checklist

* The PR resolves #2968
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
