### PR TITLE
API Accounts approval results changed from 1.4.1 to 1.5.0-rc.1 - Closes #2971

### DIFF
--- a/api/controllers/accounts.js
+++ b/api/controllers/accounts.js
@@ -65,7 +65,10 @@ function accountFormatter(totalSupply, account) {
 		object.delegate.rank = parseInt(object.delegate.rank);
 
 		// Computed fields
-		object.delegate.approval = calculateApproval(object.vote, totalSupply);
+		object.delegate.approval = calculateApproval(
+			object.delegate.vote,
+			totalSupply
+		);
 	}
 
 	object.publicKey = object.publicKey || '';

--- a/test/common/helpers/api.js
+++ b/test/common/helpers/api.js
@@ -17,6 +17,7 @@
 const lisk = require('lisk-elements').default;
 const Promise = require('bluebird');
 const accountFixtures = require('../../fixtures/accounts');
+const { calculateApproval } = require('../../../helpers/http_api');
 const SwaggerSpec = require('../swagger_spec');
 
 const http = {
@@ -407,4 +408,5 @@ module.exports = {
 	expectSwaggerParamError,
 	createSignatureObject,
 	getNotFoundEndpointPromise,
+	calculateApproval,
 };

--- a/test/functional/http/get/accounts/accounts.js
+++ b/test/functional/http/get/accounts/accounts.js
@@ -28,6 +28,7 @@ const expectSwaggerParamError = apiHelpers.expectSwaggerParamError;
 describe('GET /accounts', () => {
 	const account = randomUtil.account();
 	const accountsEndpoint = new SwaggerEndpoint('GET /accounts');
+	const constantsEndPoint = new SwaggerEndpoint('GET /node/constants 200');
 
 	describe('?', () => {
 		describe('address', () => {
@@ -391,6 +392,26 @@ describe('GET /accounts', () => {
 						accountFixtures.existingDelegate.delegateName
 					);
 				});
+		});
+
+		it('should return correct delegate approval for a delegate account', async () => {
+			const promises = [
+				constantsEndPoint.makeRequest(),
+				accountsEndpoint.makeRequest(
+					{ address: accountFixtures.existingDelegate.address },
+					200
+				),
+			];
+
+			const [
+				{ body: { data: constansts } },
+				{ body: { data: [{ delegate }] } },
+			] = await Promise.all(promises);
+			const calculatedApproval = parseFloat(
+				(delegate.vote / constansts.supply * 100).toFixed(2)
+			);
+
+			expect(delegate.approval).to.be.eql(calculatedApproval);
 		});
 
 		it('should return empty delegate property for a non delegate account', () => {

--- a/test/functional/http/get/accounts/accounts.js
+++ b/test/functional/http/get/accounts/accounts.js
@@ -407,10 +407,11 @@ describe('GET /accounts', () => {
 				{ body: { data: constansts } },
 				{ body: { data: [{ delegate }] } },
 			] = await Promise.all(promises);
-			const calculatedApproval = parseFloat(
-				(delegate.vote / constansts.supply * 100).toFixed(2)
-			);
 
+			const calculatedApproval = apiHelpers.calculateApproval(
+				delegate.vote,
+				constansts.supply
+			);
 			expect(delegate.approval).to.be.eql(calculatedApproval);
 		});
 


### PR DESCRIPTION
### What was the problem?
`api/accounts` returning wrong value for `approval` when account is a delegate

### How did I fix it?
Used the correct attribute when calculating the approval value

### How to test it?
`/api/accounts?address=10431374778810601967L`

### Review checklist

* The PR resolves #2971
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
