### PR TITLE
Add validation for delegate asset - Closes #2979

### DIFF
--- a/api/controllers/transactions.js
+++ b/api/controllers/transactions.js
@@ -46,6 +46,10 @@ function transactionFormatter(transaction) {
 	result.recipientPublicKey = result.recipientPublicKey || '';
 	result.signSignature = result.signSignature || '';
 	result.signatures = result.signatures || [];
+	if (transaction.type === 2) {
+		result.asset.delegate.publicKey = result.senderPublicKey;
+		result.asset.delegate.address = result.senderId;
+	}
 
 	return result;
 }

--- a/api/controllers/transactions.js
+++ b/api/controllers/transactions.js
@@ -17,6 +17,7 @@
 const _ = require('lodash');
 const swaggerHelper = require('../../helpers/swagger');
 const ApiError = require('../../helpers/api_error');
+const transactionTypes = require('../../helpers/transaction_types');
 
 // Private Fields
 let modules;
@@ -46,7 +47,7 @@ function transactionFormatter(transaction) {
 	result.recipientPublicKey = result.recipientPublicKey || '';
 	result.signSignature = result.signSignature || '';
 	result.signatures = result.signatures || [];
-	if (transaction.type === 2) {
+	if (transaction.type === transactionTypes.DELEGATE) {
 		result.asset.delegate.publicKey = result.senderPublicKey;
 		result.asset.delegate.address = result.senderId;
 	}

--- a/test/functional/http/get/transactions.js
+++ b/test/functional/http/get/transactions.js
@@ -1014,13 +1014,31 @@ describe('GET /api/transactions', () => {
 			});
 		});
 
+		describe('asset', () => {
+			it('assets for type 2 transactions should contain key username, publicKey and address', () => {
+				return transactionsEndpoint
+					.makeRequest({ type: transactionTypes.DELEGATE, limit: 1 }, 200)
+					.then(res => {
+						expect(res.body.data).to.not.empty;
+						res.body.data.map(transaction => {
+							expect(transaction.asset).to.have.key('delegate');
+							return expect(transaction.asset.delegate).to.have.all.keys(
+								'username',
+								'publicKey',
+								'address'
+							);
+						});
+					});
+			});
+		});
+
 		/**
 		 * This tests will fail because type 6 and type 7 transactions got disabled in Lisk Core v1.0
 		 * You can make it pass locally, by changing the value for disableDappTransfer
 		 * in config/default/exceptions to a value bigger than 0
 		 * */
 		/* eslint-disable mocha/no-skipped-tests */
-		describe.skip('assets', () => {
+		describe.skip('dapp', () => {
 			before(() => {
 				return sendTransactionPromise(transaction4) // send type 0 transaction
 					.then(result => {


### PR DESCRIPTION
### What was the problem?
When registering a delegate via type 2 transaction, we only pass the `username` field.
The API response should contain an asset field with the following properties:
- `username`
- `address`
- `publicKey`

However, only `username` is present which breaks the explorer.

### How did I fix it?
Modify returned transaction via `transactionFormatter` to return `publicKey` and `address` at `api/controllers/transactions.js`.

Test title: `assets for type 2 transactions should contain key username, publicKey and address`.

### How to test it?
Start network: `node app.js`
Run test: `npm run mocha -- test/functional/http/get/transactions.js `

### Review checklist

* The PR resolves #2979 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
