### PR TITLE
API returns wrong height snapshot mode - Closes #2999

### DIFF
--- a/api/controllers/node.js
+++ b/api/controllers/node.js
@@ -57,8 +57,12 @@ function NodeController(scope) {
 	};
 	blockReward = new BlockReward();
 	getNetworkHeight = promisify(library.modules.peers.networkHeight);
-	getTransactionsCount = promisify(library.modules.transactions.shared.getTransactionsCount);
-	updateForgingStatus = promisify(library.modules.delegates.updateForgingStatus);
+	getTransactionsCount = promisify(
+		library.modules.transactions.shared.getTransactionsCount
+	);
+	updateForgingStatus = promisify(
+		library.modules.delegates.updateForgingStatus
+	);
 }
 
 /**
@@ -116,19 +120,13 @@ NodeController.getStatus = async (context, next) => {
 			normalized: false,
 		});
 
-		const [lastBlock] = await library.storage.entities.Block.get(
-			{},
-			{ sort: 'height:desc', limit: 1 }
-		);
-		const { height } = lastBlock;
-
 		// TODO: Replace all library.modules calls after chain module extraction is done as part of https://github.com/LiskHQ/lisk/issues/2763.
 		const data = {
 			broadhash: library.modules.system.getBroadhash(),
 			consensus: library.modules.peers.getLastConsensus() || 0,
 			currentTime: Date.now(),
 			secondsSinceEpoch: slots.getTime(),
-			height,
+			height: library.modules.blocks.lastBlock.get().height,
 			loaded: library.modules.loader.loaded(),
 			networkHeight: networkHeight || 0,
 			syncing: library.modules.loader.syncing(),
@@ -149,7 +147,9 @@ NodeController.getStatus = async (context, next) => {
  * @todo Add description for the function and the params
  */
 NodeController.getForgingStatus = async (context, next) => {
-	if (!checkIpInList(library.config.forging.access.whiteList, context.request.ip)) {
+	if (
+		!checkIpInList(library.config.forging.access.whiteList, context.request.ip)
+	) {
 		context.statusCode = apiCodes.FORBIDDEN;
 		return next(new Error('Access Denied'));
 	}
@@ -171,7 +171,9 @@ NodeController.getForgingStatus = async (context, next) => {
  * @todo Add description for the function and the params
  */
 NodeController.updateForgingStatus = async (context, next) => {
-	if (!checkIpInList(library.config.forging.access.whiteList, context.request.ip)) {
+	if (
+		!checkIpInList(library.config.forging.access.whiteList, context.request.ip)
+	) {
 		context.statusCode = apiCodes.FORBIDDEN;
 		return next(new Error('Access Denied'));
 	}


### PR DESCRIPTION
### What was the problem?
The API always returns the target height (parameter passed to `-s`) when in snapshot mode. This means the snapshotting process cannot be monitored anymore.
### How did I fix it?
API node controller no longer uses Storage Block entity and uses `modules.blocks.lastBlock.get()` instead.
### How to test it?
Run `node app.js -s all`
Open `localhost:7000/api/node/status` in a web browser, keep refreshing and check the `height` attribute.
### Review checklist

* The PR resolves #2999 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
