### PR TITLE
Remove storageRead call from http_api to chain - Closes #2989

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -233,8 +233,6 @@ module.exports = class Chain {
 					action.params[0],
 					action.params[1]
 				),
-			storageRead: async action =>
-				this.scope.logic.block.storageRead(action.params[0]),
 			getLastConsensus: async () => this.scope.modules.peers.getLastConsensus(),
 			loaderLoaded: async () => this.scope.modules.loader.loaded(),
 			loaderSyncing: async () => this.scope.modules.loader.syncing(),

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -65,7 +65,6 @@ module.exports = class ChainModule extends BaseModule {
 			getPeersCountByFilter: async action =>
 				this.chain.actions.getPeersCountByFilter(action),
 			postSignature: async action => this.chain.actions.postSignature(action),
-			storageRead: async action => this.chain.actions.storageRead(action),
 			getLastConsensus: async () => this.chain.actions.getLastConsensus(),
 			loaderLoaded: async () => this.chain.actions.loaderLoaded(),
 			loaderSyncing: async () => this.chain.actions.loaderSyncing(),

--- a/framework/src/modules/chain/logic/block.js
+++ b/framework/src/modules/chain/logic/block.js
@@ -517,11 +517,10 @@ Block.prototype.dbRead = function(raw) {
 };
 
 /**
- * Creates block object based on raw data.
+ * Creates block object based on raw database block data.
  *
- * @param {Object} raw
+ * @param {Object} raw Raw database data block object
  * @returns {null|block} Block object
- * @todo Add description for the params
  */
 Block.prototype.storageRead = function(raw) {
 	if (!raw.id) {

--- a/framework/src/modules/http_api/controllers/blocks.js
+++ b/framework/src/modules/http_api/controllers/blocks.js
@@ -20,7 +20,6 @@ const apiCodes = require('../helpers/api_codes.js');
 const ApiError = require('../helpers/api_error.js');
 const Bignum = require('../helpers/bignum.js');
 
-const __private = {};
 let library;
 let sortFields;
 
@@ -119,7 +118,7 @@ BlocksController.getBlocks = function(context, next) {
  * @returns {address} address
  * @todo Replace by Lisk Elements once integrated.
  */
-__private.getAddressByPublicKey = function(publicKey) {
+function getAddressByPublicKey(publicKey) {
 	const publicKeyHash = crypto
 		.createHash('sha256')
 		.update(publicKey, 'hex')
@@ -132,7 +131,7 @@ __private.getAddressByPublicKey = function(publicKey) {
 
 	const address = `${Bignum.fromBuffer(temp).toString()}L`;
 	return address;
-};
+}
 
 /**
  * Parse raw block data from database into expected API response type for blocks
@@ -152,22 +151,21 @@ function parseBlockFromDatabase(raw) {
 		height: parseInt(raw.height),
 		previousBlock: raw.previousBlockId,
 		numberOfTransactions: parseInt(raw.numberOfTransactions),
-		totalAmount: new Bignum(raw.totalAmount),
-		totalFee: new Bignum(raw.totalFee),
-		reward: new Bignum(raw.reward),
+		totalAmount: new Bignum(raw.totalAmount).toString(),
+		totalFee: new Bignum(raw.totalFee).toString(),
+		reward: new Bignum(raw.reward).toString(),
 		payloadLength: parseInt(raw.payloadLength),
 		payloadHash: raw.payloadHash,
 		generatorPublicKey: raw.generatorPublicKey,
-		generatorId: __private.getAddressByPublicKey(raw.generatorPublicKey),
+		generatorId: getAddressByPublicKey(raw.generatorPublicKey),
 		blockSignature: raw.blockSignature,
 		confirmations: parseInt(raw.confirmations),
+		totalForged: new Bignum(raw.totalFee).plus(raw.reward).toString(),
 	};
 
 	if (raw.transactions) {
 		block.transactions = raw.transactions;
 	}
-
-	block.totalForged = block.totalFee.plus(block.reward).toString();
 
 	return block;
 }

--- a/framework/src/modules/http_api/controllers/blocks.js
+++ b/framework/src/modules/http_api/controllers/blocks.js
@@ -134,6 +134,12 @@ __private.getAddressByPublicKey = function(publicKey) {
 	return address;
 };
 
+/**
+ * Parse raw block data from database into expected API response type for blocks
+ *
+ * @param {Object} raw Raw block data from database
+ * @return {block} Block formatted according to API specification
+ */
 function parseBlockFromDatabase(raw) {
 	if (!raw.id) {
 		return null;

--- a/framework/test/mocha/unit/modules/http_api/controllers/blocks.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/blocks.js
@@ -54,7 +54,6 @@ describe('blocks/api', () => {
 			entities: {
 				Block: {
 					get: sinonSandbox.stub().resolves([]),
-					getRaw: sinonSandbox.stub().resolves(rawBlock),
 				},
 			},
 		};


### PR DESCRIPTION
### What was the problem?
`storageRead` was intended to make the non-breaking changes for the network layer. Any kind of formatting you need for blocks for the APIs, should be done in API module itself. So directly use `storage.entities.Block.get`, and format the response how the API is required.

### How did I fix it?
Remove `channel.invoke` call to `storageRead` in `http_api` module and move the API specific formatting logic for a block to the `http_api` module.

### How to test it?
Run tests.

### Comments
We can move the functionality of `parseBlockFromDatabase` into a `helper` object later.

### Review checklist

* The PR resolves #2989 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
