### PR TITLE
Integrate @liskhq/lisk-p2p module in chain module - Closes #2874

### DIFF
--- a/framework/src/components/system/index.js
+++ b/framework/src/components/system/index.js
@@ -16,8 +16,8 @@
 
 const System = require('./system');
 
-function createSystemComponent(config, logger, storage, onUpdateHandler) {
-	return new System(config, logger, storage, onUpdateHandler);
+function createSystemComponent(config, logger, storage) {
+	return new System(config, logger, storage);
 }
 
 module.exports = {

--- a/framework/src/components/system/index.js
+++ b/framework/src/components/system/index.js
@@ -16,8 +16,8 @@
 
 const System = require('./system');
 
-function createSystemComponent(config, logger, storage) {
-	return new System(config, logger, storage);
+function createSystemComponent(config, logger, storage, onUpdateHandler) {
+	return new System(config, logger, storage, onUpdateHandler);
 }
 
 module.exports = {

--- a/framework/src/components/system/system.js
+++ b/framework/src/components/system/system.js
@@ -17,6 +17,7 @@
 const os = require('os');
 const crypto = require('crypto');
 const semver = require('semver');
+const { EventEmitter } = require('events');
 
 /**
  * Main system methods. Initializes library with scope content and headers:
@@ -38,8 +39,9 @@ const semver = require('semver');
  * @param {Object} options - System options
  * @param {Object} logger
  */
-class System {
-	constructor(config, logger, storage, onUpdateHandler) {
+class System extends EventEmitter {
+	constructor(config, logger, storage) {
+		super();
 		this.logger = logger;
 		this.storage = storage;
 		this.headers = {
@@ -54,7 +56,6 @@ class System {
 			broadhash: config.nethash,
 			nonce: config.nonce,
 		};
-		this.onUpdateHandler = onUpdateHandler;
 	}
 
 	/**
@@ -139,9 +140,7 @@ class System {
 				.toString('hex');
 			this.headers.broadhash = newBroadhash;
 			this.logger.debug('System headers', this.headers);
-			if (this.onUpdateHandler) {
-				this.onUpdateHandler(this.headers);
-			}
+			this.emit('update', this.headers);
 			return true;
 		} catch (err) {
 			this.logger.error(err.stack);

--- a/framework/src/components/system/system.js
+++ b/framework/src/components/system/system.js
@@ -39,7 +39,7 @@ const semver = require('semver');
  * @param {Object} logger
  */
 class System {
-	constructor(config, logger, storage) {
+	constructor(config, logger, storage, onUpdateHandler) {
 		this.logger = logger;
 		this.storage = storage;
 		this.headers = {
@@ -54,6 +54,7 @@ class System {
 			broadhash: config.nethash,
 			nonce: config.nonce,
 		};
+		this.onUpdateHandler = onUpdateHandler;
 	}
 
 	/**
@@ -138,6 +139,9 @@ class System {
 				.toString('hex');
 			this.headers.broadhash = newBroadhash;
 			this.logger.debug('System headers', this.headers);
+			if (this.onUpdateHandler) {
+				this.onUpdateHandler(this.headers);
+			}
 			return true;
 		} catch (err) {
 			this.logger.error(err.stack);

--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -85,7 +85,7 @@ class Application {
 		label,
 		genesisBlock,
 		constants = {},
-		config = { components: { logger: null }, modules: { network: {} } }
+		config = { components: { logger: null }, modules: { chain: {}, network: {} } }
 	) {
 		if (typeof label === 'function') {
 			label = label.call();

--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -9,6 +9,7 @@ const { createLoggerComponent } = require('../components/logger');
 
 const ChainModule = require('../modules/chain');
 const HttpAPIModule = require('../modules/http_api');
+const NetworkModule = require('../modules/network');
 
 // Private __private used because private keyword is restricted
 const __private = {
@@ -84,7 +85,7 @@ class Application {
 		label,
 		genesisBlock,
 		constants = {},
-		config = { components: { logger: null } }
+		config = { components: { logger: null }, modules: { network: {} } }
 	) {
 		if (typeof label === 'function') {
 			label = label.call();
@@ -123,8 +124,8 @@ class Application {
 			genesisBlock: this.genesisBlock,
 			constants: this.constants,
 		});
-
 		this.registerModule(HttpAPIModule);
+		this.registerModule(NetworkModule, this.config.modules.network);
 	}
 
 	/**

--- a/framework/src/controller/schema/application.js
+++ b/framework/src/controller/schema/application.js
@@ -181,6 +181,15 @@ module.exports = {
 			},
 			modules: {
 				type: 'object',
+				properties: {
+					chain: {
+						type: 'object',
+					},
+					network: {
+						type: 'object',
+					},
+				},
+				additionalProperties: true,
 			},
 		},
 		additionalProperties: false,

--- a/framework/src/controller/schema/application.js
+++ b/framework/src/controller/schema/application.js
@@ -179,6 +179,9 @@ module.exports = {
 					},
 				},
 			},
+			modules: {
+				type: 'object',
+			},
 		},
 		additionalProperties: false,
 	},

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -79,6 +79,10 @@ module.exports = class Chain {
 			'system'
 		);
 
+		const handleNodeInfoUpdate = (headers) => {
+			this.channel.publish('chain:updateNodeInfo', headers);
+		};
+
 		this.logger = createLoggerComponent(loggerConfig);
 		const dbLogger =
 			storageConfig.logFileName &&
@@ -118,7 +122,12 @@ module.exports = class Chain {
 
 			// System
 			this.logger.debug('Initiating system...');
-			const system = createSystemComponent(systemConfig, this.logger, storage);
+			const system = createSystemComponent(
+				systemConfig,
+				this.logger,
+				storage,
+				handleNodeInfoUpdate
+			);
 
 			if (!this.options.config) {
 				throw Error('Failed to assign nethash from genesis block');

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -80,7 +80,7 @@ module.exports = class Chain {
 		);
 
 		const handleNodeInfoUpdate = (headers) => {
-			this.channel.publish('chain:updateNodeInfo', headers);
+			this.channel.publish('chain:system:updateNodeInfo', headers);
 		};
 
 		this.logger = createLoggerComponent(loggerConfig);

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -79,7 +79,7 @@ module.exports = class Chain {
 			'system'
 		);
 
-		const handleNodeInfoUpdate = (headers) => {
+		const handleNodeInfoUpdate = headers => {
 			this.channel.publish('chain:system:updateNodeInfo', headers);
 		};
 

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -44,7 +44,7 @@ module.exports = class ChainModule extends BaseModule {
 			'delegates:fork',
 			'loader:sync',
 			'dapps:change',
-			'system:updateNodeInfo'
+			'system:updateNodeInfo',
 		];
 	}
 

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -44,7 +44,7 @@ module.exports = class ChainModule extends BaseModule {
 			'delegates:fork',
 			'loader:sync',
 			'dapps:change',
-			'updateNodeInfo'
+			'system:updateNodeInfo'
 		];
 	}
 

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -44,6 +44,7 @@ module.exports = class ChainModule extends BaseModule {
 			'delegates:fork',
 			'loader:sync',
 			'dapps:change',
+			'updateNodeInfo'
 		];
 	}
 

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -36,6 +36,7 @@ module.exports = class ChainModule extends BaseModule {
 	get events() {
 		return [
 			'blocks:change',
+			'ready',
 			'signature:change',
 			'transactions:change',
 			'rounds:change',
@@ -50,6 +51,7 @@ module.exports = class ChainModule extends BaseModule {
 
 	get actions() {
 		return {
+			getNodeInfo: () => this.chain.actions.getNodeInfo(),
 			calculateSupply: action => this.chain.actions.calculateSupply(action),
 			calculateMilestone: action =>
 				this.chain.actions.calculateMilestone(action),
@@ -89,8 +91,9 @@ module.exports = class ChainModule extends BaseModule {
 	async load(channel) {
 		this.chain = new Chain(channel, this.options);
 
-		channel.once('lisk:ready', () => {
-			this.chain.bootstrap();
+		channel.once('lisk:ready', async () => {
+			await this.chain.bootstrap();
+			channel.publish('chain:ready');
 		});
 	}
 

--- a/framework/src/modules/network/defaults/index.js
+++ b/framework/src/modules/network/defaults/index.js
@@ -1,7 +1,7 @@
 module.exports = {
 	blacklistedPeers: [],
 	connectTimeout: 5000,
-	ackTimeout: 5000,
+	ackTimeout: 10000,
 	discoveryInterval: 30000,
 	seedPeers: [],
 	wsEngine: 'ws',

--- a/framework/src/modules/network/defaults/index.js
+++ b/framework/src/modules/network/defaults/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  blacklistedPeers: [],
+  connectTimeout: 5000,
+  seedPeers: [],
+  wsEngine: 'ws',
+  nodeInfo: {
+    wsPort: 5001, // TODO: Change to 5000
+    height: 0,
+  },
+};

--- a/framework/src/modules/network/defaults/index.js
+++ b/framework/src/modules/network/defaults/index.js
@@ -1,10 +1,12 @@
 module.exports = {
-  blacklistedPeers: [],
-  connectTimeout: 5000,
-  seedPeers: [],
-  wsEngine: 'ws',
-  nodeInfo: {
-    wsPort: 5001, // TODO: Change to 5000
-    height: 0,
-  },
+	blacklistedPeers: [],
+	connectTimeout: 5000,
+	ackTimeout: 5000,
+	discoveryInterval: 30000,
+	seedPeers: [],
+	wsEngine: 'ws',
+	nodeInfo: {
+		wsPort: 5001, // TODO: Change to 5000
+		height: 0,
+	},
 };

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -33,7 +33,7 @@ module.exports = class NetworkModule extends BaseModule {
 	}
 
 	get events() {
-		return [];
+		return ['ready'];
 	}
 
 	get actions() {
@@ -51,7 +51,11 @@ module.exports = class NetworkModule extends BaseModule {
 			...this.options,
 		};
 		this.network = new Network(options);
-		await this.network.bootstrap(channel);
+
+		channel.once('chain:ready', async () => {
+			await this.network.bootstrap(channel);
+			channel.publish('network:ready');
+		});
 	}
 
 	async unload() {

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -41,7 +41,6 @@ module.exports = class NetworkModule extends BaseModule {
 			request: async action => this.network.actions.request(action),
 			send: action => this.network.actions.send(action),
 			getNetworkStatus: action => this.network.actions.getNetworkStatus(action),
-			applyPenalty: action => this.network.actions.applyPenalty(action),
 		};
 	}
 

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -37,7 +37,10 @@ module.exports = class NetworkModule extends BaseModule {
 	}
 
 	get actions() {
-		return {};
+		return {
+			request: async action => this.network.actions.request(action),
+			send: action => this.network.actions.send(action),
+		};
 	}
 
 	async load(channel) {
@@ -45,11 +48,8 @@ module.exports = class NetworkModule extends BaseModule {
 			...defaults,
 			...this.options,
 		};
-		this.network = new Network(channel, options);
-
-		channel.once('lisk:ready', () => {
-			this.network.bootstrap();
-		});
+		this.network = new Network(options);
+		await this.network.bootstrap(channel);
 	}
 
 	async unload() {

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -11,6 +11,7 @@ const BaseModule = require('../base_module');
  * @type {module.NetworkModule}
  */
 module.exports = class NetworkModule extends BaseModule {
+	/* eslint-disable-next-line no-useless-constructor */
 	constructor(options) {
 		super(options);
 	}
@@ -40,9 +41,9 @@ module.exports = class NetworkModule extends BaseModule {
 	}
 
 	async load(channel) {
-		let options = {
+		const options = {
 			...defaults,
-			...this.options
+			...this.options,
 		};
 		this.network = new Network(channel, options);
 

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -40,6 +40,8 @@ module.exports = class NetworkModule extends BaseModule {
 		return {
 			request: async action => this.network.actions.request(action),
 			send: action => this.network.actions.send(action),
+			getNetworkStatus: action => this.network.actions.getNetworkStatus(action),
+			applyPenalty: action => this.network.actions.applyPenalty(action),
 		};
 	}
 

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -1,0 +1,57 @@
+const defaults = require('./defaults');
+const Network = require('./network');
+const BaseModule = require('../base_module');
+
+/* eslint-disable class-methods-use-this */
+
+/**
+ * Network module specification
+ *
+ * @namespace Framework.Modules
+ * @type {module.NetworkModule}
+ */
+module.exports = class NetworkModule extends BaseModule {
+	constructor(options) {
+		super(options);
+	}
+
+	static get alias() {
+		return 'network';
+	}
+
+	static get info() {
+		return {
+			author: 'LiskHQ',
+			version: '0.1.0',
+			name: 'lisk-core-network',
+		};
+	}
+
+	get defaults() {
+		return defaults;
+	}
+
+	get events() {
+		return [];
+	}
+
+	get actions() {
+		return {};
+	}
+
+	async load(channel) {
+		let options = {
+			...defaults,
+			...this.options
+		};
+		this.network = new Network(channel, options);
+
+		channel.once('lisk:ready', () => {
+			this.network.bootstrap();
+		});
+	}
+
+	async unload() {
+		return this.network.cleanup(0);
+	}
+};

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -1,4 +1,8 @@
-const P2P = require('@liskhq/lisk-p2p').P2P;
+const {
+	P2P,
+	EVENT_REQUEST_RECEIVED,
+	EVENT_MESSAGE_RECEIVED,
+} = require('@liskhq/lisk-p2p');
 const { createSystemComponent } = require('../../components/system');
 const { createStorageComponent } = require('../../components/storage');
 const { createLoggerComponent } = require('../../components/logger');
@@ -10,62 +14,88 @@ const { createLoggerComponent } = require('../../components/logger');
  * @type {module.Network}
  */
 module.exports = class Network {
-	constructor(channel, options) {
-		this.channel = channel;
+	constructor(options) {
 		this.options = options;
+		this.channel = null;
 		this.logger = null;
+		this.system = null;
 	}
 
-	async bootstrap() {
-		const loggerConfig = await this.channel.invoke(
-			'lisk:getComponentConfig',
-			'logger'
-		);
-		const storageConfig = await this.channel.invoke(
-			'lisk:getComponentConfig',
-			'storage'
-		);
-		const systemConfig = await this.channel.invoke(
-			'lisk:getComponentConfig',
-			'system'
-		);
-
-		this.logger = createLoggerComponent(loggerConfig);
-		const dbLogger =
-			storageConfig.logFileName &&
-			storageConfig.logFileName === loggerConfig.logFileName
-				? this.logger
-				: createLoggerComponent(
-						Object.assign({}, loggerConfig, {
-							logFileName: storageConfig.logFileName,
-						})
-					);
+	async bootstrap(channel) {
+		this.channel = channel;
 
 		try {
+			const loggerConfig = await this.channel.invoke(
+				'lisk:getComponentConfig',
+				'logger'
+			);
+			const storageConfig = await this.channel.invoke(
+				'lisk:getComponentConfig',
+				'storage'
+			);
+			const systemConfig = await this.channel.invoke(
+				'lisk:getComponentConfig',
+				'system'
+			);
+
+			this.logger = createLoggerComponent(loggerConfig);
+			const dbLogger =
+				storageConfig.logFileName &&
+				storageConfig.logFileName === loggerConfig.logFileName
+					? this.logger
+					: createLoggerComponent(
+							Object.assign({}, loggerConfig, {
+								logFileName: storageConfig.logFileName,
+							})
+						);
+
 			// Storage
 			this.logger.debug('Initiating storage...');
 			const storage = createStorageComponent(storageConfig, dbLogger);
 
 			// System
 			this.logger.debug('Initiating system...');
-			const system = createSystemComponent(systemConfig, this.logger, storage);
+			this.system = createSystemComponent(systemConfig, this.logger, storage);
+		} catch (error) {
+			this.logger.fatal('Network initialization', {
+				message: error.message,
+				stack: error.stack,
+			});
+			process.emit('cleanup', error);
 
-			const p2pConfig = {
-				...this.options,
-				nodeInfo: {
-					...system.headers,
-					wsPort: this.options.nodeInfo.wsPort,
-				},
-			};
+			return;
+		}
 
-			this.p2p = new P2P(p2pConfig);
+		const p2pConfig = {
+			...this.options,
+			nodeInfo: {
+				...this.system.headers,
+				wsPort: this.options.nodeInfo.wsPort,
+			},
+		};
 
-			this._handleUpdateNodeInfo = event => {
-				this.p2p.applyNodeInfo(event.data);
-			};
+		this.p2p = new P2P(p2pConfig);
 
-			this.channel.subscribe('chain:system:updateNodeInfo', this._handleUpdateNodeInfo);
+		this._handleUpdateNodeInfo = event => {
+			this.p2p.applyNodeInfo(event.data);
+		};
 
+		this.channel.subscribe('chain:system:updateNodeInfo', this._handleUpdateNodeInfo);
+
+		this.p2p.on(EVENT_REQUEST_RECEIVED, async request => {
+			try {
+				const result = await this.channel.invoke(request.procedure, request.data);
+				request.end(result); // Send the response back to the peer.
+			} catch (error) {
+				request.error(error); // Send an error back to the peer.
+			}
+		});
+
+		this.p2p.on(EVENT_MESSAGE_RECEIVED, async packet => {
+			this.channel.publish(`network:${packet.event}`, packet.data);
+		});
+
+		try {
 			await this.p2p.start();
 		} catch (error) {
 			this.logger.fatal('Network initialization', {
@@ -74,6 +104,20 @@ module.exports = class Network {
 			});
 			process.emit('cleanup', error);
 		}
+	}
+
+	get actions() {
+		return {
+			request: async action =>
+				this.p2p.request({
+					procedure: action.params.procedure,
+					data: action.params.data,
+				}),
+			send: action => this.p2p.send({
+					event: action.params.event,
+					data: action.params.data,
+				}),
+		};
 	}
 
 	/* eslint-disable-next-line class-methods-use-this */

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -60,7 +60,7 @@ module.exports = class Network {
 
 			this.p2p = new P2P(p2pConfig);
 
-			this._handleUpdateNodeInfo = (event) => {
+			this._handleUpdateNodeInfo = event => {
 				this.p2p.applyNodeInfo(event.data);
 			};
 
@@ -76,6 +76,7 @@ module.exports = class Network {
 		}
 	}
 
+	/* eslint-disable-next-line class-methods-use-this */
 	async cleanup() {
 		// TODO: Unsubscribe 'chain:system:updateNodeInfo' from channel.
 	}

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -158,9 +158,8 @@ module.exports = class Network {
 		};
 	}
 
-	/* eslint-disable-next-line class-methods-use-this */
 	async cleanup() {
 		// TODO: Unsubscribe 'chain:system:updateNodeInfo' from channel.
-		await this.p2p.stop();
+		return this.p2p.stop();
 	}
 };

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -80,11 +80,17 @@ module.exports = class Network {
 			this.p2p.applyNodeInfo(event.data);
 		};
 
-		this.channel.subscribe('chain:system:updateNodeInfo', this._handleUpdateNodeInfo);
+		this.channel.subscribe(
+			'chain:system:updateNodeInfo',
+			this._handleUpdateNodeInfo
+		);
 
 		this.p2p.on(EVENT_REQUEST_RECEIVED, async request => {
 			try {
-				const result = await this.channel.invoke(request.procedure, request.data);
+				const result = await this.channel.invoke(
+					request.procedure,
+					request.data
+				);
 				request.end(result); // Send the response back to the peer.
 			} catch (error) {
 				request.error(error); // Send an error back to the peer.
@@ -113,15 +119,19 @@ module.exports = class Network {
 					procedure: action.params.procedure,
 					data: action.params.data,
 				}),
-			send: action => this.p2p.send({
+			send: action =>
+				this.p2p.send({
 					event: action.params.event,
 					data: action.params.data,
 				}),
+			getNetworkStatus: () => this.p2p.getNetworkStatus(),
+			applyPenalty: action => this.p2p.applyPenalty(action.params),
 		};
 	}
 
 	/* eslint-disable-next-line class-methods-use-this */
 	async cleanup() {
 		// TODO: Unsubscribe 'chain:system:updateNodeInfo' from channel.
+		await this.p2p.stop();
 	}
 };

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -64,7 +64,7 @@ module.exports = class Network {
 				this.p2p.applyNodeInfo(event.data);
 			};
 
-			this.channel.subscribe('chain:updateNodeInfo', this._handleUpdateNodeInfo);
+			this.channel.subscribe('chain:system:updateNodeInfo', this._handleUpdateNodeInfo);
 
 			await this.p2p.start();
 		} catch (error) {
@@ -77,6 +77,6 @@ module.exports = class Network {
 	}
 
 	async cleanup() {
-		// TODO: Unsubscribe 'chain:updateNodeInfo' from channel.
+		// TODO: Unsubscribe 'chain:system:updateNodeInfo' from channel.
 	}
 };

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -1,0 +1,82 @@
+const P2P = require('@liskhq/lisk-p2p').P2P;
+const { createSystemComponent } = require('../../components/system');
+const { createStorageComponent } = require('../../components/storage');
+const { createLoggerComponent } = require('../../components/logger');
+
+/**
+ * Network Module
+ *
+ * @namespace Framework.modules.network
+ * @type {module.Network}
+ */
+module.exports = class Network {
+	constructor(channel, options) {
+		this.channel = channel;
+		this.options = options;
+		this.logger = null;
+	}
+
+	async bootstrap() {
+		const loggerConfig = await this.channel.invoke(
+			'lisk:getComponentConfig',
+			'logger'
+		);
+		const storageConfig = await this.channel.invoke(
+			'lisk:getComponentConfig',
+			'storage'
+		);
+		const systemConfig = await this.channel.invoke(
+			'lisk:getComponentConfig',
+			'system'
+		);
+
+		this.logger = createLoggerComponent(loggerConfig);
+		const dbLogger =
+			storageConfig.logFileName &&
+			storageConfig.logFileName === loggerConfig.logFileName
+				? this.logger
+				: createLoggerComponent(
+						Object.assign({}, loggerConfig, {
+							logFileName: storageConfig.logFileName,
+						})
+					);
+
+		try {
+			// Storage
+			this.logger.debug('Initiating storage...');
+			const storage = createStorageComponent(storageConfig, dbLogger);
+
+			// System
+			this.logger.debug('Initiating system...');
+			const system = createSystemComponent(systemConfig, this.logger, storage);
+
+			const p2pConfig = {
+				...this.options,
+				nodeInfo: {
+					...system.headers,
+					wsPort: this.options.nodeInfo.wsPort,
+				},
+			};
+
+			this.p2p = new P2P(p2pConfig);
+
+			this._handleUpdateNodeInfo = (event) => {
+				this.p2p.applyNodeInfo(event.data);
+			};
+
+			this.channel.subscribe('chain:updateNodeInfo', this._handleUpdateNodeInfo);
+
+			await this.p2p.start();
+		} catch (error) {
+			this.logger.fatal('Network initialization', {
+				message: error.message,
+				stack: error.stack,
+			});
+			process.emit('cleanup', error);
+		}
+	}
+
+	async cleanup() {
+		// TODO: Unsubscribe 'chain:updateNodeInfo' from channel.
+	}
+};

--- a/framework/test/mocha/network/setup/config.js
+++ b/framework/test/mocha/network/setup/config.js
@@ -60,6 +60,8 @@ const config = {
 				network: {
 					blacklistedPeers: [],
 					connectTimeout: 5000,
+					ackTimeout: 5000,
+					discoveryInterval: 30000,
 					seedPeers: [],
 					wsEngine: 'ws',
 					nodeInfo: {

--- a/framework/test/mocha/network/setup/config.js
+++ b/framework/test/mocha/network/setup/config.js
@@ -56,6 +56,18 @@ const config = {
 			devConfigCopy.wsPort = 5000 + index;
 			devConfigCopy.httpPort = 4000 + index;
 			devConfigCopy.logFileName = `../logs/lisk_node_${index}.log`;
+			devConfigCopy.modules = {
+				network: {
+				  blacklistedPeers: [],
+				  connectTimeout: 5000,
+				  seedPeers: [],
+				  wsEngine: 'ws',
+				  nodeInfo: {
+				    wsPort: 6000 + index,
+				    height: 0,
+				  }
+				}
+			};
 			return devConfigCopy;
 		});
 

--- a/framework/test/mocha/network/setup/config.js
+++ b/framework/test/mocha/network/setup/config.js
@@ -58,15 +58,15 @@ const config = {
 			devConfigCopy.logFileName = `../logs/lisk_node_${index}.log`;
 			devConfigCopy.modules = {
 				network: {
-				  blacklistedPeers: [],
-				  connectTimeout: 5000,
-				  seedPeers: [],
-				  wsEngine: 'ws',
-				  nodeInfo: {
-				    wsPort: 6000 + index,
-				    height: 0,
-				  }
-				}
+					blacklistedPeers: [],
+					connectTimeout: 5000,
+					seedPeers: [],
+					wsEngine: 'ws',
+					nodeInfo: {
+						wsPort: 6000 + index,
+						height: 0,
+					},
+				},
 			};
 			return devConfigCopy;
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,3218 @@
 				}
 			}
 		},
+		"@liskhq/lisk-p2p": {
+			"version": "0.1.0-alpha.1",
+			"requires": {
+				"@types/lodash.shuffle": "4.2.4",
+				"lodash.shuffle": "4.2.0",
+				"semver": "5.6.0",
+				"socketcluster-client": "14.2.1",
+				"socketcluster-server": "14.4.0",
+				"validator": "10.11.0",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"bundled": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.3.2",
+					"bundled": true,
+					"requires": {
+						"@babel/types": "^7.3.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.10",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.1.0",
+					"bundled": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/template": "^7.1.0",
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0",
+					"bundled": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0",
+					"bundled": true,
+					"requires": {
+						"@babel/types": "^7.0.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"bundled": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.3.2",
+					"bundled": true
+				},
+				"@babel/template": {
+					"version": "7.2.2",
+					"bundled": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.2.2",
+						"@babel/types": "^7.2.2"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.2.3",
+					"bundled": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.2.2",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/parser": "^7.2.3",
+						"@babel/types": "^7.2.2",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.10"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.3.2",
+					"bundled": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.10",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@sinonjs/commons": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"type-detect": "4.0.8"
+					}
+				},
+				"@sinonjs/formatio": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"@sinonjs/samsam": "^2 || ^3"
+					}
+				},
+				"@sinonjs/samsam": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"@sinonjs/commons": "^1.0.2",
+						"array-from": "^2.1.1",
+						"lodash.get": "^4.4.2"
+					}
+				},
+				"@types/async": {
+					"version": "2.0.50",
+					"bundled": true
+				},
+				"@types/chai": {
+					"version": "4.1.7",
+					"bundled": true
+				},
+				"@types/chai-as-promised": {
+					"version": "7.1.0",
+					"bundled": true,
+					"requires": {
+						"@types/chai": "*"
+					}
+				},
+				"@types/component-emitter": {
+					"version": "1.2.7",
+					"bundled": true
+				},
+				"@types/events": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"@types/expect": {
+					"version": "1.20.3",
+					"bundled": true
+				},
+				"@types/expirymanager": {
+					"version": "0.9.0",
+					"bundled": true
+				},
+				"@types/fleximap": {
+					"version": "0.9.0",
+					"bundled": true
+				},
+				"@types/jquery": {
+					"version": "3.3.29",
+					"bundled": true,
+					"requires": {
+						"@types/sizzle": "*"
+					}
+				},
+				"@types/json5": {
+					"version": "0.0.29",
+					"bundled": true
+				},
+				"@types/jsonwebtoken": {
+					"version": "8.3.0",
+					"bundled": true,
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/lodash": {
+					"version": "4.14.120",
+					"bundled": true
+				},
+				"@types/lodash.shuffle": {
+					"version": "4.2.4",
+					"bundled": true,
+					"requires": {
+						"@types/lodash": "*"
+					}
+				},
+				"@types/mocha": {
+					"version": "5.2.5",
+					"bundled": true
+				},
+				"@types/node": {
+					"version": "10.12.21",
+					"bundled": true
+				},
+				"@types/sc-auth": {
+					"version": "5.0.0",
+					"bundled": true,
+					"requires": {
+						"@types/jsonwebtoken": "*"
+					}
+				},
+				"@types/sc-broker": {
+					"version": "5.1.1",
+					"bundled": true,
+					"requires": {
+						"@types/expirymanager": "*",
+						"@types/fleximap": "*",
+						"@types/socketcluster": "*",
+						"@types/socketcluster-server": "*"
+					}
+				},
+				"@types/sc-broker-cluster": {
+					"version": "6.1.1",
+					"bundled": true,
+					"requires": {
+						"@types/async": "*",
+						"@types/expirymanager": "*",
+						"@types/fleximap": "*",
+						"@types/sc-broker": "*",
+						"@types/sc-channel": "*",
+						"@types/socketcluster": "*",
+						"@types/socketcluster-server": "*"
+					}
+				},
+				"@types/sc-channel": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"@types/component-emitter": "*",
+						"@types/sc-broker-cluster": "*"
+					}
+				},
+				"@types/semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"@types/sinon": {
+					"version": "7.0.5",
+					"bundled": true
+				},
+				"@types/sinon-chai": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"@types/chai": "*",
+						"@types/sinon": "*"
+					}
+				},
+				"@types/sizzle": {
+					"version": "2.3.2",
+					"bundled": true
+				},
+				"@types/socketcluster": {
+					"version": "14.0.1",
+					"bundled": true,
+					"requires": {
+						"@types/sc-auth": "*",
+						"@types/sc-broker-cluster": "*",
+						"@types/socketcluster-server": "*"
+					}
+				},
+				"@types/socketcluster-client": {
+					"version": "13.0.0",
+					"bundled": true,
+					"requires": {
+						"@types/component-emitter": "*",
+						"@types/sc-auth": "*",
+						"@types/sc-channel": "*",
+						"@types/socketcluster-server": "*",
+						"@types/ws": "*"
+					}
+				},
+				"@types/socketcluster-server": {
+					"version": "14.2.2",
+					"bundled": true,
+					"requires": {
+						"@types/component-emitter": "*",
+						"@types/jsonwebtoken": "*",
+						"@types/sc-auth": "*",
+						"@types/sc-broker-cluster": "*",
+						"@types/ws": "*"
+					}
+				},
+				"@types/validator": {
+					"version": "10.9.0",
+					"bundled": true
+				},
+				"@types/verror": {
+					"version": "1.10.3",
+					"bundled": true
+				},
+				"@types/ws": {
+					"version": "6.0.1",
+					"bundled": true,
+					"requires": {
+						"@types/events": "*",
+						"@types/node": "*"
+					}
+				},
+				"JSONStream": {
+					"version": "1.3.5",
+					"bundled": true,
+					"requires": {
+						"jsonparse": "^1.2.0",
+						"through": ">=2.2.7 <3"
+					}
+				},
+				"acorn": {
+					"version": "6.0.7",
+					"bundled": true
+				},
+				"acorn-dynamic-import": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"acorn-node": {
+					"version": "1.6.2",
+					"bundled": true,
+					"requires": {
+						"acorn": "^6.0.2",
+						"acorn-dynamic-import": "^4.0.0",
+						"acorn-walk": "^6.1.0",
+						"xtend": "^4.0.1"
+					}
+				},
+				"acorn-walk": {
+					"version": "6.1.1",
+					"bundled": true
+				},
+				"ajv": {
+					"version": "6.8.1",
+					"bundled": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"bundled": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"arg": {
+					"version": "4.1.0",
+					"bundled": true
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"bundled": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"array-filter": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"array-from": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"array-map": {
+					"version": "0.0.0",
+					"bundled": true
+				},
+				"array-reduce": {
+					"version": "0.0.0",
+					"bundled": true
+				},
+				"asn1": {
+					"version": "0.2.4",
+					"bundled": true,
+					"requires": {
+						"safer-buffer": "~2.1.0"
+					}
+				},
+				"asn1.js": {
+					"version": "4.10.1",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"assert": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"util": "0.10.3"
+					},
+					"dependencies": {
+						"inherits": {
+							"version": "2.0.1",
+							"bundled": true
+						},
+						"util": {
+							"version": "0.10.3",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.1"
+							}
+						}
+					}
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"assertion-error": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "2.3.0",
+					"bundled": true,
+					"requires": {
+						"lodash": "^4.14.0"
+					}
+				},
+				"async-limiter": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"bundled": true
+				},
+				"aws4": {
+					"version": "1.8.0",
+					"bundled": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "2.2.1",
+							"bundled": true
+						},
+						"chalk": {
+							"version": "1.1.3",
+							"bundled": true,
+							"requires": {
+								"ansi-styles": "^2.2.1",
+								"escape-string-regexp": "^1.0.2",
+								"has-ansi": "^2.0.0",
+								"strip-ansi": "^3.0.0",
+								"supports-color": "^2.0.0"
+							}
+						},
+						"js-tokens": {
+							"version": "3.0.2",
+							"bundled": true
+						},
+						"supports-color": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base-64": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"base64-js": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"base64id": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"tweetnacl": "^0.14.3"
+					}
+				},
+				"bn.js": {
+					"version": "4.11.8",
+					"bundled": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"brorand": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"browser-pack": {
+					"version": "6.1.0",
+					"bundled": true,
+					"requires": {
+						"JSONStream": "^1.0.3",
+						"combine-source-map": "~0.8.0",
+						"defined": "^1.0.0",
+						"safe-buffer": "^5.1.1",
+						"through2": "^2.0.0",
+						"umd": "^3.0.0"
+					}
+				},
+				"browser-resolve": {
+					"version": "1.11.3",
+					"bundled": true,
+					"requires": {
+						"resolve": "1.1.7"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.1.7",
+							"bundled": true
+						}
+					}
+				},
+				"browser-stdout": {
+					"version": "1.3.1",
+					"bundled": true
+				},
+				"browserify": {
+					"version": "16.2.3",
+					"bundled": true,
+					"requires": {
+						"JSONStream": "^1.0.3",
+						"assert": "^1.4.0",
+						"browser-pack": "^6.0.1",
+						"browser-resolve": "^1.11.0",
+						"browserify-zlib": "~0.2.0",
+						"buffer": "^5.0.2",
+						"cached-path-relative": "^1.0.0",
+						"concat-stream": "^1.6.0",
+						"console-browserify": "^1.1.0",
+						"constants-browserify": "~1.0.0",
+						"crypto-browserify": "^3.0.0",
+						"defined": "^1.0.0",
+						"deps-sort": "^2.0.0",
+						"domain-browser": "^1.2.0",
+						"duplexer2": "~0.1.2",
+						"events": "^2.0.0",
+						"glob": "^7.1.0",
+						"has": "^1.0.0",
+						"htmlescape": "^1.1.0",
+						"https-browserify": "^1.0.0",
+						"inherits": "~2.0.1",
+						"insert-module-globals": "^7.0.0",
+						"labeled-stream-splicer": "^2.0.0",
+						"mkdirp": "^0.5.0",
+						"module-deps": "^6.0.0",
+						"os-browserify": "~0.3.0",
+						"parents": "^1.0.1",
+						"path-browserify": "~0.0.0",
+						"process": "~0.11.0",
+						"punycode": "^1.3.2",
+						"querystring-es3": "~0.2.0",
+						"read-only-stream": "^2.0.0",
+						"readable-stream": "^2.0.2",
+						"resolve": "^1.1.4",
+						"shasum": "^1.0.0",
+						"shell-quote": "^1.6.1",
+						"stream-browserify": "^2.0.0",
+						"stream-http": "^2.0.0",
+						"string_decoder": "^1.1.1",
+						"subarg": "^1.0.0",
+						"syntax-error": "^1.1.1",
+						"through2": "^2.0.0",
+						"timers-browserify": "^1.0.1",
+						"tty-browserify": "0.0.1",
+						"url": "~0.11.0",
+						"util": "~0.10.1",
+						"vm-browserify": "^1.0.0",
+						"xtend": "^4.0.0"
+					}
+				},
+				"browserify-aes": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"buffer-xor": "^1.0.3",
+						"cipher-base": "^1.0.0",
+						"create-hash": "^1.1.0",
+						"evp_bytestokey": "^1.0.3",
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"browserify-cipher": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"browserify-aes": "^1.0.4",
+						"browserify-des": "^1.0.0",
+						"evp_bytestokey": "^1.0.0"
+					}
+				},
+				"browserify-des": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"cipher-base": "^1.0.1",
+						"des.js": "^1.0.0",
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.1.2"
+					}
+				},
+				"browserify-rsa": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.1.0",
+						"randombytes": "^2.0.1"
+					}
+				},
+				"browserify-sign": {
+					"version": "4.0.4",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.1.1",
+						"browserify-rsa": "^4.0.0",
+						"create-hash": "^1.1.0",
+						"create-hmac": "^1.1.2",
+						"elliptic": "^6.0.0",
+						"inherits": "^2.0.1",
+						"parse-asn1": "^5.0.0"
+					}
+				},
+				"browserify-zlib": {
+					"version": "0.2.0",
+					"bundled": true,
+					"requires": {
+						"pako": "~1.0.5"
+					}
+				},
+				"buffer": {
+					"version": "5.2.1",
+					"bundled": true,
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
+				"buffer-equal-constant-time": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"buffer-from": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"buffer-xor": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"builtin-status-codes": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"cached-path-relative": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"chai": {
+					"version": "4.2.0",
+					"bundled": true,
+					"requires": {
+						"assertion-error": "^1.1.0",
+						"check-error": "^1.0.2",
+						"deep-eql": "^3.0.1",
+						"get-func-name": "^2.0.0",
+						"pathval": "^1.1.0",
+						"type-detect": "^4.0.5"
+					}
+				},
+				"chai-as-promised": {
+					"version": "7.1.1",
+					"bundled": true,
+					"requires": {
+						"check-error": "^1.0.2"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"check-error": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cipher-base": {
+					"version": "1.0.4",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"clone": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"bundled": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"bundled": true
+				},
+				"combine-source-map": {
+					"version": "0.8.0",
+					"bundled": true,
+					"requires": {
+						"convert-source-map": "~1.1.0",
+						"inline-source-map": "~0.6.0",
+						"lodash.memoize": "~3.0.3",
+						"source-map": "~0.5.3"
+					}
+				},
+				"combined-stream": {
+					"version": "1.0.7",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"commander": {
+					"version": "2.15.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"bundled": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
+					}
+				},
+				"console-browserify": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"date-now": "^0.1.4"
+					}
+				},
+				"constants-browserify": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.1.3",
+					"bundled": true
+				},
+				"core-js": {
+					"version": "2.6.4",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"create-ecdh": {
+					"version": "4.0.3",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.1.0",
+						"elliptic": "^6.0.0"
+					}
+				},
+				"create-hash": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"cipher-base": "^1.0.1",
+						"inherits": "^2.0.1",
+						"md5.js": "^1.3.4",
+						"ripemd160": "^2.0.1",
+						"sha.js": "^2.4.0"
+					}
+				},
+				"create-hmac": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"cipher-base": "^1.0.3",
+						"create-hash": "^1.1.0",
+						"inherits": "^2.0.1",
+						"ripemd160": "^2.0.0",
+						"safe-buffer": "^5.0.1",
+						"sha.js": "^2.4.8"
+					}
+				},
+				"crypto-browserify": {
+					"version": "3.12.0",
+					"bundled": true,
+					"requires": {
+						"browserify-cipher": "^1.0.0",
+						"browserify-sign": "^4.0.0",
+						"create-ecdh": "^4.0.0",
+						"create-hash": "^1.1.0",
+						"create-hmac": "^1.1.0",
+						"diffie-hellman": "^5.0.0",
+						"inherits": "^2.0.1",
+						"pbkdf2": "^3.0.3",
+						"public-encrypt": "^4.0.0",
+						"randombytes": "^2.0.0",
+						"randomfill": "^1.0.3"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"date-now": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"deep-eql": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"type-detect": "^4.0.0"
+					}
+				},
+				"deepmerge": {
+					"version": "2.2.1",
+					"bundled": true
+				},
+				"defined": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"deps-sort": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"JSONStream": "^1.0.3",
+						"shasum": "^1.0.0",
+						"subarg": "^1.0.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"des.js": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"detective": {
+					"version": "5.2.0",
+					"bundled": true,
+					"requires": {
+						"acorn-node": "^1.6.1",
+						"defined": "^1.0.0",
+						"minimist": "^1.1.1"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"bundled": true
+				},
+				"diffie-hellman": {
+					"version": "5.0.3",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.1.0",
+						"miller-rabin": "^4.0.0",
+						"randombytes": "^2.0.0"
+					}
+				},
+				"domain-browser": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"duplexer2": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"ecc-jsbn": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ecdsa-sig-formatter": {
+					"version": "1.0.10",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"elliptic": {
+					"version": "6.4.1",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"hmac-drbg": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.0"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"bundled": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true
+				},
+				"events": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"evp_bytestokey": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"md5.js": "^1.3.4",
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true
+				},
+				"form-data": {
+					"version": "2.3.3",
+					"bundled": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"function-bind": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"get-assigned-identifiers": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"get-func-name": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.10.0",
+					"bundled": true
+				},
+				"growl": {
+					"version": "1.10.5",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"har-validator": {
+					"version": "5.1.3",
+					"bundled": true,
+					"requires": {
+						"ajv": "^6.5.5",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"has": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"function-bind": "^1.1.1"
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"hash-base": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.1"
+					}
+				},
+				"he": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"hmac-drbg": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"hash.js": "^1.0.3",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.1"
+					}
+				},
+				"hoek": {
+					"version": "5.0.4",
+					"bundled": true
+				},
+				"htmlescape": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"https-browserify": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"ieee754": {
+					"version": "1.1.12",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"inline-source-map": {
+					"version": "0.6.2",
+					"bundled": true,
+					"requires": {
+						"source-map": "~0.5.3"
+					}
+				},
+				"insert-module-globals": {
+					"version": "7.2.0",
+					"bundled": true,
+					"requires": {
+						"JSONStream": "^1.0.3",
+						"acorn-node": "^1.5.2",
+						"combine-source-map": "^0.8.0",
+						"concat-stream": "^1.6.1",
+						"is-buffer": "^1.1.0",
+						"path-is-absolute": "^1.0.1",
+						"process": "~0.11.0",
+						"through2": "^2.0.0",
+						"undeclared-identifiers": "^1.1.2",
+						"xtend": "^4.0.0"
+					}
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isemail": {
+					"version": "3.2.0",
+					"bundled": true,
+					"requires": {
+						"punycode": "2.x.x"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "2.1.1",
+							"bundled": true
+						}
+					}
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"@babel/generator": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"istanbul-lib-coverage": "^2.0.3",
+						"semver": "^5.5.0"
+					}
+				},
+				"joi": {
+					"version": "13.7.0",
+					"bundled": true,
+					"requires": {
+						"hoek": "5.x.x",
+						"isemail": "3.x.x",
+						"topo": "3.x.x"
+					}
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"js-yaml": {
+					"version": "3.12.1",
+					"bundled": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"bundled": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"bundled": true
+				},
+				"json-stable-stringify": {
+					"version": "0.0.1",
+					"bundled": true,
+					"requires": {
+						"jsonify": "~0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true
+				},
+				"jsonparse": {
+					"version": "1.3.1",
+					"bundled": true
+				},
+				"jsonwebtoken": {
+					"version": "8.4.0",
+					"bundled": true,
+					"requires": {
+						"jws": "^3.1.5",
+						"lodash.includes": "^4.3.0",
+						"lodash.isboolean": "^3.0.3",
+						"lodash.isinteger": "^4.0.4",
+						"lodash.isnumber": "^3.0.3",
+						"lodash.isplainobject": "^4.0.6",
+						"lodash.isstring": "^4.0.1",
+						"lodash.once": "^4.0.0",
+						"ms": "^2.1.1"
+					}
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"just-extend": {
+					"version": "4.0.2",
+					"bundled": true
+				},
+				"jwa": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"buffer-equal-constant-time": "1.0.1",
+						"ecdsa-sig-formatter": "1.0.10",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"jws": {
+					"version": "3.2.1",
+					"bundled": true,
+					"requires": {
+						"jwa": "^1.2.0",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"labeled-stream-splicer": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"isarray": "^2.0.4",
+						"stream-splicer": "^2.0.0"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "2.0.4",
+							"bundled": true
+						}
+					}
+				},
+				"linked-list": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"bundled": true
+				},
+				"lodash.clonedeep": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.get": {
+					"version": "4.4.2",
+					"bundled": true
+				},
+				"lodash.includes": {
+					"version": "4.3.0",
+					"bundled": true
+				},
+				"lodash.isboolean": {
+					"version": "3.0.3",
+					"bundled": true
+				},
+				"lodash.isinteger": {
+					"version": "4.0.4",
+					"bundled": true
+				},
+				"lodash.isnumber": {
+					"version": "3.0.3",
+					"bundled": true
+				},
+				"lodash.isplainobject": {
+					"version": "4.0.6",
+					"bundled": true
+				},
+				"lodash.isstring": {
+					"version": "4.0.1",
+					"bundled": true
+				},
+				"lodash.memoize": {
+					"version": "3.0.4",
+					"bundled": true
+				},
+				"lodash.once": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"lodash.shuffle": {
+					"version": "4.2.0",
+					"bundled": true
+				},
+				"lolex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"make-error": {
+					"version": "1.3.5",
+					"bundled": true
+				},
+				"md5.js": {
+					"version": "1.3.5",
+					"bundled": true,
+					"requires": {
+						"hash-base": "^3.0.0",
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.1.2"
+					}
+				},
+				"miller-rabin": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.0.0",
+						"brorand": "^1.0.1"
+					}
+				},
+				"mime-db": {
+					"version": "1.37.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.21",
+					"bundled": true,
+					"requires": {
+						"mime-db": "~1.37.0"
+					}
+				},
+				"minimalistic-assert": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"minimalistic-crypto-utils": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						}
+					}
+				},
+				"mocha": {
+					"version": "5.2.0",
+					"bundled": true,
+					"requires": {
+						"browser-stdout": "1.3.1",
+						"commander": "2.15.1",
+						"debug": "3.1.0",
+						"diff": "3.5.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.5",
+						"he": "1.1.1",
+						"minimatch": "3.0.4",
+						"mkdirp": "0.5.1",
+						"supports-color": "5.4.0"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
+				},
+				"module-deps": {
+					"version": "6.2.0",
+					"bundled": true,
+					"requires": {
+						"JSONStream": "^1.0.3",
+						"browser-resolve": "^1.7.0",
+						"cached-path-relative": "^1.0.0",
+						"concat-stream": "~1.6.0",
+						"defined": "^1.0.0",
+						"detective": "^5.0.2",
+						"duplexer2": "^0.1.2",
+						"inherits": "^2.0.1",
+						"parents": "^1.0.0",
+						"readable-stream": "^2.0.2",
+						"resolve": "^1.4.0",
+						"stream-combiner2": "^1.1.1",
+						"subarg": "^1.0.0",
+						"through2": "^2.0.0",
+						"xtend": "^4.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"nise": {
+					"version": "1.4.8",
+					"bundled": true,
+					"requires": {
+						"@sinonjs/formatio": "^3.1.0",
+						"just-extend": "^4.0.2",
+						"lolex": "^2.3.2",
+						"path-to-regexp": "^1.7.0",
+						"text-encoding": "^0.6.4"
+					},
+					"dependencies": {
+						"lolex": {
+							"version": "2.7.5",
+							"bundled": true
+						}
+					}
+				},
+				"nyc": {
+					"version": "13.2.0",
+					"bundled": true,
+					"requires": {
+						"archy": "^1.0.0",
+						"arrify": "^1.0.1",
+						"caching-transform": "^3.0.1",
+						"convert-source-map": "^1.6.0",
+						"find-cache-dir": "^2.0.0",
+						"find-up": "^3.0.0",
+						"foreground-child": "^1.5.6",
+						"glob": "^7.1.3",
+						"istanbul-lib-coverage": "^2.0.3",
+						"istanbul-lib-hook": "^2.0.3",
+						"istanbul-lib-instrument": "^3.0.1",
+						"istanbul-lib-report": "^2.0.4",
+						"istanbul-lib-source-maps": "^3.0.2",
+						"istanbul-reports": "^2.1.0",
+						"make-dir": "^1.3.0",
+						"merge-source-map": "^1.1.0",
+						"resolve-from": "^4.0.0",
+						"rimraf": "^2.6.3",
+						"signal-exit": "^3.0.2",
+						"spawn-wrap": "^1.4.2",
+						"test-exclude": "^5.1.0",
+						"uuid": "^3.3.2",
+						"yargs": "^12.0.5",
+						"yargs-parser": "^11.1.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"append-transform": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"default-require-extensions": "^2.0.0"
+							}
+						},
+						"archy": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"arrify": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"async": {
+							"version": "2.6.1",
+							"bundled": true,
+							"requires": {
+								"lodash": "^4.17.10"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"builtin-modules": {
+							"version": "1.1.1",
+							"bundled": true
+						},
+						"caching-transform": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"hasha": "^3.0.0",
+								"make-dir": "^1.3.0",
+								"package-hash": "^3.0.0",
+								"write-file-atomic": "^2.3.0"
+							}
+						},
+						"camelcase": {
+							"version": "5.0.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"commander": {
+							"version": "2.17.1",
+							"bundled": true,
+							"optional": true
+						},
+						"commondir": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"convert-source-map": {
+							"version": "1.6.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.1"
+							}
+						},
+						"cross-spawn": {
+							"version": "4.0.2",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"which": "^1.2.9"
+							}
+						},
+						"debug": {
+							"version": "4.1.1",
+							"bundled": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"decamelize": {
+							"version": "1.2.0",
+							"bundled": true
+						},
+						"default-require-extensions": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"strip-bom": "^3.0.0"
+							}
+						},
+						"end-of-stream": {
+							"version": "1.4.1",
+							"bundled": true,
+							"requires": {
+								"once": "^1.4.0"
+							}
+						},
+						"error-ex": {
+							"version": "1.3.2",
+							"bundled": true,
+							"requires": {
+								"is-arrayish": "^0.2.1"
+							}
+						},
+						"es6-error": {
+							"version": "4.1.1",
+							"bundled": true
+						},
+						"execa": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"cross-spawn": "^6.0.0",
+								"get-stream": "^4.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
+							},
+							"dependencies": {
+								"cross-spawn": {
+									"version": "6.0.5",
+									"bundled": true,
+									"requires": {
+										"nice-try": "^1.0.4",
+										"path-key": "^2.0.1",
+										"semver": "^5.5.0",
+										"shebang-command": "^1.2.0",
+										"which": "^1.2.9"
+									}
+								}
+							}
+						},
+						"find-cache-dir": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"commondir": "^1.0.1",
+								"make-dir": "^1.0.0",
+								"pkg-dir": "^3.0.0"
+							}
+						},
+						"find-up": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"foreground-child": {
+							"version": "1.5.6",
+							"bundled": true,
+							"requires": {
+								"cross-spawn": "^4",
+								"signal-exit": "^3.0.0"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"get-caller-file": {
+							"version": "1.0.3",
+							"bundled": true
+						},
+						"get-stream": {
+							"version": "4.1.0",
+							"bundled": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.3",
+							"bundled": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"graceful-fs": {
+							"version": "4.1.15",
+							"bundled": true
+						},
+						"handlebars": {
+							"version": "4.0.12",
+							"bundled": true,
+							"requires": {
+								"async": "^2.5.0",
+								"optimist": "^0.6.1",
+								"source-map": "^0.6.1",
+								"uglify-js": "^3.1.4"
+							},
+							"dependencies": {
+								"source-map": {
+									"version": "0.6.1",
+									"bundled": true
+								}
+							}
+						},
+						"has-flag": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"hasha": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"is-stream": "^1.0.1"
+							}
+						},
+						"hosted-git-info": {
+							"version": "2.7.1",
+							"bundled": true
+						},
+						"imurmurhash": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"invert-kv": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"is-arrayish": {
+							"version": "0.2.1",
+							"bundled": true
+						},
+						"is-builtin-module": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"builtin-modules": "^1.0.0"
+							}
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"is-stream": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"isexe": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"istanbul-lib-coverage": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"istanbul-lib-hook": {
+							"version": "2.0.3",
+							"bundled": true,
+							"requires": {
+								"append-transform": "^1.0.0"
+							}
+						},
+						"istanbul-lib-report": {
+							"version": "2.0.4",
+							"bundled": true,
+							"requires": {
+								"istanbul-lib-coverage": "^2.0.3",
+								"make-dir": "^1.3.0",
+								"supports-color": "^6.0.0"
+							},
+							"dependencies": {
+								"supports-color": {
+									"version": "6.1.0",
+									"bundled": true,
+									"requires": {
+										"has-flag": "^3.0.0"
+									}
+								}
+							}
+						},
+						"istanbul-lib-source-maps": {
+							"version": "3.0.2",
+							"bundled": true,
+							"requires": {
+								"debug": "^4.1.1",
+								"istanbul-lib-coverage": "^2.0.3",
+								"make-dir": "^1.3.0",
+								"rimraf": "^2.6.2",
+								"source-map": "^0.6.1"
+							},
+							"dependencies": {
+								"source-map": {
+									"version": "0.6.1",
+									"bundled": true
+								}
+							}
+						},
+						"istanbul-reports": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"handlebars": "^4.0.11"
+							}
+						},
+						"json-parse-better-errors": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"lcid": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"invert-kv": "^2.0.0"
+							}
+						},
+						"load-json-file": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^4.0.0",
+								"pify": "^3.0.0",
+								"strip-bom": "^3.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"lodash": {
+							"version": "4.17.11",
+							"bundled": true
+						},
+						"lodash.flattendeep": {
+							"version": "4.4.0",
+							"bundled": true
+						},
+						"lru-cache": {
+							"version": "4.1.5",
+							"bundled": true,
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							}
+						},
+						"make-dir": {
+							"version": "1.3.0",
+							"bundled": true,
+							"requires": {
+								"pify": "^3.0.0"
+							}
+						},
+						"map-age-cleaner": {
+							"version": "0.1.3",
+							"bundled": true,
+							"requires": {
+								"p-defer": "^1.0.0"
+							}
+						},
+						"mem": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"map-age-cleaner": "^0.1.1",
+								"mimic-fn": "^1.0.0",
+								"p-is-promise": "^1.1.0"
+							}
+						},
+						"merge-source-map": {
+							"version": "1.1.0",
+							"bundled": true,
+							"requires": {
+								"source-map": "^0.6.1"
+							},
+							"dependencies": {
+								"source-map": {
+									"version": "0.6.1",
+									"bundled": true
+								}
+							}
+						},
+						"mimic-fn": {
+							"version": "1.2.0",
+							"bundled": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.10",
+							"bundled": true
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "0.0.8"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "0.0.8",
+									"bundled": true
+								}
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"nice-try": {
+							"version": "1.0.5",
+							"bundled": true
+						},
+						"normalize-package-data": {
+							"version": "2.4.0",
+							"bundled": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"is-builtin-module": "^1.0.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"npm-run-path": {
+							"version": "2.0.2",
+							"bundled": true,
+							"requires": {
+								"path-key": "^2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"optimist": {
+							"version": "0.6.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "~0.0.1",
+								"wordwrap": "~0.0.2"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"os-locale": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"execa": "^1.0.0",
+								"lcid": "^2.0.0",
+								"mem": "^4.0.0"
+							}
+						},
+						"p-defer": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"p-finally": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"p-is-promise": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"p-limit": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"package-hash": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"graceful-fs": "^4.1.15",
+								"hasha": "^3.0.0",
+								"lodash.flattendeep": "^4.4.0",
+								"release-zalgo": "^1.0.0"
+							}
+						},
+						"parse-json": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"error-ex": "^1.3.1",
+								"json-parse-better-errors": "^1.0.1"
+							}
+						},
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"path-key": {
+							"version": "2.0.1",
+							"bundled": true
+						},
+						"path-type": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"pify": "^3.0.0"
+							}
+						},
+						"pify": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"pkg-dir": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"find-up": "^3.0.0"
+							}
+						},
+						"pseudomap": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"pump": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "^1.1.0",
+								"once": "^1.3.1"
+							}
+						},
+						"read-pkg": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"load-json-file": "^4.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^3.0.0"
+							}
+						},
+						"read-pkg-up": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"find-up": "^3.0.0",
+								"read-pkg": "^3.0.0"
+							}
+						},
+						"release-zalgo": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"es6-error": "^4.0.1"
+							}
+						},
+						"require-directory": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"require-main-filename": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"resolve-from": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"rimraf": {
+							"version": "2.6.3",
+							"bundled": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true
+						},
+						"semver": {
+							"version": "5.6.0",
+							"bundled": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"shebang-command": {
+							"version": "1.2.0",
+							"bundled": true,
+							"requires": {
+								"shebang-regex": "^1.0.0"
+							}
+						},
+						"shebang-regex": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true
+						},
+						"spawn-wrap": {
+							"version": "1.4.2",
+							"bundled": true,
+							"requires": {
+								"foreground-child": "^1.5.6",
+								"mkdirp": "^0.5.0",
+								"os-homedir": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"signal-exit": "^3.0.2",
+								"which": "^1.3.0"
+							}
+						},
+						"spdx-correct": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"spdx-expression-parse": "^3.0.0",
+								"spdx-license-ids": "^3.0.0"
+							}
+						},
+						"spdx-exceptions": {
+							"version": "2.2.0",
+							"bundled": true
+						},
+						"spdx-expression-parse": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"spdx-exceptions": "^2.1.0",
+								"spdx-license-ids": "^3.0.0"
+							}
+						},
+						"spdx-license-ids": {
+							"version": "3.0.3",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"bundled": true,
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						},
+						"strip-bom": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"strip-eof": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"test-exclude": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"arrify": "^1.0.1",
+								"minimatch": "^3.0.4",
+								"read-pkg-up": "^4.0.0",
+								"require-main-filename": "^1.0.1"
+							}
+						},
+						"uglify-js": {
+							"version": "3.4.9",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"commander": "~2.17.1",
+								"source-map": "~0.6.1"
+							},
+							"dependencies": {
+								"source-map": {
+									"version": "0.6.1",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"uuid": {
+							"version": "3.3.2",
+							"bundled": true
+						},
+						"validate-npm-package-license": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"spdx-correct": "^3.0.0",
+								"spdx-expression-parse": "^3.0.0"
+							}
+						},
+						"which": {
+							"version": "1.3.1",
+							"bundled": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						},
+						"which-module": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"wordwrap": {
+							"version": "0.0.3",
+							"bundled": true
+						},
+						"wrap-ansi": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1"
+							},
+							"dependencies": {
+								"ansi-regex": {
+									"version": "2.1.1",
+									"bundled": true
+								},
+								"is-fullwidth-code-point": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"number-is-nan": "^1.0.0"
+									}
+								},
+								"string-width": {
+									"version": "1.0.2",
+									"bundled": true,
+									"requires": {
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
+									}
+								},
+								"strip-ansi": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"ansi-regex": "^2.0.0"
+									}
+								}
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"write-file-atomic": {
+							"version": "2.4.2",
+							"bundled": true,
+							"requires": {
+								"graceful-fs": "^4.1.11",
+								"imurmurhash": "^0.1.4",
+								"signal-exit": "^3.0.2"
+							}
+						},
+						"y18n": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"bundled": true
+						},
+						"yargs": {
+							"version": "12.0.5",
+							"bundled": true,
+							"requires": {
+								"cliui": "^4.0.0",
+								"decamelize": "^1.2.0",
+								"find-up": "^3.0.0",
+								"get-caller-file": "^1.0.1",
+								"os-locale": "^3.0.0",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^1.0.1",
+								"set-blocking": "^2.0.0",
+								"string-width": "^2.0.0",
+								"which-module": "^2.0.0",
+								"y18n": "^3.2.1 || ^4.0.0",
+								"yargs-parser": "^11.1.1"
+							}
+						},
+						"yargs-parser": {
+							"version": "11.1.1",
+							"bundled": true,
+							"requires": {
+								"camelcase": "^5.0.0",
+								"decamelize": "^1.2.0"
+							}
+						}
+					}
+				},
+				"oauth-sign": {
+					"version": "0.9.0",
+					"bundled": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-browserify": {
+					"version": "0.3.0",
+					"bundled": true
+				},
+				"pako": {
+					"version": "1.0.8",
+					"bundled": true
+				},
+				"parents": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"path-platform": "~0.11.15"
+					}
+				},
+				"parse-asn1": {
+					"version": "5.1.3",
+					"bundled": true,
+					"requires": {
+						"asn1.js": "^4.0.0",
+						"browserify-aes": "^1.0.0",
+						"create-hash": "^1.1.0",
+						"evp_bytestokey": "^1.0.0",
+						"pbkdf2": "^3.0.3",
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"path-browserify": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"bundled": true
+				},
+				"path-platform": {
+					"version": "0.11.15",
+					"bundled": true
+				},
+				"path-to-regexp": {
+					"version": "1.7.0",
+					"bundled": true,
+					"requires": {
+						"isarray": "0.0.1"
+					},
+					"dependencies": {
+						"isarray": {
+							"version": "0.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"pathval": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"pbkdf2": {
+					"version": "3.0.17",
+					"bundled": true,
+					"requires": {
+						"create-hash": "^1.1.2",
+						"create-hmac": "^1.1.4",
+						"ripemd160": "^2.0.1",
+						"safe-buffer": "^5.0.1",
+						"sha.js": "^2.4.8"
+					}
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"prettier": {
+					"version": "1.16.4",
+					"bundled": true
+				},
+				"process": {
+					"version": "0.11.10",
+					"bundled": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"psl": {
+					"version": "1.1.31",
+					"bundled": true
+				},
+				"public-encrypt": {
+					"version": "4.0.3",
+					"bundled": true,
+					"requires": {
+						"bn.js": "^4.1.0",
+						"browserify-rsa": "^4.0.0",
+						"create-hash": "^1.1.0",
+						"parse-asn1": "^5.0.0",
+						"randombytes": "^2.0.1",
+						"safe-buffer": "^5.1.2"
+					}
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true
+				},
+				"qs": {
+					"version": "6.5.2",
+					"bundled": true
+				},
+				"querystring": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"querystring-es3": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"randombytes": {
+					"version": "2.0.6",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.0"
+					}
+				},
+				"randomfill": {
+					"version": "1.0.4",
+					"bundled": true,
+					"requires": {
+						"randombytes": "^2.0.5",
+						"safe-buffer": "^5.1.0"
+					}
+				},
+				"read-only-stream": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					},
+					"dependencies": {
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"request": {
+					"version": "2.88.0",
+					"bundled": true,
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.0",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.4.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
+					},
+					"dependencies": {
+						"uuid": {
+							"version": "3.3.2",
+							"bundled": true
+						}
+					}
+				},
+				"resolve": {
+					"version": "1.10.0",
+					"bundled": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"ripemd160": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"hash-base": "^3.0.0",
+						"inherits": "^2.0.1"
+					}
+				},
+				"rx": {
+					"version": "4.1.0",
+					"bundled": true
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"sc-auth": {
+					"version": "5.0.2",
+					"bundled": true,
+					"requires": {
+						"jsonwebtoken": "^8.3.0",
+						"sc-errors": "^1.4.1"
+					}
+				},
+				"sc-channel": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"component-emitter": "1.2.1"
+					}
+				},
+				"sc-errors": {
+					"version": "1.4.1",
+					"bundled": true
+				},
+				"sc-formatter": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"sc-simple-broker": {
+					"version": "2.1.3",
+					"bundled": true,
+					"requires": {
+						"sc-channel": "^1.2.0"
+					}
+				},
+				"sc-uws": {
+					"version": "10.148.2",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.6.0",
+					"bundled": true
+				},
+				"sha.js": {
+					"version": "2.4.11",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"shasum": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"json-stable-stringify": "~0.0.0",
+						"sha.js": "~2.4.4"
+					}
+				},
+				"shell-quote": {
+					"version": "1.6.1",
+					"bundled": true,
+					"requires": {
+						"array-filter": "~0.0.0",
+						"array-map": "~0.0.0",
+						"array-reduce": "~0.0.0",
+						"jsonify": "~0.0.0"
+					}
+				},
+				"simple-concat": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"sinon": {
+					"version": "7.2.3",
+					"bundled": true,
+					"requires": {
+						"@sinonjs/commons": "^1.3.0",
+						"@sinonjs/formatio": "^3.1.0",
+						"@sinonjs/samsam": "^3.0.2",
+						"diff": "^3.5.0",
+						"lolex": "^3.0.0",
+						"nise": "^1.4.8",
+						"supports-color": "^5.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"bundled": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"sinon-chai": {
+					"version": "3.3.0",
+					"bundled": true
+				},
+				"socketcluster-client": {
+					"version": "14.2.1",
+					"bundled": true,
+					"requires": {
+						"base-64": "0.1.0",
+						"clone": "2.1.1",
+						"component-emitter": "1.2.1",
+						"linked-list": "0.1.0",
+						"querystring": "0.2.0",
+						"sc-channel": "^1.2.0",
+						"sc-errors": "^1.4.1",
+						"sc-formatter": "^3.0.1",
+						"uuid": "3.2.1",
+						"ws": "5.1.1"
+					}
+				},
+				"socketcluster-server": {
+					"version": "14.4.0",
+					"bundled": true,
+					"requires": {
+						"async": "2.3.0",
+						"base64id": "1.0.0",
+						"component-emitter": "1.2.1",
+						"lodash.clonedeep": "4.5.0",
+						"sc-auth": "^5.0.2",
+						"sc-errors": "^1.4.1",
+						"sc-formatter": "^3.0.2",
+						"sc-simple-broker": "^2.1.3",
+						"sc-uws": "^10.148.2",
+						"uuid": "3.2.1",
+						"ws": "6.1.2"
+					},
+					"dependencies": {
+						"ws": {
+							"version": "6.1.2",
+							"bundled": true,
+							"requires": {
+								"async-limiter": "~1.0.0"
+							}
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-support": {
+					"version": "0.5.10",
+					"bundled": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"sshpk": {
+					"version": "1.16.1",
+					"bundled": true,
+					"requires": {
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.0.2",
+						"tweetnacl": "~0.14.0"
+					}
+				},
+				"stream-browserify": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"inherits": "~2.0.1",
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"stream-combiner2": {
+					"version": "1.1.1",
+					"bundled": true,
+					"requires": {
+						"duplexer2": "~0.1.0",
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"stream-http": {
+					"version": "2.8.3",
+					"bundled": true,
+					"requires": {
+						"builtin-status-codes": "^3.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.3.6",
+						"to-arraybuffer": "^1.0.0",
+						"xtend": "^4.0.0"
+					}
+				},
+				"stream-splicer": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"subarg": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"minimist": "^1.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"bundled": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"syntax-error": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"acorn-node": "^1.2.0"
+					}
+				},
+				"text-encoding": {
+					"version": "0.6.4",
+					"bundled": true
+				},
+				"through": {
+					"version": "2.3.8",
+					"bundled": true
+				},
+				"through2": {
+					"version": "2.0.5",
+					"bundled": true,
+					"requires": {
+						"readable-stream": "~2.3.6",
+						"xtend": "~4.0.1"
+					}
+				},
+				"timers-browserify": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"process": "~0.11.0"
+					}
+				},
+				"to-arraybuffer": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"topo": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"hoek": "6.x.x"
+					},
+					"dependencies": {
+						"hoek": {
+							"version": "6.1.2",
+							"bundled": true
+						}
+					}
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"bundled": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ts-node": {
+					"version": "8.0.2",
+					"bundled": true,
+					"requires": {
+						"arg": "^4.1.0",
+						"diff": "^3.1.0",
+						"make-error": "^1.1.1",
+						"source-map-support": "^0.5.6",
+						"yn": "^3.0.0"
+					}
+				},
+				"tsconfig-paths": {
+					"version": "3.8.0",
+					"bundled": true,
+					"requires": {
+						"@types/json5": "^0.0.29",
+						"deepmerge": "^2.0.1",
+						"json5": "^1.0.1",
+						"minimist": "^1.2.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"tslib": {
+					"version": "1.9.3",
+					"bundled": true
+				},
+				"tslint": {
+					"version": "5.12.1",
+					"bundled": true,
+					"requires": {
+						"babel-code-frame": "^6.22.0",
+						"builtin-modules": "^1.1.1",
+						"chalk": "^2.3.0",
+						"commander": "^2.12.1",
+						"diff": "^3.2.0",
+						"glob": "^7.1.1",
+						"js-yaml": "^3.7.0",
+						"minimatch": "^3.0.4",
+						"resolve": "^1.3.2",
+						"semver": "^5.3.0",
+						"tslib": "^1.8.0",
+						"tsutils": "^2.27.2"
+					}
+				},
+				"tslint-config-prettier": {
+					"version": "1.18.0",
+					"bundled": true
+				},
+				"tslint-immutable": {
+					"version": "5.1.2",
+					"bundled": true,
+					"requires": {
+						"tsutils": "^2.28.0 || ^3.0.0"
+					}
+				},
+				"tsutils": {
+					"version": "2.29.0",
+					"bundled": true,
+					"requires": {
+						"tslib": "^1.8.1"
+					}
+				},
+				"tty-browserify": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true
+				},
+				"type-detect": {
+					"version": "4.0.8",
+					"bundled": true
+				},
+				"typedarray": {
+					"version": "0.0.6",
+					"bundled": true
+				},
+				"typescript": {
+					"version": "3.3.1",
+					"bundled": true
+				},
+				"uglify-es": {
+					"version": "3.3.9",
+					"bundled": true,
+					"requires": {
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.13.0",
+							"bundled": true
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"umd": {
+					"version": "3.0.3",
+					"bundled": true
+				},
+				"undeclared-identifiers": {
+					"version": "1.1.2",
+					"bundled": true,
+					"requires": {
+						"acorn-node": "^1.3.0",
+						"get-assigned-identifiers": "^1.2.0",
+						"simple-concat": "^1.0.0",
+						"xtend": "^4.0.1"
+					}
+				},
+				"uri-js": {
+					"version": "4.2.2",
+					"bundled": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "2.1.1",
+							"bundled": true
+						}
+					}
+				},
+				"url": {
+					"version": "0.11.0",
+					"bundled": true,
+					"requires": {
+						"punycode": "1.3.2",
+						"querystring": "0.2.0"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "1.3.2",
+							"bundled": true
+						}
+					}
+				},
+				"util": {
+					"version": "0.10.4",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"validator": {
+					"version": "10.11.0",
+					"bundled": true
+				},
+				"verror": {
+					"version": "1.10.0",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "^1.2.0"
+					}
+				},
+				"vm-browserify": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"wait-on": {
+					"version": "3.2.0",
+					"bundled": true,
+					"requires": {
+						"core-js": "^2.5.7",
+						"joi": "^13.0.0",
+						"minimist": "^1.2.0",
+						"request": "^2.88.0",
+						"rx": "^4.1.0"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"ws": {
+					"version": "5.1.1",
+					"bundled": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				},
+				"xtend": {
+					"version": "4.0.1",
+					"bundled": true
+				},
+				"yn": {
+					"version": "3.0.0",
+					"bundled": true
+				}
+			}
+		},
 		"@newrelic/koa": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
@@ -5261,21 +8473,27 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -5284,11 +8502,14 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5296,29 +8517,36 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5326,22 +8554,28 @@
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5349,12 +8583,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -5369,7 +8605,9 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -5382,12 +8620,15 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -5395,7 +8636,9 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -5403,7 +8646,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -5412,39 +8656,49 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"minipass": {
 					"version": "2.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5452,7 +8706,9 @@
 				},
 				"minizlib": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5460,19 +8716,23 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -5482,7 +8742,9 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.10.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -5499,7 +8761,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -5508,12 +8771,16 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -5522,7 +8789,9 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -5533,33 +8802,40 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -5568,17 +8844,22 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -5589,14 +8870,17 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -5610,7 +8894,9 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -5618,36 +8904,47 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"resolved": false,
+					"integrity":
+						"sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5656,7 +8953,9 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -5664,19 +8963,23 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -5690,12 +8993,15 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity":
+						"sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -5703,11 +9009,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"resolved": false,
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
 				}
 			}
 		},
@@ -21360,12 +24668,23 @@
 			"dev": true
 		},
 		"md5.js": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity":
+				"sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 			"requires": {
 				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved":
+						"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity":
+						"sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"media-typer": {
@@ -22978,9 +26297,10 @@
 			"dev": true
 		},
 		"pbkdf2": {
-			"version": "3.0.16",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
-			"integrity": "sha1-dAQgjsawG2LYW/g4U6gGT42cKlw=",
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+			"integrity":
+				"sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -23689,11 +27009,11 @@
 			}
 		},
 		"randombytes": {
-			"version": "2.0.6",
+			"version": "2.1.0",
 			"resolved":
-				"https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+				"https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity":
-				"sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+				"sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -27544,9 +30864,10 @@
 			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
 		},
 		"unorm": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-			"integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.5.0.tgz",
+			"integrity":
+				"sha512-sMfSWoiRaXXeDZSXC+YRZ23H4xchQpwxjpw1tmfR+kgbBCaOgln4NI0LXejJIhnBuKINrB3WRn+ZI8IWssirVw=="
 		},
 		"unpipe": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"js-yaml": "3.12.1",
 		"json-refs": "3.0.12",
 		"lisk-commander": "2.0.0",
-		"lisk-elements": "1.0.0",
+		"lisk-elements": "2.0.0",
 		"lisk-newrelic": "LiskHQ/lisk-newrelic#d1ca762",
 		"lodash": "4.17.11",
 		"method-override": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"js-yaml": "3.12.1",
 		"json-refs": "3.0.12",
 		"lisk-commander": "2.0.0",
-		"lisk-elements": "2.0.0",
+		"lisk-elements": "1.0.0",
 		"lisk-newrelic": "LiskHQ/lisk-newrelic#d1ca762",
 		"lodash": "4.17.11",
 		"method-override": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"prepublishOnly": "npm run check:dependencies"
 	},
 	"dependencies": {
+		"@liskhq/lisk-p2p": "0.1.0-alpha.1",
 		"ajv": "6.7.0",
 		"async": "2.6.1",
 		"bignumber.js": "8.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,7 @@ try {
 				nonce: config.nonce,
 			},
 		},
-		modules: {
-			network: {}
-		}
+		modules: config.modules || { modules: { chain: {}, network: {} } }
 	});
 
 	app.overrideModuleOptions('chain', { exceptions: config.exceptions, config });

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ try {
 				nonce: config.nonce,
 			},
 		},
-		modules: config.modules || { modules: { chain: {}, network: {} } }
+		modules: config.modules || { modules: { chain: {}, network: {} } },
 	});
 
 	app.overrideModuleOptions('chain', { exceptions: config.exceptions, config });

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,9 @@ try {
 				nonce: config.nonce,
 			},
 		},
+		modules: {
+			network: {}
+		}
 	});
 
 	app.overrideModuleOptions('chain', { exceptions: config.exceptions, config });


### PR DESCRIPTION
### What was the problem?

Lisk core needed to have the new Network module integrated and running so that other modules can start using it.

### How did I fix it?

- Created the Network module inside Lisk core.
- Passed configs to P2P library from the appropriate section of the Lisk config.
- Exposed actions from the Network module.
- Made the Network module publish events to the channel.
- Added support for invoking actions on modules from remote peers.

### How to test it?

Run the test suite.

### Review checklist

* The PR resolves #2874
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
