### PR TITLE
Fix coverage paths in Jenkinsfile - Closes #3051

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,9 +55,9 @@ def teardown(test_name) {
 			sh """
 			rm -rf coverage_${test_name}; mkdir -p coverage_${test_name}
 			npx istanbul report --root framework/test/mocha/.coverage-unit/ --dir framework/test/mocha/.coverage-unit/
-			cp test/.coverage-unit/lcov.info coverage_${test_name}/ || true
+			cp framework/test/mocha/.coverage-unit/lcov.info coverage_${test_name}/ || true
 			npx istanbul report cobertura --root framework/test/mocha/.coverage-unit/ --dir framework/test/mocha/.coverage-unit/
-			cp test/.coverage-unit/cobertura-coverage.xml coverage_${test_name}/ || true
+			cp framework/test/mocha/.coverage-unit/cobertura-coverage.xml coverage_${test_name}/ || true
 			curl --silent http://localhost:4000/coverage/download --output functional-coverage.zip
 			unzip functional-coverage.zip lcov.info -d coverage_${test_name}/functional/
 			"""


### PR DESCRIPTION
### What was the problem?
Coverage report file paths were wrong in the jenkinsfile which was causing Jenkins jobs to fail.
### How did I fix it?
I fixed the file paths.
### How to test it?

### Review checklist

* The PR resolves #3051 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
