### PR TITLE
Remove symlinks from http api - Closes #3047

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -20,6 +20,7 @@ const {
 	initModules,
 } = require('./init_steps');
 const defaults = require('./defaults');
+const slots = require('./helpers/slots');
 
 // Begin reading from stdin
 process.stdin.resume();
@@ -260,6 +261,7 @@ module.exports = class Chain {
 					action.params[0],
 					action.params[1]
 				),
+			getSlotsHelper: async () => slots,
 		};
 	}
 

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -20,7 +20,6 @@ const {
 	initModules,
 } = require('./init_steps');
 const defaults = require('./defaults');
-const slots = require('./helpers/slots');
 
 // Begin reading from stdin
 process.stdin.resume();
@@ -57,6 +56,7 @@ module.exports = class Chain {
 		this.logger = null;
 		this.scope = null;
 		this.blockReward = null;
+		this.slots = null;
 	}
 
 	async bootstrap() {
@@ -106,6 +106,8 @@ module.exports = class Chain {
 
 		const BlockReward = require('./logic/block_reward');
 		this.blockReward = new BlockReward();
+		// Needs to be loaded here as its using constants that need to be initialized first
+		this.slots = require('./helpers/slots');
 
 		try {
 			// Cache
@@ -261,7 +263,7 @@ module.exports = class Chain {
 					action.params[0],
 					action.params[1]
 				),
-			getSlotsHelper: async () => slots,
+			getSlotsHelper: async () => this.slots,
 		};
 	}
 

--- a/framework/src/modules/chain/helpers/z_schema.js
+++ b/framework/src/modules/chain/helpers/z_schema.js
@@ -18,9 +18,9 @@ const ip = require('ip');
 const _ = require('lodash');
 const z_schema = require('z-schema');
 const FormatValidators = require('z-schema/src/FormatValidators');
-const Bignum = require('./bignum');
+const Bignumber = require('bignumber.js');
 // new BigNumber(2).pow(64).minus(1)
-const UINT64_MAX = new Bignum('18446744073709551615');
+const UINT64_MAX = new Bignumber('18446744073709551615');
 
 /**
  * Uses JSON Schema validator z_schema to register custom formats.
@@ -107,7 +107,7 @@ const liskFormats = {
 		}
 
 		// Address can not exceed the max limit
-		if (new Bignum(str.slice(0, -1)).isGreaterThan(UINT64_MAX)) {
+		if (new Bignumber(str.slice(0, -1)).isGreaterThan(UINT64_MAX)) {
 			return false;
 		}
 
@@ -325,7 +325,7 @@ const liskFormats = {
 		 * global.constants will be defined in test/setup.js.
 		 */
 		const { TOTAL_AMOUNT } = global.constants;
-		if (value instanceof Bignum) {
+		if (value instanceof Bignumber) {
 			return (
 				value.isGreaterThanOrEqualTo(0) &&
 				value.isLessThanOrEqualTo(TOTAL_AMOUNT)
@@ -333,7 +333,7 @@ const liskFormats = {
 		}
 
 		if (typeof value === 'string' && /^[0-9]+$/.test(value)) {
-			const num = new Bignum(value);
+			const num = new Bignumber(value);
 			return (
 				num.isGreaterThanOrEqualTo(0) && num.isLessThanOrEqualTo(TOTAL_AMOUNT)
 			);

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -81,6 +81,7 @@ module.exports = class ChainModule extends BaseModule {
 				this.chain.actions.postTransaction(action),
 			getDelegateBlocksRewards: async action =>
 				this.chain.actions.getDelegateBlocksRewards(action),
+			getSlotsHelper: async action => this.chain.actions.getSlotsLogic(action),
 		};
 	}
 

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -81,7 +81,7 @@ module.exports = class ChainModule extends BaseModule {
 				this.chain.actions.postTransaction(action),
 			getDelegateBlocksRewards: async action =>
 				this.chain.actions.getDelegateBlocksRewards(action),
-			getSlotsHelper: async action => this.chain.actions.getSlotsLogic(action),
+			getSlotsHelper: async action => this.chain.actions.getSlotsHelper(action),
 		};
 	}
 

--- a/framework/src/modules/http_api/controllers/blocks.js
+++ b/framework/src/modules/http_api/controllers/blocks.js
@@ -15,10 +15,10 @@
 'use strict';
 
 const _ = require('lodash');
-const crypto = require('crypto');
+const { getAddressFromPublicKey } = require('@liskhq/lisk-cryptography');
+const Bignumber = require('bignumber.js');
 const ApiError = require('../api_error');
 const apiCodes = require('../api_codes');
-const Bignum = require('../helpers/bignum');
 
 let library;
 let sortFields;
@@ -111,29 +111,6 @@ BlocksController.getBlocks = function(context, next) {
 };
 
 /**
- * Gets address by public.
- *
- * @private
- * @param {publicKey} publicKey Public key
- * @returns {address} address
- * @todo Replace by Lisk Elements once integrated.
- */
-function getAddressByPublicKey(publicKey) {
-	const publicKeyHash = crypto
-		.createHash('sha256')
-		.update(publicKey, 'hex')
-		.digest();
-	const temp = Buffer.alloc(8);
-
-	for (let i = 0; i < 8; i++) {
-		temp[i] = publicKeyHash[7 - i];
-	}
-
-	const address = `${Bignum.fromBuffer(temp).toString()}L`;
-	return address;
-}
-
-/**
  * Parse raw block data from database into expected API response type for blocks
  *
  * @param {Object} raw Raw block data from database
@@ -151,16 +128,16 @@ function parseBlockFromDatabase(raw) {
 		height: parseInt(raw.height),
 		previousBlock: raw.previousBlockId,
 		numberOfTransactions: parseInt(raw.numberOfTransactions),
-		totalAmount: new Bignum(raw.totalAmount).toString(),
-		totalFee: new Bignum(raw.totalFee).toString(),
-		reward: new Bignum(raw.reward).toString(),
+		totalAmount: new Bignumber(raw.totalAmount).toString(),
+		totalFee: new Bignumber(raw.totalFee).toString(),
+		reward: new Bignumber(raw.reward).toString(),
 		payloadLength: parseInt(raw.payloadLength),
 		payloadHash: raw.payloadHash,
 		generatorPublicKey: raw.generatorPublicKey,
-		generatorId: getAddressByPublicKey(raw.generatorPublicKey),
+		generatorId: getAddressFromPublicKey(raw.generatorPublicKey),
 		blockSignature: raw.blockSignature,
 		confirmations: parseInt(raw.confirmations),
-		totalForged: new Bignum(raw.totalFee).plus(raw.reward).toString(),
+		totalForged: new Bignumber(raw.totalFee).plus(raw.reward).toString(),
 	};
 
 	if (raw.transactions) {

--- a/framework/src/modules/http_api/controllers/blocks.js
+++ b/framework/src/modules/http_api/controllers/blocks.js
@@ -128,16 +128,16 @@ function parseBlockFromDatabase(raw) {
 		height: parseInt(raw.height),
 		previousBlock: raw.previousBlockId,
 		numberOfTransactions: parseInt(raw.numberOfTransactions),
-		totalAmount: new Bignumber(raw.totalAmount).toString(),
-		totalFee: new Bignumber(raw.totalFee).toString(),
-		reward: new Bignumber(raw.reward).toString(),
+		totalAmount: new Bignumber(raw.totalAmount).toFixed(),
+		totalFee: new Bignumber(raw.totalFee).toFixed(),
+		reward: new Bignumber(raw.reward).toFixed(),
 		payloadLength: parseInt(raw.payloadLength),
 		payloadHash: raw.payloadHash,
 		generatorPublicKey: raw.generatorPublicKey,
 		generatorId: getAddressFromPublicKey(raw.generatorPublicKey),
 		blockSignature: raw.blockSignature,
 		confirmations: parseInt(raw.confirmations),
-		totalForged: new Bignumber(raw.totalFee).plus(raw.reward).toString(),
+		totalForged: new Bignumber(raw.totalFee).plus(raw.reward).toFixed(),
 	};
 
 	if (raw.transactions) {

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -271,16 +271,16 @@ async function _getForgingStatistics(filters) {
 		return {
 			rewards: account.rewards,
 			fees: account.fees,
-			count: new Bignumber(account.producedBlocks).toString(),
+			count: new Bignumber(account.producedBlocks).toFixed(),
 			forged: new Bignumber(account.rewards)
 				.plus(new Bignumber(account.fees))
-				.toString(),
+				.toFixed(),
 		};
 	}
 	const reward = await _aggregateBlocksReward(filters);
 	reward.forged = new Bignumber(reward.fees)
 		.plus(new Bignumber(reward.rewards))
-		.toString();
+		.toFixed();
 
 	return reward;
 }

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -15,12 +15,11 @@
 'use strict';
 
 const _ = require('lodash');
-const Bignum = require('../helpers/bignum');
+const Bignumber = require('bignumber.js');
 const swaggerHelper = require('../helpers/swagger');
 const apiCodes = require('../api_codes');
 const ApiError = require('../api_error');
 const { calculateApproval } = require('../helpers/utils');
-const slots = require('../helpers/slots');
 // Private Fields
 let storage;
 let logger;
@@ -186,6 +185,8 @@ async function _getForgers(filters) {
 		{ sort: 'height:desc', limit: 1 }
 	);
 
+	const slots = await channel.invoke('chain:getSlotsHelper');
+
 	const lastBlockSlot = slots.getSlotNumber(lastBlock.timestamp);
 	const currentSlot = slots.getSlotNumber();
 	const forgerKeys = [];
@@ -270,15 +271,15 @@ async function _getForgingStatistics(filters) {
 		return {
 			rewards: account.rewards,
 			fees: account.fees,
-			count: new Bignum(account.producedBlocks).toString(),
-			forged: new Bignum(account.rewards)
-				.plus(new Bignum(account.fees))
+			count: new Bignumber(account.producedBlocks).toString(),
+			forged: new Bignumber(account.rewards)
+				.plus(new Bignumber(account.fees))
 				.toString(),
 		};
 	}
 	const reward = await _aggregateBlocksReward(filters);
-	reward.forged = new Bignum(reward.fees)
-		.plus(new Bignum(reward.rewards))
+	reward.forged = new Bignumber(reward.fees)
+		.plus(new Bignumber(reward.rewards))
 		.toString();
 
 	return reward;

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -18,7 +18,6 @@ const _ = require('lodash');
 const checkIpInList = require('../helpers/check_ip_in_list');
 const apiCodes = require('../api_codes');
 const swaggerHelper = require('../helpers/swagger');
-const slots = require('../helpers/slots');
 
 const { EPOCH_TIME, FEES } = global.constants;
 
@@ -136,6 +135,8 @@ NodeController.getStatus = async (context, next) => {
 		const transactions = await library.channel.invoke(
 			'chain:getAllTransactionsCount'
 		);
+
+		const slots = await library.channel.invoke('chain:getSlotsHelper');
 
 		const data = {
 			broadhash: library.components.system.headers.broadhash,

--- a/framework/src/modules/http_api/helpers/bignum.js
+++ b/framework/src/modules/http_api/helpers/bignum.js
@@ -1,1 +1,0 @@
-../../chain/helpers/bignum.js

--- a/framework/src/modules/http_api/helpers/slots.js
+++ b/framework/src/modules/http_api/helpers/slots.js
@@ -1,1 +1,0 @@
-../../chain/helpers/slots.js

--- a/framework/src/modules/http_api/helpers/transaction_types.js
+++ b/framework/src/modules/http_api/helpers/transaction_types.js
@@ -1,1 +1,41 @@
-../../chain/helpers/transaction_types.js
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+/**
+ * Description of the namespace.
+ *
+ * @namespace transaction_types
+ * @memberof helpers
+ * @see Parent: {@link helpers}
+ * @property {number} SEND
+ * @property {number} SIGNATURE
+ * @property {number} DELEGATE
+ * @property {number} VOTE
+ * @property {number} MULTI
+ * @property {number} IN_TRANSFER
+ * @property {number} OUT_TRANSFER
+ * @todo Add description for the namespace and the properties
+ */
+module.exports = {
+	SEND: 0,
+	SIGNATURE: 1,
+	DELEGATE: 2,
+	VOTE: 3,
+	MULTI: 4,
+	DAPP: 5,
+	IN_TRANSFER: 6,
+	OUT_TRANSFER: 7,
+};

--- a/framework/src/modules/http_api/helpers/utils.js
+++ b/framework/src/modules/http_api/helpers/utils.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const Bignum = require('bignumber.js');
+const Bignumber = require('bignumber.js');
 
 // TODO: This file will be renamed or deleted after deciding where calculateApproval belongs
 
@@ -22,8 +22,8 @@ const Bignum = require('bignumber.js');
 function calculateApproval(votersBalance, totalSupply) {
 	// votersBalance and totalSupply are sent as strings,
 	// we convert them into bignum and send the response as number as well
-	const votersBalanceBignum = new Bignum(votersBalance || 0);
-	const totalSupplyBignum = new Bignum(totalSupply);
+	const votersBalanceBignum = new Bignumber(votersBalance || 0);
+	const totalSupplyBignum = new Bignumber(totalSupply);
 	const approvalBignum = votersBalanceBignum
 		.dividedBy(totalSupplyBignum)
 		.multipliedBy(100)

--- a/framework/src/modules/http_api/helpers/z_schema.js
+++ b/framework/src/modules/http_api/helpers/z_schema.js
@@ -1,1 +1,407 @@
-../../chain/helpers/z_schema.js
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const ip = require('ip');
+const _ = require('lodash');
+const z_schema = require('z-schema');
+const FormatValidators = require('z-schema/src/FormatValidators');
+const Bignumber = require('bignumber.js');
+// new BigNumber(2).pow(64).minus(1)
+const UINT64_MAX = new Bignumber('18446744073709551615');
+
+/**
+ * Uses JSON Schema validator z_schema to register custom formats.
+ * Since an IP is not considered to be a hostname while used with SSL.
+ * So have to apply additional validation for IP and FQDN with **ipOrFQDN**.
+ * - id
+ * - address
+ * - amount
+ * - bignum
+ * - username
+ * - hex
+ * - publicKey
+ * - csv
+ * - signature
+ * - queryList
+ * - delegatesList
+ * - parsedInt
+ * - ip
+ * - ipOrFQDN
+ * - os
+ * - version
+ *
+ * @module
+ * @see {@link https://github.com/zaggino/z-schema}
+ * @requires ip
+ * @requires lodash
+ * @requires z-schema
+ * @returns {boolean} True if the format is valid
+ * @see Parent: {@link helpers}
+ */
+
+/**
+ * @exports helpers/z_schema
+ */
+const liskFormats = {
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	id(str) {
+		return str === '' || /^[0-9]+$/g.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	additionalData(str) {
+		/**
+		 * This deconstruction has to take place here because
+		 * global.constants will be defined in test/setup.js.
+		 */
+		const { ADDITIONAL_DATA } = global.constants;
+		if (typeof str !== 'string') {
+			return false;
+		}
+		return Buffer.from(str).length <= ADDITIONAL_DATA.MAX_LENGTH;
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	address(str) {
+		if (str === '') {
+			return true;
+		}
+
+		// Address can not have leading zeros
+		if (/^0[0-9]+L$/g.test(str)) {
+			return false;
+		}
+
+		// Address can not have non decimal numbers
+		if (!/^[0-9]+L$/g.test(str)) {
+			return false;
+		}
+
+		// Address can not exceed the max limit
+		if (new Bignumber(str.slice(0, -1)).isGreaterThan(UINT64_MAX)) {
+			return false;
+		}
+
+		return true;
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	username(str) {
+		if (typeof str !== 'string') {
+			return false;
+		}
+
+		return /^[a-z0-9!@$&_.]*$/gi.test(str);
+	},
+
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	hex(str) {
+		return str === '' || /^[a-f0-9]+$/i.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	publicKey(str) {
+		return str === '' || /^[a-f0-9]{64}$/i.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	// Currently this allow empty values e.g. ',,,' or '' - is this correct?
+	csv(str) {
+		if (typeof str !== 'string') {
+			return false;
+		}
+
+		const a = str.split(',');
+
+		if (a.length > 0 && a.length <= 1000) {
+			return true;
+		}
+		return false;
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	signature(str) {
+		return str === '' || /^[a-f0-9]{128}$/i.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	encryptedPassphrase(str) {
+		// Explanation of regex structure:
+		// - 1 or more 'key=value' pairs delimited with '&'
+		// Examples:
+		// - cipherText=abcd1234
+		// - cipherText=abcd1234&iterations=10000&iv=ef012345
+		// NOTE: Maximum lengths chosen here are arbitrary
+		const keyRegExp = /[a-zA-Z0-9]{2,15}/;
+		const valueRegExp = /[a-f0-9]{1,256}/;
+		const keyValueRegExp = new RegExp(
+			`${keyRegExp.source}=${valueRegExp.source}`
+		);
+		const encryptedPassphraseRegExp = new RegExp(
+			`^(${keyValueRegExp.source})(?:&(${keyValueRegExp.source})){0,10}$`
+		);
+		return encryptedPassphraseRegExp.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {Object} obj
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	queryList(obj) {
+		if (!_.isObject(obj) || Array.isArray(obj)) {
+			return false;
+		}
+
+		obj.limit = 100;
+		return true;
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {Object} obj
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	delegatesList(obj) {
+		if (!_.isObject(obj) || Array.isArray(obj)) {
+			return false;
+		}
+
+		obj.limit = 101;
+		return true;
+	},
+
+	/**
+	 * Description of the function.
+	 *
+	 * @param {number} value
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	parsedInt(value) {
+		if (
+			Number.isNaN(value) ||
+			parseInt(value).toString() !== String(value) ||
+			Number.isNaN(parseInt(value, 10))
+		) {
+			return false;
+		}
+		value = parseInt(value);
+		return true;
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	ip(str) {
+		return ip.isV4Format(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	os(str) {
+		if (typeof str !== 'string') {
+			return false;
+		}
+
+		return /^[a-z0-9-_.+]*$/gi.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	version(str) {
+		return (
+			str === '' ||
+			/^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})(-(alpha|beta|rc)\.[0-9]{1,3}(\.[0-9]{1,3})?)?$/.test(
+				str
+			)
+		);
+	},
+	/**
+	 * Validation for the protocol version format.
+	 * @param str
+	 * @returns {boolean}
+	 */
+	protocolVersion(str) {
+		return str === '' || /^(\d|[1-9]\d{1,2})\.(\d|[1-9]\d{1,2})$/.test(str);
+	},
+	/**
+	 * Description of the function.
+	 *
+	 * @param {string} str
+	 * @returns {boolean}
+	 * @todo Add description for the function, the params and the return value
+	 */
+	ipOrFQDN(str) {
+		if (typeof str !== 'string') {
+			return false;
+		}
+
+		return ip.isV4Format(str) || FormatValidators.hostname(str);
+	},
+	/**
+	 * Transaction amount/fee.
+	 * Also validate string amount to be lower than TOTAL_AMOUNT constant
+	 *
+	 * @param {Object} value
+	 * @returns {boolean}
+	 */
+	amount(value) {
+		/**
+		 * This deconstruction has to take place here because
+		 * global.constants will be defined in test/setup.js.
+		 */
+		const { TOTAL_AMOUNT } = global.constants;
+		if (value instanceof Bignumber) {
+			return (
+				value.isGreaterThanOrEqualTo(0) &&
+				value.isLessThanOrEqualTo(TOTAL_AMOUNT)
+			);
+		}
+
+		if (typeof value === 'string' && /^[0-9]+$/.test(value)) {
+			const num = new Bignumber(value);
+			return (
+				num.isGreaterThanOrEqualTo(0) && num.isLessThanOrEqualTo(TOTAL_AMOUNT)
+			);
+		}
+
+		return false;
+	},
+	/**
+	 * Returns true for integer or null.
+	 *
+	 * @param {Object} value
+	 * @returns {boolean}
+	 */
+	integerOrNull(value) {
+		return Number.isInteger(value) || value === null;
+	},
+	/**
+	 * Returns true if integer is odd.
+	 *
+	 * @param {Object} value
+	 * @returns {boolean}
+	 */
+	oddInteger: {
+		type: 'number',
+		validate: value => Number.isInteger(value) && /^\d*[13579]$/.test(value),
+	},
+	/**
+	 * Returns true if `MULTISIG_CONSTRAINTS.MIN.MAXIMUM` is lower than or equal to `MULTISIG_CONSTRAINTS.KEYSGROUP.MAX_ITEMS`.
+	 *
+	 * @param {Object} value
+	 * @returns {boolean}
+	 */
+	keysgroupLimit: {
+		type: 'number',
+		validate: value => {
+			const { MULTISIG_CONSTRAINTS } = global.constants;
+			return (
+				Number.isInteger(value) &&
+				MULTISIG_CONSTRAINTS.MIN.MAXIMUM <=
+					MULTISIG_CONSTRAINTS.KEYSGROUP.MAX_ITEMS
+			);
+		},
+	},
+	/**
+	 * Returns true if `MAX_VOTES_PER_ACCOUNT` is lower than or equal to `ACTIVE_DELEGATES`.
+	 *
+	 * @param {Object} value
+	 * @returns {boolean}
+	 */
+	maxVotesAccount: {
+		type: 'number',
+		validate: value => {
+			const { ACTIVE_DELEGATES, MAX_VOTES_PER_ACCOUNT } = global.constants;
+			return (
+				Number.isInteger(value) && MAX_VOTES_PER_ACCOUNT <= ACTIVE_DELEGATES
+			);
+		},
+	},
+};
+
+// Register the formats
+Object.keys(liskFormats).forEach(formatName => {
+	z_schema.registerFormat(formatName, liskFormats[formatName]);
+});
+
+// Assigned as custom attribute to be used later
+// since z_schema.getRegisteredFormats() only returns keys not the methods
+z_schema.formatsCache = liskFormats;
+
+// Exports
+module.exports = z_schema;

--- a/framework/test/mocha/functional/http/get/delegates.js
+++ b/framework/test/mocha/functional/http/get/delegates.js
@@ -21,6 +21,7 @@ const {
 	registerSecondPassphrase,
 	registerDelegate,
 } = require('@liskhq/lisk-transactions');
+const Bignum = require('bignumber.js');
 const genesisDelegates = require('../../../data/genesis_delegates.json');
 const accountFixtures = require('../../../fixtures/accounts');
 const slots = require('../../../../../src/modules/chain/helpers/slots');
@@ -28,7 +29,6 @@ const randomUtil = require('../../../common/utils/random');
 const waitFor = require('../../../common/utils/wait_for');
 const SwaggerEndpoint = require('../../../common/swagger_spec');
 const apiHelpers = require('../../../common/helpers/api');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum.js');
 
 Promise.promisify(waitFor.newRound);
 const { FEES } = global.constants;

--- a/framework/test/mocha/functional/http/get/voters.js
+++ b/framework/test/mocha/functional/http/get/voters.js
@@ -21,12 +21,12 @@ const {
 	castVotes,
 	registerDelegate,
 } = require('@liskhq/lisk-transactions');
+const Bignum = require('bignumber.js');
 const accountFixtures = require('../../../fixtures/accounts');
 const randomUtil = require('../../../common/utils/random');
 const SwaggerEndpoint = require('../../../common/swagger_spec');
 const waitFor = require('../../../common/utils/wait_for');
 const apiHelpers = require('../../../common/helpers/api');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum.js');
 
 const { FEES } = global.constants;
 const expectSwaggerParamError = apiHelpers.expectSwaggerParamError;

--- a/framework/test/mocha/functional/http/get/votes.js
+++ b/framework/test/mocha/functional/http/get/votes.js
@@ -21,12 +21,12 @@ const {
 	registerDelegate,
 	castVotes,
 } = require('@liskhq/lisk-transactions');
+const Bignum = require('bignumber.js');
 const accountFixtures = require('../../../fixtures/accounts');
 const randomUtil = require('../../../common/utils/random');
 const SwaggerEndpoint = require('../../../common/swagger_spec');
 const waitFor = require('../../../common/utils/wait_for');
 const apiHelpers = require('../../../common/helpers/api');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum.js');
 
 const { FEES, MAX_VOTES_PER_ACCOUNT } = global.constants;
 const expectSwaggerParamError = apiHelpers.expectSwaggerParamError;

--- a/framework/test/mocha/functional/http/post/0.transfer.js
+++ b/framework/test/mocha/functional/http/post/0.transfer.js
@@ -20,6 +20,7 @@ const {
 	transfer,
 	utils: transactionUtils,
 } = require('@liskhq/lisk-transactions');
+const Bignum = require('bignumber.js');
 const accountFixtures = require('../../../fixtures/accounts');
 const typesRepresentatives = require('../../../fixtures/types_representatives');
 const phases = require('../../../common/phases');
@@ -27,7 +28,6 @@ const sendTransactionPromise = require('../../../common/helpers/api')
 	.sendTransactionPromise;
 const randomUtil = require('../../../common/utils/random');
 const apiCodes = require('../../../../../src/modules/http_api/api_codes');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum.js');
 
 const { NORMALIZER } = global.constants;
 

--- a/framework/test/mocha/functional/http/post/6.dapps.in_transfer.js
+++ b/framework/test/mocha/functional/http/post/6.dapps.in_transfer.js
@@ -16,10 +16,10 @@
 
 require('../../functional.js');
 const { transfer, createDapp } = require('@liskhq/lisk-transactions');
+const Bignum = require('bignumber.js');
 const Promise = require('bluebird');
 const phases = require('../../../common/phases');
 const accountFixtures = require('../../../fixtures/accounts');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum.js');
 const randomUtil = require('../../../common/utils/random');
 const waitFor = require('../../../common/utils/wait_for');
 const apiHelpers = require('../../../common/helpers/api');

--- a/framework/test/mocha/functional/http/post/7.dapps.out_transfer.js
+++ b/framework/test/mocha/functional/http/post/7.dapps.out_transfer.js
@@ -15,11 +15,11 @@
 'use strict';
 
 require('../../functional.js');
+const Bignum = require('bignumber.js');
 const { transfer, createDapp } = require('@liskhq/lisk-transactions');
 const Promise = require('bluebird');
 const accountFixtures = require('../../../fixtures/accounts');
 const phases = require('../../../common/phases');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum.js');
 const randomUtil = require('../../../common/utils/random');
 const waitFor = require('../../../common/utils/wait_for');
 const elements = require('../../../common/utils/elements');

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -1,5 +1,5 @@
 const rewire = require('rewire');
-const Bignum = require('../../../../../../src/modules/chain/helpers/bignum');
+const Bignumber = require('bignumber.js');
 
 const DelegatesController = rewire(
 	'../../../../../../src/modules/http_api/controllers/delegates'
@@ -22,8 +22,8 @@ describe('delegates/api', () => {
 	const expectedForgingStatisticsResult = {
 		...blocksRewardReturnStub,
 		...{
-			forged: new Bignum(blocksRewardReturnStub.fees)
-				.plus(new Bignum(blocksRewardReturnStub.rewards))
+			forged: new Bignumber(blocksRewardReturnStub.fees)
+				.plus(new Bignumber(blocksRewardReturnStub.rewards))
 				.toString(),
 		},
 	};
@@ -274,9 +274,9 @@ describe('delegates/api', () => {
 			expect(data).to.deep.equal({
 				rewards: getAccountResponse.rewards,
 				fees: getAccountResponse.fees,
-				count: new Bignum(getAccountResponse.producedBlocks).toString(),
-				forged: new Bignum(getAccountResponse.rewards)
-					.plus(new Bignum(getAccountResponse.fees))
+				count: new Bignumber(getAccountResponse.producedBlocks).toString(),
+				forged: new Bignumber(getAccountResponse.rewards)
+					.plus(new Bignumber(getAccountResponse.fees))
 					.toString(),
 			});
 			expect(aggregateBlocksRewardStub).to.not.have.been.called;
@@ -333,6 +333,10 @@ describe('delegates/api', () => {
 
 		beforeEach(() => {
 			channelStub.invoke.resolves(dummyDelegates);
+			channelStub.invoke.withArgs('chain:getSlotsHelper').resolves({
+				getSlotNumber: sinonSandbox.stub().returns(1),
+				calcRound: sinonSandbox.stub().returns(3004),
+			});
 			return __private.getForgers(filters);
 		});
 


### PR DESCRIPTION
### What was the problem?
Symlinks were used on HTTP API module to reference Chain files
### How did I fix it?
Removed symlinks and removed unused logic from `http_api/helpers`:
- Our custom implementation of Bignumber.js is not needed on API. The only needed configuration for it is not allowing it to display scientific notation numbers. `bignum.js` has been removed and this issue has been solved by using `toFixed()` instead of `toString()` on big numbers when needed (API scope)
- `transaction_types.js`: symlink is removed but the content is exactly the same as the one in Chain. It will be moved/deleted/updated when we decided how to share common logic across independent modules.
- `zschema.js`: the same as above.
- `swagger_security_handlers.js`: it has been removed. Empty file and not used anywhere in API
### How to test it?
Run all tests
### Review checklist
* The PR resolves #3047 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
