### PR TITLE
Functional tests for validating asset field API - Closes #3053

### DIFF
--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -19,6 +19,7 @@ const Promise = require('bluebird');
 const {
 	transfer,
 	registerSecondPassphrase,
+	castVotes,
 } = require('@liskhq/lisk-transactions');
 const accountFixtures = require('../../../fixtures/accounts');
 const randomUtil = require('../../../common/utils/random');
@@ -70,6 +71,10 @@ describe('GET /api/transactions', () => {
 		passphrase: accountFixtures.genesis.passphrase,
 		recipientId: accountSecondPass.address,
 		data: 'tx 5',
+	});
+	const transactionType3 = castVotes({
+		passphrase: account2.passphrase,
+		votes: [`${accountFixtures.existingDelegate.publicKey}`],
 	});
 	const transactionType5 = {
 		amount: '0',
@@ -130,6 +135,7 @@ describe('GET /api/transactions', () => {
 			'8249786301f5cc7184b0681563dc5c5856568ff967bec22b778f773b0a86532b13d1ede9234f581e62388ada2d1e1366adaa03151a9e6508fb7c3a3e59425109',
 		id: '18307756018345914129',
 	};
+
 	// Crediting accounts'
 	before(() => {
 		const promises = [];
@@ -145,11 +151,15 @@ describe('GET /api/transactions', () => {
 			return waitFor
 				.confirmations(_.map(transactionList, 'id'))
 				.then(() => {
-					return apiHelpers.sendTransactionPromise(transaction3);
+					return Promise.all([
+						apiHelpers.sendTransactionPromise(transaction3),
+						apiHelpers.sendTransactionPromise(transactionType3),
+					]);
 				})
 				.then(() => {
 					transactionList.push(transaction3);
-					return waitFor.confirmations([transaction3.id]);
+					transactionList.push(transactionType3);
+					return waitFor.confirmations([transaction3.id, transactionType3.id]);
 				});
 		});
 	});
@@ -339,22 +349,118 @@ describe('GET /api/transactions', () => {
 
 		describe('type', () => {
 			it('using invalid type should fail', async () => {
-				return transactionsEndpoint.makeRequest({ type: 8 }, 400).then(res => {
-					expectSwaggerParamError(res, 'type');
-				});
+				const res = await transactionsEndpoint.makeRequest({ type: 8 }, 400);
+				expectSwaggerParamError(res, 'type');
 			});
 
 			it('using type should be ok', async () => {
-				return transactionsEndpoint
-					.makeRequest({ type: TRANSACTION_TYPES.SEND }, 200)
-					.then(res => {
-						expect(res.body.data).to.not.empty;
-						res.body.data.map(transaction => {
-							return expect(transaction.type).to.be.equal(
-								TRANSACTION_TYPES.SEND
-							);
-						});
+				const res = await transactionsEndpoint.makeRequest(
+					{ type: TRANSACTION_TYPES.SEND },
+					200
+				);
+
+				expect(res.body.data).to.not.empty;
+				res.body.data.map(transaction => {
+					return expect(transaction.type).to.be.equal(TRANSACTION_TYPES.SEND);
+				});
+			});
+
+			describe('asset field', () => {
+				it('using type 0 should return asset field with correct properties', async () => {
+					const res = await transactionsEndpoint.makeRequest(
+						{ type: TRANSACTION_TYPES.SEND },
+						200
+					);
+
+					expect(res.body.data).to.not.empty;
+					res.body.data.map(transaction =>
+						expect(Object.keys(transaction.asset).length).to.be.below(2)
+					);
+				});
+
+				it('using type 1 should return asset field with correct properties', async () => {
+					const res = await transactionsEndpoint.makeRequest(
+						{ type: TRANSACTION_TYPES.SIGNATURE },
+						200
+					);
+
+					expect(res.body.data).to.not.empty;
+					res.body.data.map(transaction =>
+						expect(transaction.asset.signature.publicKey).to.be.a('string')
+					);
+				});
+
+				it('using type 2 should return asset field with correct properties', async () => {
+					const res = await transactionsEndpoint.makeRequest(
+						{ type: TRANSACTION_TYPES.DELEGATE },
+						200
+					);
+
+					expect(res.body.data).to.not.empty;
+					res.body.data.map(transaction => {
+						expect(transaction.asset.delegate).to.have.property('publicKey');
+						expect(transaction.asset.delegate).to.have.property('username');
+						return expect(transaction.asset.delegate).to.have.property(
+							'address'
+						);
 					});
+				});
+
+				it('using type 3 should return asset field with correct properties', async () => {
+					const res = await transactionsEndpoint.makeRequest(
+						{ type: TRANSACTION_TYPES.VOTE },
+						200
+					);
+
+					expect(res.body.data).to.not.empty;
+					// Skip Genesis vote transaction - exception as it contains 101 votes
+					const transactionsType3 = res.body.data.filter(
+						transaction => transaction.recipientId !== '16313739661670634666L'
+					);
+					expect(transactionsType3.length).to.be.above(0);
+					transactionsType3.map(transaction => {
+						expect(Object.keys(transaction.asset).length).to.equal(1);
+						return expect(transaction.asset.votes.length).to.be.within(1, 33);
+					});
+				});
+
+				it('using type 4 should return asset field with correct properties', async () => {
+					const res = await transactionsEndpoint.makeRequest(
+						{ type: TRANSACTION_TYPES.MULTI },
+						200
+					);
+
+					expect(res.body.data).to.not.empty;
+					res.body.data.map(transaction => {
+						expect(Object.keys(transaction.asset).length).to.equal(1);
+						expect(transaction.asset.multisignature.min).to.be.within(2, 15);
+						expect(transaction.asset.multisignature.lifetime).to.be.within(
+							1,
+							72
+						);
+						expect(transaction.asset.multisignature.keysgroup).to.be.an(
+							'array'
+						);
+						return expect(transaction.asset.multisignature.keysgroup).to.not
+							.empty;
+					});
+				});
+
+				it('using type 5 should return asset field with correct properties', async () => {
+					const res = await transactionsEndpoint.makeRequest(
+						{ type: TRANSACTION_TYPES.DAPP },
+						200
+					);
+
+					expect(res.body.data).to.not.empty;
+					res.body.data.map(transaction => {
+						expect(Object.keys(transaction.asset).length).to.equal(1);
+						// Required properties: name, category, type
+						expect(transaction.asset.dapp).to.have.property('name');
+						expect(transaction.asset.dapp.type).to.be.within(0, 2);
+						return expect(transaction.asset.dapp.category).to.be.within(0, 9);
+					});
+				});
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
No checks for properties of asset field for each type returned by `API` when querying `/transactions` endpoint.

`http://localhost:4000/api/transactions?type=N`

### How did I fix it?
Add tests.

### How to test it?
Run tests for file.

### Review checklist

* The PR resolves /
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
