### PR TITLE
Drop `blocks_list` and `trs_list` views Closes - #2908

### DIFF
--- a/framework/src/modules/chain/components/storage/sql/migrations/updates/20190313102300_drop_blocks_list_and_trs_list_views.sql
+++ b/framework/src/modules/chain/components/storage/sql/migrations/updates/20190313102300_drop_blocks_list_and_trs_list_views.sql
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: Drop `blocks_list` and `trs_list` views as they are not used after Storage implementation in v1.5
+
+  PARAMETERS: None
+*/
+
+DROP VIEW IF EXISTS blocks_list;
+DROP VIEW IF EXISTS trs_list;

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -94,7 +94,7 @@ class Transactions {
 
 // Private methods
 /**
- * Counts totals and gets transaction list from `trs_list` view.
+ * Counts totals and gets transaction list from storage component.
  *
  * @private
  * @param {Object} params


### PR DESCRIPTION
### What was the problem?
Unused views still present in the database

### How did I fix it?
I wrote a migration to remove them

### How to test it?
Run regular tests suite

### Review checklist

* The PR resolves #2908
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
