### PR TITLE
Updating memberPublicKeys property for account does not work if the updated value is an empty array - Closes #3063

### DIFF
--- a/framework/src/modules/chain/components/storage/entities/account.js
+++ b/framework/src/modules/chain/components/storage/entities/account.js
@@ -68,10 +68,10 @@ const sqlFiles = {
 	createDependentRecords: 'accounts/create_dependent_records.sql',
 	deleteDependentRecord: 'accounts/delete_dependent_record.sql',
 	deleteDependentRecords: 'accounts/delete_dependent_records.sql',
+	deleteAllDependentRecords: 'accounts/delete_all_dependent_records.sql',
 	delegateBlocksRewards: 'accounts/delegate_blocks_rewards.sql',
 	syncDelegatesRank: 'accounts/sync_delegates_rank.sql',
 	insertFork: 'accounts/insert_fork.sql',
-	deleteVotes: 'accounts/delete_votes.sql',
 };
 
 class ChainAccount extends AccountEntity {
@@ -186,8 +186,24 @@ class ChainAccount extends AccountEntity {
 			data.votedDelegatesPublicKeys.length === 0
 		) {
 			await this.adapter.executeFile(
-				this.SQLs.deleteVotes,
-				{ accountId: filters.address },
+				this.SQLs.deleteAllDependentRecords,
+				{
+					accountId: filters.address,
+					tableName: dependentFieldsTableMap.votedDelegatesPublicKeys,
+				},
+				{},
+				tx
+			);
+		}
+
+		// Account remove all multisignatures
+		if (data.membersPublicKeys && data.membersPublicKeys.length === 0) {
+			await this.adapter.executeFile(
+				this.SQLs.deleteAllDependentRecords,
+				{
+					accountId: filters.address,
+					tableName: dependentFieldsTableMap.membersPublicKeys,
+				},
 				{},
 				tx
 			);

--- a/framework/src/modules/chain/components/storage/sql/accounts/delete_all_dependent_records.sql
+++ b/framework/src/modules/chain/components/storage/sql/accounts/delete_all_dependent_records.sql
@@ -20,4 +20,4 @@
   PARAMETERS: accountId
 */
 
-DELETE FROM mem_accounts2delegates WHERE "accountId" = ${accountId};
+DELETE FROM ${tableName:name} WHERE "accountId" = ${accountId};


### PR DESCRIPTION
### What was the problem?
Removing all memberPublicKeys for an account was not working as expected.
### How did I fix it?
Added the functionality for removing all dependent rows from mem_account2multisignatures table when memberPublicKeys is an empty array.
### How to test it?

### Review checklist

* The PR resolves #3063 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
