### PR TITLE
Validate filters for getter methods in Account and Transaction entities - Closes #3005

### DIFF
--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -359,7 +359,7 @@ describe('GET /api/transactions', () => {
 			});
 
 			describe('asset field', () => {
-				it('using type 0 should return asset field', async () => {
+				it('using type 0 should return asset field with correct properties', async () => {
 					return transactionsEndpoint
 						.makeRequest({ type: transactionTypes.SEND }, 200)
 						.then(res => {
@@ -370,6 +370,116 @@ describe('GET /api/transactions', () => {
 								return expect(
 									Object.keys(transaction.asset).length
 								).to.be.below(2);
+							});
+						});
+				});
+
+				it('using type 1 should return asset field with correct properties', async () => {
+					return transactionsEndpoint
+						.makeRequest({ type: transactionTypes.SIGNATURE }, 200)
+						.then(res => {
+							expect(res.body.data).to.not.empty;
+
+							res.body.data.map(transaction => {
+								expect(transaction).to.have.property('asset');
+								expect(transaction.asset).to.have.property('signature');
+								expect(transaction.asset.signature).to.have.property(
+									'publicKey'
+								);
+								return expect(transaction.asset.signature.publicKey).to.be.a(
+									'string'
+								);
+							});
+						});
+				});
+
+				it('using type 2 should return asset field with correct properties', async () => {
+					return transactionsEndpoint
+						.makeRequest({ type: transactionTypes.DELEGATE }, 200)
+						.then(res => {
+							expect(res.body.data).to.not.empty;
+
+							res.body.data.map(transaction => {
+								expect(transaction).to.have.property('asset');
+								expect(transaction.asset).to.have.property('delegate');
+								expect(transaction.asset.delegate).to.have.property(
+									'publicKey'
+								);
+								expect(transaction.asset.delegate).to.have.property('username');
+								return expect(transaction.asset.delegate).to.have.property(
+									'address'
+								);
+							});
+						});
+				});
+
+				it('using type 3 should return asset field with correct properties', async () => {
+					return transactionsEndpoint
+						.makeRequest({ type: transactionTypes.VOTE }, 200)
+						.then(res => {
+							expect(res.body.data).to.not.empty;
+
+							res.body.data.map(transaction => {
+								expect(transaction).to.have.property('asset');
+								expect(transaction.asset).to.have.property('votes');
+								expect(Object.keys(transaction.asset).length).to.equal(1);
+								return expect(transaction.asset.votes).to.be.an('array');
+							});
+						});
+				});
+
+				it('using type 4 should return asset field with correct properties', async () => {
+					return transactionsEndpoint
+						.makeRequest({ type: transactionTypes.MULTI }, 200)
+						.then(res => {
+							expect(res.body.data).to.not.empty;
+
+							res.body.data.map(transaction => {
+								expect(transaction).to.have.property('asset');
+								expect(transaction.asset).to.have.property('multisignature');
+								expect(Object.keys(transaction.asset).length).to.equal(1);
+								expect(transaction.asset.multisignature).to.have.property(
+									'min'
+								);
+								expect(transaction.asset.multisignature).to.have.property(
+									'lifetime'
+								);
+								expect(transaction.asset.multisignature).to.have.property(
+									'keysgroup'
+								);
+								expect(transaction.asset.multisignature.keysgroup).to.be.an(
+									'array'
+								);
+								return expect(transaction.asset.multisignature.keysgroup).to.not
+									.empty;
+							});
+						});
+				});
+
+				it('using type 5 should return asset field with correct properties', async () => {
+					return transactionsEndpoint
+						.makeRequest({ type: transactionTypes.DAPP }, 200)
+						.then(res => {
+							expect(res.body.data).to.not.empty;
+
+							res.body.data.map(transaction => {
+								expect(transaction).to.have.property('asset');
+								expect(transaction.asset).to.have.property('dapp');
+								expect(Object.keys(transaction.asset).length).to.equal(1);
+								expect(transaction.asset.dapp).to.have.keys(
+									'icon',
+									'link',
+									'name',
+									'tags',
+									'category',
+									'description',
+									'type'
+								);
+								expect(transaction.asset.dapp.type).to.be.within(0, 2);
+								return expect(transaction.asset.dapp.category).to.be.within(
+									0,
+									9
+								);
 							});
 						});
 				});

--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -412,8 +412,11 @@ describe('GET /api/transactions', () => {
 						.makeRequest({ type: transactionTypes.VOTE }, 200)
 						.then(res => {
 							expect(res.body.data).to.not.empty;
-
-							res.body.data.map(transaction => {
+							const transactionsType3 = res.body.data.filter(
+								transaction =>
+									transaction.recipientId !== '16313739661670634666L'
+							);
+							transactionsType3.map(transaction => {
 								expect(Object.keys(transaction.asset).length).to.equal(1);
 								return expect(transaction.asset.votes.length).to.be.within(
 									1,

--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -467,14 +467,10 @@ describe('GET /api/transactions', () => {
 								expect(transaction.asset).to.have.property('dapp');
 								expect(Object.keys(transaction.asset).length).to.equal(1);
 								expect(transaction.asset.dapp).to.have.keys(
-									'icon',
-									'link',
 									'name',
-									'tags',
 									'category',
-									'description',
 									'type'
-								);
+								); // Required properties
 								expect(transaction.asset.dapp.type).to.be.within(0, 2);
 								return expect(transaction.asset.dapp.category).to.be.within(
 									0,

--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -365,12 +365,9 @@ describe('GET /api/transactions', () => {
 						.then(res => {
 							expect(res.body.data).to.not.empty;
 
-							res.body.data.map(transaction => {
-								expect(transaction).to.have.property('asset');
-								return expect(
-									Object.keys(transaction.asset).length
-								).to.be.below(2);
-							});
+							res.body.data.map(transaction =>
+								expect(Object.keys(transaction.asset).length).to.be.below(2)
+							);
 						});
 				});
 
@@ -381,7 +378,6 @@ describe('GET /api/transactions', () => {
 							expect(res.body.data).to.not.empty;
 
 							res.body.data.map(transaction => {
-								expect(transaction).to.have.property('asset');
 								expect(transaction.asset).to.have.property('signature');
 								expect(transaction.asset.signature).to.have.property(
 									'publicKey'
@@ -400,8 +396,6 @@ describe('GET /api/transactions', () => {
 							expect(res.body.data).to.not.empty;
 
 							res.body.data.map(transaction => {
-								expect(transaction).to.have.property('asset');
-								expect(transaction.asset).to.have.property('delegate');
 								expect(transaction.asset.delegate).to.have.property(
 									'publicKey'
 								);
@@ -420,8 +414,6 @@ describe('GET /api/transactions', () => {
 							expect(res.body.data).to.not.empty;
 
 							res.body.data.map(transaction => {
-								expect(transaction).to.have.property('asset');
-								expect(transaction.asset).to.have.property('votes');
 								expect(Object.keys(transaction.asset).length).to.equal(1);
 								return expect(transaction.asset.votes).to.be.an('array');
 							});
@@ -435,17 +427,12 @@ describe('GET /api/transactions', () => {
 							expect(res.body.data).to.not.empty;
 
 							res.body.data.map(transaction => {
-								expect(transaction).to.have.property('asset');
-								expect(transaction.asset).to.have.property('multisignature');
 								expect(Object.keys(transaction.asset).length).to.equal(1);
 								expect(transaction.asset.multisignature).to.have.property(
 									'min'
 								);
 								expect(transaction.asset.multisignature).to.have.property(
 									'lifetime'
-								);
-								expect(transaction.asset.multisignature).to.have.property(
-									'keysgroup'
 								);
 								expect(transaction.asset.multisignature.keysgroup).to.be.an(
 									'array'
@@ -463,14 +450,9 @@ describe('GET /api/transactions', () => {
 							expect(res.body.data).to.not.empty;
 
 							res.body.data.map(transaction => {
-								expect(transaction).to.have.property('asset');
-								expect(transaction.asset).to.have.property('dapp');
 								expect(Object.keys(transaction.asset).length).to.equal(1);
-								expect(transaction.asset.dapp).to.have.keys(
-									'name',
-									'category',
-									'type'
-								); // Required properties
+								// Required properties: name, category, type
+								expect(transaction.asset.dapp).to.have.property('name');
 								expect(transaction.asset.dapp.type).to.be.within(0, 2);
 								return expect(transaction.asset.dapp.category).to.be.within(
 									0,

--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -357,6 +357,23 @@ describe('GET /api/transactions', () => {
 						});
 					});
 			});
+
+			describe('asset field', () => {
+				it('using type 0 should return asset field', async () => {
+					return transactionsEndpoint
+						.makeRequest({ type: transactionTypes.SEND }, 200)
+						.then(res => {
+							expect(res.body.data).to.not.empty;
+
+							res.body.data.map(transaction => {
+								expect(transaction).to.have.property('asset');
+								return expect(
+									Object.keys(transaction.asset).length
+								).to.be.below(2);
+							});
+						});
+				});
+			});
 		});
 
 		describe('senderId', () => {

--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -415,7 +415,10 @@ describe('GET /api/transactions', () => {
 
 							res.body.data.map(transaction => {
 								expect(Object.keys(transaction.asset).length).to.equal(1);
-								return expect(transaction.asset.votes).to.be.an('array');
+								return expect(transaction.asset.votes.length).to.be.within(
+									1,
+									33
+								);
 							});
 						});
 				});
@@ -428,11 +431,13 @@ describe('GET /api/transactions', () => {
 
 							res.body.data.map(transaction => {
 								expect(Object.keys(transaction.asset).length).to.equal(1);
-								expect(transaction.asset.multisignature).to.have.property(
-									'min'
+								expect(transaction.asset.multisignature.min).to.be.within(
+									2,
+									15
 								);
-								expect(transaction.asset.multisignature).to.have.property(
-									'lifetime'
+								expect(transaction.asset.multisignature.lifetime).to.be.within(
+									1,
+									72
 								);
 								expect(transaction.asset.multisignature.keysgroup).to.be.an(
 									'array'


### PR DESCRIPTION
### What was the problem?
I expect the storage entities Account and Transaction to validate the passed filters and throw and error if a filter is not valid. Also, unit tests should be added to cover this scenario.

### How did I fix it?
Add `validateFilters` and `validateOptions` method to throw a proper error when one of the properties contains a non-supported filter/option. Respective tests added.

### How to test it?
Run test suite.

### Review checklist

* The PR resolves #3005 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
