### PR TITLE
Fix protocol version parsing with double digits - Closes #3081

### DIFF
--- a/framework/src/components/system/system.js
+++ b/framework/src/components/system/system.js
@@ -93,9 +93,11 @@ class System {
 		if (!protocolVersion) {
 			return false;
 		}
-		const peerHard = parseInt(protocolVersion.split('.')[0]);
-		const myHard = parseInt(this.headers.protocolVersion.split('.')[0]);
-		return myHard === peerHard && peerHard >= 1;
+		const peerHardForks = parseInt(protocolVersion.split('.')[0]);
+		const systemHardForks = parseInt(
+			this.headers.protocolVersion.split('.')[0]
+		);
+		return systemHardForks === peerHardForks && peerHardForks >= 1;
 	}
 
 	/**

--- a/framework/src/components/system/system.js
+++ b/framework/src/components/system/system.js
@@ -93,8 +93,8 @@ class System {
 		if (!protocolVersion) {
 			return false;
 		}
-		const peerHard = parseInt(protocolVersion[0]);
-		const myHard = parseInt(this.headers.protocolVersion[0]);
+		const peerHard = parseInt(protocolVersion.split('.')[0]);
+		const myHard = parseInt(this.headers.protocolVersion.split('.')[0]);
 		return myHard === peerHard && peerHard >= 1;
 	}
 

--- a/framework/test/mocha/unit/components/system/system.js
+++ b/framework/test/mocha/unit/components/system/system.js
@@ -160,37 +160,83 @@ describe('components: system', () => {
 	});
 
 	describe('protocolVersionCompatible', () => {
-		describe('when protocol version is exactly equal to system protocol version', () => {
-			it('should return true', async () =>
-				expect(systemComponent.protocolVersionCompatible('1.0')).to.be.true);
-		});
-		describe('when the hard part of protocol is not exactly equal than the one of the system protocol version', () => {
-			it("should return false if it's greater or lesser", async () =>
-				expect(systemComponent.protocolVersionCompatible('2.0')).to.be.false);
-			it("should return false if it's lesser", async () =>
-				expect(systemComponent.protocolVersionCompatible('0.0')).to.be.false);
-		});
-		describe('when the hard part of protocol is equal to  the one of the system protocol version', () => {
-			it('should return true', async () =>
-				expect(systemComponent.protocolVersionCompatible('1.5')).to.be.true);
-		});
-		describe('when the hard part of the protocol version is already compatible', () => {
-			beforeEach(done => {
-				systemComponent.headers.protocolVersion = '1.1'; // So we can test smaller values for the soft part
-				done();
-			});
-
-			afterEach(done => {
+		describe('when the hard for part has one digit', () => {
+			beforeEach(async () => {
 				systemComponent.headers.protocolVersion = '1.0';
-				done();
 			});
 
-			it('should return true if the soft part is lesser, equal or greater than the soft part of the system protocol version', async () =>
-				['1.0', '1.1', '1.2'].forEach(
-					protocolVersion =>
-						expect(systemComponent.protocolVersionCompatible(protocolVersion))
-							.to.be.true
-				));
+			describe('when protocol version is exactly equal to system protocol version', () => {
+				it('should return true', async () =>
+					expect(systemComponent.protocolVersionCompatible('1.0')).to.be.true);
+			});
+			describe('when the hard part of protocol is not exactly equal than the one of the system protocol version', () => {
+				it("should return false if it's greater or lesser", async () =>
+					expect(systemComponent.protocolVersionCompatible('2.0')).to.be.false);
+				it("should return false if it's lesser", async () =>
+					expect(systemComponent.protocolVersionCompatible('0.0')).to.be.false);
+			});
+			describe('when the hard part of protocol is equal to  the one of the system protocol version', () => {
+				it('should return true', async () =>
+					expect(systemComponent.protocolVersionCompatible('1.5')).to.be.true);
+			});
+			describe('when the hard part of the protocol version is already compatible', () => {
+				beforeEach(done => {
+					systemComponent.headers.protocolVersion = '1.1'; // So we can test smaller values for the soft part
+					done();
+				});
+
+				afterEach(done => {
+					systemComponent.headers.protocolVersion = '1.0';
+					done();
+				});
+
+				it('should return true if the soft part is lesser, equal or greater than the soft part of the system protocol version', async () =>
+					['1.0', '1.1', '1.2'].forEach(
+						protocolVersion =>
+							expect(systemComponent.protocolVersionCompatible(protocolVersion))
+								.to.be.true
+					));
+			});
+		});
+
+		describe('when the hard for part has more than one digit', () => {
+			beforeEach(async () => {
+				systemComponent.headers.protocolVersion = '10.0';
+			});
+
+			describe('when protocol version is exactly equal to system protocol version', () => {
+				it('should return true', async () =>
+					expect(systemComponent.protocolVersionCompatible('10.0')).to.be.true);
+			});
+			describe('when the hard part of protocol is not exactly equal than the one of the system protocol version', () => {
+				it("should return false if it's greater or lesser", async () =>
+					expect(systemComponent.protocolVersionCompatible('11.0')).to.be
+						.false);
+				it("should return false if it's lesser", async () =>
+					expect(systemComponent.protocolVersionCompatible('9.0')).to.be.false);
+			});
+			describe('when the hard part of protocol is equal to  the one of the system protocol version', () => {
+				it('should return true', async () =>
+					expect(systemComponent.protocolVersionCompatible('10.5')).to.be.true);
+			});
+			describe('when the hard part of the protocol version is already compatible', () => {
+				beforeEach(done => {
+					systemComponent.headers.protocolVersion = '10.1'; // So we can test smaller values for the soft part
+					done();
+				});
+
+				afterEach(done => {
+					systemComponent.headers.protocolVersion = '10.0';
+					done();
+				});
+
+				it('should return true if the soft part is lesser, equal or greater than the soft part of the system protocol version', async () =>
+					['10.0', '10.1', '10.2'].forEach(
+						protocolVersion =>
+							expect(systemComponent.protocolVersionCompatible(protocolVersion))
+								.to.be.true
+					));
+			});
 		});
 	});
 

--- a/framework/test/mocha/unit/components/system/system.js
+++ b/framework/test/mocha/unit/components/system/system.js
@@ -160,7 +160,7 @@ describe('components: system', () => {
 	});
 
 	describe('protocolVersionCompatible', () => {
-		describe('when the hard for part has one digit', () => {
+		describe('when the hard fork part has one digit', () => {
 			beforeEach(async () => {
 				systemComponent.headers.protocolVersion = '1.0';
 			});
@@ -169,7 +169,7 @@ describe('components: system', () => {
 				it('should return true', async () =>
 					expect(systemComponent.protocolVersionCompatible('1.0')).to.be.true);
 			});
-			describe('when the hard part of protocol is not exactly equal than the one of the system protocol version', () => {
+			describe('when the hard part of the peer protocol is not exactly equal to the system protocol version', () => {
 				it("should return false if it's greater or lesser", async () =>
 					expect(systemComponent.protocolVersionCompatible('2.0')).to.be.false);
 				it("should return false if it's lesser", async () =>
@@ -199,7 +199,7 @@ describe('components: system', () => {
 			});
 		});
 
-		describe('when the hard for part has more than one digit', () => {
+		describe('when the hard fork part has more than one digit', () => {
 			beforeEach(async () => {
 				systemComponent.headers.protocolVersion = '10.0';
 			});
@@ -208,7 +208,7 @@ describe('components: system', () => {
 				it('should return true', async () =>
 					expect(systemComponent.protocolVersionCompatible('10.0')).to.be.true);
 			});
-			describe('when the hard part of protocol is not exactly equal than the one of the system protocol version', () => {
+			describe('when the hard part of the peer protocol is not exactly equal to the system protocol version', () => {
 				it("should return false if it's greater or lesser", async () =>
 					expect(systemComponent.protocolVersionCompatible('11.0')).to.be
 						.false);


### PR DESCRIPTION
### What was the problem?
The protocol version was being incorrectly parsed.
Using values with more than one digit on the hard
part caused the validation to only take in account
the first one.
### How did I fix it?
Now the hard part and the soft part of the protocol
version are correctly parsed by being delimited by
a perdiod `.`
### How to test it?
Run network tests and unit tests.
### Review checklist
* The PR resolves #3081
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
