### PR TITLE
Add missing functional:put tests on Jenkins - Closes #3060

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ pipeline {
 			sh 'rm -rf coverage; mkdir -p coverage'
 			script {
 				dir('coverage') {
-					['get', 'post', 'ws', 'unit', 'integration'].each {
+					['get', 'post', 'put', 'ws', 'unit', 'integration'].each {
 						// some test stages might have failed and have no coverage data
 						try {
 							unstash "coverage_${it}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,6 +148,18 @@ pipeline {
 						}
 					}
 				}
+				stage('Functional HTTP PUT tests') {
+					agent { node { label 'lisk-core' } }
+					steps {
+						setup()
+						run_test('functional:put')
+					}
+					post {
+						cleanup {
+							teardown('put')
+						}
+					}
+				}
 				stage ('Functional WS tests') {
 					agent { node { label 'lisk-core' } }
 					steps {

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Tests are run using the following command:
 npm run mocha:<testType> -- [testPathPattern] [mochaCliOptions]
 ```
 
-* Where **testType** can be one of `unit`, `integration`, `functional:ws`, `functional:get`, `functional:post`, `functional`, `network` (required).
+* Where **testType** can be one of `unit`, `integration`, `functional:ws`, `functional:get`, `functional:post`, `functional:put`, `functional`, `network` (required).
 * Where **testPathPattern** is a regexp pattern string that is matched against all tests paths before executing the test (optional).
 * Where **mochaCliOptions** can be any of mocha's [`command line options`](https://mochajs.org/#command-line-usage) (optional).
 
@@ -447,6 +447,7 @@ npm run mocha:integration -- --grep="@unstable" --invert
 npm run mocha:functional:ws
 npm run mocha:functional:get
 npm run mocha:functional:post
+npm run mocha:functional:put
 ```
 
 Individual test files can be run using the following commands:

--- a/framework/test/mocha/common/lisk-mocha-runner/file_manager.js
+++ b/framework/test/mocha/common/lisk-mocha-runner/file_manager.js
@@ -22,6 +22,7 @@ const testTypesMap = {
 	'functional:ws': 'framework/test/mocha/functional/ws/',
 	'functional:get': 'framework/test/mocha/functional/http/get/',
 	'functional:post': 'framework/test/mocha/functional/http/post/',
+	'functional:put': 'framework/test/mocha/functional/http/put/',
 	functional: 'framework/test/mocha/functional/',
 	network: 'framework/test/mocha/network/',
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
 			"node framework/test/mocha/common/lisk-mocha-runner functional:get",
 		"mocha:functional:post":
 			"node framework/test/mocha/common/lisk-mocha-runner functional:post",
+		"mocha:functional:put":
+			"node framework/test/mocha/common/lisk-mocha-runner functional:put",
 		"mocha:network":
 			"node framework/test/mocha/common/lisk-mocha-runner network",
 		"docs:build": "jsdoc -c docs/conf.json --verbose --pedantic",


### PR DESCRIPTION
### What was the problem?
We were not running put tests for http_api module
### How did I fix it?
I added necessary scripts and Jenkins steps
### How to test it?

### Review checklist

* The PR resolves #3060 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
