### PR TITLE
Functional test code coverage is broken - Closes #3100

### DIFF
--- a/framework/src/modules/http_api/init_steps/setup_servers.js
+++ b/framework/src/modules/http_api/init_steps/setup_servers.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const express = require('express');
 
 module.exports = ({ components: { logger }, config }) => {
@@ -10,7 +11,9 @@ module.exports = ({ components: { logger }, config }) => {
 		logger.debug(
 			'Hook loader for coverage - Do not use in production environment!'
 		);
-		im.hookLoader(__dirname);
+		/** @TODO hookLoader path must be updated
+		 * to be able to dynamically find the root folder */
+		im.hookLoader(path.join(__dirname, '../../../'));
 		expressApp.use('/coverage', im.createHandler());
 	}
 


### PR DESCRIPTION
### What was the problem?
`lcov.info` that was provided from functional tests were empty because hook path was wrong in the `setup_server.js` file
### How did I fix it?
I corrected the path
### How to test it?

### Review checklist

* The PR resolves #3100 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
