### PR TITLE
Implemment once() for ChildProcessChannel subSocket - Closes #3102

### DIFF
--- a/framework/src/controller/channels/child_process_channel.js
+++ b/framework/src/controller/channels/child_process_channel.js
@@ -78,7 +78,6 @@ class ChildProcessChannel extends BaseChannel {
 		if (event.module === this.moduleAlias) {
 			this.localBus.once(eventName, cb);
 		} else {
-			// TODO: make it `once` instead of `on`
 			this.subSocket.on(eventName, data => {
 				this.subSocket.off(eventName);
 				cb(data);

--- a/framework/src/controller/channels/child_process_channel.js
+++ b/framework/src/controller/channels/child_process_channel.js
@@ -80,6 +80,7 @@ class ChildProcessChannel extends BaseChannel {
 		} else {
 			// TODO: make it `once` instead of `on`
 			this.subSocket.on(eventName, data => {
+				this.subSocket.off(eventName);
 				cb(data);
 			});
 		}


### PR DESCRIPTION
### What was the problem?
`subscription socket` interface by `Axon` library doesn't implement the once() listener.
### How did I fix it?
I have fixed it by calling `.on()` and then `.off()` to achieve the same behavior on `ChildProcessChannel`
### How to test it?
Run the application
### Review checklist
* The PR resolves #3102
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
