### PR TITLE
Process incoming signatures using statestore and elements - Closes #2825

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -169,7 +169,6 @@ module.exports = class Chain {
 			// Ready to bind modules
 			scope.logic.peers.bindModules(scope.modules);
 			scope.logic.block.bindModules(scope.modules);
-
 			// Fire onBind event in every module
 			scope.bus.message('bind', scope);
 

--- a/framework/src/modules/chain/submodules/multisignatures.js
+++ b/framework/src/modules/chain/submodules/multisignatures.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const { Status: TransactionStatus } = require('@liskhq/lisk-transactions');
 const async = require('async');
 
 // Private fields
@@ -49,6 +50,68 @@ function Multisignatures(cb, scope) {
 
 	setImmediate(cb, null, self);
 }
+
+// Public methods
+
+/**
+ * Main function for processing received signature, includes:
+ * - multisignature account creation
+ * - send from multisignature account
+ *
+ * @public
+ * @param {Object} signature - Signature data
+ * @param {string} [signature.publicKey] - Public key of account that created the signature (optional)
+ * @param {string} signature.transactionId - Id of transaction that signature was created for
+ * @param {string} signature.signature - Actual signature
+ * @param {function} cb - Callback function
+ * @implements {library.balancesSequence.add} - All processing here is done through balancesSequence
+ * @returns {setImmediateCallback} cb, err
+ */
+Multisignatures.prototype.getTransactionAndProcessSignature = (
+	signature,
+	cb
+) => {
+	if (!signature) {
+		const message = 'Unable to process signature, signature not provided';
+		library.logger.error(message);
+		return setImmediate(cb, new Error(message));
+	}
+	// Grab transaction with corresponding ID from transaction pool
+	const transaction = modules.transactions.getMultisignatureTransaction(
+		signature.transactionId
+	);
+
+	if (!transaction) {
+		const message =
+			'Unable to process signature, corresponding transaction not found';
+		library.logger.error(message, { signature });
+		return setImmediate(cb, new Error(message));
+	}
+
+	return modules.processTransactions
+		.processSignature(transaction, signature)
+		.then(transactionResponse => {
+			if (
+				transactionResponse.status === TransactionStatus.FAIL &&
+				transactionResponse.errors.length > 0
+			) {
+				const message = `Error processing signature: ${
+					transactionResponse.errors[0].message
+				}`;
+				library.logger.error(message, { signature });
+				return setImmediate(cb, new Error(message));
+			}
+			// Emit events
+			library.channel.publish(
+				'chain:multisignatures:signature:change',
+				transaction.id
+			);
+			library.bus.message('signature', signature, true);
+
+			return setImmediate(cb);
+		})
+		.catch(err => setImmediate(cb, err));
+};
 
 /**
  * Description of getGroup.
@@ -137,6 +200,7 @@ Multisignatures.prototype.onBind = function(scope) {
 	modules = {
 		accounts: scope.modules.accounts,
 		transactions: scope.modules.transactions,
+		processTransactions: scope.modules.processTransactions,
 	};
 };
 

--- a/framework/src/modules/chain/submodules/process_transactions.js
+++ b/framework/src/modules/chain/submodules/process_transactions.js
@@ -65,7 +65,9 @@ class ProcessTransactions {
 			...persistedTransactions.map(transaction => ({
 				id: transaction.id,
 				status: TransactionStatus.FAIL,
-				errors: [`Transaction is already confirmed: ${transaction.id}`],
+				errors: [
+					new Error(`Transaction is already confirmed: ${transaction.id}`),
+				],
 			})),
 		];
 
@@ -138,6 +140,17 @@ class ProcessTransactions {
 		return {
 			transactionsResponses,
 		};
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	async processSignature(transaction, signature) {
+		// Get data required for processing signature
+		const stateStore = library.logic.stateManager.createStore({
+			mutate: false,
+		});
+		await transaction.prepare(stateStore);
+		// Add multisignature to transaction and process
+		return transaction.addMultisignature(stateStore, signature);
 	}
 }
 

--- a/framework/src/modules/chain/submodules/transport.js
+++ b/framework/src/modules/chain/submodules/transport.js
@@ -148,7 +148,7 @@ __private.receiveSignatures = function(signatures = []) {
 };
 
 /**
- * Validates signature with schema and calls processSignature.
+ * Validates signature with schema and calls getTransactionAndProcessSignature.
  *
  * @private
  * @param {Object} query
@@ -157,14 +157,14 @@ __private.receiveSignatures = function(signatures = []) {
  * @returns {setImmediateCallback} cb, err
  * @todo Add description for the params
  */
-__private.receiveSignature = function(query, cb) {
-	library.schema.validate(query, definitions.Signature, err => {
+__private.receiveSignature = function(signature, cb) {
+	library.schema.validate(signature, definitions.Signature, err => {
 		if (err) {
 			return setImmediate(cb, `Invalid signature body ${err[0].message}`);
 		}
 
-		return modules.multisignatures.processSignature(
-			query,
+		return modules.multisignatures.getTransactionAndProcessSignature(
+			signature,
 			processSignatureErr => {
 				if (processSignatureErr) {
 					return setImmediate(

--- a/framework/test/mocha/integration/transactions/4_multisignature/duplicate_signatures.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/duplicate_signatures.js
@@ -24,9 +24,6 @@ const {
 const accountsFixtures = require('../../../fixtures/accounts');
 const randomUtil = require('../../../common/utils/random');
 const localCommon = require('../../common');
-const Bignum = require('../../../../../src/modules/chain/helpers/bignum');
-
-const exceptions = global.exceptions;
 
 describe('duplicate_signatures', () => {
 	let library;
@@ -132,87 +129,6 @@ describe('duplicate_signatures', () => {
 		return [transactions, signatures];
 	};
 
-	describe('process multiple signatures from the same public key', () => {
-		const transaction = {
-			type: 0,
-			id: '15181013796707110990',
-			timestamp: 77612766,
-			senderPublicKey:
-				'24193236b7cbeaf5e6feafbbf7a791095ea64ec73abde8f0470001fee5d39d9d',
-			senderId: '4368107197830030479L',
-			recipientId: '4368107197830030479L',
-			recipientPublicKey:
-				'24193236b7cbeaf5e6feafbbf7a791095ea64ec73abde8f0470001fee5d39d9d',
-			amount: new Bignum('100000000'),
-			fee: new Bignum('10000000'),
-			signature:
-				'dc8fe25f817c81572585b3769f3c6df13d3dc93ff470b2abe807f43a3359ed94e9406d2539013971431f2d540e42dc7d3d71c7442da28572c827d59adc5dfa08',
-			signatures: [
-				'2df1fae6865ec72783dcb5f87a7d906fe20b71e66ad9613c01a89505ebd77279e67efa2c10b5ad880abd09efd27ea350dd8a094f44efa3b4b2c8785fbe0f7e00',
-				'2ec5bbc4ff552f991262867cd8f1c30a417e4596e8343d882b7c4fc86288b9e53592031f3de75ffe8cf4d431a7291b76c758999bb52f46a4da62a27c8901b60a',
-				'36d5c7da5f54007e22609105570fad04597f4f2b00d46baba603c213eaed8de55e9f3e5d0f39789dbc396330b2d9d4da46b7d67187075e86220bc0341c3f7802',
-			],
-			asset: {
-				data: 'the real test',
-			},
-		};
-
-		const sender = {
-			address: '4368107197830030479L',
-			publicKey:
-				'24193236b7cbeaf5e6feafbbf7a791095ea64ec73abde8f0470001fee5d39d9d',
-			membersPublicKeys: [
-				'c44a88e68196e4d2f608873467c7350fb92b954eb7c3b31a989b1afd8d55ebdb',
-				'2eca11a4786f35f367299e1defd6a22ac4eb25d2552325d6c5126583a3bdd0fb',
-				'a17e03f21bfa187d2a30fe389aa78431c587bf850e9fa851b3841274fc9f100f',
-				'758fc45791faf5796e8201e49950a9ee1ee788192714b935be982f315b1af8cd',
-				'9af12d260cf5fcc49bf8e8fce2880b34268c7a4ac8915e549c07429a01f2e4a5',
-			],
-			balance: new Bignum('10000000000'),
-			u_balance: new Bignum('10000000000'),
-		};
-
-		it('should call a callback with error when there are multiple signatures', done => {
-			const requester = null;
-			const lib = library.rewiredModules.transactions.__get__('library');
-			lib.logic.transaction.verify(
-				transaction,
-				sender,
-				requester,
-				false,
-				err => {
-					expect(err).to.equal(
-						`Failed to verify multisignature: ${transaction.signatures[1]}`
-					);
-					done();
-				},
-				null
-			);
-		});
-
-		it('should call a callback with no error when exception is in place', done => {
-			const requester = null;
-			const lib = library.rewiredModules.transactions.__get__('library');
-			exceptions.duplicatedSignatures = {
-				'15181013796707110990': [
-					'2ec5bbc4ff552f991262867cd8f1c30a417e4596e8343d882b7c4fc86288b9e53592031f3de75ffe8cf4d431a7291b76c758999bb52f46a4da62a27c8901b60a',
-					'36d5c7da5f54007e22609105570fad04597f4f2b00d46baba603c213eaed8de55e9f3e5d0f39789dbc396330b2d9d4da46b7d67187075e86220bc0341c3f7802',
-				],
-			};
-			lib.logic.transaction.verify(
-				transaction,
-				sender,
-				requester,
-				false,
-				err => {
-					expect(err).not.exist;
-					done();
-				},
-				null
-			);
-		});
-	});
-
 	describe('process multiple signatures for the same transaction', () => {
 		describe('when signatures are unique', () => {
 			describe('during multisignature account registration', () => {
@@ -267,13 +183,13 @@ describe('duplicate_signatures', () => {
 					async.parallel(
 						async.reflectAll([
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[0],
 									parallelCb
 								);
 							},
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[1],
 									parallelCb
 								);
@@ -377,13 +293,13 @@ describe('duplicate_signatures', () => {
 					async.parallel(
 						async.reflectAll([
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[0],
 									parallelCb
 								);
 							},
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[1],
 									parallelCb
 								);
@@ -474,19 +390,19 @@ describe('duplicate_signatures', () => {
 					async.parallel(
 						async.reflectAll([
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[0],
 									parallelCb
 								);
 							},
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[0],
 									parallelCb
 								);
 							},
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[1],
 									parallelCb
 								);
@@ -496,7 +412,7 @@ describe('duplicate_signatures', () => {
 							// There should be an error from processing only for duplicated signature
 							expect(results[0].value).to.be.undefined;
 							expect(results[1].error.message).to.eql(
-								'Unable to process signature, signature already exists'
+								'Error processing signature: Encountered duplicate signature in transaction'
 							);
 							expect(results[2].value).to.be.undefined;
 
@@ -593,19 +509,19 @@ describe('duplicate_signatures', () => {
 					async.parallel(
 						async.reflectAll([
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[0],
 									parallelCb
 								);
 							},
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[0],
 									parallelCb
 								);
 							},
 							parallelCb => {
-								library.modules.multisignatures.processSignature(
+								library.modules.multisignatures.getTransactionAndProcessSignature(
 									signatures[1],
 									parallelCb
 								);
@@ -615,7 +531,9 @@ describe('duplicate_signatures', () => {
 							// There should be an error from processing only for duplicated signature
 							expect(results[0].value).to.be.undefined;
 							expect(results[1].error.message).to.eql(
-								'Unable to process signature, signature already exists'
+								`Error processing signature: Signature '${
+									signatures[0].signature
+								}' already present in transaction.`
 							);
 							expect(results[2].value).to.be.undefined;
 

--- a/framework/test/mocha/unit/modules/chain/submodules/multisignatures.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/multisignatures.js
@@ -25,10 +25,7 @@ const RewiredMultisignatures = rewire(
 
 const validAccount = new accountsFixtures.Account();
 
-// TODO: revisit once multisignatures are completed in feature branch
-// eslint-disable-next-line
-describe.skip('multisignatures', () => {
-	let __private;
+describe('multisignatures', () => {
 	let self;
 	let library;
 	let validScope;
@@ -74,18 +71,6 @@ describe.skip('multisignatures', () => {
 		};
 		stubs.logic.account = sinonSandbox.stub();
 
-		stubs.Multisignature = sinonSandbox.stub();
-		set('Multisignature', stubs.Multisignature);
-
-		stubs.logic.multisignature = new stubs.Multisignature(
-			stubs.schema,
-			stubs.logic.transaction,
-			stubs.logic.account,
-			stubs.logger,
-			stubs.channel
-		);
-		stubs.Multisignature.resetHistory();
-
 		// Create stubbed scope
 		validScope = {
 			components: {
@@ -109,6 +94,7 @@ describe.skip('multisignatures', () => {
 			modules: {
 				accounts: sinonSandbox.stub(),
 				transactions: sinonSandbox.stub(),
+				processTransactions: sinonSandbox.stub(),
 			},
 		};
 
@@ -116,7 +102,6 @@ describe.skip('multisignatures', () => {
 		multisignaturesInstance = new RewiredMultisignatures(
 			(err, __multisignatures) => {
 				self = __multisignatures;
-				__private = get('__private');
 				library = get('library');
 				self.onBind(stubs.bindings);
 				done(err);
@@ -133,41 +118,11 @@ describe.skip('multisignatures', () => {
 			expect(library.schema).to.eql(validScope.schema);
 			expect(library.bus).to.eql(validScope.bus);
 			expect(library.balancesSequence).to.eql(validScope.balancesSequence);
-			expect(library.logic.transaction).to.eql(validScope.logic.transaction);
-			expect(library.logic.account).to.eql(validScope.logic.account);
-			return expect(library.logic.multisignature).to.eql(
-				validScope.logic.multisignature
-			);
-		});
-
-		it('should instantiate Multisignature logic with proper params', async () => {
-			expect(stubs.Multisignature).to.have.been.calledOnce;
-			return expect(stubs.Multisignature).to.have.been.calledWith({
-				components: {
-					logger: validScope.components.logger,
-				},
-				schema: validScope.schema,
-				logic: {
-					transaction: validScope.logic.transaction,
-					account: validScope.logic.account,
-				},
-				channel: validScope.channel,
-			});
+			return expect(library.logic.account).to.eql(validScope.logic.account);
 		});
 
 		it('should call callback with result = self', async () =>
 			expect(self).to.be.deep.equal(multisignaturesInstance));
-
-		describe('__private', () => {
-			it('should call library.logic.transaction.attachAssetType', async () =>
-				expect(library.logic.transaction.attachAssetType).to.have.been
-					.calledOnce);
-
-			it('should assign __private.assetTypes[TRANSACTION_TYPES.MULTI]', async () =>
-				expect(__private.assetTypes)
-					.to.have.property(TRANSACTION_TYPES.MULTI)
-					.which.is.equal(attachAssetTypeStubResponse));
-		});
 	});
 
 	describe('onBind', () => {
@@ -175,649 +130,18 @@ describe.skip('multisignatures', () => {
 			expect(get('modules')).to.deep.equal(stubs.bindings.modules));
 	});
 
-	describe('__private.isValidSignature', () => {
+	describe('getTransactionAndProcessSignature', () => {
+		let transactionResponse;
 		beforeEach(done => {
 			// Set some random data used for tests
 			data.transaction = new transactionsFixtures.Transaction({
 				type: TRANSACTION_TYPES.MULTI,
 			});
-			data.signatures = [
-				{
-					transactionId: data.transaction.id,
-					publicKey: 'publicKey1',
-					signature: 'signature1',
-				},
-				{
-					transactionId: data.transaction.id,
-					publicKey: 'publicKey2',
-					signature: 'signature2',
-				},
-			];
-			data.signature = data.signatures[0];
-			data.membersPublicKeys = ['publicKey1', 'publicKey2'];
-			done();
-		});
-
-		describe('when signature data contains publicKey', () => {
-			describe('when publicKey is not present as member of multisignature account in transaction', () => {
-				it('should return false', async () => {
-					data.signature.publicKey = 'not_present';
-					const result = __private.isValidSignature(
-						data.signature,
-						data.membersPublicKeys,
-						data.transaction
-					);
-					expect(library.logger.error).to.have.been.calledWith(
-						'Unable to process signature, signer not in keysgroup.',
-						{
-							signature: data.signature,
-							membersPublicKeys: data.membersPublicKeys,
-							transaction: data.transaction,
-						}
-					);
-					expect(stubs.verifySignature).to.have.not.been.called;
-					return expect(result).to.be.false;
-				});
-			});
-
-			describe('when publicKey is present as member of multisignature account in transaction', () => {
-				describe('after calling library.logic.transaction.verifySignature', () => {
-					describe('when validation is successfull', () => {
-						it('should return true', async () => {
-							stubs.verifySignature.returns(true);
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.signature.publicKey,
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledOnce;
-							expect(library.logger.error).to.have.not.been.called;
-							return expect(result).to.be.true;
-						});
-					});
-
-					describe('when validation fails', () => {
-						it('should return false', async () => {
-							stubs.verifySignature.returns(false);
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.signature.publicKey,
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledOnce;
-							expect(library.logger.error).to.have.not.been.called;
-							return expect(result).to.be.false;
-						});
-					});
-
-					describe('when error is thrown', () => {
-						it('should return true', async () => {
-							stubs.verifySignature.throws('verifySignature#ERR');
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.signature.publicKey,
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledOnce;
-							expect(library.logger.error).to.have.been.calledWithMatch(
-								'Unable to process signature, verification failed.',
-								{
-									signature: data.signature,
-									membersPublicKeys: data.membersPublicKeys,
-									transaction: data.transaction,
-								}
-							);
-							expect(library.logger.error.args[0][1].error).to.include(
-								'verifySignature#ERR'
-							);
-							return expect(result).to.be.false;
-						});
-					});
-				});
-			});
-		});
-
-		describe('when signature data contains no publicKey', () => {
-			beforeEach(done => {
-				delete data.signature.publicKey;
-				done();
-			});
-
-			describe('after calling library.logic.transaction.verifySignature', () => {
-				describe('when membersPublicKeys is empty', () => {
-					it('should return false', async () => {
-						data.membersPublicKeys = [];
-
-						const result = __private.isValidSignature(
-							data.signature,
-							data.membersPublicKeys,
-							data.transaction
-						);
-						expect(library.logger.error).to.have.not.been.called;
-						expect(stubs.verifySignature).to.have.not.been.called;
-						return expect(result).to.be.false;
-					});
-				});
-
-				describe('when membersPublicKeys contains 1 entry', () => {
-					beforeEach(done => {
-						data.membersPublicKeys = [data.membersPublicKeys[0]];
-						done();
-					});
-
-					describe('when validation is successfull', () => {
-						it('should return true', async () => {
-							stubs.verifySignature.returns(true);
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.membersPublicKeys[0],
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledOnce;
-							return expect(result).to.be.true;
-						});
-					});
-
-					describe('when validation fails', () => {
-						it('should return false', async () => {
-							stubs.verifySignature.returns(false);
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.membersPublicKeys[0],
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledOnce;
-							return expect(result).to.be.false;
-						});
-					});
-
-					describe('when error is thrown', () => {
-						it('should return true', async () => {
-							stubs.verifySignature.throws('verifySignature#ERR');
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.membersPublicKeys[0],
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledOnce;
-							expect(library.logger.error).to.have.been.calledWithMatch(
-								'Unable to process signature, verification failed.',
-								{
-									signature: data.signature,
-									membersPublicKeys: data.membersPublicKeys,
-									transaction: data.transaction,
-								}
-							);
-							expect(library.logger.error.args[0][1].error).to.include(
-								'verifySignature#ERR'
-							);
-							return expect(result).to.be.false;
-						});
-					});
-				});
-
-				describe('when membersPublicKeys contains 2 entries', () => {
-					describe('when first entry passes validation', () => {
-						describe('when second entry fails validation', () => {
-							it('should return true', async () => {
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[0],
-										data.signature.signature
-									)
-									.returns(true);
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[1],
-										data.signature.signature
-									)
-									.returns(false);
-
-								const result = __private.isValidSignature(
-									data.signature,
-									data.membersPublicKeys,
-									data.transaction
-								);
-								expect(stubs.verifySignature).to.have.been.calledWith(
-									data.transaction,
-									data.membersPublicKeys[0],
-									data.signature.signature
-								);
-								expect(stubs.verifySignature).to.have.been.calledOnce;
-								return expect(result).to.be.true;
-							});
-						});
-
-						describe('when error is thrown for second entry', () => {
-							it('should return true', async () => {
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[0],
-										data.signature.signature
-									)
-									.returns(true);
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[1],
-										data.signature.signature
-									)
-									.throws('verifySignature#ERR');
-
-								const result = __private.isValidSignature(
-									data.signature,
-									data.membersPublicKeys,
-									data.transaction
-								);
-								expect(stubs.verifySignature).to.have.been.calledWith(
-									data.transaction,
-									data.membersPublicKeys[0],
-									data.signature.signature
-								);
-								expect(stubs.verifySignature).to.have.been.calledOnce;
-								return expect(result).to.be.true;
-							});
-						});
-					});
-
-					describe('when second entry passes validation', () => {
-						describe('when first entry fails validation', () => {
-							it('should return true', async () => {
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[0],
-										data.signature.signature
-									)
-									.returns(false);
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[1],
-										data.signature.signature
-									)
-									.returns(true);
-
-								const result = __private.isValidSignature(
-									data.signature,
-									data.membersPublicKeys,
-									data.transaction
-								);
-								expect(stubs.verifySignature).to.have.been.calledWith(
-									data.transaction,
-									data.membersPublicKeys[0],
-									data.signature.signature
-								);
-								expect(stubs.verifySignature).to.have.been.calledWith(
-									data.transaction,
-									data.membersPublicKeys[1],
-									data.signature.signature
-								);
-								expect(stubs.verifySignature).to.have.been.calledTwice;
-								return expect(result).to.be.true;
-							});
-						});
-
-						describe('when error is thrown for first entry', () => {
-							it('should return false', async () => {
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[0],
-										data.signature.signature
-									)
-									.throws('verifySignature#ERR');
-								stubs.verifySignature
-									.withArgs(
-										data.transaction,
-										data.membersPublicKeys[1],
-										data.signature.signature
-									)
-									.returns(true);
-
-								const result = __private.isValidSignature(
-									data.signature,
-									data.membersPublicKeys,
-									data.transaction
-								);
-								expect(stubs.verifySignature).to.have.been.calledWith(
-									data.transaction,
-									data.membersPublicKeys[0],
-									data.signature.signature
-								);
-								expect(stubs.verifySignature).to.have.been.calledOnce;
-								expect(library.logger.error).to.have.been.calledWithMatch(
-									'Unable to process signature, verification failed.',
-									{
-										signature: data.signature,
-										membersPublicKeys: data.membersPublicKeys,
-										transaction: data.transaction,
-									}
-								);
-								expect(library.logger.error.args[0][1].error).to.include(
-									'verifySignature#ERR'
-								);
-								return expect(result).to.be.false;
-							});
-						});
-					});
-
-					describe('when no entry passes validation', () => {
-						it('should return false', async () => {
-							stubs.verifySignature
-								.withArgs(
-									data.transaction,
-									data.membersPublicKeys[0],
-									data.signature.signature
-								)
-								.returns(false);
-							stubs.verifySignature
-								.withArgs(
-									data.transaction,
-									data.membersPublicKeys[1],
-									data.signature.signature
-								)
-								.returns(false);
-
-							const result = __private.isValidSignature(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.membersPublicKeys[0],
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledWith(
-								data.transaction,
-								data.membersPublicKeys[1],
-								data.signature.signature
-							);
-							expect(stubs.verifySignature).to.have.been.calledTwice;
-							return expect(result).to.be.false;
-						});
-					});
-				});
-			});
-		});
-	});
-
-	describe('__private.validateSignature', () => {
-		beforeEach(done => {
-			data.sender = new accountsFixtures.Account();
-			stubs.isValidSignature = sinonSandbox.stub();
-			__private.isValidSignature = stubs.isValidSignature;
-			done();
-		});
-
-		describe('after calling __private.isValidSignature', () => {
-			describe('when signature is invalid', () => {
-				it('should call a callback with Error instance', done => {
-					stubs.isValidSignature.returns(false);
-					__private.validateSignature(
-						data.signature,
-						data.membersPublicKeys,
-						data.transaction,
-						data.sender,
-						err => {
-							expect(stubs.isValidSignature).to.have.been.calledWith(
-								data.signature,
-								data.membersPublicKeys,
-								data.transaction
-							);
-							expect(stubs.isValidSignature).to.have.been.calledOnce;
-							expect(err).to.be.an.instanceof(Error);
-							expect(err.message).to.eql(
-								'Unable to process signature, verification failed'
-							);
-							done();
-						}
-					);
-				});
-			});
-
-			describe('when signature is valid', () => {
-				beforeEach(done => {
-					stubs.ready = sinonSandbox.stub().returns('ready');
-					library.logic.multisignature = { ready: stubs.ready };
-					stubs.isValidSignature.returns(true);
-					__private.validateSignature(
-						data.signature,
-						data.membersPublicKeys,
-						data.transaction,
-						data.sender,
-						done
-					);
-				});
-
-				it('should set transaction.signature', async () =>
-					expect(data.transaction.signatures).to.eql([
-						data.signature.signature,
-					]));
-
-				it('should set transaction.ready', async () => {
-					expect(stubs.ready).to.have.been.calledWith(
-						data.transaction,
-						data.sender
-					);
-					expect(stubs.ready).to.have.been.calledOnce;
-					return expect(data.transaction.ready).to.eql('ready');
-				});
-
-				it('should publish events with proper data using channel', async () => {
-					expect(stubs.channelPublish).to.have.been.calledWith(
-						'chain:multisignatures:signature:change',
-						data.transaction
-					);
-					expect(stubs.channelPublish).to.have.been.calledOnce;
-					expect(stubs.busMessage).to.have.been.calledWith(
-						'signature',
-						data.signature,
-						true
-					);
-					return expect(stubs.busMessage).to.have.been.calledOnce;
-				});
-			});
-		});
-	});
-
-	describe('__private.processSignatureForMultisignatureAccountCreation', () => {
-		beforeEach(done => {
-			// Set some random data used for tests
-			data.transaction = new transactionsFixtures.Transaction({
-				type: TRANSACTION_TYPES.MULTI,
-			});
-			data.transaction.asset.multisignature.keysgroup = [
-				'+publicKey1',
-				'+publicKey2',
-			];
-			data.signature = {
-				transactionId: data.transaction.id,
-				publicKey: 'publicKey1',
-				signature: 'signature1',
+			transactionResponse = {
+				id: data.transaction.id,
+				status: 1,
+				errors: [],
 			};
-
-			// Initialize stubs
-			stubs.validateSignature = sinonSandbox.stub().callsArgWith(4, null);
-
-			set('__private.validateSignature', stubs.validateSignature);
-			__private.processSignatureForMultisignatureAccountCreation(
-				data.signature,
-				data.transaction,
-				done
-			);
-		});
-
-		describe('when calling __private.validateSignature', () => {
-			it('should be called with proper data', async () => {
-				const memberPublicKeys = ['publicKey1', 'publicKey2'];
-				const sender = {};
-				expect(stubs.validateSignature).to.have.been.calledWith(
-					data.signature,
-					memberPublicKeys,
-					data.transaction,
-					sender
-				);
-				return expect(stubs.validateSignature).to.have.been.calledOnce;
-			});
-		});
-	});
-
-	describe('__private.processSignatureFromMultisignatureAccount', () => {
-		beforeEach(done => {
-			// Set some random data used for tests
-			data.sender = new accountsFixtures.Account();
-			data.sender.membersPublicKeys = ['publicKey1', 'publicKey2'];
-
-			data.transaction = new transactionsFixtures.Transaction({
-				type: TRANSACTION_TYPES.MULTI,
-			});
-			data.signature = {
-				transactionId: data.transaction.id,
-				publicKey: 'publicKey1',
-				signature: 'signature1',
-			};
-
-			// Initialize stubs
-			stubs.validateSignature = sinonSandbox.stub().callsArgWith(4, null);
-			set('__private.validateSignature', stubs.validateSignature);
-
-			stubs.getAccount = sinonSandbox.stub();
-			stubs.bindings.modules.accounts.getAccount = stubs.getAccount;
-			done();
-		});
-
-		describe('when modules.accounts.getAccount returns an error', () => {
-			it('should call a callback with Error instance', done => {
-				stubs.getAccount.callsArgWith(1, 'getAccount#ERR');
-
-				__private.processSignatureFromMultisignatureAccount(
-					data.signature,
-					data.transaction,
-					err => {
-						expect(stubs.getAccount).to.have.been.calledWith({
-							address: data.transaction.senderId,
-						});
-						expect(stubs.getAccount).to.have.been.calledOnce;
-						expect(err).to.be.an.instanceof(Error);
-						expect(err.message).to.eql(
-							'Unable to process signature, account not found'
-						);
-						expect(library.logger.error).to.have.been.calledWith(
-							'Unable to process signature, account not found',
-							{
-								signature: data.signature,
-								transaction: data.transaction,
-								error: 'getAccount#ERR',
-							}
-						);
-						done();
-					}
-				);
-			});
-		});
-
-		describe('when modules.accounts.getAccount returns no error but sender = undefined', () => {
-			it('should call a callback with Error instance', done => {
-				const sender = undefined;
-				stubs.getAccount.callsArgWith(1, null, sender);
-
-				__private.processSignatureFromMultisignatureAccount(
-					data.signature,
-					data.transaction,
-					err => {
-						expect(stubs.getAccount).to.have.been.calledWith({
-							address: data.transaction.senderId,
-						});
-						expect(stubs.getAccount).to.have.been.calledOnce;
-						expect(err).to.be.an.instanceof(Error);
-						expect(err.message).to.eql(
-							'Unable to process signature, account not found'
-						);
-						expect(library.logger.error).to.have.been.calledWith(
-							'Unable to process signature, account not found',
-							{
-								signature: data.signature,
-								transaction: data.transaction,
-								error: null,
-							}
-						);
-						done();
-					}
-				);
-			});
-		});
-
-		describe('when modules.accounts.getAccount returns no error', () => {
-			describe('when calling __private.validateSignature', () => {
-				it('should be called with proper data', done => {
-					stubs.getAccount.callsArgWith(1, null, data.sender);
-
-					__private.processSignatureFromMultisignatureAccount(
-						data.signature,
-						data.transaction,
-						err => {
-							expect(stubs.getAccount).to.have.been.calledWith({
-								address: data.transaction.senderId,
-							});
-							expect(stubs.getAccount).to.have.been.calledOnce;
-							expect(err).to.not.exist;
-							expect(stubs.validateSignature).to.have.been.calledWith(
-								data.signature,
-								data.sender.membersPublicKeys,
-								data.transaction,
-								data.sender
-							);
-							expect(stubs.validateSignature).to.have.been.calledOnce;
-							done();
-						}
-					);
-				});
-			});
-		});
-	});
-
-	describe('processSignature', () => {
-		beforeEach(done => {
-			// Set some random data used for tests
-
-			data.transaction = new transactionsFixtures.Transaction({
-				type: TRANSACTION_TYPES.MULTI,
-			});
 			data.signature = {
 				transactionId: data.transaction.id,
 				publicKey: 'publicKey1',
@@ -826,36 +150,26 @@ describe.skip('multisignatures', () => {
 			data.transaction.signatures = [];
 
 			// Initialize stubs
-			stubs.balancesSequence = sinonSandbox
-				.stub()
-				.callsFake((callback, doneCallback) => {
-					callback(doneCallback);
-				});
-			library.balancesSequence.add = stubs.balancesSequence;
-
 			stubs.getMultisignatureTransaction = sinonSandbox.stub();
 			stubs.getMultisignatureTransaction.returns(data.transaction);
 			stubs.bindings.modules.transactions.getMultisignatureTransaction =
 				stubs.getMultisignatureTransaction;
+			stubs.processSignature = sinonSandbox
+				.stub()
+				.resolves(transactionResponse);
+			stubs.bindings.modules.processTransactions.processSignature =
+				stubs.processSignature;
 
 			stubs.processSignatureForMultisignatureAccountCreation = sinonSandbox
 				.stub()
 				.callsArgWith(2, null);
-			__private.processSignatureForMultisignatureAccountCreation =
-				stubs.processSignatureForMultisignatureAccountCreation;
-
-			stubs.processSignatureFromMultisignatureAccount = sinonSandbox
-				.stub()
-				.callsArgWith(2, null);
-			__private.processSignatureFromMultisignatureAccount =
-				stubs.processSignatureFromMultisignatureAccount;
 			done();
 		});
 
 		describe('when signature is not present', () => {
 			it('should call a callback with Error instance', done => {
 				const signature = undefined;
-				self.processSignature(signature, err => {
+				self.getTransactionAndProcessSignature(signature, err => {
 					expect(err).to.be.an.instanceof(Error);
 					expect(err.message).to.eql(
 						'Unable to process signature, signature not provided'
@@ -871,7 +185,7 @@ describe.skip('multisignatures', () => {
 		describe('when modules.transactions.getMultisignatureTransaction returns no transaction', () => {
 			it('should call a callback with Error instance', done => {
 				stubs.getMultisignatureTransaction.returns(undefined);
-				self.processSignature(data.signature, err => {
+				self.getTransactionAndProcessSignature(data.signature, err => {
 					expect(err).to.be.an.instanceof(Error);
 					expect(err.message).to.eql(
 						'Unable to process signature, corresponding transaction not found'
@@ -887,53 +201,26 @@ describe.skip('multisignatures', () => {
 
 		describe('when signature already exists in transaction', () => {
 			it('should call a callback with Error instance', done => {
+				stubs.processSignature.resolves({
+					...transactionResponse,
+					status: 0,
+					errors: [new Error('Signature already present in transaction.')],
+				});
 				data.transaction.signatures = ['signature1'];
-				self.processSignature(data.signature, err => {
+				self.getTransactionAndProcessSignature(data.signature, err => {
 					expect(stubs.getMultisignatureTransaction).to.have.been.calledWith(
 						data.signature.transactionId
 					);
 					expect(stubs.getMultisignatureTransaction).to.have.been.calledOnce;
+					expect(stubs.processSignature).to.have.been.calledOnce;
 					expect(err).to.be.an.instanceof(Error);
 					expect(err.message).to.eql(
-						'Unable to process signature, signature already exists'
+						'Error processing signature: Signature already present in transaction.'
 					);
 					expect(library.logger.error).to.have.been.calledWith(
-						'Unable to process signature, signature already exists',
-						{ signature: data.signature, transaction: data.transaction }
+						'Error processing signature: Signature already present in transaction.',
+						{ signature: data.signature }
 					);
-					done();
-				});
-			});
-		});
-
-		describe('when transaction have type MULTI', () => {
-			it('should call __private.processSignatureForMultisignatureAccountCreation with proper params', done => {
-				self.processSignature(data.signature, err => {
-					expect(
-						stubs.processSignatureForMultisignatureAccountCreation
-					).to.have.been.calledWith(data.signature, data.transaction);
-					expect(stubs.processSignatureForMultisignatureAccountCreation).to.have
-						.been.calledOnce;
-					expect(stubs.processSignatureFromMultisignatureAccount).to.have.not
-						.been.called;
-					expect(err).to.not.exist;
-					done();
-				});
-			});
-		});
-
-		describe('when transaction have type other than MULTI', () => {
-			it('should call __private.processSignatureFromMultisignatureAccount with proper params', done => {
-				data.transaction.type = TRANSACTION_TYPES.SEND;
-				self.processSignature(data.signature, err => {
-					expect(
-						stubs.processSignatureFromMultisignatureAccount
-					).to.have.been.calledWith(data.signature, data.transaction);
-					expect(stubs.processSignatureFromMultisignatureAccount).to.have.been
-						.calledOnce;
-					expect(stubs.processSignatureForMultisignatureAccountCreation).to.have
-						.not.been.called;
-					expect(err).to.not.exist;
 					done();
 				});
 			});

--- a/framework/test/mocha/unit/modules/chain/submodules/transport.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/transport.js
@@ -163,10 +163,6 @@ describe('transport', () => {
 			add: async () => {},
 		};
 
-		transactionStub = {
-			attachAssetType: sinonSandbox.stub(),
-		};
-
 		blockStub = {};
 		peersStub = {};
 
@@ -478,7 +474,7 @@ describe('transport', () => {
 				};
 
 				modules.multisignatures = {
-					processSignature: sinonSandbox.stub().callsArg(1),
+					getTransactionAndProcessSignature: sinonSandbox.stub().callsArg(1),
 				};
 
 				done();
@@ -487,7 +483,7 @@ describe('transport', () => {
 			describe('when library.schema.validate succeeds', () => {
 				describe('when modules.multisignatures.processSignature succeeds', () => {
 					beforeEach(done => {
-						modules.multisignatures.processSignature = sinonSandbox
+						modules.multisignatures.getTransactionAndProcessSignature = sinonSandbox
 							.stub()
 							.callsArg(1);
 
@@ -508,7 +504,7 @@ describe('transport', () => {
 					it('should call modules.multisignatures.processSignature with signature', async () => {
 						expect(error).to.equal(undefined);
 						return expect(
-							modules.multisignatures.processSignature.calledWith(
+							modules.multisignatures.getTransactionAndProcessSignature.calledWith(
 								SAMPLE_SIGNATURE_1
 							)
 						).to.be.true;
@@ -523,7 +519,7 @@ describe('transport', () => {
 
 					beforeEach(done => {
 						processSignatureError = new Error('Transaction not found');
-						modules.multisignatures.processSignature = sinonSandbox
+						modules.multisignatures.getTransactionAndProcessSignature = sinonSandbox
 							.stub()
 							.callsArgWith(1, processSignatureError);
 


### PR DESCRIPTION
### What was the problem?

Incoming signatures were being processed using old code. 

### How did I fix it?

`processSignature` function in `processTransactions` module which uses StateStore and Transactions library from elements now handles incoming signature objects.

### How to test it?

Run unit test for transport 

### Review checklist

* The PR resolves #2825 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
