### PR TITLE
Update packages versions - Closes #3147

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,25 @@
 				}
 			}
 		},
+		"@liskhq/bignum": {
+			"version": "1.3.1",
+			"resolved":
+				"https://registry.npmjs.org/@liskhq/bignum/-/bignum-1.3.1.tgz",
+			"integrity":
+				"sha512-q9+NvqbpmXOqpPmV8Y+XSEIUJFMZDGyfW6rkN9Ej3nzPb/qurY/Ic2UPTeTTaj8+q/bcw5JUwTb86hi7PIziDg==",
+			"requires": {
+				"@types/node": "11.11.2"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "11.11.2",
+					"resolved":
+						"https://registry.npmjs.org/@types/node/-/node-11.11.2.tgz",
+					"integrity":
+						"sha512-iEaHiDNkHv4Jrm9O5T37OYEUwjJesiyt6ZlhLFK0sbo4CLD0jyCOB4Pc2F9iD3MbW2397SLNxZKdDGntGaBjQQ=="
+				}
+			}
+		},
 		"@liskhq/lisk-cryptography": {
 			"version": "2.0.0",
 			"resolved":
@@ -379,24 +398,24 @@
 			}
 		},
 		"@liskhq/lisk-transaction-pool": {
-			"version": "0.1.0-alpha.0",
+			"version": "0.1.0-alpha.1",
 			"resolved":
-				"https://registry.npmjs.org/@liskhq/lisk-transaction-pool/-/lisk-transaction-pool-0.1.0-alpha.0.tgz",
+				"https://registry.npmjs.org/@liskhq/lisk-transaction-pool/-/lisk-transaction-pool-0.1.0-alpha.1.tgz",
 			"integrity":
-				"sha512-/RK6Cx3pVtEB1eXOb8a3KYMwjbmXYjR7+a4L2ovudpLhly3IHwobotLbPpQRqNCCq261k6kIZEfqjZb8bL51EA=="
+				"sha512-lrqbvy3eik2E2i57EkqQTm3D0N7onOen6ideIQNw2C9GatZ5njsWVyX4ye+3f4vdBa36po4E0H5FTto+7H3Svg=="
 		},
 		"@liskhq/lisk-transactions": {
-			"version": "2.1.0-alpha.2",
+			"version": "2.1.0-alpha.3",
 			"resolved":
-				"https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-2.1.0-alpha.2.tgz",
+				"https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-2.1.0-alpha.3.tgz",
 			"integrity":
-				"sha512-zXj9z+fv7lMCehIA46DD3CVWIyC4uldkSE4cIHoxCQHRnmkSMoL6LG3jpBSuI0j8vQIepm5LXRiT3Jhh5tp10w==",
+				"sha512-KwKW47omw+3a/1PmstF8YZIK42GGCslhxkYOLnTnzf1YiT6iRmkKI1p43z01tpvPiL9rm8DmSukwUvsIbZFBZQ==",
 			"requires": {
+				"@liskhq/bignum": "1.3.1",
 				"@liskhq/lisk-cryptography": "2.1.0-alpha.0",
 				"@types/node": "10.12.21",
 				"ajv": "6.8.1",
 				"ajv-merge-patch": "4.1.0",
-				"browserify-bignum": "1.3.0-2",
 				"verror": "1.10.0"
 			},
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
 		"prepublishOnly": "npm run check:dependencies"
 	},
 	"dependencies": {
-		"@liskhq/lisk-transaction-pool": "0.1.0-alpha.0",
-		"@liskhq/lisk-transactions": "2.1.0-alpha.2",
+		"@liskhq/lisk-transaction-pool": "0.1.0-alpha.1",
+		"@liskhq/lisk-transactions": "2.1.0-alpha.3",
 		"ajv": "6.7.0",
 		"async": "2.6.1",
 		"bignumber.js": "8.0.2",


### PR DESCRIPTION
### What was the problem?

-`@liskhq/lisk-transaction-pool` was at version `0.1.0-alpha.0`
-`@liskhq/lisk-transactions` was at version `2.1.0-alpha.2`

### How did I fix it?

- updated `@liskhq/lisk-transaction-pool` to version `0.1.0-alpha.1`
- updated `@liskhq/lisk-transactions` to version `2.1.0-alpha.3`

### How to test it?

- Check package.json
- `npm i` and then npm list and check the package versions

### Review checklist

* The PR resolves #3147
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
