### PR TITLE
Event & Action name validation regex definitions are different in Base class - Closes #3008

### DIFF
--- a/framework/src/controller/channels/base.js
+++ b/framework/src/controller/channels/base.js
@@ -1,6 +1,6 @@
 const Event = require('../event');
 const Action = require('../action');
-const { INTERNAL_EVENTS } = require('./base/constants');
+const { INTERNAL_EVENTS, eventWithModuleNameReg } = require('./base/constants');
 
 const _eventsList = new WeakMap();
 const _actionsList = new WeakMap();
@@ -91,7 +91,7 @@ class BaseChannel {
 	}
 
 	isValidEventName(name, throwError = true) {
-		const result = /[A-Za-z0-9]+:[A-Za-z0-9]+/.test(name);
+		const result = eventWithModuleNameReg.test(name);
 		if (throwError && !result) {
 			throw new Error(
 				`[${this.moduleAlias.alias}] Invalid event name ${name}.`
@@ -101,7 +101,7 @@ class BaseChannel {
 	}
 
 	isValidActionName(name, throwError = true) {
-		const result = /[A-Za-z0-9]+:[A-Za-z0-9]+/.test(name);
+		const result = eventWithModuleNameReg.test(name);
 		if (throwError && !result) {
 			throw new Error(
 				`[${this.moduleAlias.alias}] Invalid action name ${name}.`

--- a/framework/src/controller/channels/base/constants.js
+++ b/framework/src/controller/channels/base/constants.js
@@ -4,7 +4,7 @@ const INTERNAL_EVENTS = Object.freeze([
 	'loading:finished',
 ]);
 
-const eventWithModuleNameReg = /[A-Za-z]+[A-Za-z0-9]*:[A-Za-z]+[A-Za-z0-9]*/;
+const eventWithModuleNameReg = /^([^\d][\w]+)((?::[^\d][\w]+)+)$/;
 
 module.exports = {
 	eventWithModuleNameReg,

--- a/framework/src/controller/channels/base/constants.js
+++ b/framework/src/controller/channels/base/constants.js
@@ -4,6 +4,9 @@ const INTERNAL_EVENTS = Object.freeze([
 	'loading:finished',
 ]);
 
+const eventWithModuleNameReg = /[A-Za-z]+[A-Za-z0-9]*:[A-Za-z]+[A-Za-z0-9]*/;
+
 module.exports = {
+	eventWithModuleNameReg,
 	INTERNAL_EVENTS,
 };

--- a/framework/src/controller/event.js
+++ b/framework/src/controller/event.js
@@ -13,7 +13,7 @@ class Event {
 	/**
 	 * Create Event object.
 	 *
-	 * @param {string} name - Can be simple event or be combination of module:event
+	 * @param {string} name - Combination of module:event
 	 * @param {string|Object} [data] - Data associated with the event
 	 */
 	constructor(name, data = null) {
@@ -21,11 +21,10 @@ class Event {
 			eventWithModuleNameReg.test(name),
 			`Event name "${name}" must be a valid name with module name.`
 		);
-
+		this.data = data;
 		[, this.module, this.name] = eventWithModuleNameReg.exec(name);
 		// Remove the first prefixed ':' symbol
 		this.name = this.name.substring(1);
-		this.data = data;
 	}
 
 	/**

--- a/framework/src/controller/event.js
+++ b/framework/src/controller/event.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
-
-const eventWithModuleNameReg = /^([a-zA-Z][a-zA-Z0-9]*)((?::[a-zA-Z][a-zA-Z0-9]*)+)$/;
+const { eventWithModuleNameReg } = require('./channels/base/constants');
 
 /**
  * An event class which instance will be received by every event listener


### PR DESCRIPTION
### What was the problem?
Event & Action name validation regex definitions are different in Base class.
### How did I fix it?
Fixed the `module:event` regexp and reuse the same in base and event.

### Review checklist

* The PR resolves #3008
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
