### PR TITLE
Lisk Core should start without Redis - Closes #3176

### DIFF
--- a/framework/src/components/cache/cache.js
+++ b/framework/src/components/cache/cache.js
@@ -46,6 +46,8 @@ class Cache {
 			this.client.once('error', err => {
 				// Called if the "error" event occured before "ready" event
 				this.logger.warn('App was unable to connect to Cache server', err);
+				// Error handler needs to exist to ignore the error
+				this.client.on('error', () => {});
 				resolve();
 			});
 			this.client.once('ready', () => {

--- a/framework/src/components/cache/cache.js
+++ b/framework/src/components/cache/cache.js
@@ -41,17 +41,16 @@ class Cache {
 		// TODO: implement retry_strategy
 		// TOFIX: app crashes with FTL error when launchin app with CACHE_ENABLE=true
 		// but cache server is not available.
-		const self = this;
-		return new Promise((resolve, reject) => {
-			self.client = redis.createClient(self.options);
-			self.client.once('error', err => {
+		return new Promise(resolve => {
+			this.client = redis.createClient(this.options);
+			this.client.once('error', err => {
 				// Called if the "error" event occured before "ready" event
-				self.logger.warn('App was unable to connect to Cache server', err);
-				return reject(err);
+				this.logger.warn('App was unable to connect to Cache server', err);
+				resolve();
 			});
-			self.client.once('ready', () => {
-				self._onReady();
-				return resolve();
+			this.client.once('ready', () => {
+				this._onReady();
+				resolve();
 			});
 		});
 	}


### PR DESCRIPTION
### What was the problem?
When redis cannot be connected, application crashes

### How did I fix it?
changed to resolve the bootstrap even when it fails, and register empty error handler to ignore the error

### How to test it?
- Start application with cacheEnabled "on" without redis
- Start application with cacheEnabled "off" without redis
and make sure application starts

### Review checklist

* The PR resolves #3176 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
