### PR TITLE
Revert child process auto-reload - Closes #3191

### DIFF
--- a/framework/src/controller/bus.js
+++ b/framework/src/controller/bus.js
@@ -135,37 +135,6 @@ class Bus extends EventEmitter2 {
 	}
 
 	/**
-	 * Unregister channel from bus.
-	 *
-	 * @async
-	 * @param {string} moduleAlias - Alias for module used during registration
-	 *
-	 * @throws {Error} If channel not registered.
-	 */
-	async unregisterChannel(moduleAlias) {
-		Object.keys(this.events).forEach(eventName => {
-			const [moduleName] = eventName.split(':');
-			if (moduleName === moduleAlias) {
-				delete this.events[eventName];
-			}
-		});
-
-		Object.keys(this.actions).forEach(actionName => {
-			const [moduleName] = actionName.split(':');
-			if (moduleName === moduleAlias) {
-				delete this.actions[actionName];
-			}
-		});
-
-		const rpcSocket = this.rpcClients[moduleAlias];
-		if (rpcSocket) {
-			rpcSocket.close();
-		}
-
-		delete this.channels[moduleAlias];
-	}
-
-	/**
 	 * Invoke action on bus.
 	 *
 	 * @param {Object|string} actionData - Object or stringified object containing action data like name, module, souce, and params.

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -86,15 +86,10 @@ module.exports = class ChainModule extends BaseModule {
 
 	async load(channel) {
 		this.chain = new Chain(channel, this.options);
-		const isLiskReady = await channel.invoke('lisk:isLiskReady');
 
-		if (isLiskReady) {
+		channel.once('lisk:ready', async () => {
 			await this.chain.bootstrap();
-		} else {
-			channel.once('lisk:ready', async () => {
-				await this.chain.bootstrap();
-			});
-		}
+		});
 	}
 
 	async unload() {

--- a/framework/src/modules/http_api/index.js
+++ b/framework/src/modules/http_api/index.js
@@ -41,15 +41,10 @@ class HttpAPIModule extends BaseModule {
 
 	async load(channel) {
 		this.httpApi = new HttpApi(channel, this.options);
-		const isLiskReady = await channel.invoke('lisk:isLiskReady');
 
-		if (isLiskReady) {
+		channel.once('lisk:ready', async () => {
 			await this.httpApi.bootstrap();
-		} else {
-			channel.once('lisk:ready', async () => {
-				await this.httpApi.bootstrap();
-			});
-		}
+		});
 	}
 
 	async unload() {


### PR DESCRIPTION
### What was the problem?
There was no mechanism to limit the amount of retries if a child process crashes

### How did I fix it?
I've reverted the current implementation and it will be implemented properly later.

### How to test it?
Run the application with httpApi modules as child process:
`NODE_ENV=test LISK_CHILD_PROCESS_MODULES=httpApi node src/index.js -n devnet`

Kill httpApi process (it should crash the application):
`pgrep -f http_api | xargs kill -9`

### Review checklist

* The PR resolves #3191
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
