### PR TITLE
Node inspect can't be run with default child process - Closes #3193

### DIFF
--- a/framework/src/controller/controller.js
+++ b/framework/src/controller/controller.js
@@ -227,7 +227,18 @@ class Controller {
 			JSON.stringify({ config: this.config, moduleOptions: options }),
 		];
 
-		const child = child_process.fork(program, parameters);
+		const forkedProcessOptions = {};
+		const maxPort = 20000;
+		const minPort = 10000;
+		process.env.NODE_DEBUG
+			? (forkedProcessOptions.execArgv = [
+					`--inspect=${Math.floor(
+						Math.random() * (maxPort - minPort) + minPort
+					)}`,
+				])
+			: [];
+
+		const child = child_process.fork(program, parameters, forkedProcessOptions);
 
 		this.childrenList.push(child);
 
@@ -235,7 +246,6 @@ class Controller {
 			this.logger.error(
 				`Module ${moduleAlias}(${name}:${version}) exited with code: ${code} and signal: ${signal}`
 			);
-
 			// Exits the main process with a failure code
 			process.exit(1);
 		});

--- a/framework/src/controller/controller.js
+++ b/framework/src/controller/controller.js
@@ -227,6 +227,7 @@ class Controller {
 			JSON.stringify({ config: this.config, moduleOptions: options }),
 		];
 
+		// Avoid child processes and the main process sharing the same debugging ports causing a conflict
 		const forkedProcessOptions = {};
 		const maxPort = 20000;
 		const minPort = 10000;


### PR DESCRIPTION
### What was the problem?

After the introduction of child processes it was not possible anymore to run nodejs' inspector

### How did I fix it?

By adding code to assign different random ports to the debugger if the environmental variable NODE_DEBUG is set to true

### How to test it?

Run `NODE_DEBUG=true node --inspect src/index.js` and the debugger and inspector should work

### Review checklist

* The PR resolves #3193
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
