### PR TITLE
Build failed with errors - Closes #3199

### DIFF
--- a/framework/src/modules/http_api/init_steps/setup_servers.js
+++ b/framework/src/modules/http_api/init_steps/setup_servers.js
@@ -20,13 +20,13 @@ const express = require('express');
 const http = require('http');
 const https = require('https');
 const socketIO = require('socket.io');
-// eslint-disable-next-line import/no-extraneous-dependencies
-const im = require('istanbul-middleware');
 
 module.exports = ({ components: { logger }, config }) => {
 	const expressApp = express();
 
 	if (config.coverage) {
+		// eslint-disable-next-line import/no-extraneous-dependencies
+		const im = require('istanbul-middleware');
 		logger.debug(
 			'Hook loader for coverage - Do not use in production environment!'
 		);


### PR DESCRIPTION
### What was the problem?
Application was crashing on start because it couldn't find `istanbul-middleware`.
### How did I fix it?
`istanbul-middleware` now is loaded only if coverage config is set to true
### How to test it?
`make LISK_NETWORK=testnet`
And then execute `node src/index.js`. `Istanbul` error shouldn't be present anymore.
### Review checklist

* The PR resolves #3199
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
