### PR TITLE
Newrelic throws error on start - Closes #3200

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21003,8 +21003,8 @@
 		},
 		"lisk-newrelic": {
 			"version":
-				"github:LiskHQ/lisk-newrelic#fa23caa396af1f7b61ceeb64563bce373592870d",
-			"from": "github:LiskHQ/lisk-newrelic#fa23caa",
+				"github:LiskHQ/lisk-newrelic#b3dadc5cf35882eb6ba28d5a4bc86f96fe2a1c3b",
+			"from": "github:LiskHQ/lisk-newrelic#b3dadc5",
 			"requires": {
 				"debug": "4.0.1"
 			},

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"lisk-commander": "2.0.0",
 		"@liskhq/lisk-transactions": "2.0.0",
 		"@liskhq/lisk-cryptography": "2.0.0",
-		"lisk-newrelic": "LiskHQ/lisk-newrelic#fa23caa",
+		"lisk-newrelic": "LiskHQ/lisk-newrelic#b3dadc5",
 		"lodash": "4.17.11",
 		"method-override": "3.0.0",
 		"newrelic": "5.0.0",


### PR DESCRIPTION
### What was the problem?
NewRelic failing on start
```
Error: ENOENT: no such file or directory, scandir '/Users/manu/lisk_ecosystem/lisk/api/controllers/'
    at Object.readdirSync (fs.js:785:3)
    at LiskNewRelic.instrumentWeb (/Users/manu/lisk_ecosystem/lisk/node_modules/lisk-newrelic/src/index.js:75:6)
```
### How did I fix it?
Fix was introduced in https://github.com/LiskHQ/lisk-newrelic/pull/12 so I have just matched the new version
### How to test it?

### Review checklist
* The PR resolves #3200
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
