### PR TITLE
Fix typo in newrelic lisk - Closes #3206

### DIFF
--- a/framework/src/modules/chain/helpers/newrelic_lisk.js
+++ b/framework/src/modules/chain/helpers/newrelic_lisk.js
@@ -28,7 +28,7 @@ newrelicLisk.instrumentBackgroundJobs();
 // TOFIX: fix callbackMethods converted to async in #2579
 // callBackMethods array only support one level of nesting
 const modulesToInstrument = {
-	'./componentes/cache/cache': {
+	'./components/cache/cache': {
 		identifier: 'components.cache',
 		callbackMethods: [
 			'getJsonForKey',
@@ -37,8 +37,8 @@ const modulesToInstrument = {
 			'removeByPattern',
 		],
 	},
-	'./componentes/system.js': {
-		identifier: 'componentes.system',
+	'./components/system.js': {
+		identifier: 'components.system',
 		callbackMethods: ['update'],
 	},
 	'./helpers/sequence.js': {


### PR DESCRIPTION
### What was the problem?
`components` is actually written as `componentes` in `newrelic_lisk.js`
### How did I fix it?
By correcting the naming of `componentes` to `components`
### How to test it?

### Review checklist

* The PR resolves #3206 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
