### PR TITLE
Change jest:unit test folder structure

### DIFF
--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -92,7 +92,7 @@ class Application {
 
 		if (!config.components.logger) {
 			config.components.logger = {
-				filename: `~/.lisk/${label}/lisk.log`,
+				filename: `logs/${label}/lisk.log`,
 			};
 		}
 

--- a/framework/test/jest/specs/unit/controller/application.spec.js
+++ b/framework/test/jest/specs/unit/controller/application.spec.js
@@ -4,12 +4,13 @@ const applicationSchema = require('../../../../../src/controller/schema/applicat
 const constantsSchema = require('../../../../../src/controller/schema/constants');
 const version = require('../../../../../src/version');
 
+jest.mock('../../../../../src/components/logger');
 jest.mock('../../../../../src/controller/helpers/validator');
 
 describe('Application', () => {
 	// Arrange
 	const params = {
-		label: '#LABEL',
+		label: 'jest-unit',
 		genesisBlock: {},
 		constants: {},
 		config: { components: { logger: null } },
@@ -18,7 +19,7 @@ describe('Application', () => {
 	describe('#constructor', () => {
 		it('should accept function as label argument', () => {
 			// Arrange
-			const labelFn = () => '#LABEL';
+			const labelFn = () => 'jest-unit';
 
 			// Act
 			const app = new Application(
@@ -45,7 +46,7 @@ describe('Application', () => {
 			);
 
 			expect(config.components.logger.filename).toBe(
-				`~/.lisk/${params.label}/lisk.log`
+				`logs/${params.label}/lisk.log`
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
Running `jest:unit` creates a folder structure `~/.lisk/#LABEL/lisk.log` in the root of the project.
This behavior happens when no logger config is passed to `new Application` function. 

### How did I fix it?
1. Mock creation of logger config.
2. Modify the default path if no config is passed to `log/${label}/lisk.log`.
+ Relevant tests updated.

### How to test it?
Run `jest:unit` and run application.

### Review checklist

* The PR resolves #3139 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
