### PR TITLE
Exit event does not kill all the processes - Closes #3201

### DIFF
--- a/framework/src/controller/child_process_loader.js
+++ b/framework/src/controller/child_process_loader.js
@@ -26,4 +26,9 @@ const loadModule = async () => {
 	channel.publish(`${moduleAlias}:loading:finished`);
 };
 
+// TODO: Removed after https://github.com/LiskHQ/lisk/issues/3210 is fixed
+process.on('disconnect', () => {
+	process.exit();
+});
+
 loadModule();


### PR DESCRIPTION
### What was the problem?
Starting the application with `npm start` doesn't kill the child processes.

### How did I fix it?
It was fixed by forcing the child process to exit when it receives the `disconnect` signal.
This solution is temporary and should be removed after https://github.com/LiskHQ/lisk/issues/3210 is fixed

### How to test it?
Starting the application with `npm start`.
Exit the application with `ctrl + C`
Main process and child processes should be exited

### Review checklist

* The PR resolves #3201
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
