### PR TITLE
Lisk Node failed to start with snapshot mode - Closes #3214

### DIFF
--- a/framework/src/modules/chain/init_steps/create_socket_cluster.js
+++ b/framework/src/modules/chain/init_steps/create_socket_cluster.js
@@ -11,13 +11,6 @@ module.exports = async ({
 	modules: { transport },
 	components: { logger },
 }) => {
-	if (!config.peers.enabled) {
-		logger.info(
-			'Skipping P2P server initialization due to the config settings - "peers.enabled" is set to false.'
-		);
-		return true;
-	}
-
 	const webSocketConfig = {
 		workers: 1,
 		port: config.wsPort,


### PR DESCRIPTION
### What was the problem?
During snapshot `config.peers.enabled` is set to false preventing to create the webSocket server and crashing when trying to listen. 

### How did I fix it?
I check if peers is enabled before creating and listening to webSocket server.

### How to test it?
`node src/index.js -s 1000 -n testnet`

### Review checklist

* The PR resolves #3214
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
