### PR TITLE
PM2 does not show CPU and Memory usage as expected - Closes #3215

### DIFF
--- a/build/target/etc/pm2-lisk.json
+++ b/build/target/etc/pm2-lisk.json
@@ -1,8 +1,7 @@
 {
         "apps": [{
                 "name": "lisk.app",
-                "script": "npm",
-                "args": "start -- -c config.json",
+                "script": "src/index.js",
                 "cwd": ".",
                 "pid_file": "./pids/lisk.app.pid",
                 "out_file": "./logs/lisk.app.log",
@@ -12,6 +11,7 @@
                 "kill_timeout" : 10000,
                 "max_memory_restart": "1024M",
                 "node_args": "--max_old_space_size=1024",
+                "args": "-c config.json",
                 "min_uptime": 20000,
                 "max_restarts": 10
         }]

--- a/build/target/etc/pm2-snapshot.json
+++ b/build/target/etc/pm2-snapshot.json
@@ -1,17 +1,17 @@
 {
         "apps": [{
                 "name": "lisk.snapshot",
-                "script": "npm",
-                "args": "start -- -c config.json",
+                "script": "src/index.js",
                 "cwd": ".",
                 "pid_file": "./pids/lisk.snapshot.pid",
                 "out_file": "./logs/lisk.snapshot.log",
                 "error_file": "./logs/lisk.snapshot.err",
                 "log_date_format": "YYYY-MM-DD HH:mm:ss SSS",
+                "autorestart": false,
                 "watch": false,
                 "kill_timeout" : 10000,
                 "max_memory_restart": "2048M",
                 "node_args": "--max_old_space_size=2048",
-                "autorestart": false
+                "args": "-c etc/snapshot.json -s highest"
         }]
 }


### PR DESCRIPTION
### What was the problem?
PM2 not showing CPU and memory usage when using `npm start`

### How did I fix it?
I've reverted https://github.com/LiskHQ/lisk/pull/3050/commits/f062d62b86a90b4a4747a7cc50b9ae7778bd88ac for 1.6 release and another issue will be created to tackle this properly

### How to test it?
`pm2 start build/target/etc/pm2-lisk.json`
`pm2 status`

CPU and Memory should be displayed acordingly

### Review checklist

* The PR resolves #3215
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
