### PR TITLE
Remove topAccounts from config file - Closes #2592

### DIFF
--- a/config/default/config.json
+++ b/config/default/config.json
@@ -6,7 +6,6 @@
 	"logFileName": "logs/lisk.log",
 	"consoleLogLevel": "none",
 	"trustProxy": false,
-	"topAccounts": false,
 	"cacheEnabled": false,
 	"db": {
 		"host": "localhost",

--- a/framework/src/modules/chain/schema/config.js
+++ b/framework/src/modules/chain/schema/config.js
@@ -45,9 +45,6 @@ module.exports = {
 			trustProxy: {
 				type: 'boolean',
 			},
-			topAccounts: {
-				type: 'boolean',
-			},
 			cacheEnabled: {
 				type: 'boolean',
 			},
@@ -368,7 +365,6 @@ module.exports = {
 			'logFileName',
 			'consoleLogLevel',
 			'trustProxy',
-			'topAccounts',
 			'db',
 			'api',
 			'peers',


### PR DESCRIPTION
### What was the problem?
`topAccounts` still present in config and schema

### How did I fix it?
Removed them

### Review checklist

* The PR resolves #2592
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
