### PR TITLE
Snapshot creation failed due to frozen transaction type 7 - Closes #3229

### DIFF
--- a/framework/src/modules/chain/logic/in_transfer.js
+++ b/framework/src/modules/chain/logic/in_transfer.js
@@ -59,9 +59,10 @@ class InTransfer {
  * @todo Add description for the params
  */
 // TODO: Remove this method as modules will be loaded prior to trs logic.
-InTransfer.prototype.bind = function(accounts, sharedApi) {
+InTransfer.prototype.bind = function(accounts, blocks, sharedApi) {
 	__scope.modules = {
 		accounts,
+		blocks,
 	};
 	__scope.shared = sharedApi;
 };
@@ -87,48 +88,43 @@ InTransfer.prototype.calculateFee = function() {
  * @todo Add description for the params
  */
 InTransfer.prototype.verify = function(transaction, sender, cb, tx) {
-	__scope.components.storage.entities.Block.get(
+	const lastBlock = __scope.modules.blocks.lastBlock.get();
+
+	if (lastBlock.height >= exceptions.precedent.disableDappTransfer) {
+		return setImmediate(cb, `Transaction type ${transaction.type} is frozen`);
+	}
+
+	if (transaction.recipientId) {
+		return setImmediate(cb, 'Invalid recipient');
+	}
+
+	const amount = new Bignum(transaction.amount);
+	if (amount.isLessThanOrEqualTo(0)) {
+		return setImmediate(cb, 'Invalid transaction amount');
+	}
+
+	if (!transaction.asset || !transaction.asset.inTransfer) {
+		return setImmediate(cb, 'Invalid transaction asset');
+	}
+
+	return __scope.components.storage.entities.Transaction.isPersisted(
+		{
+			id: transaction.asset.inTransfer.dappId,
+			type: TRANSACTION_TYPES.DAPP,
+		},
 		{},
-		{ sort: 'height:desc', limit: 1 }
-	).then(lastBlock => {
-		lastBlock = lastBlock[0];
-
-		if (lastBlock.height >= exceptions.precedent.disableDappTransfer) {
-			return setImmediate(cb, `Transaction type ${transaction.type} is frozen`);
+		tx
+	)
+	.then(isPersisted => {
+		if (!isPersisted) {
+			return setImmediate(
+				cb,
+				`Application not found: ${transaction.asset.inTransfer.dappId}`
+			);
 		}
-
-		if (transaction.recipientId) {
-			return setImmediate(cb, 'Invalid recipient');
-		}
-
-		const amount = new Bignum(transaction.amount);
-		if (amount.isLessThanOrEqualTo(0)) {
-			return setImmediate(cb, 'Invalid transaction amount');
-		}
-
-		if (!transaction.asset || !transaction.asset.inTransfer) {
-			return setImmediate(cb, 'Invalid transaction asset');
-		}
-
-		return __scope.components.storage.entities.Transaction.isPersisted(
-			{
-				id: transaction.asset.inTransfer.dappId,
-				type: TRANSACTION_TYPES.DAPP,
-			},
-			{},
-			tx
-		)
-			.then(isPersisted => {
-				if (!isPersisted) {
-					return setImmediate(
-						cb,
-						`Application not found: ${transaction.asset.inTransfer.dappId}`
-					);
-				}
-				return setImmediate(cb);
-			})
-			.catch(err => setImmediate(cb, err));
-	});
+		return setImmediate(cb);
+	})
+	.catch(err => setImmediate(cb, err));
 };
 
 /**

--- a/framework/src/modules/chain/logic/out_transfer.js
+++ b/framework/src/modules/chain/logic/out_transfer.js
@@ -56,9 +56,10 @@ class OutTransfer {
  * @todo Add description for the params
  */
 // TODO: Remove this method as modules will be loaded prior to trs logic.
-OutTransfer.prototype.bind = function(accounts) {
+OutTransfer.prototype.bind = function(accounts, blocks) {
 	__scope.modules = {
 		accounts,
+		blocks,
 	};
 };
 
@@ -81,39 +82,34 @@ OutTransfer.prototype.calculateFee = function() {
  * @todo Add description for the params
  */
 OutTransfer.prototype.verify = function(transaction, sender, cb) {
-	return __scope.components.storage.entities.Block.get(
-		{},
-		{ sort: 'height:desc', limit: 1 }
-	).then(lastBlock => {
-		lastBlock = lastBlock[0];
+	const lastBlock = __scope.modules.blocks.lastBlock.get();
 
-		if (lastBlock.height >= exceptions.precedent.disableDappTransfer) {
-			return setImmediate(cb, `Transaction type ${transaction.type} is frozen`);
-		}
+	if (lastBlock.height >= exceptions.precedent.disableDappTransfer) {
+		return setImmediate(cb, `Transaction type ${transaction.type} is frozen`);
+	}
 
-		if (!transaction.recipientId) {
-			return setImmediate(cb, 'Invalid recipient');
-		}
+	if (!transaction.recipientId) {
+		return setImmediate(cb, 'Invalid recipient');
+	}
 
-		const amount = new Bignum(transaction.amount);
-		if (amount.isLessThanOrEqualTo(0)) {
-			return setImmediate(cb, 'Invalid transaction amount');
-		}
+	const amount = new Bignum(transaction.amount);
+	if (amount.isLessThanOrEqualTo(0)) {
+		return setImmediate(cb, 'Invalid transaction amount');
+	}
 
-		if (!transaction.asset || !transaction.asset.outTransfer) {
-			return setImmediate(cb, 'Invalid transaction asset');
-		}
+	if (!transaction.asset || !transaction.asset.outTransfer) {
+		return setImmediate(cb, 'Invalid transaction asset');
+	}
 
-		if (!/^[0-9]+$/.test(transaction.asset.outTransfer.dappId)) {
-			return setImmediate(cb, 'Invalid outTransfer dappId');
-		}
+	if (!/^[0-9]+$/.test(transaction.asset.outTransfer.dappId)) {
+		return setImmediate(cb, 'Invalid outTransfer dappId');
+	}
 
-		if (!/^[0-9]+$/.test(transaction.asset.outTransfer.transactionId)) {
-			return setImmediate(cb, 'Invalid outTransfer transactionId');
-		}
+	if (!/^[0-9]+$/.test(transaction.asset.outTransfer.transactionId)) {
+		return setImmediate(cb, 'Invalid outTransfer transactionId');
+	}
 
-		return setImmediate(cb, null, transaction);
-	});
+	return setImmediate(cb, null, transaction);
 };
 
 /**

--- a/framework/src/modules/chain/submodules/dapps.js
+++ b/framework/src/modules/chain/submodules/dapps.js
@@ -137,11 +137,13 @@ DApps.prototype.onBind = function(scope) {
 
 	__private.assetTypes[TRANSACTION_TYPES.IN_TRANSFER].bind(
 		scope.modules.accounts,
+		scope.modules.blocks,
 		shared
 	);
 
 	__private.assetTypes[TRANSACTION_TYPES.OUT_TRANSFER].bind(
 		scope.modules.accounts,
+		scope.modules.blocks,
 		scope.modules.dapps
 	);
 };

--- a/framework/test/mocha/unit/modules/chain/logic/in_transfer.js
+++ b/framework/test/mocha/unit/modules/chain/logic/in_transfer.js
@@ -102,6 +102,7 @@ describe('inTransfer', () => {
 	let inTransfer;
 	let sharedStub;
 	let accountsStub;
+	let blocksStub;
 	let storageStub;
 
 	let trs;
@@ -120,9 +121,6 @@ describe('inTransfer', () => {
 				Transaction: {
 					isPersisted: sinonSandbox.stub().resolves(),
 				},
-				Block: {
-					get: sinonSandbox.stub().resolves([dummyBlock]),
-				},
 			},
 		};
 
@@ -135,6 +133,11 @@ describe('inTransfer', () => {
 			mergeAccountAndGet: sinonSandbox.stub().callsArg(1),
 			getAccount: sinonSandbox.stub(),
 		};
+		blocksStub = {
+			lastBlock: {
+				get: sinonSandbox.stub().returns(dummyBlock),
+			},
+		};
 		inTransfer = new InTransfer({
 			components: {
 				storage: storageStub,
@@ -142,7 +145,7 @@ describe('inTransfer', () => {
 			schema: modulesLoader.scope.schema,
 		});
 
-		inTransfer.bind(accountsStub, sharedStub);
+		inTransfer.bind(accountsStub, blocksStub, sharedStub);
 
 		trs = _.cloneDeep(validTransaction);
 		rawTrs = _.cloneDeep(rawValidTransaction);
@@ -186,7 +189,7 @@ describe('inTransfer', () => {
 		let shared;
 
 		beforeEach(done => {
-			inTransfer.bind(accountsStub, sharedStub);
+			inTransfer.bind(accountsStub, blocksStub, sharedStub);
 			modules = InTransfer.__get__('__scope.modules');
 			shared = InTransfer.__get__('__scope.shared');
 			done();
@@ -197,6 +200,11 @@ describe('inTransfer', () => {
 				expect(modules)
 					.to.have.property('accounts')
 					.eql(accountsStub));
+
+			it('should assign blocks', async () =>
+				expect(modules)
+					.to.have.property('blocks')
+					.eql(blocksStub));
 		});
 
 		it('should assign shared', async () => expect(shared).to.eql(sharedStub));
@@ -208,7 +216,7 @@ describe('inTransfer', () => {
 	});
 
 	describe('verify', () => {
-		beforeEach(() => inTransfer.bind(accountsStub, sharedStub));
+		beforeEach(() => inTransfer.bind(accountsStub, blocksStub, sharedStub));
 
 		describe('when trs.recipientId exists', () => {
 			it('should call callback with error = "Transaction type 6 is frozen"', done => {
@@ -300,9 +308,9 @@ describe('inTransfer', () => {
 			});
 		});
 
-		it('should call entities.Block.get', done => {
-			inTransfer.verify(trs, sender, async () => {
-				expect(storageStub.entities.Block.get).to.be.calledOnce;
+		it('should call modules.blocks.lastBlock.get', done => {
+			inTransfer.verify(trs, sender, () => {
+				expect(blocksStub.lastBlock.get).to.be.calledOnce;
 				done();
 			});
 		});

--- a/framework/test/mocha/unit/modules/chain/logic/out_transfer.js
+++ b/framework/test/mocha/unit/modules/chain/logic/out_transfer.js
@@ -35,6 +35,7 @@ describe('outTransfer', () => {
 	let outTransfer;
 	let storageStub;
 	let accountsStub;
+	let blocksStub;
 
 	let dummyBlock;
 	let transaction;
@@ -47,15 +48,18 @@ describe('outTransfer', () => {
 				Transaction: {
 					isPersisted: sinonSandbox.stub().resolves(),
 				},
-				Block: {
-					get: sinonSandbox.stub().resolves([dummyBlock]),
-				},
 			},
 		};
 
 		accountsStub = {
 			mergeAccountAndGet: sinonSandbox.stub().callsArg(1),
 			setAccountAndGet: sinonSandbox.stub().callsArg(1),
+		};
+
+		blocksStub = {
+			lastBlock: {
+				get: sinonSandbox.stub().returns(dummyBlock),
+			},
 		};
 
 		dummyBlock = {
@@ -77,7 +81,7 @@ describe('outTransfer', () => {
 			schema: modulesLoader.scope.schema,
 		});
 
-		return outTransfer.bind(accountsStub);
+		return outTransfer.bind(accountsStub, blocksStub);
 	});
 
 	describe('constructor', () => {
@@ -112,7 +116,7 @@ describe('outTransfer', () => {
 		let modules;
 
 		beforeEach(done => {
-			outTransfer.bind(accountsStub);
+			outTransfer.bind(accountsStub, blocksStub);
 			modules = OutTransfer.__get__('__scope.modules');
 			done();
 		});
@@ -122,6 +126,11 @@ describe('outTransfer', () => {
 				expect(modules)
 					.to.have.property('accounts')
 					.eql(accountsStub));
+
+			it('should assign blocks', async () =>
+				expect(modules)
+					.to.have.property('blocks')
+					.eql(blocksStub));
 		});
 	});
 
@@ -132,11 +141,12 @@ describe('outTransfer', () => {
 	});
 
 	describe('verify', () => {
-		beforeEach(() => outTransfer.bind(accountsStub));
+		beforeEach(() => outTransfer.bind(accountsStub, blocksStub));
 
-		it('should call __scope.components.storage.entities.Block.get once', async () => {
+		it('should call modules.blocks.lastBlock.get', done => {
 			outTransfer.verify(transaction, sender, () => {
-				expect(storageStub.entities.Block.get).to.be.calledOnce;
+				expect(blocksStub.lastBlock.get).to.be.calledOnce;
+				done();
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
`InTransfer` and `OutTransfer` verification was using last block from database in order to verify `disableDappTransfer` exception.

### How did I fix it?
Now it's using `modules.blocks.lastBlock.get` which is kept in-memory by Chain Module.

### How to test it?
`node src/index.js -n mainnet -s 85000`

### Review checklist

* The PR resolves #3229
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
