### PR TITLE
Fix npmrc settting - Closes #2944

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
-save-prefix = "="
+message = ":arrow_up: Version %s"
+save-exact = true
 engine-strict = true

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"cors": "2.8.5",
 		"debug": "4.1.1",
 		"deep-diff": "1.0.2",
-		"eventemitter2": "=5.0.1",
+		"eventemitter2": "5.0.1",
 		"express": "4.16.4",
 		"express-domain-middleware": "0.1.0",
 		"express-query-int": "3.0.0",


### PR DESCRIPTION
### What was the problem?
original npmrc was wrongly used

### How did I fix it?
Update to use the specifying version correctly

### How to test it?
Try to add new npm package, and check if it uses format without `=`
"xxx": "x.x.x"

### Review checklist

* The PR resolves #2944 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
