### PR TITLE
Fix lintstage setting to check eslint after prettier - Closes #2952

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-	"*.js": ["eslint", "prettier --write", "git add"],
+	"*.js": ["prettier --write", "eslint", "git add"],
 	"*.{json,md}": ["prettier --write", "git add"]
 }


### PR DESCRIPTION
### What was the problem?
eslint was applied before prettier, which might cause eslint error

### How did I fix it?
Change the order of eslint and prettier

### Review checklist

* The PR resolves #2952 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
