### PR TITLE
Convert error strings to objects - Closes #3189 

### DIFF
--- a/framework/src/modules/chain/helpers/error_handlers.js
+++ b/framework/src/modules/chain/helpers/error_handlers.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+/**
+ * Converts array of errors into string
+ *
+ * @class
+ * @memberof helpers
+ * @param {array | object} errors
+ * @see Parent: {@link helpers}
+ * @todo Add description for the params
+ */
+// TODO: Move this functionality to logger component
+function convertErrorsToString(errors) {
+	if (Array.isArray(errors) && errors.length > 0) {
+		return errors
+			.filter(e => e instanceof Error)
+			.map(error => error.toString())
+			.join(', ');
+	}
+
+	if (errors instanceof Error) {
+		return errors.toString();
+	}
+
+	if (typeof errors === 'string') {
+		return errors;
+	}
+
+	return '';
+}
+
+module.exports = {
+	convertErrorsToString,
+};

--- a/framework/src/modules/chain/logic/account.js
+++ b/framework/src/modules/chain/logic/account.js
@@ -133,7 +133,7 @@ class Account {
 			.then(() => setImmediate(cb))
 			.catch(err => {
 				library.logger.error(err.stack);
-				return setImmediate(cb, 'Account#resetMemTables error');
+				return setImmediate(cb, new Error('Account#resetMemTables error'));
 			});
 	}
 
@@ -151,13 +151,15 @@ class Account {
 		);
 
 		if (!report) {
-			throw `Failed to validate account schema: ${this.scope.schema
-				.getLastErrors()
-				.map(err => {
-					const path = err.path.replace('#/', '').trim();
-					return [path, ': ', err.message, ' (', account[path], ')'].join('');
-				})
-				.join(', ')}`;
+			throw new Error(
+				`Failed to validate account schema: ${this.scope.schema
+					.getLastErrors()
+					.map(err => {
+						const path = err.path.replace('#/', '').trim();
+						return [path, ': ', err.message, ' (', account[path], ')'].join('');
+					})
+					.join(', ')}`
+			);
 		}
 
 		return account;
@@ -173,15 +175,15 @@ class Account {
 		if (publicKey !== undefined) {
 			// Check type
 			if (typeof publicKey !== 'string') {
-				throw 'Invalid public key, must be a string';
+				throw new Error('Invalid public key, must be a string');
 			}
 			// Check length
 			if (publicKey.length !== 64) {
-				throw 'Invalid public key, must be 64 characters long';
+				throw new Error('Invalid public key, must be 64 characters long');
 			}
 
 			if (!this.scope.schema.validate(publicKey, { format: 'hex' })) {
-				throw 'Invalid public key, must be a hex string';
+				throw new Error('Invalid public key, must be a hex string');
 			}
 		}
 	}
@@ -305,7 +307,7 @@ class Account {
 			})
 			.catch(err => {
 				library.logger.error(err.stack);
-				return setImmediate(cb, 'Account#getAll error');
+				return setImmediate(cb, new Error('Account#getAll error'));
 			});
 	}
 

--- a/framework/src/modules/chain/logic/block.js
+++ b/framework/src/modules/chain/logic/block.js
@@ -234,10 +234,12 @@ class Block {
 		});
 		const report = this.scope.schema.validate(block, Block.prototype.schema);
 		if (!report) {
-			throw `Failed to validate block schema: ${this.scope.schema
-				.getLastErrors()
-				.map(err => err.message)
-				.join(', ')}`;
+			throw new Error(
+				`Failed to validate block schema: ${this.scope.schema
+					.getLastErrors()
+					.map(err => err.message)
+					.join(', ')}`
+			);
 		}
 		try {
 			const {
@@ -251,9 +253,7 @@ class Block {
 				throw invalidTransactionResponse.errors;
 			}
 		} catch (errors) {
-			const error =
-				Array.isArray(errors) && errors.length > 0 ? errors[0] : errors;
-			throw error;
+			throw errors;
 		}
 
 		return block;

--- a/framework/src/modules/chain/logic/block.js
+++ b/framework/src/modules/chain/logic/block.js
@@ -241,19 +241,14 @@ class Block {
 					.join(', ')}`
 			);
 		}
-		try {
-			const {
-				transactionsResponses,
-			} = modules.processTransactions.validateTransactions(block.transactions);
-			const invalidTransactionResponse = transactionsResponses.find(
-				transactionResponse =>
-					transactionResponse.status !== TransactionStatus.OK
-			);
-			if (invalidTransactionResponse) {
-				throw invalidTransactionResponse.errors;
-			}
-		} catch (errors) {
-			throw errors;
+		const {
+			transactionsResponses,
+		} = modules.processTransactions.validateTransactions(block.transactions);
+		const invalidTransactionResponse = transactionsResponses.find(
+			transactionResponse => transactionResponse.status !== TransactionStatus.OK
+		);
+		if (invalidTransactionResponse) {
+			throw invalidTransactionResponse.errors;
 		}
 
 		return block;

--- a/framework/src/modules/chain/logic/dapp.js
+++ b/framework/src/modules/chain/logic/dapp.js
@@ -496,10 +496,12 @@ DApp.prototype.objectNormalize = function(transaction) {
 	);
 
 	if (!report) {
-		throw `Failed to validate dapp schema: ${__scope.schema
-			.getLastErrors()
-			.map(err => err.message)
-			.join(', ')}`;
+		throw new Error(
+			`Failed to validate dapp schema: ${__scope.schema
+				.getLastErrors()
+				.map(err => err.message)
+				.join(', ')}`
+		);
 	}
 
 	return transaction;

--- a/framework/src/modules/chain/logic/init_transaction.js
+++ b/framework/src/modules/chain/logic/init_transaction.js
@@ -167,7 +167,7 @@ class Transaction {
 		const assetDbRead = this.assetDbReadMap.get(transactionJSON.type);
 
 		if (!assetDbRead) {
-			throw `Unknown transaction type ${transactionJSON.type}`;
+			throw new Error(`Unknown transaction type ${transactionJSON.type}`);
 		}
 
 		const asset = assetDbRead(raw);

--- a/framework/src/modules/chain/logic/round.js
+++ b/framework/src/modules/chain/logic/round.js
@@ -79,7 +79,7 @@ class Round {
 		// Iterate over requiredProperties, checking for undefined scope properties
 		requiredProperties.forEach(property => {
 			if (scope[property] === undefined) {
-				throw `Missing required scope property: ${property}`;
+				throw new Error(`Missing required scope property: ${property}`);
 			}
 		});
 	}

--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -33,13 +33,13 @@ const wrapAddTransactionResponseInCb = (
 		return cb(err);
 	}
 	if (addTransactionResponse.isFull) {
-		return cb('Transaction pool is full');
+		return cb(new Error('Transaction pool is full'));
 	}
 	if (addTransactionResponse.alreadyExists) {
 		if (addTransactionResponse.queueName === readyQueue) {
-			return cb('Transaction is already in unconfirmed state');
+			return cb(new Error('Transaction is already in unconfirmed state'));
 		}
-		return cb(`Transaction is already processed: ${transaction.id}`);
+		return cb(new Error(`Transaction is already processed: ${transaction.id}`));
 	}
 	return cb();
 };

--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -331,7 +331,7 @@ class TransactionPool {
 		if (this.transactionInPool(transaction.id)) {
 			return setImmediate(
 				cb,
-				`Transaction is already processed: ${transaction.id}`
+				new Error(`Transaction is already processed: ${transaction.id}`)
 			);
 		}
 		return this.verifyTransactions([transaction]).then(

--- a/framework/src/modules/chain/submodules/accounts.js
+++ b/framework/src/modules/chain/submodules/accounts.js
@@ -201,7 +201,7 @@ Accounts.prototype.setAccountAndGet = function(data, cb, tx) {
 
 	return taskPromise
 		.then(taskPromiseData => setImmediate(cb, null, taskPromiseData))
-		.catch(taskPromiseErr => setImmediate(cb, new Error(taskPromiseErr)));
+		.catch(taskPromiseErr => setImmediate(cb, taskPromiseErr));
 };
 
 /**

--- a/framework/src/modules/chain/submodules/accounts.js
+++ b/framework/src/modules/chain/submodules/accounts.js
@@ -81,7 +81,7 @@ Accounts.prototype.generateAddressByPublicKey = function(publicKey) {
 	const address = `${Bignum.fromBuffer(temp).toString()}L`;
 
 	if (!address) {
-		throw `Invalid public key: ${publicKey}`;
+		throw new Error(`Invalid public key: ${publicKey}`);
 	}
 
 	return address;
@@ -132,12 +132,12 @@ Accounts.prototype.setAccountAndGet = function(data, cb, tx) {
 		if (data.publicKey) {
 			address = self.generateAddressByPublicKey(data.publicKey);
 		} else {
-			err = 'Missing address or public key';
+			err = new Error('Missing address or public key');
 		}
 	}
 
 	if (!address) {
-		err = 'Invalid public key';
+		err = new Error('Invalid public key');
 	}
 
 	if (err) {
@@ -201,7 +201,7 @@ Accounts.prototype.setAccountAndGet = function(data, cb, tx) {
 
 	return taskPromise
 		.then(taskPromiseData => setImmediate(cb, null, taskPromiseData))
-		.catch(taskPromiseErr => setImmediate(cb, taskPromiseErr));
+		.catch(taskPromiseErr => setImmediate(cb, new Error(taskPromiseErr)));
 };
 
 /**
@@ -221,12 +221,12 @@ Accounts.prototype.mergeAccountAndGet = function(data, cb, tx) {
 		if (data.publicKey) {
 			address = self.generateAddressByPublicKey(data.publicKey);
 		} else {
-			err = 'Missing address or public key';
+			err = new Error('Missing address or public key');
 		}
 	}
 
 	if (!address) {
-		err = 'Invalid public key';
+		err = new Error('Invalid public key');
 	}
 
 	if (err) {

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -490,7 +490,10 @@ __private.loadSecondLastBlockStep = function(secondLastBlockId, tx) {
 			{ id: secondLastBlockId },
 			(err, blocks) => {
 				if (err || !blocks.length) {
-					library.logger.error('Failed to get loadBlocksPart', err);
+					library.logger.error(
+						'Failed to get loadBlocksPart',
+						err.message ? err.message : err
+					);
 					return setImmediate(reject, err || 'previousBlock is null');
 				}
 				return setImmediate(resolve, blocks[0]);

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -492,7 +492,10 @@ __private.loadSecondLastBlockStep = function(secondLastBlockId, tx) {
 				if (err || !blocks.length) {
 					const error = Array.isArray(err) && err.length > 0 ? err[0] : err;
 					library.logger.error('Failed to get loadBlocksPart', error);
-					return setImmediate(reject, err || 'previousBlock is null');
+					return setImmediate(
+						reject,
+						err || new Error('previousBlock is null')
+					);
 				}
 				return setImmediate(resolve, blocks[0]);
 			},

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -490,10 +490,8 @@ __private.loadSecondLastBlockStep = function(secondLastBlockId, tx) {
 			{ id: secondLastBlockId },
 			(err, blocks) => {
 				if (err || !blocks.length) {
-					library.logger.error(
-						'Failed to get loadBlocksPart',
-						err.message ? err.message : err
-					);
+					const error = Array.isArray(err) && err.length > 0 ? err[0] : err;
+					library.logger.error('Failed to get loadBlocksPart', error);
 					return setImmediate(reject, err || 'previousBlock is null');
 				}
 				return setImmediate(resolve, blocks[0]);

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -19,6 +19,7 @@ const async = require('async');
 const _ = require('lodash');
 const { Status: TransactionStatus } = require('@liskhq/lisk-transactions');
 const slots = require('../../helpers/slots.js');
+const { convertErrorsToString } = require('../../helpers/error_handlers');
 const {
 	CACHE_KEYS_DELEGATES,
 	CACHE_KEYS_TRANSACTION_COUNT,
@@ -490,8 +491,7 @@ __private.loadSecondLastBlockStep = function(secondLastBlockId, tx) {
 			{ id: secondLastBlockId },
 			(err, blocks) => {
 				if (err || !blocks.length) {
-					const error = Array.isArray(err) && err.length > 0 ? err[0] : err;
-					library.logger.error('Failed to get loadBlocksPart', error);
+					library.logger.error('Failed to get loadBlocksPart', convertErrorsToString(err));
 					return setImmediate(
 						reject,
 						err || new Error('previousBlock is null')

--- a/framework/src/modules/chain/submodules/blocks/process.js
+++ b/framework/src/modules/chain/submodules/blocks/process.js
@@ -17,6 +17,7 @@
 const _ = require('lodash');
 const async = require('async');
 const { Status: TransactionStatus } = require('@liskhq/lisk-transactions');
+const { convertErrorsToString } = require('../../helpers/error_handlers');
 const slots = require('../../helpers/slots');
 const definitions = require('../../schema/definitions');
 
@@ -146,11 +147,7 @@ __private.receiveForkOne = function(block, lastBlock, cb) {
 		],
 		err => {
 			if (err) {
-				const error =
-					Array.isArray(err) && err.length > 0
-						? err.map(e => e.message).join(', ')
-						: err;
-				library.logger.error('Fork recovery failed', error);
+				library.logger.error('Fork recovery failed', convertErrorsToString(err));
 			}
 			return setImmediate(cb, err);
 		}
@@ -227,11 +224,7 @@ __private.receiveForkFive = function(block, lastBlock, cb) {
 		],
 		err => {
 			if (err) {
-				const error =
-					Array.isArray(err) && err.length > 0
-						? err.map(e => e.message).join(', ')
-						: err;
-				library.logger.error('Fork recovery failed', error);
+				library.logger.error('Fork recovery failed', convertErrorsToString(err));
 			}
 			return setImmediate(cb, err);
 		}

--- a/framework/src/modules/chain/submodules/blocks/process.js
+++ b/framework/src/modules/chain/submodules/blocks/process.js
@@ -146,7 +146,11 @@ __private.receiveForkOne = function(block, lastBlock, cb) {
 		],
 		err => {
 			if (err) {
-				library.logger.error('Fork recovery failed', err);
+				const error =
+					Array.isArray(err) && err.length > 0
+						? err.map(e => e.message).join(', ')
+						: err;
+				library.logger.error('Fork recovery failed', error);
 			}
 			return setImmediate(cb, err);
 		}
@@ -223,7 +227,11 @@ __private.receiveForkFive = function(block, lastBlock, cb) {
 		],
 		err => {
 			if (err) {
-				library.logger.error('Fork recovery failed', err);
+				const error =
+					Array.isArray(err) && err.length > 0
+						? err.map(e => e.message).join(', ')
+						: err;
+				library.logger.error('Fork recovery failed', error);
 			}
 			return setImmediate(cb, err);
 		}

--- a/framework/src/modules/chain/submodules/blocks/verify.js
+++ b/framework/src/modules/chain/submodules/blocks/verify.js
@@ -98,7 +98,9 @@ __private.checkTransactions = async (transactions, checkExists) => {
 
 		if (persistedTransactions.length > 0) {
 			modules.transactions.onConfirmedTransactions([persistedTransactions[0]]);
-			throw `Transaction is already confirmed: ${persistedTransactions[0].id}`;
+			throw new Error(
+				`Transaction is already confirmed: ${persistedTransactions[0].id}`
+			);
 		}
 	}
 

--- a/framework/src/modules/chain/submodules/delegates.js
+++ b/framework/src/modules/chain/submodules/delegates.js
@@ -609,7 +609,7 @@ Delegates.prototype.validateBlockSlotAgainstPreviousRound = function(
  */
 Delegates.prototype.getDelegates = function(query, cb) {
 	if (!_.isObject(query)) {
-		throw 'Invalid query argument, expected object';
+		throw new Error('Invalid query argument, expected object');
 	}
 	if (query.search) {
 		query.username_like = `%${query.search}%`;

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -16,6 +16,7 @@
 
 const async = require('async');
 const { Status: TransactionStatus } = require('@liskhq/lisk-transactions');
+const { convertErrorsToString } = require('../helpers/error_handlers');
 const jobsQueue = require('../helpers/jobs_queue');
 const slots = require('../helpers/slots');
 const definitions = require('../schema/definitions');
@@ -335,7 +336,7 @@ __private.loadTransactions = function(cb) {
 							err => {
 								if (err) {
 									// TODO: Validate if error propagation required
-									library.logger.debug(err);
+									library.logger.debug(convertErrorsToString(err));
 								}
 								return setImmediate(eachSeriesCb);
 							}
@@ -896,9 +897,7 @@ __private.loadBlocksFromNetwork = function(cb) {
 				waterErr => {
 					if (waterErr) {
 						failedAttemptsToLoad += 1;
-						library.logger.error(
-							waterErr.message ? waterErr.message : waterErr
-						);
+						library.logger.error(convertErrorsToString(waterErr));
 					}
 					whilstCb();
 				}

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -486,7 +486,7 @@ __private.loadBlockChain = function() {
 			if (matched) {
 				library.logger.info('Genesis block matched with database');
 			} else {
-				throw 'Failed to match genesis block with database';
+				throw new Error('Failed to match genesis block with database');
 			}
 		}
 	}
@@ -896,7 +896,9 @@ __private.loadBlocksFromNetwork = function(cb) {
 				waterErr => {
 					if (waterErr) {
 						failedAttemptsToLoad += 1;
-						library.logger.error(waterErr);
+						library.logger.error(
+							waterErr.message ? waterErr.message : waterErr
+						);
 					}
 					whilstCb();
 				}

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -481,7 +481,7 @@ Transactions.prototype.getMergedTransactionList = function(reverse, limit) {
 Transactions.prototype.getTransactions = function(filters, cb) {
 	__private.list(filters, (err, data) => {
 		if (err) {
-			return setImmediate(cb, `Failed to get transactions: ${err}`);
+			return setImmediate(cb, new Error(`Failed to get transactions: ${err}`));
 		}
 		return setImmediate(cb, null, {
 			transactions: data.transactions,

--- a/framework/src/modules/chain/submodules/transport.js
+++ b/framework/src/modules/chain/submodules/transport.js
@@ -253,7 +253,7 @@ __private.receiveTransaction = function(
 	}
 
 	if (transaction.requesterPublicKey) {
-		return setImmediate(cb, 'Multisig request is not allowed');
+		return setImmediate(cb, new Error('Multisig request is not allowed'));
 	}
 
 	return library.balancesSequence.add(balancesSequenceCb => {

--- a/framework/src/modules/http_api/controllers/transactions.js
+++ b/framework/src/modules/http_api/controllers/transactions.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { convertErrorsToString } = require('../helpers/error_handlers');
 const swaggerHelper = require('../helpers/swagger');
 const ApiError = require('../api_error');
 const apiCodes = require('../api_codes');
@@ -146,10 +147,11 @@ TransactionsController.postTransaction = async function(context, next) {
 				meta: { status: true },
 			});
 		}
-
-		error = new ApiError(data.message, apiCodes.PROCESSING_ERROR);
 	} catch (err) {
-		error = new ApiError(err, apiCodes.INTERNAL_SERVER_ERROR);
+		error = new ApiError(
+			convertErrorsToString(err),
+			apiCodes.INTERNAL_SERVER_ERROR
+		);
 	}
 
 	context.statusCode = error.code;

--- a/framework/src/modules/http_api/helpers/error_handlers.js
+++ b/framework/src/modules/http_api/helpers/error_handlers.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+/**
+ * Converts array of errors into string
+ *
+ * @class
+ * @memberof helpers
+ * @param {array | object} errors
+ * @see Parent: {@link helpers}
+ * @todo Add description for the params
+ */
+// TODO: Move this functionality to logger component
+function convertErrorsToString(errors) {
+	if (Array.isArray(errors) && errors.length > 0) {
+		return errors
+			.filter(e => e instanceof Error)
+			.map(error => error.toString())
+			.join(', ');
+	}
+
+	if (errors instanceof Error) {
+		return errors.toString();
+	}
+
+	if (typeof errors === 'string') {
+		return errors;
+	}
+
+	return '';
+}
+
+module.exports = {
+	convertErrorsToString,
+};

--- a/framework/test/mocha/unit/modules/chain/logic/round.js
+++ b/framework/test/mocha/unit/modules/chain/logic/round.js
@@ -125,7 +125,7 @@ describe('round', () => {
 					try {
 						round = new Round(scope, task);
 					} catch (err) {
-						expect(err).to.equal(
+						expect(err.message).to.equal(
 							`Missing required scope property: ${property}`
 						);
 					}
@@ -140,7 +140,7 @@ describe('round', () => {
 					try {
 						round = new Round(scope, task);
 					} catch (err) {
-						expect(err).to.equal(
+						expect(err.message).to.equal(
 							`Missing required scope property: ${property}`
 						);
 					}
@@ -162,7 +162,7 @@ describe('round', () => {
 						try {
 							round = new Round(scope, task);
 						} catch (err) {
-							expect(err).to.equal(
+							expect(err.message).to.equal(
 								`Missing required scope property: ${property}`
 							);
 						}
@@ -177,7 +177,7 @@ describe('round', () => {
 						try {
 							round = new Round(scope, task);
 						} catch (err) {
-							expect(err).to.equal(
+							expect(err.message).to.equal(
 								`Missing required scope property: ${property}`
 							);
 						}
@@ -192,7 +192,7 @@ describe('round', () => {
 						try {
 							round = new Round(scope, task);
 						} catch (err) {
-							expect(err).to.equal(
+							expect(err.message).to.equal(
 								`Missing required scope property: ${property}`
 							);
 						}
@@ -207,7 +207,7 @@ describe('round', () => {
 						try {
 							round = new Round(scope, task);
 						} catch (err) {
-							expect(err).to.equal(
+							expect(err.message).to.equal(
 								`Missing required scope property: ${property}`
 							);
 						}

--- a/framework/test/mocha/unit/modules/chain/submodules/accounts.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/accounts.js
@@ -151,7 +151,7 @@ describe('accounts', () => {
 			delete account.publicKey;
 
 			accounts.setAccountAndGet(account, (error, data) => {
-				expect(error).to.be.eql('Invalid public key');
+				expect(error.message).to.be.eql('Invalid public key');
 				expect(data).to.be.undefined;
 				done();
 			});


### PR DESCRIPTION
### What was the problem?

Application was inconsistently throwing strings instead of Error objects in some areas of the code.

### How did I fix it?

Converted thrown strings to Error Objects and related changes.

API related error changes to be handled in separate PR. 

### How to test it?

npm run mocha:unit

### Review checklist

* The PR resolves #3189 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
