### PR TITLE
Avoid mutation of roundRewards in rewardsAtRound() - Closes #3242

### DIFF
--- a/framework/src/modules/chain/logic/round.js
+++ b/framework/src/modules/chain/logic/round.js
@@ -303,7 +303,7 @@ class Round {
 	 */
 	rewardsAtRound(index) {
 		let roundFees = Math.floor(this.scope.roundFees) || 0;
-		const roundRewards = this.scope.roundRewards || [];
+		const roundRewards = [...this.scope.roundRewards] || [];
 
 		// Apply exception for round if required
 		if (exceptions.rounds[this.scope.round]) {

--- a/framework/test/mocha/unit/modules/chain/logic/round.js
+++ b/framework/test/mocha/unit/modules/chain/logic/round.js
@@ -592,12 +592,18 @@ describe('round', () => {
 	describe('rewardsAtRound', () => {
 		const validLocalScope = _.cloneDeep(validScope);
 		const rewardsAt = 2;
+		const roundExceptionCopy = _.clone(
+			global.exceptions.rounds
+		);
 
-		beforeEach(done => {
+		beforeEach(async () => {
 			validLocalScope.round = 1;
 			validLocalScope.roundFees = 500;
 			validLocalScope.roundRewards = [0, 0, 100, 10];
-			done();
+		});
+
+		afterEach(async () => {
+			global.exceptions.rounds = roundExceptionCopy;
 		});
 
 		it('should calculate round changes from valid scope', async () => {

--- a/framework/test/mocha/unit/modules/chain/logic/round.js
+++ b/framework/test/mocha/unit/modules/chain/logic/round.js
@@ -636,6 +636,19 @@ describe('round', () => {
 			const expectedBalance = 1779894192932990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990099009900990199; // 1.7976931348623157e+308 / 101 (delegates num) + 100
 			return expect(res.balance).equal(expectedBalance);
 		});
+
+		it('should not mutate roundRewards if round exception exists', () => {
+			const [rewards_factor, fees_factor, fees_bonus] = [2, 2, 10000000];
+			global.exceptions.rounds = {
+				[scope.round]: { rewards_factor, fees_factor, fees_bonus },
+			};
+			const roundRewards = _.clone(validLocalScope.roundRewards);
+
+			round = new Round(validLocalScope, task);
+			round.rewardsAtRound(rewardsAt);
+
+			return expect(roundRewards).to.deep.equal(validLocalScope.roundRewards);
+		});
 	});
 
 	describe('applyRound', () => {


### PR DESCRIPTION
### What was the problem?

`rewardsAtRound()` executes a piece of code when there is an exception in rounds. This code wasn't covered by unit tests.

### How did I fix it?

Cloning roundRewards variable to avoid mutation when a round exception exists. 

### How to test it?

`framework/test/mocha/unit/modules/chain/logic/round.js`

### Review checklist

* The PR resolves #3242
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
