### PR TITLE
App doesn't start when using child process on mainnet - Closes #3256

### DIFF
--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -119,20 +119,14 @@ class Application {
 		__private.modules.set(this, {});
 		__private.transactions.set(this, {});
 
-		// TODO: move this configuration to module especific config file
-		const childProcessModules = process.env.LISK_CHILD_PROCESS_MODULES
-			? process.env.LISK_CHILD_PROCESS_MODULES.split(',')
-			: ['httpApi'];
-
 		this.registerModule(ChainModule, {
 			genesisBlock: this.genesisBlock,
 			constants: this.constants,
-			loadAsChildProcess: childProcessModules.includes(ChainModule.alias),
 		});
 
 		this.registerModule(HttpAPIModule, {
 			constants: this.constants,
-			loadAsChildProcess: childProcessModules.includes(HttpAPIModule.alias),
+			loadAsChildProcess: true,
 		});
 	}
 

--- a/framework/src/controller/child_process_loader.js
+++ b/framework/src/controller/child_process_loader.js
@@ -5,7 +5,7 @@ const { ChildProcessChannel } = require('./channels');
 // eslint-disable-next-line import/no-dynamic-require
 const Klass = require(modulePath);
 
-const loadModule = async (config, moduleOptions) => {
+const _loadModule = async (config, moduleOptions) => {
 	const module = new Klass(moduleOptions);
 	const moduleAlias = module.constructor.alias;
 
@@ -25,9 +25,9 @@ const loadModule = async (config, moduleOptions) => {
 	channel.publish(`${moduleAlias}:loading:finished`);
 };
 
-process.on('message', data => {
-	if (data.loadModule) {
-		loadModule(data.config, data.moduleOptions);
+process.on('message', ({ loadModule, config, moduleOptions }) => {
+	if (loadModule) {
+		_loadModule(config, moduleOptions);
 	}
 });
 

--- a/framework/src/controller/child_process_loader.js
+++ b/framework/src/controller/child_process_loader.js
@@ -1,12 +1,11 @@
 // Parameters passed by `child_process.fork(_, parameters)`
 const modulePath = process.argv[2];
-const { moduleOptions, config } = JSON.parse(process.argv[3]);
 
 const { ChildProcessChannel } = require('./channels');
 // eslint-disable-next-line import/no-dynamic-require
 const Klass = require(modulePath);
 
-const loadModule = async () => {
+const loadModule = async (config, moduleOptions) => {
 	const module = new Klass(moduleOptions);
 	const moduleAlias = module.constructor.alias;
 
@@ -26,9 +25,13 @@ const loadModule = async () => {
 	channel.publish(`${moduleAlias}:loading:finished`);
 };
 
+process.on('message', data => {
+	if (data.loadModule) {
+		loadModule(data.config, data.moduleOptions);
+	}
+});
+
 // TODO: Removed after https://github.com/LiskHQ/lisk/issues/3210 is fixed
 process.on('disconnect', () => {
 	process.exit();
 });
-
-loadModule();

--- a/framework/src/controller/controller.js
+++ b/framework/src/controller/controller.js
@@ -222,12 +222,16 @@ class Controller {
 
 		const program = path.resolve(__dirname, 'child_process_loader.js');
 
-		const parameters = [
-			modulePath,
-			JSON.stringify({ config: this.config, moduleOptions: options }),
-		];
+		const parameters = [modulePath];
 
 		const child = child_process.fork(program, parameters);
+
+		// TODO: Check which config and options are actually required to avoid sending large data
+		child.send({
+			loadModule: true,
+			config: this.config,
+			moduleOptions: options,
+		});
 
 		this.childrenList.push(child);
 

--- a/framework/src/modules/README.md
+++ b/framework/src/modules/README.md
@@ -135,7 +135,9 @@ By default, modules will load in the same process as the controller.
 
 Communicates with modules which do not reside in the same process as the Controller.
 
-To load a module in a child process, make sure you have `ipc` enabled in the config file and set the environment variable `LISK_CHILD_PROCESS_MODULES` with the module alias. Multiple modules can be defined by using commas like `LISK_CHILD_PROCESS_MODULES=httpApi,chain`.
+To load a module as a child process, make sure you have `ipc` enabled in the config file and set the option `loadAsChildProcess: true` when registering the module using the Application method `registerModule`.
+
+Currently, the only Lisk native module supported is HTTP API module which will be loaded as child process if you have `ipc` enabled.
 
 ## Module Life Cycle
 


### PR DESCRIPTION
### What was the problem?
Application not starting when trying to load HTTP API as child process on mainnet network

### How did I fix it?
I've changed the way the config and options are sent to the child process. Before it was using command line arguments and now is using the channel created between parent and child. I also added a todo comment to review the config and options to avoid sending unnecessary data to the child.

### How to test it?
Enable `ipc` in config file and run the application with mainnet network

### Review checklist

* The PR resolves #3256
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
