### PR TITLE
Revert use of "npm start" in Dockerfile and docker-compose.yml - Closes #3264

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,5 @@ RUN if [ x"$( sha256sum /home/lisk/wait-for-it.sh |awk '{print $1}' )" = x"${WFI
 USER lisk
 WORKDIR /home/lisk/lisk
 
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT ["node", "/home/lisk/lisk/src/index.js"]
 CMD ["-n", "mainnet"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - db
     restart: on-failure
-    entrypoint: ["/home/lisk/wait-for-it.sh", "db:5432", "--", "npm", "start"]
+    entrypoint: ["/home/lisk/wait-for-it.sh", "db:5432", "--", "node", "/home/lisk/lisk/src/index.js"]
     command: ["-n", "${ENV_LISK_NETWORK}"]
     environment:
       - LISK_DB_HOST=db


### PR DESCRIPTION
### What was the problem?
Use of `npm start` not gracefully exiting application

### How did I fix it?
Reverted back to use `node app/path`

### How to test it?
Start app using docker image

### Review checklist

* The PR resolves #3264
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
