### PR TITLE
Fix sorting function accounts API - Closes #3249

### DIFF
--- a/framework/test/mocha/functional/http/get/accounts/accounts.js
+++ b/framework/test/mocha/functional/http/get/accounts/accounts.js
@@ -303,14 +303,20 @@ describe('GET /accounts', () => {
 
 			it('using no sort return accounts sorted by both balance and address in asending order as default behavior', async () => {
 				return accountsEndpoint.makeRequest({}, 200).then(res => {
-					const balances = _.clone(res.body.data);
+					const balances = _.cloneDeep(res.body.data);
 					expect(
 						balances.sort((a, b) => {
 							const aBignumBalance = new Bignum(a.balance);
-							return (
-								aBignumBalance.minus(b.balance) ||
-								a.address.localeCompare(b.address)
-							);
+
+							let bignumSort = 0;
+							if (aBignumBalance.gt(b.balance)) {
+								bignumSort = 1;
+							}
+							if (aBignumBalance.lt(b.balance)) {
+								bignumSort = -1;
+							}
+
+							return bignumSort || +a.address.localeCompare(b.address);
 						})
 					).to.be.eql(res.body.data);
 				});
@@ -320,14 +326,20 @@ describe('GET /accounts', () => {
 				return accountsEndpoint
 					.makeRequest({ sort: 'balance:asc' }, 200)
 					.then(res => {
-						const balances = _.clone(res.body.data);
+						const balances = _.cloneDeep(res.body.data);
 						expect(
 							balances.sort((a, b) => {
 								const aBignumBalance = new Bignum(a.balance);
-								return (
-									aBignumBalance.minus(b.balance) ||
-									a.address.localeCompare(b.address)
-								);
+
+								let bignumSort = 0;
+								if (aBignumBalance.gt(b.balance)) {
+									bignumSort = 1;
+								}
+								if (aBignumBalance.lt(b.balance)) {
+									bignumSort = -1;
+								}
+
+								return bignumSort || +a.address.localeCompare(b.address);
 							})
 						).to.be.eql(res.body.data);
 					});
@@ -337,14 +349,20 @@ describe('GET /accounts', () => {
 				return accountsEndpoint
 					.makeRequest({ sort: 'balance:desc' }, 200)
 					.then(res => {
-						const balances = _.clone(res.body.data);
+						const balances = _.cloneDeep(res.body.data);
 						expect(
 							balances.sort((a, b) => {
-								const bBignumBalance = new Bignum(b.balance);
-								return (
-									bBignumBalance.minus(a.balance) ||
-									a.address.localeCompare(b.address)
-								);
+								const aBignumBalance = new Bignum(a.balance);
+
+								let bignumSort = 0;
+								if (aBignumBalance.gt(b.balance)) {
+									bignumSort = -1;
+								}
+								if (aBignumBalance.lt(b.balance)) {
+									bignumSort = 1;
+								}
+
+								return bignumSort || +a.address.localeCompare(b.address);
 							})
 						).to.be.eql(res.body.data);
 					});

--- a/framework/test/mocha/functional/http/get/accounts/accounts.js
+++ b/framework/test/mocha/functional/http/get/accounts/accounts.js
@@ -308,15 +308,14 @@ describe('GET /accounts', () => {
 						balances.sort((a, b) => {
 							const aBignumBalance = new Bignum(a.balance);
 
-							let bignumSort = 0;
 							if (aBignumBalance.gt(b.balance)) {
-								bignumSort = 1;
+								return 1;
 							}
 							if (aBignumBalance.lt(b.balance)) {
-								bignumSort = -1;
+								return -1;
 							}
 
-							return bignumSort || +a.address.localeCompare(b.address);
+							return a.address.localeCompare(b.address);
 						})
 					).to.be.eql(res.body.data);
 				});
@@ -331,15 +330,14 @@ describe('GET /accounts', () => {
 							balances.sort((a, b) => {
 								const aBignumBalance = new Bignum(a.balance);
 
-								let bignumSort = 0;
 								if (aBignumBalance.gt(b.balance)) {
-									bignumSort = 1;
+									return 1;
 								}
 								if (aBignumBalance.lt(b.balance)) {
-									bignumSort = -1;
+									return -1;
 								}
 
-								return bignumSort || +a.address.localeCompare(b.address);
+								return a.address.localeCompare(b.address);
 							})
 						).to.be.eql(res.body.data);
 					});
@@ -354,15 +352,14 @@ describe('GET /accounts', () => {
 							balances.sort((a, b) => {
 								const aBignumBalance = new Bignum(a.balance);
 
-								let bignumSort = 0;
 								if (aBignumBalance.gt(b.balance)) {
-									bignumSort = -1;
+									return -1;
 								}
 								if (aBignumBalance.lt(b.balance)) {
-									bignumSort = 1;
+									return 1;
 								}
 
-								return bignumSort || +a.address.localeCompare(b.address);
+								return a.address.localeCompare(b.address);
 							})
 						).to.be.eql(res.body.data);
 					});


### PR DESCRIPTION
### What was the problem?
Sorting was still being inconsistent.

### How did I fix it?
Rewrite custom sorting function with `0`, `-1`, and `1` as Booleans were not converted to integer and Bignum comparison would only return 0 or 1 which gives wrong results.

### How to test it?
Run functional get tests.

### Review checklist

* The PR resolves #3249 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
