### PR TITLE
Functional tests don't stop with SIGINT - Closes #3098

### DIFF
--- a/framework/test/mocha/common/utils/wait_for.js
+++ b/framework/test/mocha/common/utils/wait_for.js
@@ -36,6 +36,11 @@ function blockchainReady(retries, timeout, baseUrl, doNotLogRetries, cb) {
 		timeout = 1000;
 	}
 
+	process.on('SIGINT', () => {
+		console.info('SIGINT received, pid: ', process.pid);
+		process.exit(1);
+	});
+
 	const totalRetries = retries;
 
 	baseUrl =


### PR DESCRIPTION
### What was the problem?

In functional tests `before` hook was preventing child process to be terminated.

### How did I fix it?
I added process signal handling in `blockchainReady` function.
### How to test it?
- Run `npm run mocha:functional -- --grep "@slow|@unstable" --invert` command.
- Try to exit main process with `CTRL + C` after it starts waiting for blockchain
### Review checklist

* The PR resolves #3098 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
