### PR TITLE
Simplify the default value generation for all configurations - Closes #3273

### DIFF
--- a/framework/src/components/cache/defaults/config.js
+++ b/framework/src/components/cache/defaults/config.js
@@ -3,13 +3,11 @@ const defaultConfig = {
 	properties: {
 		enabled: {
 			type: 'boolean',
-			default: false,
 			env: 'LISK_CACHE_ENABLED',
 		},
 		host: {
 			type: 'string',
 			format: 'ipOrFQDN',
-			default: '127.0.0.1',
 			env: 'LISK_REDIS_HOST',
 			arg: '-r,--redis',
 		},
@@ -17,23 +15,27 @@ const defaultConfig = {
 			type: 'integer',
 			minimum: 1,
 			maximum: 65535,
-			default: 6380,
 			env: 'LISK_REDIS_PORT',
 		},
 		db: {
 			type: 'integer',
 			minimum: 0,
 			maximum: 15,
-			default: 0,
 			env: 'LISK_REDIS_DB_NAME',
 		},
 		password: {
 			type: ['string', 'null'],
-			default: null,
 			env: 'LISK_REDIS_DB_PASSWORD',
 		},
 	},
 	required: ['enabled', 'host', 'port', 'db', 'password'],
+	default: {
+		enabled: true,
+		host: '127.0.0.1',
+		port: 6380,
+		db: 0,
+		password: null,
+	},
 };
 
 module.exports = defaultConfig;

--- a/framework/src/components/cache/defaults/config.js
+++ b/framework/src/components/cache/defaults/config.js
@@ -30,7 +30,7 @@ const defaultConfig = {
 	},
 	required: ['enabled', 'host', 'port', 'db', 'password'],
 	default: {
-		enabled: true,
+		enabled: false,
 		host: '127.0.0.1',
 		port: 6380,
 		db: 0,

--- a/framework/src/components/cache/index.js
+++ b/framework/src/components/cache/index.js
@@ -36,7 +36,7 @@ const { config: defaultConfig } = require('./defaults');
 const validator = require('../../controller/helpers/validator');
 
 function createCacheComponent(options, logger) {
-	const optionsWithDefaults = validator.validateWithDefaults(
+	const optionsWithDefaults = validator.parseEnvArgAndValidate(
 		defaultConfig,
 		options
 	);

--- a/framework/src/components/logger/defaults/config.js
+++ b/framework/src/components/logger/defaults/config.js
@@ -3,24 +3,26 @@ const defaultConfig = {
 	properties: {
 		fileLogLevel: {
 			type: 'string',
-			default: 'info',
 			enum: ['trace', 'debug', 'log', 'info', 'warn', 'error', 'fatal', 'none'],
 			env: 'LISK_FILE_LOG_LEVEL',
 			arg: '-l,--log',
 		},
 		logFileName: {
 			type: 'string',
-			default: 'logs/lisk.log',
 			env: 'LISK_REDIS_HOST',
 		},
 		consoleLogLevel: {
 			type: 'string',
-			default: 'none',
 			enum: ['trace', 'debug', 'log', 'info', 'warn', 'error', 'fatal', 'none'],
 			env: 'LISK_CONSOLE_LOG_LEVEL',
 		},
 	},
 	required: ['fileLogLevel', 'logFileName', 'consoleLogLevel'],
+	default: {
+		fileLogLevel: 'info',
+		consoleLogLevel: 'none',
+		logFileName: 'logs/lisk.log',
+	},
 };
 
 module.exports = defaultConfig;

--- a/framework/src/components/logger/index.js
+++ b/framework/src/components/logger/index.js
@@ -19,7 +19,7 @@ const { config: defaultConfig } = require('./defaults');
 const validator = require('../../controller/helpers/validator');
 
 function createLoggerComponent(options = {}) {
-	const optionsWithDefaults = validator.validateWithDefaults(
+	const optionsWithDefaults = validator.parseEnvArgAndValidate(
 		defaultConfig,
 		options
 	);

--- a/framework/src/components/storage/defaults/config.js
+++ b/framework/src/components/storage/defaults/config.js
@@ -3,58 +3,47 @@ const defaultConfig = {
 	properties: {
 		host: {
 			type: 'string',
-			default: 'localhost',
 			env: 'LISK_DB_HOST',
 		},
 		port: {
 			type: 'integer',
 			minimum: 1,
 			maximum: 65535,
-			default: 5432,
 			env: 'LISK_DB_PORT',
 		},
 		database: {
 			type: 'string',
-			default: '',
 			env: 'LISK_DB_NAME',
 			arg: '-d,--database',
 		},
 		user: {
 			type: 'string',
-			default: 'lisk',
 			env: 'LISK_DB_USER',
 		},
 		password: {
 			type: 'string',
-			default: 'password',
 			env: 'LISK_DB_PASSWORD',
 		},
 		min: {
 			type: 'integer',
-			default: 10,
 		},
 		max: {
 			type: 'integer',
-			default: 95,
 		},
 		poolIdleTimeout: {
 			type: 'integer',
-			default: 30000,
 		},
 		reapIntervalMillis: {
 			type: 'integer',
-			default: 1000,
 		},
 		logEvents: {
 			type: 'array',
 			items: {
 				type: 'string',
 			},
-			default: ['error'],
 		},
 		logFileName: {
 			type: 'string',
-			default: 'logs/lisk_db.log',
 		},
 	},
 	required: [
@@ -69,6 +58,19 @@ const defaultConfig = {
 		'reapIntervalMillis',
 		'logEvents',
 	],
+	default: {
+		host: 'localhost',
+		port: 5432,
+		database: '',
+		user: 'lisk',
+		password: 'password',
+		min: 10,
+		max: 95,
+		poolIdleTimeout: 30000,
+		reapIntervalMillis: 1000,
+		logEvents: ['error'],
+		logFileName: 'logs/lisk_db.log',
+	},
 };
 
 module.exports = defaultConfig;

--- a/framework/src/components/storage/index.js
+++ b/framework/src/components/storage/index.js
@@ -34,7 +34,7 @@ if (process.env.NEW_RELIC_LICENSE_KEY) {
 }
 
 function createStorageComponent(options, logger) {
-	options = validator.validateWithDefaults(defaultConfig, options);
+	options = validator.parseEnvArgAndValidate(defaultConfig, options);
 
 	const storage = new Storage(options, logger);
 

--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -122,7 +122,7 @@ class Application {
 		validator.loadSchema(constantsSchema);
 		validator.validate(applicationSchema.appLabel, appLabel);
 		validator.validate(applicationSchema.config, appConfig);
-		constants = validator.validateWithDefaults(
+		constants = validator.parseEnvArgAndValidate(
 			constantsSchema.constants,
 			constants
 		);
@@ -332,7 +332,7 @@ class Application {
 
 		Object.keys(modules).forEach(alias => {
 			this.logger.info(`Validating module options with alias: ${alias}`);
-			this.config.modules[alias] = validator.validateWithDefaults(
+			this.config.modules[alias] = validator.parseEnvArgAndValidate(
 				modules[alias].defaults,
 				this.config.modules[alias]
 			);

--- a/framework/src/controller/schema/application.js
+++ b/framework/src/controller/schema/application.js
@@ -67,7 +67,7 @@ module.exports = {
 			transactions: {
 				type: 'array',
 				items: {
-					$ref: 'transactions',
+					$ref: 'genesisTransactions',
 				},
 				uniqueItems: true,
 			},
@@ -89,8 +89,8 @@ module.exports = {
 		additionalProperties: false,
 	},
 
-	transactions: {
-		id: 'transactions',
+	genesisTransactions: {
+		id: 'genesisTransactions',
 		type: 'object',
 		required: ['type', 'timestamp', 'senderPublicKey', 'signature'],
 		properties: {

--- a/framework/src/controller/schema/config.js
+++ b/framework/src/controller/schema/config.js
@@ -57,13 +57,15 @@ module.exports = {
 				properties: {
 					enabled: {
 						type: 'boolean',
-						default: false,
 					},
 				},
 			},
 		},
 		required: ['modules', 'components'],
 		additionalProperties: false,
+		default: {
+			ipc: false,
+		},
 	},
 
 	moduleConfig: {

--- a/framework/src/controller/schema/constants.js
+++ b/framework/src/controller/schema/constants.js
@@ -30,13 +30,11 @@ module.exports = {
 				type: 'number',
 				format: 'oddInteger',
 				min: 1,
-				default: 101,
 				description: 'The default number of delegates allowed to forge a block',
 			},
 			BLOCK_SLOT_WINDOW: {
 				type: 'integer',
 				min: 1,
-				default: 5,
 				description: 'The default number of previous blocks to keep in memory',
 			},
 			ADDITIONAL_DATA: {
@@ -46,83 +44,112 @@ module.exports = {
 					MIN_LENGTH: {
 						type: 'integer',
 						min: 1,
-						default: 1,
 						description: 'Additional data (Min length)',
 					},
 					MAX_LENGTH: {
 						type: 'integer',
 						min: 1,
-						default: 64,
 						description: 'Additional data (Max length)',
 					},
-				},
-				default: {
-					MIN_LENGTH: 1,
-					MAX_LENGTH: 64,
 				},
 			},
 			BLOCK_RECEIPT_TIMEOUT: {
 				type: 'integer',
 				min: 1,
-				default: 20, // 2 blocks
 				description: 'Seconds to check if the block is fresh or not',
 			},
 			EPOCH_TIME: {
 				type: 'string',
 				format: 'date-time',
-				default: new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0)).toISOString(),
 				description:
 					'Timestamp indicating the start of Lisk Core (`Date.toISOString()`)',
 			},
 			FEES: {
-				$ref: 'fees',
-				default: {
-					SEND: '10000000',
-					VOTE: '100000000',
-					SECOND_SIGNATURE: '500000000',
-					DELEGATE: '2500000000',
-					MULTISIGNATURE: '500000000',
-					DAPP_REGISTRATION: '2500000000',
-					DAPP_WITHDRAWAL: '10000000',
-					DAPP_DEPOSIT: '10000000',
+				type: 'object',
+				description:
+					'Object representing amount of fees for different types of transactions',
+				required: [
+					'SEND',
+					'VOTE',
+					'SECOND_SIGNATURE',
+					'DELEGATE',
+					'MULTISIGNATURE',
+					'DAPP_REGISTRATION',
+					'DAPP_WITHDRAWAL',
+					'DAPP_DEPOSIT',
+				],
+				properties: {
+					SEND: {
+						type: 'string',
+						format: 'amount',
+						description: 'Fee for sending a transaction',
+					},
+					VOTE: {
+						type: 'string',
+						format: 'amount',
+						description: 'Fee for voting a delegate',
+					},
+					SECOND_SIGNATURE: {
+						type: 'string',
+						format: 'amount',
+						description: 'Fee for creating a second signature',
+					},
+					DELEGATE: {
+						type: 'string',
+						format: 'amount',
+						description: 'Fee for registering as a delegate',
+					},
+					MULTISIGNATURE: {
+						type: 'string',
+						format: 'amount',
+						description: 'Fee for multisignature transaction',
+					},
+					DAPP_REGISTRATION: {
+						type: 'string',
+						format: 'amount',
+						description: 'Fee for registering as a dapp',
+					},
+					DAPP_WITHDRAWAL: {
+						type: 'string',
+						format: 'amount',
+					},
+					DAPP_DEPOSIT: {
+						type: 'string',
+						format: 'amount',
+					},
 				},
+				additionalProperties: false,
 			},
 			MAX_PAYLOAD_LENGTH: {
 				type: 'integer',
 				min: 1,
-				default: 1024 * 1024,
 				description:
 					'Maximum transaction bytes length for 25 transactions in a single block',
 			},
 			MAX_PEERS: {
 				type: 'integer',
 				min: 1,
-				default: 100,
 				description:
 					'Maximum number of peers allowed to connect while broadcasting a block',
 			},
 			MAX_SHARED_TRANSACTIONS: {
 				type: 'integer',
 				min: 1,
-				default: 100,
 				description:
 					'Maximum number of in-memory transactions/signatures shared across peers',
 			},
 			MAX_TRANSACTIONS_PER_BLOCK: {
 				type: 'integer',
 				min: 1,
-				default: 25,
 				description: 'Maximum number of transactions allowed per block',
 			},
 			MAX_VOTES_PER_TRANSACTION: {
 				type: 'integer',
 				min: 1,
-				default: 33,
 				description: 'Maximum number of transactions allowed per block',
 			},
 			MAX_VOTES_PER_ACCOUNT: {
 				type: 'number',
-				default: 101,
 				description:
 					'The maximum number of votes allowed in transaction type(3) votes',
 				min: 1,
@@ -133,26 +160,74 @@ module.exports = {
 			MIN_BROADHASH_CONSENSUS: {
 				type: 'integer',
 				min: 1,
-				default: 51,
 				description:
 					'Minimum broadhash consensus(%) among connected {MAX_PEERS} peers',
 			},
 			MULTISIG_CONSTRAINTS: {
-				$ref: 'multisig',
-				default: {
+				type: 'object',
+				required: ['MIN', 'LIFETIME', 'KEYSGROUP'],
+				properties: {
+					KEYSGROUP: {
+						type: 'object',
+						required: ['MIN_ITEMS', 'MAX_ITEMS'],
+						properties: {
+							MIN_ITEMS: {
+								type: 'integer',
+								min: 1,
+								description:
+									'Minimum allowed number of keys inside a Multisignature pool',
+							},
+							MAX_ITEMS: {
+								type: 'integer',
+								min: 1,
+								description:
+									'Maximum allowed number of keys inside a Multisignature pool',
+							},
+						},
+						additionalProperties: false,
+					},
 					MIN: {
-						MINIMUM: 1,
-						MAXIMUM: 15,
+						type: 'object',
+						required: ['MINIMUM', 'MAXIMUM'],
+						properties: {
+							MINIMUM: {
+								type: 'integer',
+								min: 1,
+								description:
+									'Minimum allowed number of signatures required to process a multisignature transaction',
+							},
+							MAXIMUM: {
+								type: 'number',
+								min: 1,
+								maximum: {
+									$data: '/MULTISIG_CONSTRAINTS/KEYSGROUP/MAX_ITEMS',
+								},
+								description:
+									'Maximum allowed number of signatures required to process a multisignature transaction',
+							},
+						},
 					},
 					LIFETIME: {
-						MINIMUM: 1,
-						MAXIMUM: 72,
-					},
-					KEYSGROUP: {
-						MIN_ITEMS: 1,
-						MAX_ITEMS: 15,
+						type: 'object',
+						required: ['MINIMUM', 'MAXIMUM'],
+						properties: {
+							MINIMUM: {
+								type: 'integer',
+								min: 1,
+								description:
+									'Minimum timeframe in which a multisignature transaction will exist in memory before the transaction is confirmed',
+							},
+							MAXIMUM: {
+								type: 'integer',
+								min: 1,
+								description:
+									'Maximum timeframe in which multisignature transaction will exist in memory before the transaction is confirmed',
+							},
+						},
+						additionalProperties: false,
 					},
 				},
+				additionalProperties: false,
 			},
 			NETHASHES: {
 				type: 'array',
@@ -160,303 +235,178 @@ module.exports = {
 					type: 'string',
 					format: 'hex',
 				},
-				default: [
-					// Mainnet
-					'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
-					// Testnet
-					'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-				],
 				description: 'For mainnet and testnet',
 			},
 			NORMALIZER: {
 				type: 'string',
 				format: 'amount',
-				default: '100000000',
 				description: 'Use this to convert LISK amount to normal value',
 			},
 			REWARDS: {
-				$ref: 'rewards',
-				default: {
-					MILESTONES: [
-						'500000000', // Initial Reward
-						'400000000', // Milestone 1
-						'300000000', // Milestone 2
-						'200000000', // Milestone 3
-						'100000000', // Milestone 4
-					],
-					OFFSET: 2160,
-					DISTANCE: 3000000,
+				type: 'object',
+				required: ['MILESTONES', 'OFFSET', 'DISTANCE'],
+				description: 'Object representing LSK rewards milestone',
+				properties: {
+					MILESTONES: {
+						type: 'array',
+						items: {
+							type: 'string',
+							format: 'amount',
+						},
+						description: 'Initial 5, and decreasing until 1',
+					},
+					OFFSET: {
+						type: 'integer',
+						min: 1,
+						description: 'Start rewards at block (n)',
+					},
+					DISTANCE: {
+						type: 'integer',
+						min: 1,
+						description: 'Distance between each milestone',
+					},
 				},
+				additionalProperties: false,
 			},
 			TOTAL_AMOUNT: {
 				type: 'string',
 				format: 'amount',
-				default: '10000000000000000',
 				description:
 					'Total amount of LSK available in network before rewards milestone started',
 			},
 			TRANSACTION_TYPES: {
-				$ref: 'transactionTypes',
-				default: {
-					SEND: 0,
-					SIGNATURE: 1,
-					DELEGATE: 2,
-					VOTE: 3,
-					MULTI: 4,
-					DAPP: 5,
-					IN_TRANSFER: 6,
-					OUT_TRANSFER: 7,
+				type: 'object',
+				required: [
+					'SEND',
+					'SIGNATURE',
+					'DELEGATE',
+					'VOTE',
+					'MULTI',
+					'DAPP',
+					'IN_TRANSFER',
+					'OUT_TRANSFER',
+				],
+				properties: {
+					SEND: {
+						type: 'integer',
+						enum: [0],
+					},
+					SIGNATURE: {
+						type: 'integer',
+						enum: [1],
+					},
+					DELEGATE: {
+						type: 'integer',
+						enum: [2],
+					},
+					VOTE: {
+						type: 'integer',
+						enum: [3],
+					},
+					MULTI: {
+						type: 'integer',
+						enum: [4],
+					},
+					DAPP: {
+						type: 'integer',
+						enum: [5],
+					},
+					IN_TRANSFER: {
+						type: 'integer',
+						enum: [6],
+					},
+					OUT_TRANSFER: {
+						type: 'integer',
+						enum: [7],
+					},
 				},
+				additionalProperties: false,
 			},
 			UNCONFIRMED_TRANSACTION_TIMEOUT: {
 				type: 'integer',
 				min: 1,
-				default: 10800,
 				description:
 					'Expiration time for unconfirmed transaction/signatures in transaction pool',
 			},
 			EXPIRY_INTERVAL: {
 				type: 'integer',
 				min: 1,
-				default: 30000,
 				description: 'Transaction pool expiry timer in milliseconds',
 			},
 		},
 		additionalProperties: false,
-	},
-
-	fees: {
-		id: 'fees',
-		type: 'object',
-		description:
-			'Object representing amount of fees for different types of transactions',
-		required: [
-			'SEND',
-			'VOTE',
-			'SECOND_SIGNATURE',
-			'DELEGATE',
-			'MULTISIGNATURE',
-			'DAPP_REGISTRATION',
-			'DAPP_WITHDRAWAL',
-			'DAPP_DEPOSIT',
-		],
-		properties: {
-			SEND: {
-				type: 'string',
-				format: 'amount',
-				default: '10000000',
-				description: 'Fee for sending a transaction',
+		default: {
+			ACTIVE_DELEGATES: 101,
+			BLOCK_SLOT_WINDOW: 5,
+			ADDITIONAL_DATA: {
+				MIN_LENGTH: 1,
+				MAX_LENGTH: 64,
 			},
-			VOTE: {
-				type: 'string',
-				format: 'amount',
-				default: '100000000',
-				description: 'Fee for voting a delegate',
+			BLOCK_RECEIPT_TIMEOUT: 20, // 2 blocks
+			EPOCH_TIME: new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0)).toISOString(),
+			FEES: {
+				SEND: '10000000',
+				VOTE: '100000000',
+				SECOND_SIGNATURE: '500000000',
+				DELEGATE: '2500000000',
+				MULTISIGNATURE: '500000000',
+				DAPP_REGISTRATION: '2500000000',
+				DAPP_WITHDRAWAL: '10000000',
+				DAPP_DEPOSIT: '10000000',
 			},
-			SECOND_SIGNATURE: {
-				type: 'string',
-				format: 'amount',
-				default: '500000000',
-				description: 'Fee for creating a second signature',
-			},
-			DELEGATE: {
-				type: 'string',
-				format: 'amount',
-				default: '2500000000',
-				description: 'Fee for registering as a delegate',
-			},
-			MULTISIGNATURE: {
-				type: 'string',
-				format: 'amount',
-				default: '500000000',
-				description: 'Fee for multisignature transaction',
-			},
-			DAPP_REGISTRATION: {
-				type: 'string',
-				format: 'amount',
-				default: '2500000000',
-				description: 'Fee for registering as a dapp',
-			},
-			DAPP_WITHDRAWAL: {
-				type: 'string',
-				format: 'amount',
-				default: '10000000',
-			},
-			DAPP_DEPOSIT: {
-				type: 'string',
-				format: 'amount',
-				default: '10000000',
-			},
-		},
-		additionalProperties: false,
-	},
-
-	multisig: {
-		id: 'multisig',
-		type: 'object',
-		required: ['MIN', 'LIFETIME', 'KEYSGROUP'],
-		properties: {
-			KEYSGROUP: {
-				type: 'object',
-				required: ['MIN_ITEMS', 'MAX_ITEMS'],
-				properties: {
-					MIN_ITEMS: {
-						type: 'integer',
-						min: 1,
-						default: 1,
-						description:
-							'Minimum allowed number of keys inside a Multisignature pool',
-					},
-					MAX_ITEMS: {
-						type: 'integer',
-						min: 1,
-						default: 15,
-						description:
-							'Maximum allowed number of keys inside a Multisignature pool',
-					},
+			MAX_PAYLOAD_LENGTH: 1024 * 1024,
+			MAX_PEERS: 100,
+			MAX_SHARED_TRANSACTIONS: 100,
+			MAX_TRANSACTIONS_PER_BLOCK: 25,
+			MAX_VOTES_PER_TRANSACTION: 33,
+			MAX_VOTES_PER_ACCOUNT: 101,
+			MIN_BROADHASH_CONSENSUS: 51,
+			MULTISIG_CONSTRAINTS: {
+				MIN: {
+					MINIMUM: 1,
+					MAXIMUM: 15,
 				},
-				default: {
-					MIN_ITEMS: 1,
-					MAX_ITEMS: 15,
-				},
-				additionalProperties: false,
-			},
-			MIN: {
-				type: 'object',
-				required: ['MINIMUM', 'MAXIMUM'],
-				properties: {
-					MINIMUM: {
-						type: 'integer',
-						min: 1,
-						default: 1,
-						description:
-							'Minimum allowed number of signatures required to process a multisignature transaction',
-					},
-					MAXIMUM: {
-						type: 'number',
-						min: 1,
-						maximum: {
-							$data: '/MULTISIG_CONSTRAINTS/KEYSGROUP/MAX_ITEMS',
-						},
-						default: 15,
-						description:
-							'Maximum allowed number of signatures required to process a multisignature transaction',
-					},
-				},
-			},
-			LIFETIME: {
-				type: 'object',
-				required: ['MINIMUM', 'MAXIMUM'],
-				properties: {
-					MINIMUM: {
-						type: 'integer',
-						min: 1,
-						default: 1,
-						description:
-							'Minimum timeframe in which a multisignature transaction will exist in memory before the transaction is confirmed',
-					},
-					MAXIMUM: {
-						type: 'integer',
-						min: 1,
-						default: 72,
-						description:
-							'Maximum timeframe in which multisignature transaction will exist in memory before the transaction is confirmed',
-					},
-				},
-				default: {
+				LIFETIME: {
 					MINIMUM: 1,
 					MAXIMUM: 72,
 				},
-				additionalProperties: false,
-			},
-		},
-		additionalProperties: false,
-	},
-
-	rewards: {
-		id: 'rewards',
-		type: 'object',
-		required: ['MILESTONES', 'OFFSET', 'DISTANCE'],
-		description: 'Object representing LSK rewards milestone',
-		properties: {
-			MILESTONES: {
-				type: 'array',
-				items: {
-					type: 'string',
-					format: 'amount',
+				KEYSGROUP: {
+					MIN_ITEMS: 1,
+					MAX_ITEMS: 15,
 				},
-				default: [
+			},
+			NETHASHES: [
+				// Mainnet
+				'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
+				// Testnet
+				'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+			],
+			NORMALIZER: '100000000',
+			REWARDS: {
+				MILESTONES: [
 					'500000000', // Initial Reward
 					'400000000', // Milestone 1
 					'300000000', // Milestone 2
 					'200000000', // Milestone 3
 					'100000000', // Milestone 4
 				],
-				description: 'Initial 5, and decreasing until 1',
+				OFFSET: 2160, // Start rewards at first block of the second round
+				DISTANCE: 3000000, // Distance between each milestone
 			},
-			OFFSET: {
-				type: 'integer',
-				min: 1,
-				default: 2160, // Start rewards at first block of the second round
-				description: 'Start rewards at block (n)',
+			// WARNING: When changing totalAmount you also need to change getBlockRewards(int) SQL function!
+			TOTAL_AMOUNT: '10000000000000000',
+			TRANSACTION_TYPES: {
+				SEND: 0,
+				SIGNATURE: 1,
+				DELEGATE: 2,
+				VOTE: 3,
+				MULTI: 4,
+				DAPP: 5,
+				IN_TRANSFER: 6,
+				OUT_TRANSFER: 7,
 			},
-			DISTANCE: {
-				type: 'integer',
-				min: 1,
-				default: 3000000, // Distance between each milestone
-				description: 'Distance between each milestone',
-			},
+			UNCONFIRMED_TRANSACTION_TIMEOUT: 10800, // 1080 blocks
+			EXPIRY_INTERVAL: 30000,
 		},
-		additionalProperties: false,
-	},
-
-	transactionTypes: {
-		id: 'transactionTypes',
-		type: 'object',
-		required: [
-			'SEND',
-			'SIGNATURE',
-			'DELEGATE',
-			'VOTE',
-			'MULTI',
-			'DAPP',
-			'IN_TRANSFER',
-			'OUT_TRANSFER',
-		],
-		properties: {
-			SEND: {
-				type: 'integer',
-				enum: [0],
-			},
-			SIGNATURE: {
-				type: 'integer',
-				enum: [1],
-			},
-			DELEGATE: {
-				type: 'integer',
-				enum: [2],
-			},
-			VOTE: {
-				type: 'integer',
-				enum: [3],
-			},
-			MULTI: {
-				type: 'integer',
-				enum: [4],
-			},
-			DAPP: {
-				type: 'integer',
-				enum: [5],
-			},
-			IN_TRANSFER: {
-				type: 'integer',
-				enum: [6],
-			},
-			OUT_TRANSFER: {
-				type: 'integer',
-				enum: [7],
-			},
-		},
-		additionalProperties: false,
 	},
 };

--- a/framework/src/controller/schema/constants.js
+++ b/framework/src/controller/schema/constants.js
@@ -289,35 +289,35 @@ module.exports = {
 				properties: {
 					SEND: {
 						type: 'integer',
-						enum: [0],
+						const: 0,
 					},
 					SIGNATURE: {
 						type: 'integer',
-						enum: [1],
+						const: 1,
 					},
 					DELEGATE: {
 						type: 'integer',
-						enum: [2],
+						const: 2,
 					},
 					VOTE: {
 						type: 'integer',
-						enum: [3],
+						const: 3,
 					},
 					MULTI: {
 						type: 'integer',
-						enum: [4],
+						const: 4,
 					},
 					DAPP: {
 						type: 'integer',
-						enum: [5],
+						const: 5,
 					},
 					IN_TRANSFER: {
 						type: 'integer',
-						enum: [6],
+						const: 6,
 					},
 					OUT_TRANSFER: {
 						type: 'integer',
-						enum: [7],
+						const: 7,
 					},
 				},
 				additionalProperties: false,

--- a/framework/src/modules/chain/defaults/config.js
+++ b/framework/src/modules/chain/defaults/config.js
@@ -1,4 +1,4 @@
-const DefaultConfig = {
+const defaultConfig = {
 	type: 'object',
 	properties: {
 		broadcasts: {
@@ -6,37 +6,31 @@ const DefaultConfig = {
 			properties: {
 				active: {
 					type: 'boolean',
-					default: true,
 				},
 				broadcastInterval: {
 					type: 'integer',
 					minimum: 1000,
 					maximum: 60000,
-					default: 5000,
 				},
 				broadcastLimit: {
 					type: 'integer',
 					minimum: 1,
 					maximum: 100,
-					default: 25,
 				},
 				parallelLimit: {
 					type: 'integer',
 					minimum: 1,
 					maximum: 100,
-					default: 20,
 				},
 				releaseLimit: {
 					type: 'integer',
 					minimum: 1,
 					maximum: 25,
-					default: 25,
 				},
 				relayLimit: {
 					type: 'integer',
 					minimum: 1,
 					maximum: 100,
-					default: 3,
 				},
 			},
 			required: [
@@ -46,14 +40,6 @@ const DefaultConfig = {
 				'releaseLimit',
 				'relayLimit',
 			],
-			default: {
-				active: true,
-				broadcastInterval: 5000,
-				broadcastLimit: 25,
-				parallelLimit: 20,
-				releaseLimit: 25,
-				relayLimit: 3,
-			},
 		},
 		transactions: {
 			type: 'object',
@@ -62,27 +48,21 @@ const DefaultConfig = {
 					type: 'integer',
 					minimum: 100,
 					maximum: 5000,
-					default: 1000,
 				},
 			},
 			required: ['maxTransactionsPerQueue'],
-			default: {
-				maxTransactionsPerQueue: 1000,
-			},
 		},
 		forging: {
 			type: 'object',
 			properties: {
 				force: {
 					type: 'boolean',
-					default: false,
 				},
 				defaultPassword: {
 					type: 'string',
 				},
 				delegates: {
 					type: 'array',
-					default: [],
 					env: {
 						variable: 'LISK_FORGING_DELEGATES',
 						formatter: 'stringToDelegateList',
@@ -102,23 +82,15 @@ const DefaultConfig = {
 				},
 			},
 			required: ['force', 'delegates'],
-			default: {
-				force: false,
-				delegates: [],
-			},
 		},
 		syncing: {
 			type: 'object',
 			properties: {
 				active: {
 					type: 'boolean',
-					default: true,
 				},
 			},
 			required: ['active'],
-			default: {
-				active: true,
-			},
 		},
 		loading: {
 			type: 'object',
@@ -127,19 +99,13 @@ const DefaultConfig = {
 					type: 'integer',
 					minimum: 1,
 					maximum: 5000,
-					default: 5000,
 				},
 				snapshotRound: {
 					type: 'integer',
-					default: 0,
 					arg: '-s,--snapshot',
 				},
 			},
 			required: ['loadPerIteration'],
-			default: {
-				loadPerIteration: 5000,
-				snapshotRound: 0,
-			},
 		},
 		exceptions: {
 			type: 'object',
@@ -150,7 +116,6 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 				senderPublicKey: {
 					type: 'array',
@@ -158,7 +123,6 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 				signatures: {
 					type: 'array',
@@ -166,7 +130,6 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 				multisignatures: {
 					type: 'array',
@@ -174,7 +137,6 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 				votes: {
 					type: 'array',
@@ -182,7 +144,6 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 				inertTransactions: {
 					type: 'array',
@@ -190,13 +151,11 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 				rounds: {
 					type: 'object',
 					description:
 						'In the format: 27040: { rewards_factor: 2, fees_factor: 2, fees_bonus: 10000000 }',
-					default: {},
 				},
 				precedent: {
 					type: 'object',
@@ -205,42 +164,33 @@ const DefaultConfig = {
 					properties: {
 						disableDappTransfer: {
 							type: 'integer',
-							default: 0,
 						},
 					},
 					required: ['disableDappTransfer'],
-					default: {
-						disableDappTransfer: 0,
-					},
 				},
 				ignoreDelegateListCacheForRounds: {
 					type: 'array',
 					items: {
 						type: 'integer',
 					},
-					default: [],
 				},
 				blockVersions: {
 					type: 'object',
 					description:
 						'In format: { version: { start: start_height, end: end_height }}',
-					default: {},
 				},
 				recipientLeadingZero: {
 					type: 'object',
 					description: 'In format: { transaction_id: "account_address"} ',
-					default: {},
 				},
 				recipientExceedingUint64: {
 					type: 'object',
 					description: 'In format: { transaction_id: "account_address"} ',
-					default: {},
 				},
 				duplicatedSignatures: {
 					type: 'object',
 					description:
 						'In format: { transaction_id: [signature1, signature2] } ',
-					default: {},
 				},
 				transactionWithNullByte: {
 					type: 'array',
@@ -248,7 +198,6 @@ const DefaultConfig = {
 						type: 'string',
 						format: 'id',
 					},
-					default: [],
 				},
 			},
 			required: [
@@ -267,22 +216,6 @@ const DefaultConfig = {
 				'duplicatedSignatures',
 				'transactionWithNullByte',
 			],
-			default: {
-				blockRewards: [],
-				senderPublicKey: [],
-				signatures: [],
-				multisignatures: [],
-				votes: [],
-				inertTransactions: [],
-				rounds: {},
-				precedent: { disableDappTransfer: 0 },
-				ignoreDelegateListCacheForRounds: [],
-				blockVersions: {},
-				recipientLeadingZero: {},
-				recipientExceedingUint64: {},
-				duplicatedSignatures: {},
-				transactionWithNullByte: [],
-			},
 		},
 		network: {
 			type: 'object',
@@ -291,20 +224,17 @@ const DefaultConfig = {
 					type: 'integer',
 					minimum: 1,
 					maximum: 65535,
-					default: 5000,
 					env: 'LISK_WS_PORT',
 					arg: '-p,--port',
 				},
 				address: {
 					type: 'string',
 					format: 'ip',
-					default: '0.0.0.0',
 					env: 'LISK_ADDRESS',
 					arg: '-a,--address',
 				},
 				enabled: {
 					type: 'boolean',
-					default: true,
 				},
 				list: {
 					type: 'array',
@@ -324,28 +254,6 @@ const DefaultConfig = {
 					},
 					env: { variable: 'LISK_PEERS', formatter: 'stringToIpPortSet' },
 					arg: { name: '-x,--peers', formatter: 'stringToIpPortSet' }, // TODO: Need to confirm parsing logic, old logic was using network WSPort to be default port for peers, we don't have it at the time of compilation
-					default: [
-						{
-							ip: 'testnet-seed-01.lisk.io',
-							wsPort: 7001,
-						},
-						{
-							ip: 'testnet-seed-02.lisk-nodes.net',
-							wsPort: 7001,
-						},
-						{
-							ip: 'testnet-seed-03.lisk.io',
-							wsPort: 7001,
-						},
-						{
-							ip: 'testnet-seed-04.lisk-nodes.net',
-							wsPort: 7001,
-						},
-						{
-							ip: 'testnet-seed-05.lisk.io',
-							wsPort: 7001,
-						},
-					],
 				},
 				access: {
 					type: 'object',
@@ -356,83 +264,32 @@ const DefaultConfig = {
 								type: 'string',
 								format: 'ip',
 							},
-							default: [],
 						},
 					},
 					required: ['blackList'],
-					default: {
-						blackList: [],
-					},
 				},
 				options: {
 					properties: {
 						timeout: {
 							type: 'integer',
-							default: 5000,
 						},
 						broadhashConsensusCalculationInterval: {
 							type: 'integer',
-							default: 5000,
 						},
 						wsEngine: {
 							type: 'string',
-							default: 'ws',
 						},
 						httpHeadersTimeout: {
 							type: 'integer',
-							default: 5000,
 						},
 						httpServerSetTimeout: {
 							type: 'integer',
-							default: 20000,
 						},
 					},
 					required: ['timeout'],
-					default: {
-						timeout: 5000,
-						broadhashConsensusCalculationInterval: 5000,
-						wsEngine: 'ws',
-						httpHeadersTimeout: 5000,
-						httpServerSetTimeout: 20000,
-					},
 				},
 			},
 			required: ['enabled', 'list', 'access', 'options', 'wsPort', 'address'],
-			default: {
-				enabled: true,
-				list: [
-					{
-						ip: 'testnet-seed-01.lisk.io',
-						wsPort: 7001,
-					},
-					{
-						ip: 'testnet-seed-02.lisk-nodes.net',
-						wsPort: 7001,
-					},
-					{
-						ip: 'testnet-seed-03.lisk.io',
-						wsPort: 7001,
-					},
-					{
-						ip: 'testnet-seed-04.lisk-nodes.net',
-						wsPort: 7001,
-					},
-					{
-						ip: 'testnet-seed-05.lisk.io',
-						wsPort: 7001,
-					},
-				],
-				access: {
-					blackList: [],
-				},
-				options: {
-					timeout: 5000,
-					broadhashConsensusCalculationInterval: 5000,
-					wsEngine: 'ws',
-				},
-				wsPort: 5000,
-				address: '0.0.0.0',
-			},
 		},
 	},
 	required: [
@@ -444,6 +301,62 @@ const DefaultConfig = {
 		'exceptions',
 		'network',
 	],
+	default: {
+		broadcasts: {
+			active: true,
+			broadcastInterval: 5000,
+			broadcastLimit: 25,
+			parallelLimit: 20,
+			releaseLimit: 25,
+			relayLimit: 3,
+		},
+		transactions: {
+			maxTransactionsPerQueue: 1000,
+		},
+		forging: {
+			force: false,
+			delegates: [],
+		},
+		syncing: {
+			active: true,
+		},
+		loading: {
+			loadPerIteration: 5000,
+			snapshotRound: 0,
+		},
+		exceptions: {
+			blockRewards: [],
+			senderPublicKey: [],
+			signatures: [],
+			multisignatures: [],
+			votes: [],
+			inertTransactions: [],
+			rounds: {},
+			precedent: { disableDappTransfer: 0 },
+			ignoreDelegateListCacheForRounds: [],
+			blockVersions: {},
+			recipientLeadingZero: {},
+			recipientExceedingUint64: {},
+			duplicatedSignatures: {},
+			transactionWithNullByte: [],
+		},
+		network: {
+			enabled: true,
+			wsPort: 5000,
+			address: '0.0.0.0',
+			list: [],
+			access: {
+				blackList: [],
+			},
+			options: {
+				timeout: 5000,
+				broadhashConsensusCalculationInterval: 5000,
+				wsEngine: 'ws',
+				httpHeadersTimeout: 5000,
+				httpServerSetTimeout: 20000,
+			},
+		},
+	},
 };
 
-module.exports = DefaultConfig;
+module.exports = defaultConfig;

--- a/framework/src/modules/chain/workers_controller.js
+++ b/framework/src/modules/chain/workers_controller.js
@@ -38,7 +38,7 @@ const {
 const validator = require('../../controller/helpers/validator');
 const schema = require('./defaults/config');
 
-const config = validator.validateWithDefaults(schema, {});
+const config = validator.parseEnvArgAndValidate(schema, {});
 
 /**
  * Instantiate the SocketCluster SCWorker instance with custom logic

--- a/framework/src/modules/http_api/defaults/config.js
+++ b/framework/src/modules/http_api/defaults/config.js
@@ -5,36 +5,30 @@ const defaultConfig = {
 			type: 'integer',
 			minimum: 1,
 			maximum: 65535,
-			default: 4000,
 			env: 'LISK_HTTP_PORT',
 			arg: '-h,--http-port',
 		},
 		address: {
 			type: 'string',
 			format: 'ip',
-			default: '0.0.0.0',
 			env: 'LISK_ADDRESS',
 			arg: '-a,--address',
 		},
 		trustProxy: {
 			type: 'boolean',
-			default: false,
 		},
 		enabled: {
 			type: 'boolean',
-			default: true,
 		},
 		access: {
 			type: 'object',
 			properties: {
 				public: {
 					type: 'boolean',
-					default: false,
 					env: 'LISK_API_PUBLIC',
 				},
 				whiteList: {
 					type: 'array',
-					default: ['127.0.0.1'],
 					env: {
 						variable: 'LISK_API_WHITELIST',
 						formatter: 'stringToIpPortSet',
@@ -48,48 +42,28 @@ const defaultConfig = {
 			properties: {
 				enabled: {
 					type: 'boolean',
-					default: false,
 				},
 				options: {
 					type: 'object',
 					properties: {
 						port: {
 							type: 'integer',
-							default: 443,
 						},
 						address: {
 							type: 'string',
 							format: 'ip',
-							default: '0.0.0.0',
 						},
 						key: {
 							type: 'string',
-							default: './ssl/lisk.key',
 						},
 						cert: {
 							type: 'string',
-							default: './ssl/lisk.crt',
 						},
 					},
 					required: ['port', 'address', 'key', 'cert'],
-					default: {
-						port: 443,
-						address: '0.0.0.0',
-						key: './ssl/lisk.key',
-						cert: './ssl/lisk.crt',
-					},
 				},
 			},
 			required: ['enabled', 'options'],
-			default: {
-				enabled: false,
-				options: {
-					port: 443,
-					address: '0.0.0.0',
-					key: './ssl/lisk.key',
-					cert: './ssl/lisk.crt',
-				},
-			},
 		},
 		options: {
 			type: 'object',
@@ -99,31 +73,25 @@ const defaultConfig = {
 					properties: {
 						max: {
 							type: 'integer',
-							default: 0,
 						},
 						delayMs: {
 							type: 'integer',
-							default: 0,
 						},
 						delayAfter: {
 							type: 'integer',
-							default: 0,
 						},
 						windowMs: {
 							type: 'integer',
-							default: 60000,
 						},
 						headersTimeout: {
 							type: 'integer',
 							minimum: 1,
 							maximum: 40000,
-							default: 5000,
 						},
 						serverSetTimeout: {
 							type: 'integer',
 							minimum: 1,
 							maximum: 120000,
-							default: 20000,
 						},
 					},
 					required: [
@@ -134,49 +102,21 @@ const defaultConfig = {
 						'headersTimeout',
 						'serverSetTimeout',
 					],
-					default: {
-						max: 0,
-						delayMs: 0,
-						delayAfter: 0,
-						windowMs: 60000,
-						headersTimeout: 5000,
-						serverSetTimeout: 20000,
-					},
 				},
 				cors: {
 					type: 'object',
 					properties: {
 						origin: {
 							anyOf: [{ type: 'string' }, { type: 'boolean' }],
-							default: '*',
 						},
 						methods: {
 							type: 'array',
-							default: ['GET', 'POST', 'PUT'],
 						},
 					},
 					required: ['origin'],
-					default: {
-						origin: '*',
-						methods: ['GET', 'POST', 'PUT'],
-					},
 				},
 			},
 			required: ['limits', 'cors'],
-			default: {
-				limits: {
-					max: 0,
-					delayMs: 0,
-					delayAfter: 0,
-					windowMs: 60000,
-					headersTimeout: 5000,
-					serverSetTimeout: 20000,
-				},
-				cors: {
-					origin: '*',
-					methods: ['GET', 'POST', 'PUT'],
-				},
-			},
 		},
 		forging: {
 			type: 'object',
@@ -186,7 +126,6 @@ const defaultConfig = {
 					properties: {
 						whiteList: {
 							type: 'array',
-							default: ['127.0.0.1'],
 							env: {
 								variable: 'LISK_FORGING_WHITELIST',
 								formatter: 'stringToIpPortSet',
@@ -194,17 +133,9 @@ const defaultConfig = {
 						},
 					},
 					required: ['whiteList'],
-					default: {
-						whiteList: ['127.0.0.1'],
-					},
 				},
 			},
 			required: ['access'],
-			default: {
-				access: {
-					whiteList: ['127.0.0.1'],
-				},
-			},
 		},
 	},
 	required: [
@@ -218,10 +149,10 @@ const defaultConfig = {
 		'forging',
 	],
 	default: {
+		enabled: true,
 		httpPort: 4000,
 		address: '0.0.0.0',
 		trustProxy: false,
-		enabled: true,
 		access: {
 			public: false,
 			whiteList: ['127.0.0.1'],

--- a/framework/test/jest/specs/functional/controller/helpers/validator/validator.spec.js
+++ b/framework/test/jest/specs/functional/controller/helpers/validator/validator.spec.js
@@ -1,8 +1,51 @@
 const {
+	validate,
 	parseEnvArgAndValidate,
 } = require('../../../../../../../src/controller/helpers/validator');
 
 describe('helpers/validator.js', () => {
+	describe('Ajv instance', () => {
+		describe('const', () => {
+			it('should not throw error if value for "const" defined attribute is same', () => {
+				const schema = {
+					type: 'object',
+					properties: {
+						prop1: { type: 'integer', const: 5 },
+					},
+				};
+
+				expect(() => validate(schema, { prop1: 5 })).not.toThrow();
+			});
+
+			it('should throw error if value for "const" defined attribute is different', () => {
+				let errorThrown;
+
+				const schema = {
+					type: 'object',
+					properties: {
+						prop1: { type: 'integer', const: 5 },
+					},
+				};
+
+				try {
+					validate(schema, { prop1: 2 });
+				} catch (error) {
+					errorThrown = error;
+				}
+
+				expect(errorThrown.message).toBe('Schema validation error');
+				expect(errorThrown.errors).toEqual([
+					{
+						dataPath: '.prop1',
+						keyword: 'const',
+						message: 'should be equal to constant',
+						params: { allowedValue: 5 },
+						schemaPath: '#/properties/prop1/const',
+					},
+				]);
+			});
+		});
+	});
 	describe('Ajv instance with keyword parser', () => {
 		describe('parseEnvArgAndValidate()', () => {
 			it('should populate default values if provided through schema', () => {

--- a/framework/test/jest/specs/functional/controller/helpers/validator/validator.spec.js
+++ b/framework/test/jest/specs/functional/controller/helpers/validator/validator.spec.js
@@ -1,0 +1,47 @@
+const {
+	parseEnvArgAndValidate,
+} = require('../../../../../../../src/controller/helpers/validator');
+
+describe('helpers/validator.js', () => {
+	describe('Ajv instance with keyword parser', () => {
+		describe('parseEnvArgAndValidate()', () => {
+			it('should populate default values if provided through schema', () => {
+				const schema = {
+					type: 'object',
+					properties: {
+						prop1: { type: 'string' },
+						prop2: { type: 'string' },
+					},
+					required: ['prop1', 'prop2'],
+					default: { prop1: 'prop1Default', prop2: 'prop2Default' },
+				};
+
+				const data = { prop2: 'prop2' };
+				const result = parseEnvArgAndValidate(schema, data);
+
+				expect(result).toEqual({ prop1: 'prop1Default', prop2: 'prop2' });
+			});
+
+			it('should populate default values if custom default is provided', () => {
+				const schema = {
+					type: 'object',
+					properties: {
+						prop1: { type: 'string' },
+						prop2: { type: 'string' },
+					},
+					required: ['prop1', 'prop2'],
+					default: { prop1: 'prop1Default', prop2: 'prop2Default' },
+				};
+
+				const customDefault = {
+					prop1: 'prop1CustomDefault',
+					prop2: 'prop2CustomDefault',
+				};
+				const data = { prop2: 'prop2' };
+				const result = parseEnvArgAndValidate(schema, data, customDefault);
+
+				expect(result).toEqual({ prop1: 'prop1CustomDefault', prop2: 'prop2' });
+			});
+		});
+	});
+});

--- a/framework/test/jest/specs/unit/controller/application.spec.js
+++ b/framework/test/jest/specs/unit/controller/application.spec.js
@@ -96,7 +96,7 @@ describe('Application', () => {
 				params.label
 			);
 
-			expect(validator.validateWithDefaults).toHaveBeenCalledWith(
+			expect(validator.parseEnvArgAndValidate).toHaveBeenCalledWith(
 				constantsSchema.constants,
 				params.constants
 			);

--- a/framework/test/jest/specs/unit/controller/helpers/validator/validator.spec.js
+++ b/framework/test/jest/specs/unit/controller/helpers/validator/validator.spec.js
@@ -145,7 +145,9 @@ describe('helpers/validator.js', () => {
 				.mockImplementation(() => false);
 
 			// Act & Assert
-			expect(parseEnvArgAndValidate).toThrow(SchemaValidationError);
+			expect(() => {
+				parseEnvArgAndValidate({});
+			}).toThrow(SchemaValidationError);
 		});
 	});
 });

--- a/framework/test/jest/specs/unit/controller/helpers/validator/validator.spec.js
+++ b/framework/test/jest/specs/unit/controller/helpers/validator/validator.spec.js
@@ -1,12 +1,17 @@
 const Ajv = require('ajv');
 const {
 	validator,
-	validatorWithDefaults,
+	parserAndValidator,
 	loadSchema,
 	validate,
-	validateWithDefaults,
+	parseEnvArgAndValidate,
 	ZSchema,
 } = require('../../../../../../../src/controller/helpers/validator');
+const formats = require('../../../../../../../src/controller/helpers/validator/formats');
+const {
+	env,
+	arg,
+} = require('../../../../../../../src/controller/helpers/validator/keywords');
 const { SchemaValidationError } = require('../../../../../../../src/errors');
 
 jest.mock('ajv');
@@ -35,26 +40,34 @@ describe('helpers/validator.js', () => {
 		});
 	});
 
-	describe('Ajv instance with defaults', () => {
+	describe('Ajv instance with keyword parser', () => {
 		it('should be created by given arguments.', () => {
 			// Assert
 			expect(Ajv).toHaveBeenCalledWith({
 				allErrors: true,
 				schemaId: 'auto',
-				useDefaults: true,
+				useDefaults: false,
 				$data: true,
 			});
-			expect(validatorWithDefaults).toBeInstanceOf(Ajv);
+			expect(parserAndValidator).toBeInstanceOf(Ajv);
 		});
 
 		it('should load lisk validation formats after initialized .', () => {
 			// Assert
-			Object.keys(ZSchema.formatsCache).forEach(zSchemaType => {
-				expect(validatorWithDefaults.addFormat).toHaveBeenCalledWith(
-					zSchemaType,
-					ZSchema.formatsCache[zSchemaType]
+			Object.keys(formats).forEach(formatType => {
+				expect(parserAndValidator.addFormat).toHaveBeenCalledWith(
+					formatType,
+					formats[formatType]
 				);
 			});
+		});
+
+		it('should load env keyword after initialized .', () => {
+			expect(parserAndValidator.addKeyword).toHaveBeenCalledWith('env', env);
+		});
+
+		it('should load arg keyword after initialized .', () => {
+			expect(parserAndValidator.addKeyword).toHaveBeenCalledWith('arg', arg);
 		});
 	});
 
@@ -111,30 +124,28 @@ describe('helpers/validator.js', () => {
 		});
 	});
 
-	describe('validateWithDefaults()', () => {
+	describe('parseEnvArgAndValidate()', () => {
 		it('should call validate method with given arguments', () => {
 			// Arrange
 			const schema = '#SCHEMA';
 			const data = { myData: '#DATA' };
-			jest
-				.spyOn(validatorWithDefaults, 'validate')
-				.mockImplementation(() => true);
+			jest.spyOn(parserAndValidator, 'validate').mockImplementation(() => true);
 
 			// Act
-			validateWithDefaults(schema, data);
+			parseEnvArgAndValidate(schema, data);
 
 			// Assert
-			expect(validatorWithDefaults.validate).toHaveBeenCalledWith(schema, data);
+			expect(parserAndValidator.validate).toHaveBeenCalledWith(schema, data);
 		});
 
 		it('should throw "SchemaValidationError" when validation fails', () => {
 			// Arrange
 			jest
-				.spyOn(validatorWithDefaults, 'validate')
+				.spyOn(parserAndValidator, 'validate')
 				.mockImplementation(() => false);
 
 			// Act & Assert
-			expect(validateWithDefaults).toThrow(SchemaValidationError);
+			expect(parseEnvArgAndValidate).toThrow(SchemaValidationError);
 		});
 	});
 });

--- a/framework/test/jest/specs/unit/controller/schema/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/specs/unit/controller/schema/__snapshots__/application.spec.js.snap
@@ -150,7 +150,7 @@ Object {
       },
       "transactions": Object {
         "items": Object {
-          "$ref": "transactions",
+          "$ref": "genesisTransactions",
         },
         "type": "array",
         "uniqueItems": true,
@@ -175,9 +175,9 @@ Object {
     ],
     "type": "object",
   },
-  "transactions": Object {
+  "genesisTransactions": Object {
     "additionalProperties": false,
-    "id": "transactions",
+    "id": "genesisTransactions",
     "properties": Object {
       "amount": Object {
         "format": "amount",

--- a/framework/test/jest/specs/unit/controller/schema/__snapshots__/config.spec.js.snap
+++ b/framework/test/jest/specs/unit/controller/schema/__snapshots__/config.spec.js.snap
@@ -27,6 +27,9 @@ Object {
   },
   "config": Object {
     "additionalProperties": false,
+    "default": Object {
+      "ipc": false,
+    },
     "id": "config",
     "properties": Object {
       "components": Object {
@@ -67,7 +70,6 @@ Object {
         "additionalProperties": false,
         "properties": Object {
           "enabled": Object {
-            "default": false,
             "type": "boolean",
           },
         },

--- a/framework/test/jest/specs/unit/controller/schema/__snapshots__/constants.spec.js.snap
+++ b/framework/test/jest/specs/unit/controller/schema/__snapshots__/constants.spec.js.snap
@@ -339,51 +339,35 @@ Object {
         "additionalProperties": false,
         "properties": Object {
           "DAPP": Object {
-            "enum": Array [
-              5,
-            ],
+            "const": 5,
             "type": "integer",
           },
           "DELEGATE": Object {
-            "enum": Array [
-              2,
-            ],
+            "const": 2,
             "type": "integer",
           },
           "IN_TRANSFER": Object {
-            "enum": Array [
-              6,
-            ],
+            "const": 6,
             "type": "integer",
           },
           "MULTI": Object {
-            "enum": Array [
-              4,
-            ],
+            "const": 4,
             "type": "integer",
           },
           "OUT_TRANSFER": Object {
-            "enum": Array [
-              7,
-            ],
+            "const": 7,
             "type": "integer",
           },
           "SEND": Object {
-            "enum": Array [
-              0,
-            ],
+            "const": 0,
             "type": "integer",
           },
           "SIGNATURE": Object {
-            "enum": Array [
-              1,
-            ],
+            "const": 1,
             "type": "integer",
           },
           "VOTE": Object {
-            "enum": Array [
-              3,
-            ],
+            "const": 3,
             "type": "integer",
           },
         },

--- a/framework/test/jest/specs/unit/controller/schema/__snapshots__/constants.spec.js.snap
+++ b/framework/test/jest/specs/unit/controller/schema/__snapshots__/constants.spec.js.snap
@@ -4,29 +4,92 @@ exports[`schema/constants.js constants schema must match to the snapshot. 1`] = 
 Object {
   "constants": Object {
     "additionalProperties": false,
+    "default": Object {
+      "ACTIVE_DELEGATES": 101,
+      "ADDITIONAL_DATA": Object {
+        "MAX_LENGTH": 64,
+        "MIN_LENGTH": 1,
+      },
+      "BLOCK_RECEIPT_TIMEOUT": 20,
+      "BLOCK_SLOT_WINDOW": 5,
+      "EPOCH_TIME": "2016-05-24T17:00:00.000Z",
+      "EXPIRY_INTERVAL": 30000,
+      "FEES": Object {
+        "DAPP_DEPOSIT": "10000000",
+        "DAPP_REGISTRATION": "2500000000",
+        "DAPP_WITHDRAWAL": "10000000",
+        "DELEGATE": "2500000000",
+        "MULTISIGNATURE": "500000000",
+        "SECOND_SIGNATURE": "500000000",
+        "SEND": "10000000",
+        "VOTE": "100000000",
+      },
+      "MAX_PAYLOAD_LENGTH": 1048576,
+      "MAX_PEERS": 100,
+      "MAX_SHARED_TRANSACTIONS": 100,
+      "MAX_TRANSACTIONS_PER_BLOCK": 25,
+      "MAX_VOTES_PER_ACCOUNT": 101,
+      "MAX_VOTES_PER_TRANSACTION": 33,
+      "MIN_BROADHASH_CONSENSUS": 51,
+      "MULTISIG_CONSTRAINTS": Object {
+        "KEYSGROUP": Object {
+          "MAX_ITEMS": 15,
+          "MIN_ITEMS": 1,
+        },
+        "LIFETIME": Object {
+          "MAXIMUM": 72,
+          "MINIMUM": 1,
+        },
+        "MIN": Object {
+          "MAXIMUM": 15,
+          "MINIMUM": 1,
+        },
+      },
+      "NETHASHES": Array [
+        "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511",
+        "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba",
+      ],
+      "NORMALIZER": "100000000",
+      "REWARDS": Object {
+        "DISTANCE": 3000000,
+        "MILESTONES": Array [
+          "500000000",
+          "400000000",
+          "300000000",
+          "200000000",
+          "100000000",
+        ],
+        "OFFSET": 2160,
+      },
+      "TOTAL_AMOUNT": "10000000000000000",
+      "TRANSACTION_TYPES": Object {
+        "DAPP": 5,
+        "DELEGATE": 2,
+        "IN_TRANSFER": 6,
+        "MULTI": 4,
+        "OUT_TRANSFER": 7,
+        "SEND": 0,
+        "SIGNATURE": 1,
+        "VOTE": 3,
+      },
+      "UNCONFIRMED_TRANSACTION_TIMEOUT": 10800,
+    },
     "id": "constants",
     "properties": Object {
       "ACTIVE_DELEGATES": Object {
-        "default": 101,
         "description": "The default number of delegates allowed to forge a block",
         "format": "oddInteger",
         "min": 1,
         "type": "number",
       },
       "ADDITIONAL_DATA": Object {
-        "default": Object {
-          "MAX_LENGTH": 64,
-          "MIN_LENGTH": 1,
-        },
         "properties": Object {
           "MAX_LENGTH": Object {
-            "default": 64,
             "description": "Additional data (Max length)",
             "min": 1,
             "type": "integer",
           },
           "MIN_LENGTH": Object {
-            "default": 1,
             "description": "Additional data (Min length)",
             "min": 1,
             "type": "integer",
@@ -39,68 +102,101 @@ Object {
         "type": "object",
       },
       "BLOCK_RECEIPT_TIMEOUT": Object {
-        "default": 20,
         "description": "Seconds to check if the block is fresh or not",
         "min": 1,
         "type": "integer",
       },
       "BLOCK_SLOT_WINDOW": Object {
-        "default": 5,
         "description": "The default number of previous blocks to keep in memory",
         "min": 1,
         "type": "integer",
       },
       "EPOCH_TIME": Object {
-        "default": "2016-05-24T17:00:00.000Z",
         "description": "Timestamp indicating the start of Lisk Core (\`Date.toISOString()\`)",
         "format": "date-time",
         "type": "string",
       },
       "EXPIRY_INTERVAL": Object {
-        "default": 30000,
         "description": "Transaction pool expiry timer in milliseconds",
         "min": 1,
         "type": "integer",
       },
       "FEES": Object {
-        "$ref": "fees",
-        "default": Object {
-          "DAPP_DEPOSIT": "10000000",
-          "DAPP_REGISTRATION": "2500000000",
-          "DAPP_WITHDRAWAL": "10000000",
-          "DELEGATE": "2500000000",
-          "MULTISIGNATURE": "500000000",
-          "SECOND_SIGNATURE": "500000000",
-          "SEND": "10000000",
-          "VOTE": "100000000",
+        "additionalProperties": false,
+        "description": "Object representing amount of fees for different types of transactions",
+        "properties": Object {
+          "DAPP_DEPOSIT": Object {
+            "format": "amount",
+            "type": "string",
+          },
+          "DAPP_REGISTRATION": Object {
+            "description": "Fee for registering as a dapp",
+            "format": "amount",
+            "type": "string",
+          },
+          "DAPP_WITHDRAWAL": Object {
+            "format": "amount",
+            "type": "string",
+          },
+          "DELEGATE": Object {
+            "description": "Fee for registering as a delegate",
+            "format": "amount",
+            "type": "string",
+          },
+          "MULTISIGNATURE": Object {
+            "description": "Fee for multisignature transaction",
+            "format": "amount",
+            "type": "string",
+          },
+          "SECOND_SIGNATURE": Object {
+            "description": "Fee for creating a second signature",
+            "format": "amount",
+            "type": "string",
+          },
+          "SEND": Object {
+            "description": "Fee for sending a transaction",
+            "format": "amount",
+            "type": "string",
+          },
+          "VOTE": Object {
+            "description": "Fee for voting a delegate",
+            "format": "amount",
+            "type": "string",
+          },
         },
+        "required": Array [
+          "SEND",
+          "VOTE",
+          "SECOND_SIGNATURE",
+          "DELEGATE",
+          "MULTISIGNATURE",
+          "DAPP_REGISTRATION",
+          "DAPP_WITHDRAWAL",
+          "DAPP_DEPOSIT",
+        ],
+        "type": "object",
       },
       "MAX_PAYLOAD_LENGTH": Object {
-        "default": 1048576,
         "description": "Maximum transaction bytes length for 25 transactions in a single block",
         "min": 1,
         "type": "integer",
       },
       "MAX_PEERS": Object {
-        "default": 100,
         "description": "Maximum number of peers allowed to connect while broadcasting a block",
         "min": 1,
         "type": "integer",
       },
       "MAX_SHARED_TRANSACTIONS": Object {
-        "default": 100,
         "description": "Maximum number of in-memory transactions/signatures shared across peers",
         "min": 1,
         "type": "integer",
       },
       "MAX_TRANSACTIONS_PER_BLOCK": Object {
-        "default": 25,
         "description": "Maximum number of transactions allowed per block",
         "min": 1,
         "type": "integer",
       },
       "MAX_VOTES_PER_ACCOUNT": Object {
-        "default": 101,
         "description": "The maximum number of votes allowed in transaction type(3) votes",
         "maximum": Object {
           "$data": "/ACTIVE_DELEGATES",
@@ -109,39 +205,89 @@ Object {
         "type": "number",
       },
       "MAX_VOTES_PER_TRANSACTION": Object {
-        "default": 33,
         "description": "Maximum number of transactions allowed per block",
         "min": 1,
         "type": "integer",
       },
       "MIN_BROADHASH_CONSENSUS": Object {
-        "default": 51,
         "description": "Minimum broadhash consensus(%) among connected {MAX_PEERS} peers",
         "min": 1,
         "type": "integer",
       },
       "MULTISIG_CONSTRAINTS": Object {
-        "$ref": "multisig",
-        "default": Object {
+        "additionalProperties": false,
+        "properties": Object {
           "KEYSGROUP": Object {
-            "MAX_ITEMS": 15,
-            "MIN_ITEMS": 1,
+            "additionalProperties": false,
+            "properties": Object {
+              "MAX_ITEMS": Object {
+                "description": "Maximum allowed number of keys inside a Multisignature pool",
+                "min": 1,
+                "type": "integer",
+              },
+              "MIN_ITEMS": Object {
+                "description": "Minimum allowed number of keys inside a Multisignature pool",
+                "min": 1,
+                "type": "integer",
+              },
+            },
+            "required": Array [
+              "MIN_ITEMS",
+              "MAX_ITEMS",
+            ],
+            "type": "object",
           },
           "LIFETIME": Object {
-            "MAXIMUM": 72,
-            "MINIMUM": 1,
+            "additionalProperties": false,
+            "properties": Object {
+              "MAXIMUM": Object {
+                "description": "Maximum timeframe in which multisignature transaction will exist in memory before the transaction is confirmed",
+                "min": 1,
+                "type": "integer",
+              },
+              "MINIMUM": Object {
+                "description": "Minimum timeframe in which a multisignature transaction will exist in memory before the transaction is confirmed",
+                "min": 1,
+                "type": "integer",
+              },
+            },
+            "required": Array [
+              "MINIMUM",
+              "MAXIMUM",
+            ],
+            "type": "object",
           },
           "MIN": Object {
-            "MAXIMUM": 15,
-            "MINIMUM": 1,
+            "properties": Object {
+              "MAXIMUM": Object {
+                "description": "Maximum allowed number of signatures required to process a multisignature transaction",
+                "maximum": Object {
+                  "$data": "/MULTISIG_CONSTRAINTS/KEYSGROUP/MAX_ITEMS",
+                },
+                "min": 1,
+                "type": "number",
+              },
+              "MINIMUM": Object {
+                "description": "Minimum allowed number of signatures required to process a multisignature transaction",
+                "min": 1,
+                "type": "integer",
+              },
+            },
+            "required": Array [
+              "MINIMUM",
+              "MAXIMUM",
+            ],
+            "type": "object",
           },
         },
+        "required": Array [
+          "MIN",
+          "LIFETIME",
+          "KEYSGROUP",
+        ],
+        "type": "object",
       },
       "NETHASHES": Object {
-        "default": Array [
-          "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511",
-          "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba",
-        ],
         "description": "For mainnet and testnet",
         "items": Object {
           "format": "hex",
@@ -150,46 +296,110 @@ Object {
         "type": "array",
       },
       "NORMALIZER": Object {
-        "default": "100000000",
         "description": "Use this to convert LISK amount to normal value",
         "format": "amount",
         "type": "string",
       },
       "REWARDS": Object {
-        "$ref": "rewards",
-        "default": Object {
-          "DISTANCE": 3000000,
-          "MILESTONES": Array [
-            "500000000",
-            "400000000",
-            "300000000",
-            "200000000",
-            "100000000",
-          ],
-          "OFFSET": 2160,
+        "additionalProperties": false,
+        "description": "Object representing LSK rewards milestone",
+        "properties": Object {
+          "DISTANCE": Object {
+            "description": "Distance between each milestone",
+            "min": 1,
+            "type": "integer",
+          },
+          "MILESTONES": Object {
+            "description": "Initial 5, and decreasing until 1",
+            "items": Object {
+              "format": "amount",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "OFFSET": Object {
+            "description": "Start rewards at block (n)",
+            "min": 1,
+            "type": "integer",
+          },
         },
+        "required": Array [
+          "MILESTONES",
+          "OFFSET",
+          "DISTANCE",
+        ],
+        "type": "object",
       },
       "TOTAL_AMOUNT": Object {
-        "default": "10000000000000000",
         "description": "Total amount of LSK available in network before rewards milestone started",
         "format": "amount",
         "type": "string",
       },
       "TRANSACTION_TYPES": Object {
-        "$ref": "transactionTypes",
-        "default": Object {
-          "DAPP": 5,
-          "DELEGATE": 2,
-          "IN_TRANSFER": 6,
-          "MULTI": 4,
-          "OUT_TRANSFER": 7,
-          "SEND": 0,
-          "SIGNATURE": 1,
-          "VOTE": 3,
+        "additionalProperties": false,
+        "properties": Object {
+          "DAPP": Object {
+            "enum": Array [
+              5,
+            ],
+            "type": "integer",
+          },
+          "DELEGATE": Object {
+            "enum": Array [
+              2,
+            ],
+            "type": "integer",
+          },
+          "IN_TRANSFER": Object {
+            "enum": Array [
+              6,
+            ],
+            "type": "integer",
+          },
+          "MULTI": Object {
+            "enum": Array [
+              4,
+            ],
+            "type": "integer",
+          },
+          "OUT_TRANSFER": Object {
+            "enum": Array [
+              7,
+            ],
+            "type": "integer",
+          },
+          "SEND": Object {
+            "enum": Array [
+              0,
+            ],
+            "type": "integer",
+          },
+          "SIGNATURE": Object {
+            "enum": Array [
+              1,
+            ],
+            "type": "integer",
+          },
+          "VOTE": Object {
+            "enum": Array [
+              3,
+            ],
+            "type": "integer",
+          },
         },
+        "required": Array [
+          "SEND",
+          "SIGNATURE",
+          "DELEGATE",
+          "VOTE",
+          "MULTI",
+          "DAPP",
+          "IN_TRANSFER",
+          "OUT_TRANSFER",
+        ],
+        "type": "object",
       },
       "UNCONFIRMED_TRANSACTION_TIMEOUT": Object {
-        "default": 10800,
         "description": "Expiration time for unconfirmed transaction/signatures in transaction pool",
         "min": 1,
         "type": "integer",
@@ -217,263 +427,6 @@ Object {
       "TRANSACTION_TYPES",
       "UNCONFIRMED_TRANSACTION_TIMEOUT",
       "EXPIRY_INTERVAL",
-    ],
-    "type": "object",
-  },
-  "fees": Object {
-    "additionalProperties": false,
-    "description": "Object representing amount of fees for different types of transactions",
-    "id": "fees",
-    "properties": Object {
-      "DAPP_DEPOSIT": Object {
-        "default": "10000000",
-        "format": "amount",
-        "type": "string",
-      },
-      "DAPP_REGISTRATION": Object {
-        "default": "2500000000",
-        "description": "Fee for registering as a dapp",
-        "format": "amount",
-        "type": "string",
-      },
-      "DAPP_WITHDRAWAL": Object {
-        "default": "10000000",
-        "format": "amount",
-        "type": "string",
-      },
-      "DELEGATE": Object {
-        "default": "2500000000",
-        "description": "Fee for registering as a delegate",
-        "format": "amount",
-        "type": "string",
-      },
-      "MULTISIGNATURE": Object {
-        "default": "500000000",
-        "description": "Fee for multisignature transaction",
-        "format": "amount",
-        "type": "string",
-      },
-      "SECOND_SIGNATURE": Object {
-        "default": "500000000",
-        "description": "Fee for creating a second signature",
-        "format": "amount",
-        "type": "string",
-      },
-      "SEND": Object {
-        "default": "10000000",
-        "description": "Fee for sending a transaction",
-        "format": "amount",
-        "type": "string",
-      },
-      "VOTE": Object {
-        "default": "100000000",
-        "description": "Fee for voting a delegate",
-        "format": "amount",
-        "type": "string",
-      },
-    },
-    "required": Array [
-      "SEND",
-      "VOTE",
-      "SECOND_SIGNATURE",
-      "DELEGATE",
-      "MULTISIGNATURE",
-      "DAPP_REGISTRATION",
-      "DAPP_WITHDRAWAL",
-      "DAPP_DEPOSIT",
-    ],
-    "type": "object",
-  },
-  "multisig": Object {
-    "additionalProperties": false,
-    "id": "multisig",
-    "properties": Object {
-      "KEYSGROUP": Object {
-        "additionalProperties": false,
-        "default": Object {
-          "MAX_ITEMS": 15,
-          "MIN_ITEMS": 1,
-        },
-        "properties": Object {
-          "MAX_ITEMS": Object {
-            "default": 15,
-            "description": "Maximum allowed number of keys inside a Multisignature pool",
-            "min": 1,
-            "type": "integer",
-          },
-          "MIN_ITEMS": Object {
-            "default": 1,
-            "description": "Minimum allowed number of keys inside a Multisignature pool",
-            "min": 1,
-            "type": "integer",
-          },
-        },
-        "required": Array [
-          "MIN_ITEMS",
-          "MAX_ITEMS",
-        ],
-        "type": "object",
-      },
-      "LIFETIME": Object {
-        "additionalProperties": false,
-        "default": Object {
-          "MAXIMUM": 72,
-          "MINIMUM": 1,
-        },
-        "properties": Object {
-          "MAXIMUM": Object {
-            "default": 72,
-            "description": "Maximum timeframe in which multisignature transaction will exist in memory before the transaction is confirmed",
-            "min": 1,
-            "type": "integer",
-          },
-          "MINIMUM": Object {
-            "default": 1,
-            "description": "Minimum timeframe in which a multisignature transaction will exist in memory before the transaction is confirmed",
-            "min": 1,
-            "type": "integer",
-          },
-        },
-        "required": Array [
-          "MINIMUM",
-          "MAXIMUM",
-        ],
-        "type": "object",
-      },
-      "MIN": Object {
-        "properties": Object {
-          "MAXIMUM": Object {
-            "default": 15,
-            "description": "Maximum allowed number of signatures required to process a multisignature transaction",
-            "maximum": Object {
-              "$data": "/MULTISIG_CONSTRAINTS/KEYSGROUP/MAX_ITEMS",
-            },
-            "min": 1,
-            "type": "number",
-          },
-          "MINIMUM": Object {
-            "default": 1,
-            "description": "Minimum allowed number of signatures required to process a multisignature transaction",
-            "min": 1,
-            "type": "integer",
-          },
-        },
-        "required": Array [
-          "MINIMUM",
-          "MAXIMUM",
-        ],
-        "type": "object",
-      },
-    },
-    "required": Array [
-      "MIN",
-      "LIFETIME",
-      "KEYSGROUP",
-    ],
-    "type": "object",
-  },
-  "rewards": Object {
-    "additionalProperties": false,
-    "description": "Object representing LSK rewards milestone",
-    "id": "rewards",
-    "properties": Object {
-      "DISTANCE": Object {
-        "default": 3000000,
-        "description": "Distance between each milestone",
-        "min": 1,
-        "type": "integer",
-      },
-      "MILESTONES": Object {
-        "default": Array [
-          "500000000",
-          "400000000",
-          "300000000",
-          "200000000",
-          "100000000",
-        ],
-        "description": "Initial 5, and decreasing until 1",
-        "items": Object {
-          "format": "amount",
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "OFFSET": Object {
-        "default": 2160,
-        "description": "Start rewards at block (n)",
-        "min": 1,
-        "type": "integer",
-      },
-    },
-    "required": Array [
-      "MILESTONES",
-      "OFFSET",
-      "DISTANCE",
-    ],
-    "type": "object",
-  },
-  "transactionTypes": Object {
-    "additionalProperties": false,
-    "id": "transactionTypes",
-    "properties": Object {
-      "DAPP": Object {
-        "enum": Array [
-          5,
-        ],
-        "type": "integer",
-      },
-      "DELEGATE": Object {
-        "enum": Array [
-          2,
-        ],
-        "type": "integer",
-      },
-      "IN_TRANSFER": Object {
-        "enum": Array [
-          6,
-        ],
-        "type": "integer",
-      },
-      "MULTI": Object {
-        "enum": Array [
-          4,
-        ],
-        "type": "integer",
-      },
-      "OUT_TRANSFER": Object {
-        "enum": Array [
-          7,
-        ],
-        "type": "integer",
-      },
-      "SEND": Object {
-        "enum": Array [
-          0,
-        ],
-        "type": "integer",
-      },
-      "SIGNATURE": Object {
-        "enum": Array [
-          1,
-        ],
-        "type": "integer",
-      },
-      "VOTE": Object {
-        "enum": Array [
-          3,
-        ],
-        "type": "integer",
-      },
-    },
-    "required": Array [
-      "SEND",
-      "SIGNATURE",
-      "DELEGATE",
-      "VOTE",
-      "MULTI",
-      "DAPP",
-      "IN_TRANSFER",
-      "OUT_TRANSFER",
     ],
     "type": "object",
   },

--- a/framework/test/mocha/setup.js
+++ b/framework/test/mocha/setup.js
@@ -53,7 +53,7 @@ const config = {
 	protocolVersion:
 		process.env.PROTOCOL_VERSION || packageJson.lisk.protocolVersion,
 };
-config.constants = validator.validateWithDefaults(
+config.constants = validator.parseEnvArgAndValidate(
 	constantsSchema.constants,
 	constants
 );
@@ -61,13 +61,13 @@ config.constants = validator.validateWithDefaults(
 // TODO: This should be removed after https://github.com/LiskHQ/lisk/pull/2980
 global.constants = config.constants;
 
-config.genesisBlock = validator.validateWithDefaults(
+config.genesisBlock = validator.parseEnvArgAndValidate(
 	applicationSchema.genesisBlock,
 	genesisBlock
 );
 config.nethash = config.genesisBlock.payloadHash;
 
-config.modules.chain = validator.validateWithDefaults(
+config.modules.chain = validator.parseEnvArgAndValidate(
 	chainModuleSchema,
 	Object.assign({}, config.modules.chain, { exceptions })
 );
@@ -80,7 +80,7 @@ config.modules.chain = {
 	protocolVersion: config.protocolVersion,
 };
 
-config.modules.http_api = validator.validateWithDefaults(
+config.modules.http_api = validator.parseEnvArgAndValidate(
 	apiModuleSchema,
 	config.modules.http_api
 );
@@ -92,11 +92,11 @@ config.modules.http_api = {
 	minVersion: config.minVersion,
 };
 
-config.components.storage = validator.validateWithDefaults(
+config.components.storage = validator.parseEnvArgAndValidate(
 	defaultStorageConfig,
 	config.components.storage || {}
 );
-config.components.cache = validator.validateWithDefaults(
+config.components.cache = validator.parseEnvArgAndValidate(
 	defaultCacheConfig,
 	config.components.cache || {}
 );

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ const appSchema = {
 			type: 'string',
 			description:
 				'lisk network [devnet|betanet|mainnet|testnet]. Defaults to "devnet"',
-			default: 'devnet',
 			enum: ['devnet', 'alphanet', 'betanet', 'testnet', 'mainnet'],
 			env: 'LISK_NETWORK',
 			arg: '-n,--network',
@@ -35,10 +34,14 @@ const appSchema = {
 			arg: '-c,--config',
 		},
 	},
+	default: {
+		NETWORK: 'devnet',
+		CUSTOM_CONFIG_FILE: null,
+	},
 };
 
 try {
-	const { NETWORK, CUSTOM_CONFIG_FILE } = validator.validateWithDefaults(
+	const { NETWORK, CUSTOM_CONFIG_FILE } = validator.parseEnvArgAndValidate(
 		appSchema,
 		{}
 	);


### PR DESCRIPTION
### What was the problem?
There is redundant default values for nested objects due to nature of `ajv` implementation of default keyword. 

### How did I fix it?

Added custom logic to handle default values any configuration object. 

### How to test it?

Run all tests

### Review checklist

* The PR resolves #3273
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
