### PR TITLE
Restore logic of chain recover on sync - Closes #3281

### DIFF
--- a/framework/src/modules/chain/submodules/blocks/process.js
+++ b/framework/src/modules/chain/submodules/blocks/process.js
@@ -353,6 +353,12 @@ Process.prototype.loadBlocksFromNetwork = function(cb) {
 		if (!data) {
 			throw new Error('Received an invalid blocks response from the network');
 		}
+		// Check for strict equality for backwards compatibility reasons.
+		if (data.success === false) {
+			throw new Error(
+				`Peer did not have a matching lastBlockId. ${data.message}`
+			);
+		}
 
 		return data.blocks;
 	}

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -804,6 +804,17 @@ __private.loadBlocksFromNetwork = function(cb) {
 						modules.blocks.process.loadBlocksFromNetwork(
 							(loadBlocksFromNetworkErr, lastValidBlock) => {
 								if (loadBlocksFromNetworkErr) {
+									// If comparison failed and current consensus is low - perform chain recovery
+									if (modules.transport.poorConsensus()) {
+										library.logger.debug(
+											'Perform chain recovery due to poor consensus'
+										);
+										return modules.blocks.chain.recoverChain(recoveryError => {
+											waterCb(
+												`Failed chain recovery after failing to load blocks while network consensus was low. ${recoveryError}`
+											);
+										});
+									}
 									return waterCb(
 										`Failed to load blocks from the network. ${loadBlocksFromNetworkErr}`
 									);

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -805,7 +805,7 @@ __private.loadBlocksFromNetwork = function(cb) {
 							(loadBlocksFromNetworkErr, lastValidBlock) => {
 								if (loadBlocksFromNetworkErr) {
 									// If comparison failed and current consensus is low - perform chain recovery
-									if (modules.transport.poorConsensus()) {
+									if (modules.peers.isPoorConsensus()) {
 										library.logger.debug(
 											'Perform chain recovery due to poor consensus'
 										);


### PR DESCRIPTION
### What was the problem?

The `commonBlocks` call (for synching) was removed from the loader as part of the last refactoring to use the new Network module. It's possible to detect the absence of a common block using only the `blocks` endpoint directly but we still need the chain recovery to trigger when there is no common block.

### How did I fix it?

Added the chain recovery feature to trigger when the 'no common blocks' condition is identified but still without relying on a separate 'commonBlocks' call.

### How to test it?

Run tests.

### Review checklist

* The PR resolves #3281
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
