### PR TITLE
 Forger information should be updated according to input provided - Closes #6828

### DIFF
--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -257,6 +257,11 @@ export class Forger {
 				forgerInfo !== undefined &&
 				!IsEqualForgingInfo(forgingInput, forgerInfo))
 		) {
+			previouslyForgedMap.set(forgerAddress, {
+				height,
+				maxHeightPrevoted,
+				maxHeightPreviouslyForged,
+			});
 			await setPreviouslyForgedMap(this._db, previouslyForgedMap);
 			this._logger.info(forgingInput, 'Updated forgerInfo');
 		}

--- a/framework/test/unit/node/forger/forger.spec.ts
+++ b/framework/test/unit/node/forger/forger.spec.ts
@@ -328,14 +328,29 @@ describe('forger', () => {
 
 				describe('overwrite=true', () => {
 					it('should enable forging and overwrite forger info when node is synced with network', async () => {
+						const address = getAddressFromPublicKey(Buffer.from(testDelegate.publicKey, 'hex'));
+						const previouslyForgedStoreObject: PreviouslyForgedInfoStoreObject = {
+							previouslyForgedInfo: [],
+						};
+						previouslyForgedStoreObject.previouslyForgedInfo.push({
+							generatorAddress: address,
+							height: 200,
+							maxHeightPrevoted: 0,
+							maxHeightPreviouslyForged: 200,
+						});
 						const data = await forgeModule.updateForgingStatus(
-							getAddressFromPublicKey(Buffer.from(testDelegate.publicKey, 'hex')),
+							address,
 							testDelegate.password,
 							true,
 							200,
 							200,
 							0,
 							true,
+						);
+
+						expect(dbStub.put).toHaveBeenCalledWith(
+							DB_KEY_FORGER_PREVIOUSLY_FORGED,
+							codec.encode(previouslyForgedInfoSchema, previouslyForgedStoreObject),
 						);
 
 						expect(


### PR DESCRIPTION
### What was the problem?

This PR resolves #6828 

### How was it solved?

* Re-add `set` logic removed in [old commit](https://github.com/LiskHQ/lisk-sdk/commit/da9564950629be379aa56f41dcecf94ad6757d8e)

### How was it tested?
* Add logic in unit test to check if the database `put` is called with the correct value
