### PR TITLE
Encode block while broadcasting to network - Closes #7254

### DIFF
--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -535,7 +535,7 @@ export class Consensus {
 		const contextID = await this._verifyAssets(block);
 
 		if (!options.skipBroadcast) {
-			this._network.send({ event: NETWORK_EVENT_POST_BLOCK, data: block });
+			this._network.send({ event: NETWORK_EVENT_POST_BLOCK, data: block.getBytes() });
 			this.events.emit(CONSENSUS_EVENT_BLOCK_BROADCAST, {
 				block,
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #7254

### How was it solved?

`block.getBytes()` is applied in call to `this._network.send(...)`

### How was it tested?

<!--- Please describe how you tested your changes -->
