### PR TITLE
Move Chainsafe BLST from optional peer dependency to required dependency

### DIFF
--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -35,6 +35,7 @@
 		"build:check": "node -e \"require('./dist-node')\""
 	},
 	"dependencies": {
+		"@chainsafe/blst": "0.2.6",
 		"@liskhq/lisk-passphrase": "4.0.0-alpha.0",
 		"buffer-reverse": "1.0.1",
 		"ed2curve": "0.3.0",
@@ -43,14 +44,10 @@
 		"varuint-bitcoin": "1.1.2"
 	},
 	"peerDependencies": {
-		"@chainsafe/blst": "0.2.4",
 		"sodium-native": "3.2.1"
 	},
 	"peerDependenciesMeta": {
 		"sodium-native": {
-			"optional": true
-		},
-		"@chainsafe/blst": {
 			"optional": true
 		}
 	},

--- a/framework/package.json
+++ b/framework/package.json
@@ -40,7 +40,7 @@
 		"test:functional": "jest --config=./test/functional/jest.config.js --runInBand"
 	},
 	"dependencies": {
-		"@chainsafe/blst": "0.2.0",
+		"@chainsafe/blst": "0.2.6",
 		"@liskhq/lisk-api-client": "^6.0.0-alpha.4",
 		"@liskhq/lisk-chain": "^0.4.0-alpha.4",
 		"@liskhq/lisk-codec": "^0.3.0-alpha.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,13 +296,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chainsafe/blst@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.0.tgz#5e2d2707c2c0d56ff077a00179a5255eaca14099"
-  integrity sha512-eyyLm4C+Zhl18YwFa93J+xRSHj0NrBZodBO+z+aaREf71RnA7/EvOcAPVLpEW2CI7PsInhVne/ufb+A7gfHQrg==
+"@chainsafe/blst@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.6.tgz#56f17c82338d62421321dca60250951dd3a7db7a"
+  integrity sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==
   dependencies:
     node-fetch "^2.6.1"
-    node-gyp "^7.1.2"
+    node-gyp "^8.4.0"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -11336,7 +11336,7 @@ node-gyp@^5.0.2:
     tar "^4.4.12"
     which "^1.3.1"
 
-node-gyp@^7.1.0, node-gyp@^7.1.2:
+node-gyp@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
   integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
@@ -11352,7 +11352,7 @@ node-gyp@^7.1.0, node-gyp@^7.1.2:
     tar "^6.0.2"
     which "^2.0.2"
 
-node-gyp@^8.2.0:
+node-gyp@^8.2.0, node-gyp@^8.4.0:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
   integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==


### PR DESCRIPTION
### What was the problem?

I could not complete SDK bootstrap using `yarn`. I was getting error:

```
Retrieving BLST native bindings...
Error: Error importing BLST native bindings: 404 Not Found
```

### How was it solved?

Moved `@chainsafe/blst` to be a regular dependency of `lisk-cryptography` package, instead of an optional dependecy.

I also bumped it to the latest version 0.2.6.

### How was it tested?

I tried to run tests with `yarn test`, but the process hung. Probably I still have to configure something on my side to run tests? 🤔

Submitting this PR will trigger tests to run in the CI pipeline, right?