### PR TITLE
Move common methods of mainchain/sidechain to BaseInteroperabilityMethod - Closes #7565

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_method.ts
+++ b/framework/src/modules/interoperability/base_interoperability_method.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { BaseMethod } from '../base_method';
+import { BaseInteroperableMethod } from './base_interoperable_method';
+import { NamedRegistry } from '../named_registry';
+import { ImmutableMethodContext, MethodContext } from '../../state_machine';
+import { ChainAccount } from './stores/chain_account';
+import { CCMsg } from './types';
+import { StoreGetter, ImmutableStoreGetter } from '../base_store';
+import { BaseInteroperabilityStore } from './base_interoperability_store';
+
+export abstract class BaseInteroperabilityMethod<
+	T extends BaseInteroperabilityStore
+> extends BaseMethod {
+	protected readonly interoperableCCMethods = new Map<string, BaseInteroperableMethod>();
+	protected abstract getInteroperabilityStore: (context: StoreGetter | ImmutableStoreGetter) => T;
+
+	public constructor(
+		stores: NamedRegistry,
+		events: NamedRegistry,
+		interoperableCCMethods: Map<string, BaseInteroperableMethod>,
+	) {
+		super(stores, events);
+		this.interoperableCCMethods = interoperableCCMethods;
+	}
+
+	public async getChainAccount(
+		context: ImmutableMethodContext,
+		chainID: Buffer,
+	): Promise<ChainAccount> {
+		return this.getInteroperabilityStore(context).getChainAccount(chainID);
+	}
+
+	public async getChannel(context: ImmutableMethodContext, chainID: Buffer) {
+		return this.getInteroperabilityStore(context).getChannel(chainID);
+	}
+
+	public async getOwnChainAccount(context: ImmutableMethodContext) {
+		return this.getInteroperabilityStore(context).getOwnChainAccount();
+	}
+
+	public async getTerminatedStateAccount(context: ImmutableMethodContext, chainID: Buffer) {
+		return this.getInteroperabilityStore(context).getTerminatedStateAccount(chainID);
+	}
+
+	public async getTerminatedOutboxAccount(context: ImmutableMethodContext, chainID: Buffer) {
+		return this.getInteroperabilityStore(context).getTerminatedOutboxAccount(chainID);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async send(
+		_methodContext: MethodContext,
+		_feeAddress: Buffer,
+		_module: string,
+		_crossChainCommandID: string,
+		_receivingChainID: Buffer,
+		_fee: bigint,
+		_status: number,
+		_parameters: Buffer,
+	): Promise<boolean> {
+		throw new Error('Need to be implemented');
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async error(_methodContext: MethodContext, _ccm: CCMsg, _code: number): Promise<void> {
+		throw new Error('Need to be implemented');
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async terminateChain(_methodContext: MethodContext, _chainID: Buffer): Promise<void> {
+		throw new Error('Need to be implemented');
+	}
+}

--- a/framework/src/modules/interoperability/mainchain/method.ts
+++ b/framework/src/modules/interoperability/mainchain/method.ts
@@ -12,86 +12,18 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { MethodContext, ImmutableMethodContext } from '../../../state_machine';
-import { BaseMethod } from '../../base_method';
 import { MainchainInteroperabilityStore } from './store';
-import { CCMsg } from '../types';
-import { BaseInteroperableMethod } from '../base_interoperable_method';
-import { NamedRegistry } from '../../named_registry';
 import { ImmutableStoreGetter, StoreGetter } from '../../base_store';
+import { BaseInteroperabilityMethod } from '../base_interoperability_method';
 
-export class MainchainInteroperabilityMethod extends BaseMethod {
-	protected readonly interoperableCCMethods = new Map<string, BaseInteroperableMethod>();
-
-	public constructor(
-		stores: NamedRegistry,
-		events: NamedRegistry,
-		interoperableCCMethods: Map<string, BaseInteroperableMethod>,
-	) {
-		super(stores, events);
-		this.interoperableCCMethods = interoperableCCMethods;
-	}
-
-	public async getChainAccount(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getChainAccount(chainID);
-	}
-
-	public async getChannel(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getChannel(chainID);
-	}
-
-	public async getOwnChainAccount(context: ImmutableMethodContext) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getOwnChainAccount();
-	}
-
-	public async getTerminatedStateAccount(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getTerminatedStateAccount(chainID);
-	}
-
-	public async getTerminatedOutboxAccount(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getTerminatedOutboxAccount(chainID);
-	}
-
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async send(
-		_methodContext: MethodContext,
-		_feeAddress: Buffer,
-		_module: string,
-		_crossChainCommandID: string,
-		_receivingChainID: Buffer,
-		_fee: bigint,
-		_status: number,
-		_parameters: Buffer,
-	): Promise<boolean> {
-		throw new Error('Need to be implemented');
-	}
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async error(_methodContext: MethodContext, _ccm: CCMsg, _code: number): Promise<void> {
-		throw new Error('Need to be implemented');
-	}
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async terminateChain(_methodContext: MethodContext, _chainID: Buffer): Promise<void> {
-		throw new Error('Need to be implemented');
-	}
-
-	protected getInteroperabilityStore(
+export class MainchainInteroperabilityMethod extends BaseInteroperabilityMethod<MainchainInteroperabilityStore> {
+	protected getInteroperabilityStore = (
 		context: StoreGetter | ImmutableStoreGetter,
-	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(
+	): MainchainInteroperabilityStore =>
+		new MainchainInteroperabilityStore(
 			this.stores,
 			context,
 			this.interoperableCCMethods,
 			this.events,
 		);
-	}
 }

--- a/framework/src/modules/interoperability/sidechain/method.ts
+++ b/framework/src/modules/interoperability/sidechain/method.ts
@@ -12,86 +12,18 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { MethodContext, ImmutableMethodContext } from '../../../state_machine';
-import { BaseMethod } from '../../base_method';
 import { SidechainInteroperabilityStore } from './store';
-import { CCMsg } from '../types';
-import { BaseInteroperableMethod } from '../base_interoperable_method';
-import { NamedRegistry } from '../../named_registry';
 import { ImmutableStoreGetter, StoreGetter } from '../../base_store';
+import { BaseInteroperabilityMethod } from '../base_interoperability_method';
 
-export class SidechainInteroperabilityMethod extends BaseMethod {
-	protected readonly interoperableCCMethods = new Map<string, BaseInteroperableMethod>();
-
-	public constructor(
-		stores: NamedRegistry,
-		events: NamedRegistry,
-		interoperableCCMethods: Map<string, BaseInteroperableMethod>,
-	) {
-		super(stores, events);
-		this.interoperableCCMethods = interoperableCCMethods;
-	}
-
-	public async getChainAccount(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getChainAccount(chainID);
-	}
-
-	public async getChannel(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getChannel(chainID);
-	}
-
-	public async getOwnChainAccount(context: ImmutableMethodContext) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getOwnChainAccount();
-	}
-
-	public async getTerminatedStateAccount(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getTerminatedStateAccount(chainID);
-	}
-
-	public async getTerminatedOutboxAccount(context: ImmutableMethodContext, chainID: Buffer) {
-		const interoperabilityStore = this.getInteroperabilityStore(context);
-
-		return interoperabilityStore.getTerminatedOutboxAccount(chainID);
-	}
-
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async send(
-		_methodContext: MethodContext,
-		_feeAddress: Buffer,
-		_module: string,
-		_crossChainCommand: string,
-		_receivingChainID: Buffer,
-		_fee: bigint,
-		_status: number,
-		_parameters: Buffer,
-	): Promise<boolean> {
-		throw new Error('Need to be implemented');
-	}
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async error(_methodContext: MethodContext, _ccm: CCMsg, _code: number): Promise<void> {
-		throw new Error('Need to be implemented');
-	}
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async terminateChain(_methodContext: MethodContext, _chainID: Buffer): Promise<void> {
-		throw new Error('Need to be implemented');
-	}
-
-	protected getInteroperabilityStore(
+export class SidechainInteroperabilityMethod extends BaseInteroperabilityMethod<SidechainInteroperabilityStore> {
+	protected getInteroperabilityStore = (
 		context: StoreGetter | ImmutableStoreGetter,
-	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(
+	): SidechainInteroperabilityStore =>
+		new SidechainInteroperabilityStore(
 			this.stores,
 			context,
 			this.interoperableCCMethods,
 			this.events,
 		);
-	}
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #7565 

### How was it solved?

All duplicated methods are moved to parent class

### How was it tested?
- cd lisk-sdk/framework/test/unit
- yarn test framework/test/unit
