### PR TITLE
Update genesis asset schema for interoperability (with terminatedStat…

### DIFF
--- a/framework/src/modules/interoperability/mainchain/module.ts
+++ b/framework/src/modules/interoperability/mainchain/module.ts
@@ -54,7 +54,13 @@ import { TerminatedStateCreatedEvent } from '../events/terminated_state_created'
 import { TerminatedOutboxCreatedEvent } from '../events/terminated_outbox_created';
 import { MainchainInteroperabilityInternalMethod } from './internal_method';
 import { InitializeMessageRecoveryCommand } from './commands/initialize_message_recovery';
-import { FeeMethod, GenesisInteroperability, ChainInfo } from '../types';
+import {
+	FeeMethod,
+	GenesisInteroperability,
+	ChainInfo,
+	TerminatedStateAccountWithChainID,
+	TerminatedOutboxAccountWithChainID,
+} from '../types';
 import { MainchainCCChannelTerminatedCommand, MainchainCCRegistrationCommand } from './cc_commands';
 import { RecoverStateCommand } from './commands/recover_state';
 import { CcmSentFailedEvent } from '../events/ccm_send_fail';
@@ -65,6 +71,7 @@ import {
 	CHAIN_NAME_MAINCHAIN,
 	MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
 	MAX_NUM_VALIDATORS,
+	EMPTY_HASH,
 } from '../constants';
 import {
 	getMainchainID,
@@ -260,7 +267,13 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 			genesisBlockAssetBytes,
 		);
 
-		const { ownChainName, ownChainNonce, chainInfos } = genesisInteroperability;
+		const {
+			ownChainName,
+			ownChainNonce,
+			chainInfos,
+			terminatedStateAccounts,
+			terminatedOutboxAccounts,
+		} = genesisInteroperability;
 
 		// On the mainchain, the following checks are performed:
 		if (ctx.chainID.equals(getMainchainID(ctx.chainID))) {
@@ -296,6 +309,12 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 				}
 
 				this._verifyChainInfos(ctx, chainInfos);
+				this._verifyTerminatedStateAccounts(chainInfos, terminatedStateAccounts);
+				this._verifyTerminatedOutboxAccounts(
+					chainInfos,
+					terminatedStateAccounts,
+					terminatedOutboxAccounts,
+				);
 			}
 		}
 	}
@@ -426,6 +445,104 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 		const { validatorsHash } = chainData.lastCertificate;
 		if (!validatorsHash.equals(computeValidatorsHash(activeValidators, certificateThreshold))) {
 			throw new Error('Invalid validatorsHash from chainData.lastCertificate.');
+		}
+	}
+
+	// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#mainchain
+	private _verifyTerminatedStateAccounts(
+		chainInfos: ChainInfo[],
+		terminatedStateAccounts: TerminatedStateAccountWithChainID[],
+	) {
+		for (const chainInfo of chainInfos) {
+			const { chainID } = chainInfo;
+
+			if (terminatedStateAccounts.filter(a => a.chainID.equals(chainID)).length > 0) {
+				// For each entry chainInfo in chainInfos, chainInfo.chainData.status == CHAIN_STATUS_TERMINATED
+				// if and only if a corresponding entry (i.e., with chainID == chainInfo.chainID) exists in terminatedStateAccounts.
+				if (chainInfo.chainData.status !== ChainStatus.TERMINATED) {
+					throw new Error(
+						`chainInfo.chainData.status must be ${ChainStatus.TERMINATED} if chainInfo.chainID exists in terminatedStateAccounts.`,
+					);
+				}
+			}
+		}
+
+		// Each entry stateAccount in terminatedStateAccounts has a unique stateAccount.chainID
+		const chainIDs = terminatedStateAccounts.map(a => a.chainID);
+		if (!bufferArrayUniqueItems(chainIDs)) {
+			throw new Error(`terminatedStateAccounts don't hold unique chainID.`);
+		}
+
+		// terminatedStateAccounts is ordered lexicographically by stateAccount.chainID
+		const sortedByChainID = [...terminatedStateAccounts].sort((a, b) =>
+			a.chainID.compare(b.chainID),
+		);
+		for (let i = 0; i < terminatedStateAccounts.length; i += 1) {
+			if (!terminatedStateAccounts[i].chainID.equals(sortedByChainID[i].chainID)) {
+				throw new Error('terminatedStateAccounts must be ordered lexicographically by chainID.');
+			}
+		}
+
+		// For each entry stateAccount in terminatedStateAccounts holds
+		// stateAccount.stateRoot == chainData.lastCertificate.stateRoot,
+		// stateAccount.mainchainStateRoot == EMPTY_HASH, and
+		// stateAccount.initialized == True.
+		// Here chainData is the corresponding entry (i.e., with chainID == stateAccount.chainID) in chainInfos.
+		for (const chainInfo of chainInfos) {
+			const stateAccount = terminatedStateAccounts.find(a =>
+				a.chainID.equals(chainInfo.chainID),
+			)?.terminatedStateAccount;
+			if (stateAccount) {
+				if (!stateAccount.stateRoot.equals(chainInfo.chainData.lastCertificate.stateRoot)) {
+					throw new Error(
+						"stateAccount.stateRoot doesn't match chainInfo.chainData.lastCertificate.stateRoot.",
+					);
+				}
+
+				if (!stateAccount.mainchainStateRoot.equals(EMPTY_HASH)) {
+					throw new Error('stateAccount.mainchainStateRoot is not equal to EMPTY_HASH.');
+				}
+
+				if (!stateAccount.initialized) {
+					throw new Error('stateAccount is not initialized.');
+				}
+			}
+		}
+	}
+
+	// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#mainchain
+	private _verifyTerminatedOutboxAccounts(
+		_chainInfos: ChainInfo[],
+		terminatedStateAccounts: TerminatedStateAccountWithChainID[],
+		terminatedOutboxAccounts: TerminatedOutboxAccountWithChainID[],
+	) {
+		// Each entry outboxAccount in terminatedOutboxAccounts has a unique outboxAccount.chainID
+		const chainIDs = terminatedOutboxAccounts.map(a => a.chainID);
+		if (!bufferArrayUniqueItems(chainIDs)) {
+			throw new Error(`terminatedOutboxAccounts don't hold unique chainID.`);
+		}
+
+		// terminatedOutboxAccounts is ordered lexicographically by outboxAccount.chainID
+		const sortedByChainID = [...terminatedOutboxAccounts].sort((a, b) =>
+			a.chainID.compare(b.chainID),
+		);
+		for (let i = 0; i < terminatedOutboxAccounts.length; i += 1) {
+			if (!terminatedOutboxAccounts[i].chainID.equals(sortedByChainID[i].chainID)) {
+				throw new Error('terminatedOutboxAccounts must be ordered lexicographically by chainID.');
+			}
+		}
+
+		// Furthermore, an entry outboxAccount in terminatedOutboxAccounts must have a corresponding entry
+		// (i.e., with chainID == outboxAccount.chainID) in terminatedStateAccounts
+		for (const outboxAccount of terminatedOutboxAccounts) {
+			if (
+				terminatedStateAccounts.find(a => a.chainID.equals(outboxAccount.chainID)) === undefined
+			) {
+				let msg =
+					'Each entry outboxAccount in terminatedOutboxAccounts must have a corresponding entry ';
+				msg += '(with chainID == outboxAccount.chainID) in terminatedStateAccounts.';
+				throw new Error(msg);
+			}
 		}
 	}
 }

--- a/framework/src/modules/interoperability/schemas.ts
+++ b/framework/src/modules/interoperability/schemas.ts
@@ -29,6 +29,8 @@ import {
 import { chainDataSchema } from './stores/chain_account';
 import { chainValidatorsSchema } from './stores/chain_validators';
 import { channelSchema } from './stores/channel_data';
+import { terminatedStateSchema } from './stores/terminated_state';
+import { terminatedOutboxSchema } from './stores/terminated_outbox';
 
 // LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#cross-chain-message-schema
 export const ccmSchema = {
@@ -698,7 +700,7 @@ export const genesisInteroperabilitySchema = {
 				},
 			},
 		},
-		/* terminatedStateAccounts: {
+		terminatedStateAccounts: {
 			type: 'array',
 			fieldNumber: 4,
 			items: {
@@ -737,7 +739,7 @@ export const genesisInteroperabilitySchema = {
 					},
 				},
 			},
-		}, */
+		},
 	},
 };
 

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -380,8 +380,8 @@ export interface GenesisInteroperability {
 	ownChainName: string;
 	ownChainNonce: bigint;
 	chainInfos: ChainInfo[];
-	/* terminatedStateAccounts: TerminatedStateAccountWithChainID[];
-	terminatedOutboxAccounts: TerminatedOutboxAccountWithChainID[]; */
+	terminatedStateAccounts: TerminatedStateAccountWithChainID[];
+	terminatedOutboxAccounts: TerminatedOutboxAccountWithChainID[];
 }
 
 export interface CCMRegistrationParams {

--- a/framework/test/unit/modules/interoperability/mainchain/module.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/module.spec.ts
@@ -7,6 +7,7 @@ import { BaseInteroperabilityModule } from '../../../../../src/modules/interoper
 import {
 	HASH_LENGTH,
 	MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
+	EMPTY_HASH,
 	CHAIN_NAME_MAINCHAIN,
 	MAX_NUM_VALIDATORS,
 	MODULE_NAME_INTEROPERABILITY,
@@ -17,6 +18,8 @@ import {
 	ActiveValidator,
 	GenesisBlockExecuteContext,
 } from '../../../../../src';
+import { TerminatedStateAccount } from '../../../../../src/modules/interoperability/stores/terminated_state';
+import { TerminatedOutboxAccount } from '../../../../../src/modules/interoperability/stores/terminated_outbox';
 import { GenesisInteroperability } from '../../../../../src/modules/interoperability/types';
 import {
 	InMemoryPrefixedStateDB,
@@ -100,10 +103,24 @@ describe('initGenesisState', () => {
 		chainValidators,
 	};
 
+	const terminatedStateAccount: TerminatedStateAccount = {
+		stateRoot: lastCertificate.stateRoot,
+		mainchainStateRoot: EMPTY_HASH,
+		initialized: true,
+	};
+
+	const terminatedOutboxAccount: TerminatedOutboxAccount = {
+		outboxRoot: utils.getRandomBytes(HASH_LENGTH),
+		outboxSize: 1,
+		partnerChainInboxSize: 1,
+	};
+
 	const genesisInteroperability: GenesisInteroperability = {
 		ownChainName: CHAIN_NAME_MAINCHAIN,
 		ownChainNonce: BigInt(123),
 		chainInfos: [chainInfo],
+		terminatedStateAccounts: [], // handle it in `describe('terminatedStateAccounts'`
+		terminatedOutboxAccounts: [],
 	};
 
 	let params: CreateGenesisBlockContextParams;
@@ -158,6 +175,23 @@ describe('initGenesisState', () => {
 
 	describe('if chainInfos is not empty', () => {
 		certificateThreshold = BigInt(10);
+		const validChainInfos = [
+			{
+				...chainInfo,
+				chainData: {
+					...chainData,
+					status: ChainStatus.TERMINATED,
+					lastCertificate: {
+						...lastCertificate,
+						validatorsHash: computeValidatorsHash(activeValidators, certificateThreshold),
+					},
+				},
+				chainValidators: {
+					activeValidators,
+					certificateThreshold,
+				},
+			},
+		];
 
 		it('should throw error if ownChainNonce <= 0', async () => {
 			const context = createInitGenesisStateContext(
@@ -727,6 +761,245 @@ must NOT have more than ${MAX_NUM_VALIDATORS} items`,
 				);
 
 				await expect(interopMod.initGenesisState(context)).resolves.toBeUndefined();
+			});
+		});
+
+		describe('terminatedStateAccounts', () => {
+			it('should throw error if chainInfo.chainID exists in terminatedStateAccounts & chainInfo.chainData.status !== CHAIN_STATUS_TERMINATED', async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: [
+							{
+								...chainInfo,
+								chainData: {
+									...chainData,
+									lastCertificate: {
+										...lastCertificate,
+										validatorsHash: computeValidatorsHash(activeValidators, certificateThreshold),
+									},
+								},
+								chainValidators: {
+									activeValidators,
+									certificateThreshold,
+								},
+							},
+						],
+						terminatedStateAccounts: [
+							{
+								chainID: chainInfo.chainID,
+								terminatedStateAccount,
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					`chainInfo.chainData.status must be ${ChainStatus.TERMINATED} if chainInfo.chainID exists in terminatedStateAccounts.`,
+				);
+			});
+
+			it("should throw error if terminatedStateAccounts don't hold unique chainID", async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedStateAccounts: [
+							{
+								chainID: chainInfo.chainID,
+								terminatedStateAccount,
+							},
+							{
+								chainID: chainInfo.chainID,
+								terminatedStateAccount,
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					"terminatedStateAccounts don't hold unique chainID",
+				);
+			});
+
+			it('should throw error if terminatedStateAccounts is not ordered lexicographically by chainID', async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedStateAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 2]),
+								terminatedStateAccount,
+							},
+							{
+								chainID: Buffer.from([0, 0, 0, 1]),
+								terminatedStateAccount,
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					'terminatedStateAccounts must be ordered lexicographically by chainID.',
+				);
+			});
+
+			it('should throw error if some stateAccount in terminatedStateAccounts have stateRoot not equal to chainData.lastCertificate.stateRoot', async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedStateAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 1]),
+								terminatedStateAccount: {
+									...terminatedStateAccount,
+									stateRoot: Buffer.from(utils.getRandomBytes(HASH_LENGTH)),
+								},
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					"stateAccount.stateRoot doesn't match chainInfo.chainData.lastCertificate.stateRoot.",
+				);
+			});
+
+			it('should throw error if some stateAccount in terminatedStateAccounts have mainchainStateRoot not equal to EMPTY_HASH', async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedStateAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 1]),
+								terminatedStateAccount: {
+									...terminatedStateAccount,
+									mainchainStateRoot: Buffer.from(utils.getRandomBytes(HASH_LENGTH)),
+								},
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					`stateAccount.mainchainStateRoot is not equal to EMPTY_HASH.`,
+				);
+			});
+
+			it('should throw error if some stateAccount in terminatedStateAccounts is not initialized', async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedStateAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 1]),
+								terminatedStateAccount: {
+									...terminatedStateAccount,
+									initialized: false,
+								},
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					'stateAccount is not initialized.',
+				);
+			});
+		});
+
+		describe('terminatedOutboxAccounts', () => {
+			it("should throw error if terminatedOutboxAccounts don't hold unique chainID", async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedOutboxAccounts: [
+							{
+								chainID: chainInfo.chainID,
+								terminatedOutboxAccount,
+							},
+							{
+								chainID: chainInfo.chainID,
+								terminatedOutboxAccount,
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					"terminatedOutboxAccounts don't hold unique chainID",
+				);
+			});
+
+			it('should throw error if terminatedOutboxAccounts is not ordered lexicographically by chainID', async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedOutboxAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 2]),
+								terminatedOutboxAccount,
+							},
+							{
+								chainID: Buffer.from([0, 0, 0, 1]),
+								terminatedOutboxAccount,
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					'terminatedOutboxAccounts must be ordered lexicographically by chainID.',
+				);
+			});
+
+			it("should throw error if terminatedOutboxAccounts don't have a corresponding entry (with chainID == outboxAccount.chainID) in terminatedStateAccounts", async () => {
+				const context = createInitGenesisStateContext(
+					{
+						...genesisInteroperability,
+						// this is needed to verify `validatorsHash` related tests (above)
+						chainInfos: validChainInfos,
+						terminatedStateAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 2]),
+								terminatedStateAccount,
+							},
+						],
+						terminatedOutboxAccounts: [
+							{
+								chainID: Buffer.from([0, 0, 0, 1]),
+								terminatedOutboxAccount,
+							},
+						],
+					},
+					params,
+				);
+
+				await expect(interopMod.initGenesisState(context)).rejects.toThrow(
+					'Each entry outboxAccount in terminatedOutboxAccounts must have a corresponding entry (with chainID == outboxAccount.chainID) in terminatedStateAccounts.',
+				);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8151 
**Note**: To reduce size, this PR addresses changes ONLY relevant to `terminatedStateAccounts` & `terminatedOutboxAccounts`

### How was it solved?
Verification checks applied per [LIP](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#mainchain)

### How was it tested?
Relevant test cases added in module.spec.ts
