### PR TITLE
Address duplication & missing test cases in registration commands

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_register_chain_command.ts
+++ b/framework/src/modules/interoperability/base_interoperability_register_chain_command.ts
@@ -1,0 +1,190 @@
+import { objects as objectUtils } from '@liskhq/lisk-utils';
+import { codec } from '@liskhq/lisk-codec';
+import { BaseInteroperabilityCommand } from './base_interoperability_command';
+import { VerifyStatus, VerificationResult, CommandExecuteContext } from '../../state_machine';
+import {
+	RegistrationParametersValidator,
+	ChannelData,
+	InboxOutbox,
+	MainchainRegistrationParams,
+	SidechainRegistrationParams,
+	CCMsg,
+	OwnChainAccount,
+} from './types';
+import {
+	MAX_UINT64,
+	EMPTY_HASH,
+	MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
+	MODULE_NAME_INTEROPERABILITY,
+	CROSS_CHAIN_COMMAND_REGISTRATION,
+	CCMStatusCode,
+} from './constants';
+import { computeValidatorsHash } from './utils';
+import { ChainStatus, ChainAccount, ChainAccountStore } from './stores/chain_account';
+import { BaseInteroperabilityInternalMethod } from './base_interoperability_internal_methods';
+import { ChainValidatorsStore } from './stores/chain_validators';
+import { ChannelDataStore } from './stores/channel_data';
+import { OutboxRootStore } from './stores/outbox_root';
+import { registrationCCMParamsSchema } from './schemas';
+
+export abstract class BaseRegisterChainCommand<
+	T extends BaseInteroperabilityInternalMethod,
+> extends BaseInteroperabilityCommand<T> {
+	// Verifies chain validators
+	protected verifyValidators(
+		validators: RegistrationParametersValidator[],
+		certificateThreshold: bigint,
+	): VerificationResult {
+		const blsKeys = validators.map(validator => validator.blsKey);
+		// All validator keys must be distinct.
+		if (!objectUtils.bufferArrayUniqueItems(blsKeys)) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error('Duplicate BLS keys.'),
+			};
+		}
+
+		// Validator keys must be in lexicographic order.
+		if (!objectUtils.isBufferArrayOrdered(blsKeys)) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error('Validator keys should be sorted lexicographically.'),
+			};
+		}
+
+		let totalBftWeight = BigInt(0);
+		for (const validator of validators) {
+			// The bftWeight property of each element is a positive integer.
+			if (validator.bftWeight <= 0) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error('Validator bft weight must be a positive integer.'),
+				};
+			}
+			totalBftWeight += validator.bftWeight;
+			//  Total BFT weight has to be less than or equal to MAX_UINT64.
+			if (totalBftWeight > MAX_UINT64) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(`Total BFT weight has to be less than or equal to ${MAX_UINT64}.`),
+				};
+			}
+		}
+
+		// Minimum value: floor(1/3 * total BFT weight) + 1
+		// Note: BigInt truncates to floor
+		const minCertificateThreshold = totalBftWeight / BigInt(3) + BigInt(1);
+		if (certificateThreshold < minCertificateThreshold) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error(
+					`Certificate threshold is too small. Minimum value: ${minCertificateThreshold}.`,
+				),
+			};
+		}
+		if (certificateThreshold > totalBftWeight) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error(`Certificate threshold is too large. Maximum value: ${totalBftWeight}.`),
+			};
+		}
+
+		return {
+			status: VerifyStatus.OK,
+		};
+	}
+
+	protected buildChainAccount(
+		name: string,
+		validators: RegistrationParametersValidator[],
+		certificateThreshold: bigint,
+	): ChainAccount {
+		return {
+			name,
+			lastCertificate: {
+				height: 0,
+				timestamp: 0,
+				stateRoot: EMPTY_HASH,
+				validatorsHash: computeValidatorsHash(validators, certificateThreshold),
+			},
+			status: ChainStatus.REGISTERED,
+		};
+	}
+
+	protected async saveChainAccount(
+		context: CommandExecuteContext<MainchainRegistrationParams | SidechainRegistrationParams>,
+		chainID: Buffer,
+		chainAccount: ChainAccount,
+	) {
+		const chainAccountStore = this.stores.get(ChainAccountStore);
+		await chainAccountStore.set(context, chainID, chainAccount);
+	}
+
+	protected buildChannelData(mainchainTokenID: Buffer): ChannelData {
+		const inboxOutbox: InboxOutbox = { appendPath: [], size: 0, root: EMPTY_HASH };
+		return {
+			inbox: inboxOutbox,
+			outbox: inboxOutbox,
+			partnerChainOutboxRoot: EMPTY_HASH,
+			messageFeeTokenID: mainchainTokenID,
+			minReturnFeePerByte: MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
+		};
+	}
+
+	protected async saveChannelData(
+		context: CommandExecuteContext<MainchainRegistrationParams | SidechainRegistrationParams>,
+		chainID: Buffer,
+		channelData: ChannelData,
+	) {
+		const channelDataStore = this.stores.get(ChannelDataStore);
+		await channelDataStore.set(context, chainID, channelData);
+	}
+
+	protected async saveChainValidators(
+		context: CommandExecuteContext<MainchainRegistrationParams | SidechainRegistrationParams>,
+		chainID: Buffer,
+		validators: RegistrationParametersValidator[],
+		certificateThreshold: bigint,
+	) {
+		const chainValidatorsSubstore = this.stores.get(ChainValidatorsStore);
+		await chainValidatorsSubstore.set(context, chainID, {
+			activeValidators: validators,
+			certificateThreshold,
+		});
+	}
+
+	protected async saveOutboxRoot(
+		context: CommandExecuteContext<MainchainRegistrationParams | SidechainRegistrationParams>,
+		chainID: Buffer,
+		outboxRoot: Buffer,
+	) {
+		const outboxRootSubstore = this.stores.get(OutboxRootStore);
+		await outboxRootSubstore.set(context, chainID, { root: outboxRoot });
+	}
+
+	protected buildEncodedParams(name: string, chainID: Buffer, messageFeeTokenID: Buffer): Buffer {
+		return codec.encode(registrationCCMParamsSchema, {
+			name,
+			chainID,
+			messageFeeTokenID,
+			minReturnFeePerByte: MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
+		});
+	}
+
+	protected buildCCM(
+		ownChainAccount: OwnChainAccount,
+		receivingChainID: Buffer,
+		encodedParams: Buffer,
+	): CCMsg {
+		return {
+			nonce: ownChainAccount.nonce,
+			module: MODULE_NAME_INTEROPERABILITY,
+			crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
+			sendingChainID: ownChainAccount.chainID,
+			receivingChainID,
+			fee: BigInt(0),
+			status: CCMStatusCode.OK,
+			params: encodedParams,
+		};
+	}
+}

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -225,7 +225,7 @@ export interface OwnChainAccountJSON {
 	nonce: string;
 }
 
-type InboxOutbox = {
+export type InboxOutbox = {
 	appendPath: Buffer[];
 	size: number;
 	root: Buffer;

--- a/framework/test/unit/modules/interoperability/base_interoperability_register_chain.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_interoperability_register_chain.spec.ts
@@ -1,0 +1,189 @@
+import {
+	VerifyStatus,
+	RegisterSidechainCommand,
+	MainchainInteroperabilityModule,
+	TokenMethod,
+} from '../../../../src';
+import { MAX_UINT64 } from '../../../../src/modules/interoperability/constants';
+import { RegistrationParametersValidator } from '../../../../src/modules/interoperability/types';
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#try_it
+// It is defined here to avoid calling it each time from `beforeEach` for irrelevant tests
+const getTotalBftWeight = (chainValidators: RegistrationParametersValidator[]) => {
+	const initialValue = BigInt(0);
+	return chainValidators
+		.map(v => v.bftWeight)
+		.reduce((accumulator, currentValue) => accumulator + currentValue, initialValue);
+};
+
+describe('verifyValidators', () => {
+	let registerSidechainCommandPrototype: any;
+	const interopMod = new MainchainInteroperabilityModule();
+	let sidechainRegistrationCommand: RegisterSidechainCommand;
+	const tokenMethod: TokenMethod = new TokenMethod(
+		interopMod.stores,
+		interopMod.events,
+		interopMod.name,
+	);
+
+	let sidechainCertificateThreshold = BigInt(10);
+	const defaultSidechainValidators = [
+		{
+			blsKey: Buffer.from(
+				'3c1e6f29e3434f816cd6697e56cc54bc8d80927bf65a1361b383aa338cd3f63cbf82ce801b752cb32f8ecb3f8cc16835',
+				'hex',
+			),
+			bftWeight: BigInt(10),
+		},
+		{
+			blsKey: Buffer.from(
+				'4c1e6f29e3434f816cd6697e56cc54bc8d80927bf65a1361b383aa338cd3f63cbf82ce801b752cb32f8ecb3f8cc16835',
+				'hex',
+			),
+			bftWeight: BigInt(10),
+		},
+	];
+
+	beforeEach(() => {
+		sidechainRegistrationCommand = new RegisterSidechainCommand(
+			interopMod.stores,
+			interopMod.events,
+			new Map(),
+			new Map(),
+			interopMod['internalMethod'],
+		);
+
+		// Set up dependencies
+		sidechainRegistrationCommand.addDependencies({ payFee: jest.fn() }, tokenMethod);
+		registerSidechainCommandPrototype = Object.getPrototypeOf(sidechainRegistrationCommand);
+	});
+
+	it('should return error if have duplicate bls keys', async () => {
+		const sidechainValidators = [
+			{
+				...defaultSidechainValidators[0],
+				blsKey: Buffer.from(
+					'3c1e6f29e3434f816cd6697e56cc54bc8d80927bf65a1361b383aa338cd3f63cbf82ce801b752cb32f8ecb3f8cc16835',
+					'hex',
+				),
+			},
+			{
+				...defaultSidechainValidators[1],
+				blsKey: Buffer.from(
+					'3c1e6f29e3434f816cd6697e56cc54bc8d80927bf65a1361b383aa338cd3f63cbf82ce801b752cb32f8ecb3f8cc16835',
+					'hex',
+				),
+			},
+		];
+
+		const result = await registerSidechainCommandPrototype.verifyValidators(
+			sidechainValidators,
+			sidechainCertificateThreshold,
+		);
+
+		expect(result.status).toBe(VerifyStatus.FAIL);
+		expect(result.error?.message).toInclude('Duplicate BLS keys.');
+	});
+
+	it('should return error if bls keys are not sorted lexicographically', async () => {
+		const sidechainValidators = [
+			{
+				...defaultSidechainValidators[0],
+				blsKey: Buffer.from(
+					'4c1e6f29e3434f816cd6697e56cc54bc8d80927bf65a1361b383aa338cd3f63cbf82ce801b752cb32f8ecb3f8cc16835',
+					'hex',
+				),
+			},
+			{
+				...defaultSidechainValidators[1],
+				blsKey: Buffer.from(
+					'3c1e6f29e3434f816cd6697e56cc54bc8d80927bf65a1361b383aa338cd3f63cbf82ce801b752cb32f8ecb3f8cc16835',
+					'hex',
+				),
+			},
+		];
+
+		const result = await registerSidechainCommandPrototype.verifyValidators(
+			sidechainValidators,
+			sidechainCertificateThreshold,
+		);
+
+		expect(result.status).toBe(VerifyStatus.FAIL);
+		expect(result.error?.message).toInclude('Validator keys should be sorted lexicographically.');
+	});
+
+	it('should return error if some bft weight is not a positive integer', async () => {
+		const sidechainValidators = [
+			{
+				...defaultSidechainValidators[0],
+				bftWeight: BigInt(0),
+			},
+			{
+				...defaultSidechainValidators[1],
+				bftWeight: BigInt(1),
+			},
+		];
+
+		const result = await registerSidechainCommandPrototype.verifyValidators(
+			sidechainValidators,
+			sidechainCertificateThreshold,
+		);
+
+		expect(result.status).toBe(VerifyStatus.FAIL);
+		expect(result.error?.message).toInclude('Validator bft weight must be a positive integer.');
+	});
+
+	it(`should return error if totalBftWeight exceeds ${MAX_UINT64}`, async () => {
+		const sidechainValidators = [
+			{
+				...defaultSidechainValidators[0],
+				bftWeight: MAX_UINT64,
+			},
+			{
+				...defaultSidechainValidators[1],
+				bftWeight: BigInt(10),
+			},
+		];
+
+		const result = await registerSidechainCommandPrototype.verifyValidators(
+			sidechainValidators,
+			sidechainCertificateThreshold,
+		);
+
+		expect(result.status).toBe(VerifyStatus.FAIL);
+		expect(result.error?.message).toInclude(
+			`Total BFT weight has to be less than or equal to ${MAX_UINT64}.`,
+		);
+	});
+
+	it('should return error if certificate threshold is too small', async () => {
+		sidechainCertificateThreshold = BigInt(1);
+		const result = await registerSidechainCommandPrototype.verifyValidators(
+			defaultSidechainValidators,
+			sidechainCertificateThreshold,
+		);
+
+		expect(result.status).toBe(VerifyStatus.FAIL);
+
+		const minCertificateThreshold =
+			getTotalBftWeight(defaultSidechainValidators) / BigInt(3) + BigInt(1);
+		expect(result.error?.message).toInclude(
+			`Certificate threshold is too small. Minimum value: ${minCertificateThreshold}.`,
+		);
+	});
+
+	it('should return error if certificate threshold is too large', async () => {
+		sidechainCertificateThreshold = BigInt(1000);
+		const result = await registerSidechainCommandPrototype.verifyValidators(
+			defaultSidechainValidators,
+			sidechainCertificateThreshold,
+		);
+
+		expect(result.status).toBe(VerifyStatus.FAIL);
+
+		const totalBftWeight = getTotalBftWeight(defaultSidechainValidators);
+		expect(result.error?.message).toInclude(
+			`Certificate threshold is too large. Maximum value: ${totalBftWeight}.`,
+		);
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8193 

### How was it solved?

- Current code throws error `'Validators blsKeys must be unique and lexicographically ordered',` which doesn't explicitly tell whether it's _unique_ or _lexicographically ordered_ 
- It addresses duplication in registration commands (& in their test files) by moving common code to parent class
- Missing tests added

### How was it tested?

Tests are functional
